### PR TITLE
feat(analytics): funnel dashboard + submissions table/CSV/delete

### DIFF
--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -12,6 +12,7 @@ import {
   Patch,
   Post,
   Put,
+  Query,
   Req,
 } from '@nestjs/common';
 import type { Db } from '@quill/db';
@@ -34,8 +35,10 @@ import { formInputSchema, memberInviteSchema, memberPatchSchema } from '@quill/t
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
 import { SubmissionService } from './submission.service';
+import { AnalyticsService } from './analytics.service';
 import { AuthService, type ReqLike } from './auth.service';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
+import { parseBound, parseStatus } from './query-params';
 import { DB } from './tokens';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
@@ -62,6 +65,7 @@ export class AdminCrudController {
     @Inject(AuthService) private readonly auth: AuthService,
     @Inject(AdminService) private readonly admin: AdminService,
     @Inject(SubmissionService) private readonly submissions: SubmissionService,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
   ) {}
 
   // --- Identity ----------------------------------------------------------
@@ -132,12 +136,32 @@ export class AdminCrudController {
     await deleteForm(this.db, p.accountId, id);
   }
 
+  /**
+   * A page of a form's submissions. Optional query: `status`
+   * (all|completed|partial), `from`/`to` (epoch ms or YYYY-MM-DD, bound by
+   * startedAt), `limit`/`offset`. Returns a paginated envelope `{ items, total,
+   * limit, offset }` so the admin table can render page counts.
+   */
   @Get('forms/:id/submissions')
-  async formSubmissions(@Req() req: ReqLike, @Param('id') id: string) {
+  async formSubmissions(
+    @Req() req: ReqLike,
+    @Param('id') id: string,
+    @Query('status') status?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
     const p = await this.auth.resolveHost(req);
     const f = await getFormById(this.db, p.accountId, id);
     if (!f) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    return this.submissions.listSubmissions(id);
+    return this.analytics.submissionsPage(id, {
+      status: parseStatus(status),
+      from: parseBound(from, false),
+      to: parseBound(to, true),
+      limit: limit ? Number(limit) : undefined,
+      offset: offset ? Number(offset) : undefined,
+    });
   }
 
   // --- Members (workspace roster; admin/owner-only) ----------------------

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -38,7 +38,7 @@ import { SubmissionService } from './submission.service';
 import { AnalyticsService } from './analytics.service';
 import { AuthService, type ReqLike } from './auth.service';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
-import { parseBound, parseStatus } from './query-params';
+import { parseBound, parseIntParam, parseStatus } from './query-params';
 import { DB } from './tokens';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
@@ -159,8 +159,8 @@ export class AdminCrudController {
       status: parseStatus(status),
       from: parseBound(from, false),
       to: parseBound(to, true),
-      limit: limit ? Number(limit) : undefined,
-      offset: offset ? Number(offset) : undefined,
+      limit: parseIntParam(limit),
+      offset: parseIntParam(offset),
     });
   }
 

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -11,7 +11,7 @@ import {
   Res,
 } from '@nestjs/common';
 import type { Db } from '@quill/db';
-import { getFormById, querySubmissions } from '@quill/db';
+import { getFormById } from '@quill/db';
 import type { FormConfig } from '@quill/types';
 import { AuthService, type ReqLike } from './auth.service';
 import { AnalyticsService } from './analytics.service';
@@ -64,7 +64,9 @@ export class AnalyticsController {
   /**
    * Stream the form's submissions as CSV. Answers flatten to one column per
    * configured step key (form config order), after the fixed metadata columns.
-   * Paged internally so a large export never buffers the whole set in memory.
+   * Uses the un-paginated export query (`allSubmissionsForExport`) — the table
+   * query caps `limit` at 200, so paging through it would silently truncate and
+   * skip rows on large exports. Rows are still written incrementally.
    */
   @Get('forms/:id/submissions.csv')
   async exportCsv(
@@ -89,30 +91,25 @@ export class AnalyticsController {
 
     res.write(csvRow(['id', 'session_id', 'status', 'score', 'started_at', 'completed_at', ...stepKeys]));
 
-    const q = {
+    const rows = await this.analytics.exportSubmissions(id, {
       status: parseStatus(status),
       from: parseBound(from, false),
       to: parseBound(to, true),
-    };
-    const pageSize = 500;
-    for (let offset = 0; ; offset += pageSize) {
-      const page = await querySubmissions(this.db, id, { ...q, limit: pageSize, offset });
-      for (const s of page.items) {
-        const data = (s.data ?? {}) as Record<string, unknown>;
-        const st = s.completedAt != null ? 'completed' : s.partialAt != null ? 'partial' : 'in_progress';
-        res.write(
-          csvRow([
-            s.id,
-            s.sessionId,
-            st,
-            s.score,
-            iso(s.startedAt),
-            iso(s.completedAt),
-            ...stepKeys.map((k) => data[k]),
-          ]),
-        );
-      }
-      if (offset + pageSize >= page.total) break;
+    });
+    for (const s of rows) {
+      const data = (s.data ?? {}) as Record<string, unknown>;
+      const st = s.completedAt != null ? 'completed' : s.partialAt != null ? 'partial' : 'in_progress';
+      res.write(
+        csvRow([
+          s.id,
+          s.sessionId,
+          st,
+          s.score,
+          iso(s.startedAt),
+          iso(s.completedAt),
+          ...stepKeys.map((k) => data[k]),
+        ]),
+      );
     }
     res.end();
   }

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -1,0 +1,127 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Inject,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+  Res,
+} from '@nestjs/common';
+import type { Db } from '@quill/db';
+import { getFormById, querySubmissions } from '@quill/db';
+import type { FormConfig } from '@quill/types';
+import { AuthService, type ReqLike } from './auth.service';
+import { AnalyticsService } from './analytics.service';
+import { DB } from './tokens';
+import { csvRow } from './csv';
+import { parseBound, parseStatus } from './query-params';
+
+/** A minimal response shape (structurally satisfied by the express Response). */
+interface StreamRes {
+  setHeader(name: string, value: string): void;
+  write(chunk: string): void;
+  end(): void;
+}
+
+function iso(ms: number | null): string {
+  return ms == null ? '' : new Date(ms).toISOString();
+}
+
+/**
+ * Host-authed analytics + submissions read/export/delete surface. Kept separate
+ * from AdminCrudController so the analytics feature is self-contained (registered
+ * append-only in app.module). Every route resolves the host first, then scopes
+ * by the caller's account.
+ */
+@Controller('v1')
+export class AnalyticsController {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AuthService) private readonly auth: AuthService,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
+  ) {}
+
+  /** Funnel metrics + per-step drop-off for a form over an optional date range. */
+  @Get('forms/:id/analytics')
+  async formAnalytics(
+    @Req() req: ReqLike,
+    @Param('id') id: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    const p = await this.auth.resolveHost(req);
+    const result = await this.analytics.funnel(p.accountId, id, {
+      from: parseBound(from, false),
+      to: parseBound(to, true),
+    });
+    if (!result) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    return result;
+  }
+
+  /**
+   * Stream the form's submissions as CSV. Answers flatten to one column per
+   * configured step key (form config order), after the fixed metadata columns.
+   * Paged internally so a large export never buffers the whole set in memory.
+   */
+  @Get('forms/:id/submissions.csv')
+  async exportCsv(
+    @Req() req: ReqLike,
+    @Res() res: StreamRes,
+    @Param('id') id: string,
+    @Query('status') status?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ): Promise<void> {
+    const p = await this.auth.resolveHost(req);
+    const form = await getFormById(this.db, p.accountId, id);
+    if (!form) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+
+    const config = form.config as FormConfig;
+    const stepKeys = (config.steps ?? []).map((s) => s.key);
+    const filename = `${form.slug || 'submissions'}-submissions.csv`;
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Cache-Control', 'no-store');
+
+    res.write(csvRow(['id', 'session_id', 'status', 'score', 'started_at', 'completed_at', ...stepKeys]));
+
+    const q = {
+      status: parseStatus(status),
+      from: parseBound(from, false),
+      to: parseBound(to, true),
+    };
+    const pageSize = 500;
+    for (let offset = 0; ; offset += pageSize) {
+      const page = await querySubmissions(this.db, id, { ...q, limit: pageSize, offset });
+      for (const s of page.items) {
+        const data = (s.data ?? {}) as Record<string, unknown>;
+        const st = s.completedAt != null ? 'completed' : s.partialAt != null ? 'partial' : 'in_progress';
+        res.write(
+          csvRow([
+            s.id,
+            s.sessionId,
+            st,
+            s.score,
+            iso(s.startedAt),
+            iso(s.completedAt),
+            ...stepKeys.map((k) => data[k]),
+          ]),
+        );
+      }
+      if (offset + pageSize >= page.total) break;
+    }
+    res.end();
+  }
+
+  /** Delete a submission (account-scoped, idempotent → always 204). */
+  @Delete('submissions/:id')
+  @HttpCode(204)
+  async deleteSubmission(@Req() req: ReqLike, @Param('id') id: string): Promise<void> {
+    const p = await this.auth.resolveHost(req);
+    await this.analytics.deleteSubmission(p.accountId, id); // idempotent: absent/out-of-account → no-op
+  }
+}

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Analytics aggregation math, end to end on in-memory SQLite. Seeds a known set
+ * of funnel events + submissions and asserts the funnel summary + per-step
+ * drop-off table exactly (ground truth computed by hand in the comments). Also
+ * covers the date-range filter, submissions pagination/filter, and the
+ * account-scoped idempotent delete — the whole read surface's math.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createDb,
+  migrate,
+  seed,
+  recordFormEvent,
+  jsonParam,
+  querySubmissions,
+  deleteSubmissionForAccount,
+  sql,
+  type Db,
+} from '@quill/db';
+import { AnalyticsService } from './analytics.service';
+
+let db: Db;
+let svc: AnalyticsService;
+let accountId: string;
+let formId: string;
+
+/** Insert a submission row with explicit timestamps (bypasses upsert semantics). */
+async function insertSubmission(input: {
+  session: string;
+  data: Record<string, unknown>;
+  score: number;
+  startedAt: number;
+  completedAt?: number | null;
+  partialAt?: number | null;
+}) {
+  await db.run(
+    sql`INSERT INTO submission (id, form_id, session_id, data, score, started_at, completed_at, partial_at)
+        VALUES (${crypto.randomUUID()}, ${formId}, ${input.session}, ${jsonParam(input.data)},
+          ${input.score}, ${input.startedAt}, ${input.completedAt ?? null}, ${input.partialAt ?? null})`,
+  );
+}
+
+async function emit(type: string, count: number, stepIndex?: number, at?: number) {
+  for (let i = 0; i < count; i++) {
+    await recordFormEvent(db, {
+      formId,
+      sessionId: `${type}-${stepIndex ?? 'x'}-${i}`,
+      type,
+      stepIndex: stepIndex ?? null,
+      now: at,
+    });
+  }
+}
+
+const NOW = 1_800_000_000_000; // fixed instant so range math is deterministic
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db);
+  svc = new AnalyticsService(db);
+  const acc = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE code = 'acme' LIMIT 1`);
+  accountId = acc!.id;
+  const form = await db.get<{ id: string }>(sql`SELECT id FROM form WHERE slug = 'lead-qualifier' LIMIT 1`);
+  formId = form!.id;
+
+  // Funnel events (all at NOW): 10 views, 8 starts, step_views 8/6/4/3.
+  await emit('view', 10, undefined, NOW);
+  await emit('start', 8, undefined, NOW);
+  await emit('step_view', 8, 0, NOW);
+  await emit('step_view', 6, 1, NOW);
+  await emit('step_view', 4, 2, NOW);
+  await emit('step_view', 3, 3, NOW);
+
+  // 3 completed submissions with durations 30s / 60s / 90s → avg 60s.
+  await insertSubmission({ session: 'c1', data: { role: 'founder', email: 'a@x.io' }, score: 10, startedAt: NOW, completedAt: NOW + 30_000 });
+  await insertSubmission({ session: 'c2', data: { role: 'lead', email: 'b@x.io' }, score: 6, startedAt: NOW, completedAt: NOW + 60_000 });
+  await insertSubmission({ session: 'c3', data: { role: 'founder', email: 'c@x.io' }, score: 10, startedAt: NOW, completedAt: NOW + 90_000 });
+  // 2 partial-only submissions.
+  await insertSubmission({ session: 'p1', data: { role: 'individual' }, score: 2, startedAt: NOW, partialAt: NOW + 5_000 });
+  await insertSubmission({ session: 'p2', data: { role: 'lead' }, score: 6, startedAt: NOW, partialAt: NOW + 5_000 });
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('funnel aggregation', () => {
+  it('computes the funnel summary exactly', async () => {
+    const a = (await svc.funnel(accountId, formId, {}))!;
+    expect(a.views).toBe(10);
+    expect(a.starts).toBe(8);
+    expect(a.submissions).toBe(3); // completed
+    expect(a.partialSubmits).toBe(2);
+    expect(a.completionRate).toBe(37.5); // 3/8 = 37.5%
+    expect(a.avgTimeToComplete).toBe(60); // (30+60+90)/3 s
+  });
+
+  it('computes the per-step drop-off table (cover + one row per step)', async () => {
+    const a = (await svc.funnel(accountId, formId, {}))!;
+    // 4 configured steps + 1 cover row.
+    expect(a.dropoff).toHaveLength(5);
+
+    const [cover, s0, s1, s2, s3] = a.dropoff;
+    // Cover: views 10 → step0 8 ⇒ drop 2 (20%).
+    expect(cover).toMatchObject({ isCover: true, views: 10, dropoff: 2, dropoffPercent: 20 });
+    // role: 8 → 6 ⇒ drop 2 (25%).
+    expect(s0).toMatchObject({ key: 'role', views: 8, dropoff: 2, dropoffPercent: 25 });
+    // team_size: 6 → 4 ⇒ drop 2 (33.3%).
+    expect(s1).toMatchObject({ key: 'team_size', views: 6, dropoff: 2, dropoffPercent: 33.3 });
+    // company: 4 → 3 ⇒ drop 1 (25%).
+    expect(s2).toMatchObject({ key: 'company', views: 4, dropoff: 1, dropoffPercent: 25 });
+    // email: 3 → submissions 3 ⇒ drop 0 (0%).
+    expect(s3).toMatchObject({ key: 'email', views: 3, dropoff: 0, dropoffPercent: 0 });
+  });
+
+  it('applies the date-range filter (out-of-range rows excluded)', async () => {
+    // Everything was seeded at NOW; a window strictly before NOW sees nothing.
+    const empty = (await svc.funnel(accountId, formId, { from: NOW - 100_000, to: NOW - 1 }))!;
+    expect(empty.views).toBe(0);
+    expect(empty.starts).toBe(0);
+    expect(empty.submissions).toBe(0);
+    expect(empty.partialSubmits).toBe(0);
+
+    // A window covering NOW sees the full set again.
+    const full = (await svc.funnel(accountId, formId, { from: NOW - 1, to: NOW + 200_000 }))!;
+    expect(full.views).toBe(10);
+    expect(full.submissions).toBe(3);
+  });
+
+  it('returns null for a form the account does not own', async () => {
+    expect(await svc.funnel('someone-else', formId, {})).toBeNull();
+  });
+});
+
+describe('submissions query', () => {
+  it('paginates newest-first with a total', async () => {
+    const page = await querySubmissions(db, formId, { limit: 2, offset: 0 });
+    expect(page.total).toBe(5); // 3 completed + 2 partial
+    expect(page.items).toHaveLength(2);
+    expect(page.limit).toBe(2);
+  });
+
+  it('filters by status', async () => {
+    const completed = await querySubmissions(db, formId, { status: 'completed' });
+    expect(completed.total).toBe(3);
+    expect(completed.items.every((s) => s.completedAt != null)).toBe(true);
+
+    const partial = await querySubmissions(db, formId, { status: 'partial' });
+    expect(partial.total).toBe(2);
+    expect(partial.items.every((s) => s.completedAt == null && s.partialAt != null)).toBe(true);
+  });
+});
+
+describe('delete submission (account-scoped, idempotent)', () => {
+  it('deletes an owned submission and is a no-op on repeat / wrong account', async () => {
+    const one = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
+    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe(true);
+    // Idempotent second call.
+    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe(false);
+    // Wrong account never touches the row.
+    const other = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
+    expect(await deleteSubmissionForAccount(db, 'wrong-account', other.id)).toBe(false);
+    expect((await querySubmissions(db, formId, { status: 'completed' })).total).toBe(2);
+  });
+});

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -18,6 +18,10 @@ import {
   type Db,
 } from '@quill/db';
 import { AnalyticsService } from './analytics.service';
+import { AnalyticsController } from './analytics.controller';
+import type { AuthService } from './auth.service';
+import { csvField } from './csv';
+import { parseIntParam } from './query-params';
 
 let db: Db;
 let svc: AnalyticsService;
@@ -162,5 +166,103 @@ describe('delete submission (account-scoped, idempotent)', () => {
     const other = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
     expect(await deleteSubmissionForAccount(db, 'wrong-account', other.id)).toBe(false);
     expect((await querySubmissions(db, formId, { status: 'completed' })).total).toBe(2);
+  });
+});
+
+describe('CSV export (large sets, un-paginated)', () => {
+  /** Drive the real controller with a stub auth + capture-only response. */
+  async function runExport(): Promise<string[]> {
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: 'test-member', role: 'owner' as const }),
+    } as unknown as AuthService;
+    const ctrl = new AnalyticsController(db, auth, svc);
+    const chunks: string[] = [];
+    const res = {
+      setHeader: () => {},
+      write: (c: string) => {
+        chunks.push(c);
+      },
+      end: () => {},
+    };
+    await ctrl.exportCsv({ headers: {} }, res, formId, undefined, undefined, undefined);
+    return chunks.join('').trimEnd().split('\r\n');
+  }
+
+  it('exports EVERY row past the 200-row table cap (250 seeded → 250 CSV rows)', async () => {
+    // beforeEach seeded 5 submissions; add 245 more → exactly 250 total. The
+    // paginated table query caps limit at 200, so this proves the export path
+    // does NOT truncate or skip rows (OptiBot blocker).
+    for (let i = 0; i < 245; i++) {
+      await insertSubmission({
+        session: `bulk-${i}`,
+        data: { role: 'individual', email: `bulk${i}@x.io` },
+        score: 2,
+        startedAt: NOW + i,
+        completedAt: NOW + i + 1000,
+      });
+    }
+    expect((await querySubmissions(db, formId, {})).total).toBe(250);
+
+    const lines = await runExport();
+    expect(lines[0]).toMatch(/^id,session_id,status,score,started_at,completed_at/);
+    expect(lines.length - 1).toBe(250); // header + one row per submission
+  });
+
+  it('neutralizes a formula payload end-to-end in the exported CSV', async () => {
+    await insertSubmission({
+      session: 'inject-1',
+      data: { role: '=HYPERLINK("http://evil.example","click")', email: '@import' },
+      score: 0,
+      startedAt: NOW,
+      completedAt: NOW + 1,
+    });
+    const csv = (await runExport()).join('\n');
+    expect(csv).toContain(`'=HYPERLINK`);
+    expect(csv).toContain(`'@import`);
+    expect(csv).not.toMatch(/(^|,)=HYPERLINK/m); // no bare leading formula
+  });
+});
+
+describe('csvField formula-injection neutralization', () => {
+  it('prefixes a quote on formula-trigger strings', () => {
+    expect(csvField('=1+2')).toBe("'=1+2");
+    expect(csvField('+SUM(A1)')).toBe("'+SUM(A1)");
+    expect(csvField('-cmd')).toBe("'-cmd");
+    expect(csvField('@import')).toBe("'@import");
+    expect(csvField('\tpayload')).toBe("'\tpayload");
+  });
+
+  it('still RFC-4180-quotes when the neutralized value needs it', () => {
+    // Leading `=` AND a comma: neutralize first, then quote.
+    expect(csvField('=HYPERLINK("http://e.x","y")')).toBe('"\'=HYPERLINK(""http://e.x"",""y"")"');
+  });
+
+  it('leaves genuine numbers/booleans and plain strings untouched', () => {
+    expect(csvField(-5)).toBe('-5'); // negative score stays numeric
+    expect(csvField(true)).toBe('true');
+    expect(csvField('hello')).toBe('hello');
+    expect(csvField(null)).toBe('');
+  });
+
+  it('neutralizes an array whose flattened head is a trigger', () => {
+    expect(csvField(['=evil', 'b'])).toBe("'=evil; b");
+  });
+});
+
+describe('parseIntParam (NaN guard for limit/offset)', () => {
+  it('parses numeric strings and rejects everything else', () => {
+    expect(parseIntParam('50')).toBe(50);
+    expect(parseIntParam('0')).toBe(0);
+    expect(parseIntParam('12.9')).toBe(12); // truncated to an int
+    expect(parseIntParam('abc')).toBeUndefined(); // NaN must never reach SQL
+    expect(parseIntParam('1e309')).toBeUndefined(); // Infinity guarded too
+    expect(parseIntParam('')).toBeUndefined();
+    expect(parseIntParam(undefined)).toBeUndefined();
+  });
+
+  it('undefined falls back to the query default (no LIMIT NaN)', async () => {
+    const page = await querySubmissions(db, formId, { limit: parseIntParam('abc') });
+    expect(page.limit).toBe(25); // default, not NaN
+    expect(page.items.length).toBeGreaterThan(0);
   });
 });

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,0 +1,129 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Db } from '@quill/db';
+import {
+  eventTypeCounts,
+  stepViewCounts,
+  submissionAggregates,
+  querySubmissions,
+  allSubmissionsForExport,
+  deleteSubmissionForAccount,
+  getFormById,
+  type DateRange,
+  type SubmissionQuery,
+} from '@quill/db';
+import type {
+  AnalyticsResponse,
+  DropoffRow,
+  FormConfig,
+  SubmissionAnswers,
+  SubmissionsPage,
+} from '@quill/types';
+import { DB } from './tokens';
+
+/** Round to one decimal place (e.g. a completion/drop-off percentage). */
+function pct1(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+/**
+ * The admin analytics + submissions read surface. Aggregates are computed from
+ * `form_event` (funnel counts) + `submission` (completed/partial + timing) via
+ * the portable DB queries, then the funnel + per-step drop-off table is
+ * assembled here against the form's configured steps. All operations are
+ * account-scoped by the caller (the controller resolves the host first).
+ */
+@Injectable()
+export class AnalyticsService {
+  constructor(@Inject(DB) private readonly db: Db) {}
+
+  /** Funnel summary + question-by-question drop-off for a form over a range. */
+  async funnel(accountId: string, formId: string, range: DateRange): Promise<AnalyticsResponse | null> {
+    const form = await getFormById(this.db, accountId, formId);
+    if (!form) return null;
+    const config = form.config as FormConfig;
+    const steps = config.steps ?? [];
+
+    const [counts, stepViews, agg] = await Promise.all([
+      eventTypeCounts(this.db, formId, range),
+      stepViewCounts(this.db, formId, range),
+      submissionAggregates(this.db, formId, range),
+    ]);
+
+    const views = counts.view ?? 0;
+    const starts = counts.start ?? 0;
+    const submissions = agg.completed;
+    const partialSubmits = agg.partial;
+    const completionRate = pct1(submissions, starts);
+    const avgTimeToComplete =
+      agg.avgCompletionMs == null ? 0 : Math.round(agg.avgCompletionMs / 1000);
+
+    // rowViews[0] = form views (the cover/landing); rowViews[i+1] = views of step i.
+    const rowViews: number[] = [views];
+    for (let i = 0; i < steps.length; i++) rowViews.push(stepViews.get(i) ?? 0);
+
+    const dropoff: DropoffRow[] = [];
+
+    // Cover/landing row: drop between the landing and the first step.
+    const coverViews = rowViews[0] ?? 0;
+    const coverDrop = Math.max(0, coverViews - (rowViews[1] ?? 0));
+    dropoff.push({
+      stepIndex: -1,
+      key: null,
+      question: config.cover?.headline?.trim() || config.cover?.eyebrow?.trim() || 'Cover',
+      isCover: true,
+      views: coverViews,
+      dropoff: coverDrop,
+      dropoffPercent: pct1(coverDrop, coverViews),
+    });
+
+    // One row per configured step. The "next" for the last step is completed
+    // submissions (the true bottom of the funnel), matching the pilot semantics.
+    for (let i = 0; i < steps.length; i++) {
+      const viewsAtStep = rowViews[i + 1] ?? 0;
+      const viewsAtNext = i < steps.length - 1 ? (rowViews[i + 2] ?? 0) : submissions;
+      const drop = Math.max(0, viewsAtStep - viewsAtNext);
+      dropoff.push({
+        stepIndex: i,
+        key: steps[i]!.key,
+        question: steps[i]!.question?.trim() || steps[i]!.key,
+        isCover: false,
+        views: viewsAtStep,
+        dropoff: drop,
+        dropoffPercent: pct1(drop, viewsAtStep),
+      });
+    }
+
+    return {
+      views,
+      starts,
+      submissions,
+      completionRate,
+      avgTimeToComplete,
+      partialSubmits,
+      dropoff,
+      range: { from: range.from ?? null, to: range.to ?? null },
+    };
+  }
+
+  /** A page of a form's submissions (newest first) matching the filter. */
+  async submissionsPage(formId: string, q: SubmissionQuery): Promise<SubmissionsPage> {
+    const page = await querySubmissions(this.db, formId, q);
+    return {
+      items: page.items.map((r) => ({ ...r, data: (r.data ?? {}) as SubmissionAnswers })),
+      total: page.total,
+      limit: page.limit,
+      offset: page.offset,
+    };
+  }
+
+  /** Every submission matching the filter (CSV export — no pagination). */
+  exportSubmissions(formId: string, q: Omit<SubmissionQuery, 'limit' | 'offset'>) {
+    return allSubmissionsForExport(this.db, formId, q);
+  }
+
+  /** Delete a submission if it belongs to the account. Idempotent. */
+  deleteSubmission(accountId: string, submissionId: string): Promise<boolean> {
+    return deleteSubmissionForAccount(this.db, accountId, submissionId);
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,9 +15,11 @@ import type { Db } from '@quill/db';
 import { HealthController, DocsController } from './controllers';
 import { PublicController } from './public.controller';
 import { AdminCrudController } from './admin-crud.controller';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
 
 @Module({
-  controllers: [HealthController, DocsController, PublicController, AdminCrudController],
+  controllers: [HealthController, DocsController, PublicController, AdminCrudController, AnalyticsController],
   providers: [
     { provide: ENV, useFactory: () => loadServerEnv() },
     { provide: DB, useFactory: () => createDb() },
@@ -68,6 +70,7 @@ import { AdminCrudController } from './admin-crud.controller';
     { provide: RATE_LIMITER, useFactory: (env: ServerEnv) => createRateLimiter(env), inject: [ENV] },
     RateLimitGuard,
     SubmissionService,
+    AnalyticsService,
     AdminService,
     AuthService,
     EmailEffects,

--- a/apps/api/src/csv.ts
+++ b/apps/api/src/csv.ts
@@ -2,15 +2,30 @@
  * Minimal, dependency-free RFC-4180 CSV encoding for the submissions export.
  * Values are quoted when they contain a comma, quote, or newline; embedded
  * quotes are doubled. Arrays flatten to `a; b; c`; null/undefined to empty.
+ *
+ * Formula-injection hardening (OWASP CSV injection): a user-supplied value
+ * starting with `=`, `+`, `-`, `@`, tab, or CR would be executed as a formula
+ * by Excel/Sheets on open (e.g. `=HYPERLINK(...)`). Such fields are neutralized
+ * by prefixing a single quote AFTER stringification, BEFORE quoting. Genuine
+ * numbers/booleans can't carry a formula and are left untouched (so a negative
+ * score exports as `-5`, not `'-5`).
  */
 
-/** Escape a single CSV field. */
+/** Leading characters Excel/Sheets interpret as a formula trigger. */
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
+/** Escape a single CSV field (with formula-injection neutralization). */
 export function csvField(value: unknown): string {
   let s: string;
   if (value == null) s = '';
   else if (Array.isArray(value)) s = value.map((v) => (v == null ? '' : String(v))).join('; ');
   else if (typeof value === 'object') s = JSON.stringify(value);
   else s = String(value);
+  // Neutralize user-controlled strings that would execute as a spreadsheet
+  // formula; real numbers/booleans are inert and stay verbatim.
+  if (typeof value !== 'number' && typeof value !== 'boolean' && FORMULA_TRIGGER.test(s)) {
+    s = `'${s}`;
+  }
   if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
   return s;
 }

--- a/apps/api/src/csv.ts
+++ b/apps/api/src/csv.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal, dependency-free RFC-4180 CSV encoding for the submissions export.
+ * Values are quoted when they contain a comma, quote, or newline; embedded
+ * quotes are doubled. Arrays flatten to `a; b; c`; null/undefined to empty.
+ */
+
+/** Escape a single CSV field. */
+export function csvField(value: unknown): string {
+  let s: string;
+  if (value == null) s = '';
+  else if (Array.isArray(value)) s = value.map((v) => (v == null ? '' : String(v))).join('; ');
+  else if (typeof value === 'object') s = JSON.stringify(value);
+  else s = String(value);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Join a row of already-collected values into a CSV line (with CRLF). */
+export function csvRow(values: unknown[]): string {
+  return values.map(csvField).join(',') + '\r\n';
+}

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -25,3 +25,14 @@ export function parseBound(v: string | undefined, endOfDay: boolean): number | n
 export function parseStatus(v: string | undefined): SubmissionStatus {
   return v === 'completed' || v === 'partial' ? v : 'all';
 }
+
+/**
+ * Parse a non-negative integer query param (limit/offset). Non-numeric input
+ * must resolve to `undefined` — a raw `Number('abc')` is NaN, which would reach
+ * SQL as `LIMIT NaN` (empty result on SQLite, ERROR on Postgres).
+ */
+export function parseIntParam(v: string | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : undefined;
+}

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared query-param parsers for the admin read surface (analytics +
+ * submissions). A date bound accepts epoch-ms passthrough or a YYYY-MM-DD / ISO
+ * string; a status narrows the submissions filter. Kept dialect- and
+ * framework-agnostic so both controllers parse identically.
+ */
+import type { SubmissionStatus } from '@quill/db';
+
+/** Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. */
+export function parseBound(v: string | undefined, endOfDay: boolean): number | null {
+  if (!v) return null;
+  if (/^\d+$/.test(v)) return Number(v);
+  const t = Date.parse(v);
+  if (Number.isNaN(t)) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+    const d = new Date(t);
+    if (endOfDay) d.setUTCHours(23, 59, 59, 999);
+    else d.setUTCHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+  return t;
+}
+
+/** Narrow a raw status query to the allowed filter (defaults to `all`). */
+export function parseStatus(v: string | undefined): SubmissionStatus {
+  return v === 'completed' || v === 'partial' ? v : 'all';
+}

--- a/apps/web/app/admin/form-row-actions.tsx
+++ b/apps/web/app/admin/form-row-actions.tsx
@@ -1,19 +1,41 @@
 'use client';
 
+import Link from 'next/link';
 import { useTransition } from 'react';
 import { duplicateFormAction, deleteFormAction } from './actions';
 
-/** Duplicate / delete buttons for a form row (client → server actions). */
+/**
+ * Per-row actions for a form: cross-links to its Analytics + Submissions pages
+ * (analytics track — additive) plus localized Duplicate / Delete (builder track).
+ */
 export function FormRowActions({
   id,
   labels,
+  nav,
 }: {
   id: string;
   labels: { duplicate: string; delete: string; deleteConfirm: string };
+  nav?: { analytics: string; submissions: string };
 }) {
   const [pending, start] = useTransition();
   return (
     <div className="flex items-center gap-3 text-sm">
+      {nav ? (
+        <>
+          <Link
+            href={`/admin/forms/${id}/analytics`}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {nav.analytics}
+          </Link>
+          <Link
+            href={`/admin/forms/${id}/submissions`}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {nav.submissions}
+          </Link>
+        </>
+      ) : null}
       <button
         type="button"
         disabled={pending}

--- a/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, useTransition } from 'react';
+
+type Preset = '7' | '30' | '90' | 'all' | 'custom';
+
+/**
+ * Date-range control for the analytics dashboard: presets (7/30/90 days + all)
+ * plus a custom from/to. Writes the choice to the URL query so the server
+ * component re-fetches; a Suspense boundary shows the skeleton while it does
+ * (R22). Tokens-only; 44px hit targets (R28).
+ */
+export function AnalyticsFilter({
+  labels,
+}: {
+  labels: {
+    last7: string;
+    last30: string;
+    last90: string;
+    all: string;
+    custom: string;
+    from: string;
+    to: string;
+    apply: string;
+  };
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, start] = useTransition();
+
+  const current = (params.get('preset') as Preset | null) ?? 'all';
+  const [from, setFrom] = useState(params.get('from') ?? '');
+  const [to, setTo] = useState(params.get('to') ?? '');
+  const [showCustom, setShowCustom] = useState(current === 'custom');
+
+  const push = (next: URLSearchParams) => start(() => router.push(`?${next.toString()}`, { scroll: false }));
+
+  const selectPreset = (preset: Preset) => {
+    if (preset === 'custom') {
+      setShowCustom(true);
+      return;
+    }
+    setShowCustom(false);
+    const next = new URLSearchParams();
+    if (preset !== 'all') next.set('preset', preset);
+    push(next);
+  };
+
+  const applyCustom = () => {
+    if (!from && !to) return;
+    const next = new URLSearchParams();
+    next.set('preset', 'custom');
+    if (from) next.set('from', from);
+    if (to) next.set('to', to);
+    push(next);
+  };
+
+  const presets: { key: Preset; label: string }[] = [
+    { key: '7', label: labels.last7 },
+    { key: '30', label: labels.last30 },
+    { key: '90', label: labels.last90 },
+    { key: 'all', label: labels.all },
+    { key: 'custom', label: labels.custom },
+  ];
+
+  return (
+    <div className="flex flex-col gap-3" aria-busy={pending}>
+      <div className="flex flex-wrap items-center gap-2">
+        {presets.map((p) => {
+          const active = p.key === 'custom' ? showCustom : !showCustom && current === p.key;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              disabled={pending}
+              onClick={() => selectPreset(p.key)}
+              aria-pressed={active}
+              className={
+                active
+                  ? 'inline-flex h-9 items-center rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60'
+                  : 'inline-flex h-9 items-center rounded-md border border-border bg-transparent px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60'
+              }
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {showCustom ? (
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            {labels.from}
+            <input
+              type="date"
+              value={from}
+              max={to || undefined}
+              onChange={(e) => setFrom(e.target.value)}
+              className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            {labels.to}
+            <input
+              type="date"
+              value={to}
+              min={from || undefined}
+              onChange={(e) => setTo(e.target.value)}
+              className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+            />
+          </label>
+          <button
+            type="button"
+            disabled={pending || (!from && !to)}
+            onClick={applyCustom}
+            className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60"
+          >
+            {labels.apply}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/analytics/error.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/error.tsx
@@ -2,11 +2,7 @@
 
 import { getMessages } from '@quill/shared';
 
-/** Read the persisted admin locale on the client (mirrors the server cookie). */
-function clientLocale(): 'en' | 'es' {
-  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
-  return 'en';
-}
+import { clientLocale } from '@/lib/client-locale';
 
 export default function AnalyticsError({ reset }: { error: Error; reset: () => void }) {
   const m = getMessages(clientLocale()).admin.analytics;

--- a/apps/web/app/admin/forms/[id]/analytics/error.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { getMessages } from '@quill/shared';
+
+/** Read the persisted admin locale on the client (mirrors the server cookie). */
+function clientLocale(): 'en' | 'es' {
+  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
+  return 'en';
+}
+
+export default function AnalyticsError({ reset }: { error: Error; reset: () => void }) {
+  const m = getMessages(clientLocale()).admin.analytics;
+  return (
+    <div className="mx-auto max-w-md px-8 py-16 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">{m.error}</h1>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-primary px-5 py-2 font-semibold text-primary-foreground transition-transform active:scale-[0.98]"
+      >
+        {m.retry}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/analytics/loading.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/skeleton';
+
+export default function AnalyticsLoading() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <Skeleton className="mb-6 h-9 w-64" />
+      <Skeleton className="mb-6 h-9 w-80" />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" />
+        ))}
+      </div>
+      <Skeleton className="mt-8 h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/analytics/page.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/page.tsx
@@ -1,0 +1,194 @@
+import { Suspense } from 'react';
+import { notFound } from 'next/navigation';
+import type { AnalyticsResponse } from '@quill/types';
+import { getMessages, type FormsMessages } from '@quill/shared';
+import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
+import { FormTabs } from '@/components/ui/form-tabs';
+import { Skeleton } from '@/components/skeleton';
+import { AnalyticsFilter } from './analytics-filter';
+
+export const dynamic = 'force-dynamic';
+
+const DAY_MS = 86_400_000;
+
+type SP = { preset?: string; from?: string; to?: string };
+
+/** Resolve the URL query into an epoch-ms range the API understands. */
+function resolveRange(sp: SP): { from?: number; to?: number } {
+  if (sp.preset === 'custom') {
+    const from = sp.from ? Date.parse(`${sp.from}T00:00:00.000Z`) : NaN;
+    const to = sp.to ? Date.parse(`${sp.to}T23:59:59.999Z`) : NaN;
+    return {
+      from: Number.isNaN(from) ? undefined : from,
+      to: Number.isNaN(to) ? undefined : to,
+    };
+  }
+  const days = sp.preset === '7' ? 7 : sp.preset === '30' ? 30 : sp.preset === '90' ? 90 : null;
+  if (days) return { from: Date.now() - days * DAY_MS };
+  return {};
+}
+
+export default async function AnalyticsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<SP>;
+}) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const m = getMessages(await getLocale()).admin;
+  const range = resolveRange(sp);
+  const rangeKey = `${sp.preset ?? 'all'}:${sp.from ?? ''}:${sp.to ?? ''}`;
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <FormTabs formId={id} active="analytics" labels={m.nav} />
+      <div className="mb-6 flex flex-col gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">{m.analytics.title}</h1>
+          <p className="mt-1 text-muted-foreground">{m.analytics.subtitle}</p>
+        </div>
+        <AnalyticsFilter
+          labels={{
+            last7: m.analytics.rangeLast7,
+            last30: m.analytics.rangeLast30,
+            last90: m.analytics.rangeLast90,
+            all: m.analytics.rangeAll,
+            custom: m.analytics.rangeCustom,
+            from: m.analytics.rangeFrom,
+            to: m.analytics.rangeTo,
+            apply: m.analytics.rangeApply,
+          }}
+        />
+      </div>
+
+      <Suspense key={rangeKey} fallback={<AnalyticsSkeleton />}>
+        <AnalyticsData id={id} range={range} m={m.analytics} />
+      </Suspense>
+    </div>
+  );
+}
+
+/** Format seconds as `Ns` or `Nm Ss`. */
+function formatDuration(seconds: number, unit: string): string {
+  if (seconds < 60) return `${seconds}${unit}`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s === 0 ? `${m}m` : `${m}m ${s}${unit}`;
+}
+
+async function AnalyticsData({
+  id,
+  range,
+  m,
+}: {
+  id: string;
+  range: { from?: number; to?: number };
+  m: FormsMessages['admin']['analytics'];
+}) {
+  let a: AnalyticsResponse;
+  try {
+    a = await adminApi.getAnalytics(id, range);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+
+  const hasActivity = a.views + a.starts + a.submissions + a.partialSubmits > 0;
+  if (!hasActivity) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/40 p-12 text-center">
+        <p className="text-lg font-medium">{m.emptyTitle}</p>
+        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">{m.emptyBody}</p>
+      </div>
+    );
+  }
+
+  const cards = [
+    { label: m.metricViews, value: String(a.views) },
+    { label: m.metricStarts, value: String(a.starts) },
+    { label: m.metricSubmissions, value: String(a.submissions) },
+    { label: m.metricCompletionRate, value: `${a.completionRate}%` },
+    { label: m.metricAvgTime, value: formatDuration(a.avgTimeToComplete, m.seconds) },
+    { label: m.metricPartials, value: String(a.partialSubmits) },
+  ];
+
+  const maxViews = Math.max(1, ...a.dropoff.map((r) => r.views));
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {cards.map((c) => (
+          <div key={c.label} className="rounded-lg border border-border bg-card p-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{c.label}</div>
+            <div className="mt-2 text-2xl font-semibold tabular-nums">{c.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <section>
+        <h2 className="text-lg font-semibold">{m.dropoffTitle}</h2>
+        <p className="mb-3 text-sm text-muted-foreground">{m.dropoffSubtitle}</p>
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3 font-medium">{m.colStep}</th>
+                <th className="w-[45%] px-4 py-3 font-medium">{m.colViews}</th>
+                <th className="px-4 py-3 text-right font-medium">{m.colDropoff}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {a.dropoff.map((row) => (
+                <tr key={row.stepIndex} className="border-b border-border last:border-b-0">
+                  <td className="px-4 py-3">
+                    <span className="font-medium">{row.isCover ? m.coverRow : row.question}</span>
+                    {!row.isCover ? (
+                      <span className="ml-2 text-xs text-muted-foreground">#{row.stepIndex + 1}</span>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="relative h-6 w-full overflow-hidden rounded bg-muted">
+                      <div
+                        className="absolute inset-y-0 left-0 rounded bg-primary/25"
+                        style={{ width: `${Math.round((row.views / maxViews) * 100)}%` }}
+                      />
+                      <span className="absolute inset-0 flex items-center px-2 text-xs font-medium tabular-nums">
+                        {row.views}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {row.dropoff > 0 ? (
+                      <span className="text-destructive">
+                        −{row.dropoff}{' '}
+                        <span className="text-muted-foreground">({row.dropoffPercent}%)</span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function AnalyticsSkeleton() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" />
+        ))}
+      </div>
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/actions.ts
+++ b/apps/web/app/admin/forms/[id]/submissions/actions.ts
@@ -1,0 +1,10 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { adminApi } from '@/lib/admin-api';
+
+/** Delete a submission, then refresh the form's submissions table. */
+export async function deleteSubmissionAction(formId: string, submissionId: string): Promise<void> {
+  await adminApi.deleteSubmission(submissionId);
+  revalidatePath(`/admin/forms/${formId}/submissions`);
+}

--- a/apps/web/app/admin/forms/[id]/submissions/error.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/error.tsx
@@ -2,11 +2,7 @@
 
 import { getMessages } from '@quill/shared';
 
-/** Read the persisted admin locale on the client (mirrors the server cookie). */
-function clientLocale(): 'en' | 'es' {
-  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
-  return 'en';
-}
+import { clientLocale } from '@/lib/client-locale';
 
 export default function SubmissionsError({ reset }: { error: Error; reset: () => void }) {
   const m = getMessages(clientLocale()).admin.submissions;

--- a/apps/web/app/admin/forms/[id]/submissions/error.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { getMessages } from '@quill/shared';
+
+/** Read the persisted admin locale on the client (mirrors the server cookie). */
+function clientLocale(): 'en' | 'es' {
+  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
+  return 'en';
+}
+
+export default function SubmissionsError({ reset }: { error: Error; reset: () => void }) {
+  const m = getMessages(clientLocale()).admin.submissions;
+  return (
+    <div className="mx-auto max-w-md px-8 py-16 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">{m.error}</h1>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-primary px-5 py-2 font-semibold text-primary-foreground transition-transform active:scale-[0.98]"
+      >
+        {m.retry}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/export/route.ts
+++ b/apps/web/app/admin/forms/[id]/submissions/export/route.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server';
+import { hostFetch } from '@/lib/auth-session';
+
+/**
+ * CSV export proxy. The API's `/submissions.csv` needs the caller's identity
+ * headers, which live in the httpOnly session cookie — a plain `<a download>` to
+ * the API can't carry them. This server route attaches identity via `hostFetch`
+ * and streams the CSV straight back (no buffering), preserving the filter query.
+ */
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  const search = req.nextUrl.searchParams.toString();
+  const upstream = await hostFetch(`/v1/forms/${id}/submissions.csv${search ? `?${search}` : ''}`);
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response('Export failed.', { status: upstream.status || 502 });
+  }
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': upstream.headers.get('content-type') ?? 'text/csv; charset=utf-8',
+      'Content-Disposition':
+        upstream.headers.get('content-disposition') ?? 'attachment; filename="submissions.csv"',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/apps/web/app/admin/forms/[id]/submissions/loading.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/loading.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from '@/components/skeleton';
+
+export default function SubmissionsLoading() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <Skeleton className="mb-6 h-9 w-64" />
+      <Skeleton className="mb-6 h-9 w-72" />
+      <Skeleton className="h-80 w-full" />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/page.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.tsx
@@ -1,0 +1,222 @@
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { FormConfig, SubmissionsPage } from '@quill/types';
+import { getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
+import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
+import { FormTabs } from '@/components/ui/form-tabs';
+import { Skeleton } from '@/components/skeleton';
+import { SubmissionsFilter } from './submissions-filter';
+import { DeleteSubmissionButton } from './row-actions';
+
+export const dynamic = 'force-dynamic';
+
+const PAGE_SIZE = 25;
+
+type SP = { status?: string; offset?: string };
+
+function parseStatus(v: string | undefined): 'all' | 'completed' | 'partial' {
+  return v === 'completed' || v === 'partial' ? v : 'all';
+}
+
+export default async function SubmissionsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<SP>;
+}) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const locale = await getLocale();
+  const m = getMessages(locale).admin;
+  const status = parseStatus(sp.status);
+  const offset = Math.max(0, Number(sp.offset ?? 0) || 0);
+  const key = `${status}:${offset}`;
+
+  const exportQuery = status === 'all' ? '' : `?status=${status}`;
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <FormTabs formId={id} active="submissions" labels={m.nav} />
+      <div className="mb-6 flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{m.submissions.title}</h1>
+            <p className="mt-1 text-muted-foreground">{m.submissions.subtitle}</p>
+          </div>
+          <a
+            href={`/admin/forms/${id}/submissions/export${exportQuery}`}
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-border bg-transparent px-4 text-sm font-semibold text-foreground transition-colors hover:bg-accent"
+          >
+            <i aria-hidden className="pi pi-download" style={{ fontSize: 13 }} />
+            {m.submissions.export}
+          </a>
+        </div>
+        <SubmissionsFilter
+          labels={{
+            all: m.submissions.statusAll,
+            completed: m.submissions.statusCompleted,
+            partial: m.submissions.statusPartial,
+          }}
+        />
+      </div>
+
+      <Suspense key={key} fallback={<Skeleton className="h-80 w-full" />}>
+        <SubmissionsData id={id} status={status} offset={offset} locale={locale} m={m} />
+      </Suspense>
+    </div>
+  );
+}
+
+/** Flatten one answer value for a table cell. */
+function formatCell(v: unknown, na: string): string {
+  if (v == null || v === '') return na;
+  if (Array.isArray(v)) return v.length ? v.join(', ') : na;
+  if (typeof v === 'boolean') return v ? '✓' : '—';
+  return String(v);
+}
+
+async function SubmissionsData({
+  id,
+  status,
+  offset,
+  locale,
+  m,
+}: {
+  id: string;
+  status: 'all' | 'completed' | 'partial';
+  offset: number;
+  locale: Locale;
+  m: FormsMessages['admin'];
+}) {
+  let form: Awaited<ReturnType<typeof adminApi.getForm>>;
+  let page: SubmissionsPage;
+  try {
+    [form, page] = await Promise.all([
+      adminApi.getForm(id),
+      adminApi.listSubmissions(id, { status, limit: PAGE_SIZE, offset }),
+    ]);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+
+  const steps = (form.config as FormConfig).steps ?? [];
+
+  if (page.total === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/40 p-12 text-center">
+        <p className="text-lg font-medium">{m.submissions.emptyTitle}</p>
+        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">{m.submissions.emptyBody}</p>
+      </div>
+    );
+  }
+
+  const from = offset + 1;
+  const to = Math.min(offset + page.items.length, page.total);
+  const hasPrev = offset > 0;
+  const hasNext = offset + page.limit < page.total;
+  const statusParam = status === 'all' ? '' : `status=${status}&`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Horizontal scroll lives INSIDE this container (themed scrollbar, global);
+          the page body never scrolls sideways even with many step columns. */}
+      <div className="overflow-x-auto rounded-lg border border-border bg-card">
+        <table className="w-full min-w-[720px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="whitespace-nowrap px-4 py-3 font-medium">{m.submissions.colSubmitted}</th>
+              <th className="whitespace-nowrap px-4 py-3 font-medium">{m.submissions.colStatus}</th>
+              <th className="whitespace-nowrap px-4 py-3 text-right font-medium">{m.submissions.colScore}</th>
+              {steps.map((s) => (
+                <th key={s.key} className="whitespace-nowrap px-4 py-3 font-medium">
+                  {s.question?.trim() || s.key}
+                </th>
+              ))}
+              <th className="px-4 py-3" aria-label="actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {page.items.map((row) => {
+              const completed = row.completedAt != null;
+              const when = row.completedAt ?? row.partialAt ?? row.startedAt;
+              const data = (row.data ?? {}) as Record<string, unknown>;
+              return (
+                <tr key={row.id} className="border-b border-border last:border-b-0 align-top">
+                  <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
+                    {new Date(when).toLocaleString(locale)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3">
+                    <span
+                      className={
+                        completed
+                          ? 'inline-flex items-center gap-1.5 rounded-full bg-primary/20 px-2.5 py-0.5 text-xs font-medium text-foreground'
+                          : 'inline-flex items-center gap-1.5 rounded-full bg-secondary/20 px-2.5 py-0.5 text-xs font-medium text-foreground'
+                      }
+                    >
+                      <span
+                        aria-hidden
+                        className={`h-1.5 w-1.5 rounded-full ${completed ? 'bg-primary' : 'bg-secondary'}`}
+                      />
+                      {completed ? m.submissions.badgeCompleted : m.submissions.badgePartial}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums">{row.score}</td>
+                  {steps.map((s) => (
+                    <td key={s.key} className="max-w-[240px] truncate px-4 py-3" title={formatCell(data[s.key], '')}>
+                      {formatCell(data[s.key], m.submissions.na)}
+                    </td>
+                  ))}
+                  <td className="whitespace-nowrap px-4 py-3 text-right">
+                    <DeleteSubmissionButton
+                      formId={id}
+                      submissionId={row.id}
+                      labels={{ delete: m.submissions.delete, confirm: m.submissions.deleteConfirm }}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span className="text-muted-foreground tabular-nums">
+          {t(m.submissions.showing, { from, to, total: page.total })}
+        </span>
+        <div className="flex items-center gap-2">
+          {hasPrev ? (
+            <Link
+              href={`?${statusParam}offset=${Math.max(0, offset - page.limit)}`}
+              scroll={false}
+              className="inline-flex h-9 items-center rounded-md border border-border px-3 font-medium text-foreground transition-colors hover:bg-accent"
+            >
+              {m.submissions.prev}
+            </Link>
+          ) : (
+            <span className="inline-flex h-9 cursor-not-allowed items-center rounded-md border border-border px-3 font-medium text-muted-foreground opacity-50">
+              {m.submissions.prev}
+            </span>
+          )}
+          {hasNext ? (
+            <Link
+              href={`?${statusParam}offset=${offset + page.limit}`}
+              scroll={false}
+              className="inline-flex h-9 items-center rounded-md border border-border px-3 font-medium text-foreground transition-colors hover:bg-accent"
+            >
+              {m.submissions.next}
+            </Link>
+          ) : (
+            <span className="inline-flex h-9 cursor-not-allowed items-center rounded-md border border-border px-3 font-medium text-muted-foreground opacity-50">
+              {m.submissions.next}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/row-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/row-actions.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useTransition } from 'react';
+import { deleteSubmissionAction } from './actions';
+
+/** Delete-with-confirm for a submission row (client → server action). */
+export function DeleteSubmissionButton({
+  formId,
+  submissionId,
+  labels,
+}: {
+  formId: string;
+  submissionId: string;
+  labels: { delete: string; confirm: string };
+}) {
+  const [pending, start] = useTransition();
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() => {
+        if (confirm(labels.confirm)) {
+          start(() => void deleteSubmissionAction(formId, submissionId));
+        }
+      }}
+      className="text-sm text-destructive transition-opacity hover:opacity-80 disabled:opacity-50"
+    >
+      {labels.delete}
+    </button>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/submissions-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/submissions-filter.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+type Status = 'all' | 'completed' | 'partial';
+
+/**
+ * Status filter for the submissions table (all / completed / partial). Writes
+ * the choice to the URL query (resetting pagination) so the server component
+ * re-fetches; the Suspense boundary shows the skeleton meanwhile (R22).
+ */
+export function SubmissionsFilter({
+  labels,
+}: {
+  labels: { all: string; completed: string; partial: string };
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, start] = useTransition();
+  const current = (params.get('status') as Status | null) ?? 'all';
+
+  const select = (status: Status) => {
+    const next = new URLSearchParams(params.toString());
+    next.delete('offset'); // new filter → back to page 1
+    if (status === 'all') next.delete('status');
+    else next.set('status', status);
+    start(() => router.push(`?${next.toString()}`, { scroll: false }));
+  };
+
+  const options: { key: Status; label: string }[] = [
+    { key: 'all', label: labels.all },
+    { key: 'completed', label: labels.completed },
+    { key: 'partial', label: labels.partial },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" aria-busy={pending}>
+      {options.map((o) => {
+        const active = o.key === current;
+        return (
+          <button
+            key={o.key}
+            type="button"
+            disabled={pending}
+            onClick={() => select(o.key)}
+            aria-pressed={active}
+            className={
+              active
+                ? 'inline-flex h-9 items-center rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60'
+                : 'inline-flex h-9 items-center rounded-md border border-border bg-transparent px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60'
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -11,7 +11,9 @@ export const dynamic = 'force-dynamic';
 
 export default async function AdminHome() {
   const locale = await getLocale();
-  const m = getMessages(locale).admin.forms;
+  const messages = getMessages(locale).admin;
+  const m = messages.forms;
+  const nav = messages.nav;
   const [me, forms] = await Promise.all([adminApi.me(), adminApi.listForms()]);
 
   const createLabels = {
@@ -63,7 +65,11 @@ export default async function AdminHome() {
                     {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
                   </span>
                 </div>
-                <FormRowActions id={f.id} labels={rowLabels} />
+                <FormRowActions
+                  id={f.id}
+                  labels={rowLabels}
+                  nav={{ analytics: nav.analytics, submissions: nav.submissions }}
+                />
               </li>
             );
           })}

--- a/apps/web/components/ui/form-tabs.tsx
+++ b/apps/web/components/ui/form-tabs.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+
+/**
+ * Cross-page tabs for a single form's admin surfaces (Edit / Analytics /
+ * Submissions) plus a back-to-list affordance. A NEW shared component so the
+ * analytics + submissions pages get consistent navigation WITHOUT touching the
+ * editor page internals. Tokens-only styling; the active tab is unmistakable
+ * (Design Quality Bar #5).
+ */
+export type FormTab = 'edit' | 'analytics' | 'submissions';
+
+export function FormTabs({
+  formId,
+  active,
+  labels,
+}: {
+  formId: string;
+  active: FormTab;
+  labels: { edit: string; analytics: string; submissions: string; backToForms: string };
+}) {
+  const tabs: { key: FormTab; href: string; label: string }[] = [
+    { key: 'edit', href: `/admin/forms/${formId}/edit`, label: labels.edit },
+    { key: 'analytics', href: `/admin/forms/${formId}/analytics`, label: labels.analytics },
+    { key: 'submissions', href: `/admin/forms/${formId}/submissions`, label: labels.submissions },
+  ];
+  return (
+    <div className="mb-6">
+      <Link
+        href="/admin"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <i aria-hidden className="pi pi-chevron-left" style={{ fontSize: 12 }} />
+        {labels.backToForms}
+      </Link>
+      <nav className="mt-3 flex items-center gap-1 border-b border-border" aria-label="Form sections">
+        {tabs.map((t) => {
+          const isActive = t.key === active;
+          return (
+            <Link
+              key={t.key}
+              href={t.href}
+              aria-current={isActive ? 'page' : undefined}
+              className={
+                isActive
+                  ? 'relative -mb-px border-b-2 border-primary px-3 py-2 text-sm font-semibold text-foreground'
+                  : 'relative -mb-px border-b-2 border-transparent px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground'
+              }
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -5,7 +5,7 @@
  * into a redirect to /login.
  */
 import { redirect } from 'next/navigation';
-import type { FormConfig } from '@quill/types';
+import type { AnalyticsResponse, FormConfig, SubmissionsPage } from '@quill/types';
 import { getSession, clearSession, authProvider } from './auth-session';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
@@ -107,6 +107,27 @@ export interface AccountMember {
   createdAt: number;
 }
 
+export type { AnalyticsResponse, SubmissionsPage } from '@quill/types';
+
+export interface SubmissionsQuery {
+  status?: 'all' | 'completed' | 'partial';
+  from?: number;
+  to?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/** Build a `?a=b&…` string from defined params only. */
+function qs(params: Record<string, string | number | undefined | null>): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === '') continue;
+    sp.set(k, String(v));
+  }
+  const s = sp.toString();
+  return s ? `?${s}` : '';
+}
+
 export const isAdminRole = (role: AccountRole): boolean => role === 'owner' || role === 'admin';
 
 export const adminApi = {
@@ -122,7 +143,13 @@ export const adminApi = {
     req<FormDetail>('PUT', `/v1/forms/${id}`, b),
   duplicateForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/duplicate`),
   deleteForm: (id: string) => req<void>('DELETE', `/v1/forms/${id}`),
-  listSubmissions: (id: string) => req<Submission[]>('GET', `/v1/forms/${id}/submissions`),
+
+  // Analytics + submissions (this track)
+  getAnalytics: (id: string, range: { from?: number; to?: number } = {}) =>
+    req<AnalyticsResponse>('GET', `/v1/forms/${id}/analytics${qs(range)}`),
+  listSubmissions: (id: string, q: SubmissionsQuery = {}) =>
+    req<SubmissionsPage>('GET', `/v1/forms/${id}/submissions${qs({ ...q })}`),
+  deleteSubmission: (id: string) => req<void>('DELETE', `/v1/submissions/${id}`),
 
   // Members (workspace roster — admin/owner only)
   listMembers: () => req<AccountMember[]>('GET', '/v1/members'),

--- a/apps/web/lib/client-locale.ts
+++ b/apps/web/lib/client-locale.ts
@@ -1,0 +1,11 @@
+import type { Locale } from '@quill/shared';
+
+/**
+ * Client-side twin of lib/locale.ts#getLocale (that one reads next/headers and
+ * is server-only): the persisted admin locale from the document cookie.
+ * Defaults to English so a bare fork renders with no cookie.
+ */
+export function clientLocale(): Locale {
+  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
+  return 'en';
+}

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -1,0 +1,202 @@
+/**
+ * Analytics + submissions querying — the read side that powers the admin
+ * dashboard (funnel + per-step drop-off) and the submissions table (paginated,
+ * filtered, exportable). Everything goes through the portable `Db` port and
+ * `sql` templates so the identical code runs on SQLite (clone-and-run) and
+ * Postgres (prod): no dialect-specific SQL (no FILTER, no window fns) — only
+ * COUNT / SUM(CASE…) / AVG(CASE…) which behave the same on both engines.
+ */
+import { type SQL } from 'drizzle-orm';
+import { sql, type Db } from './client';
+import { parseJsonColumn } from './forms';
+import type { SubmissionRow } from './forms';
+
+/** An optional epoch-ms date window applied to the query. */
+export interface DateRange {
+  from?: number | null;
+  to?: number | null;
+}
+
+/**
+ * Build the `AND col >= from AND col <= to` fragment for an optional range.
+ * Each bound is independent; an empty range contributes no SQL. `col` is a
+ * fixed internal identifier fragment (never user input).
+ */
+function andRange(col: SQL, range?: DateRange): SQL {
+  const parts: SQL[] = [];
+  if (range?.from != null) parts.push(sql`AND ${col} >= ${range.from}`);
+  if (range?.to != null) parts.push(sql`AND ${col} <= ${range.to}`);
+  return parts.length ? sql.join(parts, sql` `) : sql``;
+}
+
+// --- Raw aggregates (the primitives the service composes) --------------------
+
+/** Count of funnel events by type within the range: `{ view: 12, start: 9, … }`. */
+export async function eventTypeCounts(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<Record<string, number>> {
+  const rows = await db.all<{ type: string; n: number | string }>(
+    sql`SELECT type, COUNT(*) AS n FROM form_event
+        WHERE form_id = ${formId} ${andRange(sql`created_at`, range)}
+        GROUP BY type`,
+  );
+  const out: Record<string, number> = {};
+  for (const r of rows) out[String(r.type)] = Number(r.n);
+  return out;
+}
+
+/** Count of `step_view` events per step index within the range. */
+export async function stepViewCounts(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<Map<number, number>> {
+  const rows = await db.all<{ step_index: number | string | null; n: number | string }>(
+    sql`SELECT step_index, COUNT(*) AS n FROM form_event
+        WHERE form_id = ${formId} AND type = 'step_view' AND step_index IS NOT NULL
+        ${andRange(sql`created_at`, range)}
+        GROUP BY step_index`,
+  );
+  const out = new Map<number, number>();
+  for (const r of rows) {
+    if (r.step_index == null) continue;
+    out.set(Number(r.step_index), Number(r.n));
+  }
+  return out;
+}
+
+export interface SubmissionAggregate {
+  /** Completed submissions (completed_at set). */
+  completed: number;
+  /** Partial-only submissions (partial_at set, completed_at null). */
+  partial: number;
+  /** Average ms from started_at→completed_at over completed rows (null if none). */
+  avgCompletionMs: number | null;
+}
+
+/**
+ * Submission counts + average completion time within the range (bounded by
+ * `started_at`). SUM(CASE…) and AVG(CASE…) are portable; AVG ignores the NULLs
+ * the CASE emits for non-completed rows, so it averages only completed sessions.
+ */
+export async function submissionAggregates(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<SubmissionAggregate> {
+  const row = await db.get<{
+    completed: number | string | null;
+    partial: number | string | null;
+    avg_ms: number | string | null;
+  }>(
+    sql`SELECT
+          SUM(CASE WHEN completed_at IS NOT NULL THEN 1 ELSE 0 END) AS completed,
+          SUM(CASE WHEN completed_at IS NULL AND partial_at IS NOT NULL THEN 1 ELSE 0 END) AS partial,
+          AVG(CASE WHEN completed_at IS NOT NULL THEN (completed_at - started_at) ELSE NULL END) AS avg_ms
+        FROM submission
+        WHERE form_id = ${formId} ${andRange(sql`started_at`, range)}`,
+  );
+  return {
+    completed: Number(row?.completed ?? 0),
+    partial: Number(row?.partial ?? 0),
+    avgCompletionMs: row?.avg_ms == null ? null : Number(row.avg_ms),
+  };
+}
+
+// --- Submissions table (paginated + filtered) --------------------------------
+
+export type SubmissionStatus = 'all' | 'completed' | 'partial';
+
+export interface SubmissionQuery extends DateRange {
+  status?: SubmissionStatus;
+  limit?: number;
+  offset?: number;
+}
+
+/** The status predicate for the submissions table (portable). */
+function statusClause(status?: SubmissionStatus): SQL {
+  if (status === 'completed') return sql`AND completed_at IS NOT NULL`;
+  if (status === 'partial') return sql`AND completed_at IS NULL AND partial_at IS NOT NULL`;
+  return sql``;
+}
+
+function mapSubmission(r: Record<string, unknown>): SubmissionRow {
+  return {
+    id: String(r.id),
+    formId: String(r.form_id),
+    sessionId: String(r.session_id),
+    data: parseJsonColumn(r.data, {}),
+    score: Number(r.score),
+    startedAt: Number(r.started_at),
+    completedAt: r.completed_at == null ? null : Number(r.completed_at),
+    partialAt: r.partial_at == null ? null : Number(r.partial_at),
+  };
+}
+
+/**
+ * A page of a form's submissions, newest first, with the total matching the
+ * filter (before pagination) so the UI can render page counts. `status` narrows
+ * to complete/partial; `from`/`to` bound `started_at`.
+ */
+export async function querySubmissions(
+  db: Db,
+  formId: string,
+  q: SubmissionQuery = {},
+): Promise<{ items: SubmissionRow[]; total: number; limit: number; offset: number }> {
+  const limit = Math.min(Math.max(q.limit ?? 25, 1), 200);
+  const offset = Math.max(q.offset ?? 0, 0);
+  const where = sql`WHERE form_id = ${formId} ${statusClause(q.status)} ${andRange(sql`started_at`, q)}`;
+
+  const totalRow = await db.get<{ n: number | string }>(
+    sql`SELECT COUNT(*) AS n FROM submission ${where}`,
+  );
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT * FROM submission ${where}
+        ORDER BY started_at DESC
+        LIMIT ${limit} OFFSET ${offset}`,
+  );
+  return { items: rows.map(mapSubmission), total: Number(totalRow?.n ?? 0), limit, offset };
+}
+
+/**
+ * Every submission for a form matching the filter, newest first — no pagination
+ * (used by the CSV export, which must include the full result set). Bounded by
+ * the same status/date filter as the table.
+ */
+export async function allSubmissionsForExport(
+  db: Db,
+  formId: string,
+  q: Omit<SubmissionQuery, 'limit' | 'offset'> = {},
+): Promise<SubmissionRow[]> {
+  const where = sql`WHERE form_id = ${formId} ${statusClause(q.status)} ${andRange(sql`started_at`, q)}`;
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT * FROM submission ${where} ORDER BY started_at DESC`,
+  );
+  return rows.map(mapSubmission);
+}
+
+// --- Account-scoped submission delete ----------------------------------------
+
+/**
+ * Delete a submission, but ONLY if it belongs to a form the account owns.
+ * Idempotent: returns false when the row is absent or out-of-account (both
+ * indistinguishable to the caller — no cross-account existence leak). The
+ * account scope is enforced in SQL via the form join, so a forged id can't
+ * touch another tenant's data.
+ */
+export async function deleteSubmissionForAccount(
+  db: Db,
+  accountId: string,
+  submissionId: string,
+): Promise<boolean> {
+  const owned = await db.get<{ id: string }>(
+    sql`SELECT s.id FROM submission s
+        JOIN form f ON f.id = s.form_id
+        WHERE s.id = ${submissionId} AND f.account_id = ${accountId} LIMIT 1`,
+  );
+  if (!owned) return false;
+  await db.run(sql`DELETE FROM submission WHERE id = ${submissionId}`);
+  return true;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,6 +6,7 @@
 export * from './client';
 export * from './crud';
 export * from './forms';
+export * from './analytics';
 export * from './members';
 export * from './short-links';
 export * from './outbox';

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -195,6 +195,69 @@ export interface FormsMessages {
         close: string;
       };
     };
+    /** Cross-page tabs shown on a form's analytics/submissions surfaces. */
+    nav: {
+      edit: string;
+      analytics: string;
+      submissions: string;
+      backToForms: string;
+    };
+    /** The analytics dashboard (funnel + per-step drop-off). */
+    analytics: {
+      title: string;
+      subtitle: string;
+      metricViews: string;
+      metricStarts: string;
+      metricSubmissions: string;
+      metricCompletionRate: string;
+      metricAvgTime: string;
+      metricPartials: string;
+      rangeLast7: string;
+      rangeLast30: string;
+      rangeLast90: string;
+      rangeAll: string;
+      rangeCustom: string;
+      rangeFrom: string;
+      rangeTo: string;
+      rangeApply: string;
+      dropoffTitle: string;
+      dropoffSubtitle: string;
+      colStep: string;
+      colViews: string;
+      colDropoff: string;
+      coverRow: string;
+      emptyTitle: string;
+      emptyBody: string;
+      error: string;
+      retry: string;
+      seconds: string; // short unit, e.g. "s"
+    };
+    /** The submissions table (responses + CSV export + delete). */
+    submissions: {
+      title: string;
+      subtitle: string;
+      statusAll: string;
+      statusCompleted: string;
+      statusPartial: string;
+      badgeCompleted: string;
+      badgePartial: string;
+      colSubmitted: string;
+      colStatus: string;
+      colScore: string;
+      export: string;
+      exporting: string;
+      delete: string;
+      deleteConfirm: string;
+      emptyTitle: string;
+      emptyBody: string;
+      prev: string;
+      next: string;
+      /** "{from}–{to} of {total}" */
+      showing: string;
+      na: string;
+      error: string;
+      retry: string;
+    };
   };
 }
 
@@ -384,6 +447,65 @@ export const en: FormsMessages = {
         close: 'Close',
       },
     },
+    nav: {
+      edit: 'Edit',
+      analytics: 'Analytics',
+      submissions: 'Submissions',
+      backToForms: 'Back to forms',
+    },
+    analytics: {
+      title: 'Analytics',
+      subtitle: 'Funnel performance and question-by-question drop-off.',
+      metricViews: 'Views',
+      metricStarts: 'Starts',
+      metricSubmissions: 'Submissions',
+      metricCompletionRate: 'Completion rate',
+      metricAvgTime: 'Avg. time to complete',
+      metricPartials: 'Partial submits',
+      rangeLast7: 'Last 7 days',
+      rangeLast30: 'Last 30 days',
+      rangeLast90: 'Last 90 days',
+      rangeAll: 'All time',
+      rangeCustom: 'Custom',
+      rangeFrom: 'From',
+      rangeTo: 'To',
+      rangeApply: 'Apply',
+      dropoffTitle: 'Question-by-question drop-off',
+      dropoffSubtitle: 'How many people reach each step, and how many leave.',
+      colStep: 'Step',
+      colViews: 'Views',
+      colDropoff: 'Drop-off',
+      coverRow: 'Cover / landing',
+      emptyTitle: 'No data yet',
+      emptyBody: 'Once people open and fill out this form, the funnel and drop-off will appear here.',
+      error: 'Couldn’t load analytics.',
+      retry: 'Try again',
+      seconds: 's',
+    },
+    submissions: {
+      title: 'Submissions',
+      subtitle: 'Every response to this form.',
+      statusAll: 'All',
+      statusCompleted: 'Completed',
+      statusPartial: 'Partial',
+      badgeCompleted: 'Completed',
+      badgePartial: 'Partial',
+      colSubmitted: 'Submitted',
+      colStatus: 'Status',
+      colScore: 'Score',
+      export: 'Download CSV',
+      exporting: 'Preparing…',
+      delete: 'Delete',
+      deleteConfirm: 'Delete this submission? This cannot be undone.',
+      emptyTitle: 'No submissions yet',
+      emptyBody: 'Responses will show up here as people complete the form.',
+      prev: 'Previous',
+      next: 'Next',
+      showing: '{from}–{to} of {total}',
+      na: '—',
+      error: 'Couldn’t load submissions.',
+      retry: 'Try again',
+    },
   },
 };
 
@@ -572,6 +694,65 @@ export const es: FormsMessages = {
         desktop: 'Escritorio',
         close: 'Cerrar',
       },
+    },
+    nav: {
+      edit: 'Editar',
+      analytics: 'Analíticas',
+      submissions: 'Respuestas',
+      backToForms: 'Volver a formularios',
+    },
+    analytics: {
+      title: 'Analíticas',
+      subtitle: 'Rendimiento del embudo y abandono pregunta por pregunta.',
+      metricViews: 'Vistas',
+      metricStarts: 'Inicios',
+      metricSubmissions: 'Respuestas',
+      metricCompletionRate: 'Tasa de finalización',
+      metricAvgTime: 'Tiempo promedio para completar',
+      metricPartials: 'Envíos parciales',
+      rangeLast7: 'Últimos 7 días',
+      rangeLast30: 'Últimos 30 días',
+      rangeLast90: 'Últimos 90 días',
+      rangeAll: 'Todo el tiempo',
+      rangeCustom: 'Personalizado',
+      rangeFrom: 'Desde',
+      rangeTo: 'Hasta',
+      rangeApply: 'Aplicar',
+      dropoffTitle: 'Abandono pregunta por pregunta',
+      dropoffSubtitle: 'Cuántas personas llegan a cada paso y cuántas se van.',
+      colStep: 'Paso',
+      colViews: 'Vistas',
+      colDropoff: 'Abandono',
+      coverRow: 'Portada / inicio',
+      emptyTitle: 'Aún no hay datos',
+      emptyBody: 'Cuando las personas abran y completen este formulario, verás aquí el embudo y el abandono.',
+      error: 'No se pudieron cargar las analíticas.',
+      retry: 'Reintentar',
+      seconds: 's',
+    },
+    submissions: {
+      title: 'Respuestas',
+      subtitle: 'Todas las respuestas a este formulario.',
+      statusAll: 'Todas',
+      statusCompleted: 'Completadas',
+      statusPartial: 'Parciales',
+      badgeCompleted: 'Completada',
+      badgePartial: 'Parcial',
+      colSubmitted: 'Enviada',
+      colStatus: 'Estado',
+      colScore: 'Puntaje',
+      export: 'Descargar CSV',
+      exporting: 'Preparando…',
+      delete: 'Eliminar',
+      deleteConfirm: '¿Eliminar esta respuesta? No se puede deshacer.',
+      emptyTitle: 'Aún no hay respuestas',
+      emptyBody: 'Las respuestas aparecerán aquí a medida que las personas completen el formulario.',
+      prev: 'Anterior',
+      next: 'Siguiente',
+      showing: '{from}–{to} de {total}',
+      na: '—',
+      error: 'No se pudieron cargar las respuestas.',
+      retry: 'Reintentar',
     },
   },
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -196,6 +196,69 @@ export const formEventSchema = z.object({
 });
 export type FormEventInput = z.infer<typeof formEventSchema>;
 
+// --- Analytics (funnel + per-step drop-off) ----------------------------------
+// ADDITIVE: new exports only. These describe the admin analytics dashboard
+// response (GET /v1/forms/:id/analytics) — a funnel summary plus a
+// question-by-question drop-off table (a cover row + one row per configured
+// step). Computed server-side from form_event + submission; works identically
+// on SQLite and Postgres.
+
+/** One row of the question-by-question drop-off table. */
+export const dropoffRowSchema = z.object({
+  /** -1 for the synthetic cover/landing row, otherwise the 0-based step index. */
+  stepIndex: z.number().int(),
+  /** The step's field key (null for the cover row). */
+  key: z.string().nullable(),
+  /** Human label for the row (the step question, or the cover title). */
+  question: z.string(),
+  /** True for the synthetic cover/landing row. */
+  isCover: z.boolean(),
+  /** Sessions that viewed this step (form views for the cover row). */
+  views: z.number().int(),
+  /** Sessions lost between this row and the next (never negative). */
+  dropoff: z.number().int(),
+  /** Drop-off as a percentage of this row's views (1 decimal). */
+  dropoffPercent: z.number(),
+});
+export type DropoffRow = z.infer<typeof dropoffRowSchema>;
+
+/** The funnel summary + drop-off table for a form over an optional date range. */
+export const analyticsResponseSchema = z.object({
+  /** Count of `view` events. */
+  views: z.number().int(),
+  /** Count of `start` events. */
+  starts: z.number().int(),
+  /** Count of completed submissions (completedAt set). */
+  submissions: z.number().int(),
+  /** submissions / starts as a percentage (1 decimal); 0 when starts=0. */
+  completionRate: z.number(),
+  /** Average seconds from startedAt→completedAt over completed submissions. */
+  avgTimeToComplete: z.number().int(),
+  /** Partial-only submissions (partialAt set, completedAt null). */
+  partialSubmits: z.number().int(),
+  /** Cover row + one row per configured step. */
+  dropoff: z.array(dropoffRowSchema),
+  /** Echoes the resolved range (epoch ms) so the client can render it. */
+  range: z.object({ from: z.number().nullable(), to: z.number().nullable() }),
+});
+export type AnalyticsResponse = z.infer<typeof analyticsResponseSchema>;
+
+// --- Submissions listing (paginated + filtered) ------------------------------
+// ADDITIVE: the admin submissions table response. `status` narrows to complete
+// or partial; `from`/`to` bound by startedAt; `limit`/`offset` paginate.
+
+export const submissionStatusFilter = ['all', 'completed', 'partial'] as const;
+export type SubmissionStatusFilter = (typeof submissionStatusFilter)[number];
+
+export const submissionsPageSchema = z.object({
+  items: z.array(submissionViewSchema),
+  /** Total rows matching the filter (before pagination). */
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+});
+export type SubmissionsPage = z.infer<typeof submissionsPageSchema>;
+
 // --- Member management (workspace roster) ------------------------------------
 
 export const memberInviteSchema = z.object({


### PR DESCRIPTION
## Track C — Analytics + Submissions

Funnel analytics dashboard + submissions management for Dapta Forms v1 (Quill).

### API (new files, registered append-only in `app.module.ts`)
- **`GET /v1/forms/:id/analytics?from&to`** — funnel metrics (views, starts, submissions, completion rate, avg time-to-complete from `startedAt→completedAt`, partial submits) + per-step drop-off table (cover row + one row per configured step). Computed from `form_event` + `submission` via **portable Drizzle `sql`** — same code on SQLite and Postgres (no `FILTER`/window fns; only `COUNT`/`SUM(CASE…)`/`AVG(CASE…)`).
- **`GET /v1/forms/:id/submissions`** — extended with `status` (all/completed/partial), `from`/`to`, `limit`/`offset` → paginated `{ items, total, limit, offset }`.
- **`GET /v1/forms/:id/submissions.csv`** — streamed CSV (paged internally), answers flattened to columns by step key, RFC-4180 escaping.
- **`DELETE /v1/submissions/:id`** — account-scoped (SQL join enforces tenant), idempotent (always 204).

### Web
- **`/admin/forms/[id]/analytics`** — 6 metric cards + question-by-question drop-off table with funnel bars + date-range filter (7/30/90/all/custom). Loading skeletons, empty state, error+retry (R22).
- **`/admin/forms/[id]/submissions`** — responses table (step columns, completed/partial badge, submitted-at), status filter, pagination, CSV download (auth-proxied server route so the httpOnly session travels), delete-with-confirm. Many-column forms scroll **inside** the table container (themed scrollbar, no page-level horizontal scroll).
- Shared **`FormTabs`** nav (new component) + Analytics/Submissions links added to the forms list rows (no editor internals touched).

### Rules honored
- `packages/types` **additive-only** (new analytics + submissions-page schemas as new exports).
- Did not touch editor internals (Track A), public renderer routes (Track B), or integrations (Track D).
- i18n EN/ES for all new strings; tokens-only styling; R27/R28 responsive. No secrets.

### Verification
- `pnpm lint/typecheck/test/build` all green (14 API tests incl. 7 new analytics tests asserting funnel + drop-off math on seeded SQLite).
- Booted api:4403 + web:3403, seeded a form + 39 events + 5 submissions (3 complete, 2 partial) via curl. Analytics matched hand-computed ground truth **exactly** (views 10, starts 8, submissions 3, completion 37.5%, drop-off 20/25/33.3/25/0%). Submissions list/filters/pagination, CSV (correct escaping + step-key columns), delete (idempotent + cross-account no-op), and date-range filter all verified. Pages render EN + ES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)