### PR TITLE
feat(builder): form editor — steps, logic, scoring, cover, outcomes, preview

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   visibleSteps,
   validateAnswer,
+  resolveQuestion,
   type Answers,
   type FormStep,
 } from '@quill/engine';
@@ -107,6 +108,11 @@ export function FormRenderer({
   if (!started && cover) {
     return (
       <div className="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-8 text-center">
+        {cover.bannerText ? (
+          <div className="mb-1 w-full rounded-md bg-primary/15 px-3 py-1.5 text-xs font-medium text-foreground">
+            {cover.bannerText}
+          </div>
+        ) : null}
         {cover.eyebrow ? (
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {cover.eyebrow}
@@ -151,7 +157,7 @@ export function FormRenderer({
       </div>
 
       <div className="flex flex-col gap-1">
-        <h2 className="text-xl font-semibold">{step.question ?? step.key}</h2>
+        <h2 className="text-xl font-semibold">{resolveQuestion(step, answers) || step.key}</h2>
         {step.helper ? <p className="text-sm text-muted-foreground">{step.helper}</p> : null}
       </div>
 

--- a/apps/web/app/admin/create-form-button.tsx
+++ b/apps/web/app/admin/create-form-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { createFormAction } from './actions';
+
+interface Labels {
+  create: string;
+  createTitle: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  cancel: string;
+}
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} className="min-w-[110px]">
+      {label}
+    </Button>
+  );
+}
+
+/**
+ * Create-form entry point following the list/create pattern (Design Quality
+ * Bar): a primary button that opens a dedicated create surface (a dialog),
+ * never an inline form under the list. Submits to the create server action,
+ * which redirects into the new form's editor.
+ */
+export function CreateFormButton({ labels, variant = 'default' }: { labels: Labels; variant?: 'default' | 'outline' }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant={variant} onClick={() => setOpen(true)}>
+        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {labels.create}
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)} title={labels.createTitle} labelId="create-form-title">
+        <form action={createFormAction} className="flex flex-col gap-4">
+          <label className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">{labels.nameLabel}</span>
+            <input
+              name="name"
+              required
+              autoComplete="off"
+              placeholder={labels.namePlaceholder}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </label>
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+              {labels.cancel}
+            </Button>
+            <SubmitButton label={labels.create} />
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/apps/web/app/admin/form-row-actions.tsx
+++ b/apps/web/app/admin/form-row-actions.tsx
@@ -4,7 +4,13 @@ import { useTransition } from 'react';
 import { duplicateFormAction, deleteFormAction } from './actions';
 
 /** Duplicate / delete buttons for a form row (client → server actions). */
-export function FormRowActions({ id }: { id: string }) {
+export function FormRowActions({
+  id,
+  labels,
+}: {
+  id: string;
+  labels: { duplicate: string; delete: string; deleteConfirm: string };
+}) {
   const [pending, start] = useTransition();
   return (
     <div className="flex items-center gap-3 text-sm">
@@ -12,21 +18,21 @@ export function FormRowActions({ id }: { id: string }) {
         type="button"
         disabled={pending}
         onClick={() => start(() => void duplicateFormAction(id))}
-        className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+        className="text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
       >
-        Duplicate
+        {labels.duplicate}
       </button>
       <button
         type="button"
         disabled={pending}
         onClick={() => {
-          if (confirm('Delete this form and all its submissions?')) {
+          if (confirm(labels.deleteConfirm)) {
             start(() => void deleteFormAction(id));
           }
         }}
-        className="text-destructive hover:opacity-80 disabled:opacity-50"
+        className="text-destructive transition-opacity hover:opacity-80 disabled:opacity-50"
       >
-        Delete
+        {labels.delete}
       </button>
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/_components/condition-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/condition-editor.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { StepCondition } from '@quill/engine';
+import { SelectField, TextField } from './fields';
+import type { EditorMessages } from './messages';
+
+/** A prior step the current step can branch on. */
+export interface PriorField {
+  key: string;
+  label: string;
+  options?: { label: string; value: string }[];
+}
+
+/**
+ * One condition row (used for both `showWhen` and `hideWhen`): pick an earlier
+ * field, then the values that trigger it. When that field has options they
+ * render as checkboxes; otherwise a comma-separated text input.
+ */
+export function ConditionEditor({
+  label,
+  condition,
+  priorFields,
+  onChange,
+  m,
+}: {
+  label: string;
+  condition: StepCondition | null | undefined;
+  priorFields: PriorField[];
+  onChange: (next: StepCondition | null) => void;
+  m: EditorMessages['logic'];
+}) {
+  const selected = priorFields.find((f) => f.key === condition?.field);
+  const values = condition?.values ?? [];
+
+  function pickField(key: string) {
+    if (!key) return onChange(null);
+    onChange({ field: key, values: [] });
+  }
+  function toggleValue(value: string) {
+    const next = values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+    onChange({ field: condition!.field, values: next });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <SelectField value={condition?.field ?? ''} onChange={(e) => pickField(e.target.value)}>
+        <option value="">{m.none}</option>
+        {priorFields.map((f) => (
+          <option key={f.key} value={f.key}>
+            {f.label}
+          </option>
+        ))}
+      </SelectField>
+
+      {condition ? (
+        selected?.options && selected.options.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {selected.options.map((o) => {
+              const on = values.includes(o.value);
+              return (
+                <button
+                  key={o.value}
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => toggleValue(o.value)}
+                  className={
+                    'rounded-full border px-3 py-1 text-xs transition-colors ' +
+                    (on
+                      ? 'border-primary bg-primary/15 text-foreground'
+                      : 'border-border text-muted-foreground hover:border-primary')
+                  }
+                >
+                  {o.label || o.value}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <TextField
+            value={values.join(', ')}
+            placeholder={m.valuesHint}
+            onChange={(e) =>
+              onChange({
+                field: condition.field,
+                values: e.target.value
+                  .split(',')
+                  .map((v) => v.trim())
+                  .filter(Boolean),
+              })
+            }
+          />
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import type { FormConfig, FormCover, FormBranding } from '@quill/engine';
+import { clampAccent, accentWasAdjusted, DEFAULT_ACCENT } from '@quill/shared';
+import { Switch } from '@/components/ui/switch';
+import { Field, TextField, TextArea, InlineField, PanelSection } from './fields';
+import { LivePreview } from './live-preview';
+import type { EditorMessages } from './messages';
+
+/**
+ * Cover / intro editor + per-form branding. The color picker feeds
+ * `branding.primaryColor`; the swatch shows the AA-clamped accent the public
+ * page will actually use, warning when the raw pick had to be nudged lighter.
+ * A live cover preview sits alongside so edits are visible immediately.
+ */
+export function CoverPanel({
+  config,
+  onCoverChange,
+  onBrandingChange,
+  m,
+}: {
+  config: FormConfig;
+  onCoverChange: (patch: Partial<FormCover>) => void;
+  onBrandingChange: (patch: Partial<FormBranding>) => void;
+  m: EditorMessages;
+}) {
+  const cover = config.cover ?? {};
+  const raw = config.branding?.primaryColor || DEFAULT_ACCENT;
+  const clamped = clampAccent(raw);
+  const adjusted = accentWasAdjusted(raw);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+      <div className="flex flex-col gap-4">
+        <PanelSection title={m.cover.title} subtitle={m.cover.subtitle}>
+          <InlineField label={m.cover.enabled}>
+            <Switch
+              checked={cover.enabled !== false}
+              onCheckedChange={(v) => onCoverChange({ enabled: v })}
+              aria-label={m.cover.enabled}
+            />
+          </InlineField>
+          <Field label={m.cover.bannerText}>
+            <TextField value={cover.bannerText ?? ''} onChange={(e) => onCoverChange({ bannerText: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.eyebrow}>
+            <TextField value={cover.eyebrow ?? ''} onChange={(e) => onCoverChange({ eyebrow: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.headline}>
+            <TextField value={cover.headline ?? ''} onChange={(e) => onCoverChange({ headline: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.subheadline}>
+            <TextArea value={cover.subheadline ?? ''} rows={2} onChange={(e) => onCoverChange({ subheadline: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.ctaText}>
+            <TextField value={cover.ctaText ?? ''} onChange={(e) => onCoverChange({ ctaText: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.trustBadge}>
+            <TextField value={cover.trustBadge ?? ''} onChange={(e) => onCoverChange({ trustBadge: e.target.value || null })} />
+          </Field>
+        </PanelSection>
+
+        <PanelSection title={m.cover.branding}>
+          <Field label={m.cover.primaryColor} hint={m.cover.primaryColorHint}>
+            <div className="flex items-center gap-3">
+              <input
+                type="color"
+                aria-label={m.cover.primaryColor}
+                value={/^#[0-9a-fA-F]{6}$/.test(raw) ? raw : DEFAULT_ACCENT}
+                onChange={(e) => onBrandingChange({ primaryColor: e.target.value })}
+                className="h-10 w-14 shrink-0 cursor-pointer rounded-md border border-input bg-background p-1"
+              />
+              <TextField
+                value={raw}
+                onChange={(e) => onBrandingChange({ primaryColor: e.target.value })}
+                className="max-w-[10rem] font-mono"
+              />
+              <span
+                aria-hidden
+                title={clamped}
+                className="h-8 w-8 shrink-0 rounded-full border border-border"
+                style={{ background: clamped }}
+              />
+            </div>
+          </Field>
+          {adjusted ? (
+            <p className="text-xs text-muted-foreground">
+              <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} />{' '}
+              {clamped}
+            </p>
+          ) : null}
+        </PanelSection>
+      </div>
+
+      <div className="lg:sticky lg:top-[7.5rem] lg:self-start">
+        <p className="mb-2 text-sm font-semibold text-foreground">{m.preview.title}</p>
+        <LivePreview config={config} selected="cover" m={m.preview} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/cn';
+import type { EditorMessages } from './messages';
+
+type Device = 'mobile' | 'desktop';
+
+/**
+ * Device preview: renders the live public form route inside a framed iframe at
+ * mobile (390px) or desktop widths. Backdrop + Esc close, focus restore. Save
+ * before opening so the iframe reflects the latest config.
+ */
+export function DevicePreviewModal({
+  open,
+  onClose,
+  publicPath,
+  m,
+}: {
+  open: boolean;
+  onClose: () => void;
+  publicPath: string;
+  m: EditorMessages['preview'];
+}) {
+  const [device, setDevice] = useState<Device>('mobile');
+  const restoreRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    restoreRef.current = document.activeElement as HTMLElement | null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      restoreRef.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center p-4">
+      <button type="button" aria-hidden tabIndex={-1} onClick={onClose} className="absolute inset-0 bg-background/85" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={m.device}
+        className="relative flex h-[90vh] w-full max-w-5xl flex-col rounded-xl border border-border bg-popover shadow-lg"
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="inline-flex rounded-md border border-border p-0.5">
+            {(['mobile', 'desktop'] as const).map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => setDevice(d)}
+                aria-pressed={device === d}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm transition-colors',
+                  device === d ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <i aria-hidden className={d === 'mobile' ? 'pi pi-mobile' : 'pi pi-desktop'} style={{ fontSize: 13 }} />
+                {d === 'mobile' ? m.mobile : m.desktop}
+              </button>
+            ))}
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label={m.close}>
+            <i aria-hidden className="pi pi-times" style={{ fontSize: 13 }} /> {m.close}
+          </Button>
+        </div>
+
+        <div className="flex flex-1 items-start justify-center overflow-auto bg-muted/30 p-4">
+          <div
+            className={cn(
+              'overflow-hidden rounded-lg border border-border bg-background shadow-sm transition-all',
+              device === 'mobile' ? 'h-[780px] w-[390px] max-w-full' : 'h-full w-full',
+            )}
+          >
+            <iframe
+              key={device}
+              src={publicPath}
+              title={m.device}
+              className="h-full w-full border-0"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+/**
+ * Small form-anatomy primitives shared by every editor panel so spacing,
+ * labels, and the inline required marker stay identical across the builder
+ * (Design Quality Bar §7/§8). Tokens only — no raw hex/px.
+ */
+
+export function Field({
+  label,
+  htmlFor,
+  required,
+  hint,
+  children,
+  className,
+}: {
+  label: string;
+  htmlFor?: string;
+  required?: boolean;
+  hint?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <label htmlFor={htmlFor} className="text-sm font-medium text-foreground">
+        {label}
+        {required ? (
+          <span aria-hidden className="ml-0.5 text-destructive">
+            *
+          </span>
+        ) : null}
+      </label>
+      {children}
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+const controlBase =
+  'w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors ' +
+  'placeholder:text-muted-foreground hover:border-muted-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+export function TextField(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  const { className, ...rest } = props;
+  return <input {...rest} className={cn(controlBase, className)} />;
+}
+
+export function TextArea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  const { className, rows = 3, ...rest } = props;
+  return <textarea {...rest} rows={rows} className={cn(controlBase, 'resize-y', className)} />;
+}
+
+export function NumberField(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  const { className, ...rest } = props;
+  return <input type="number" {...rest} className={cn(controlBase, className)} />;
+}
+
+export function SelectField(props: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  const { className, children, ...rest } = props;
+  return (
+    <select {...rest} className={cn(controlBase, 'cursor-pointer', className)}>
+      {children}
+    </select>
+  );
+}
+
+/** A row that pairs a label with an inline control (e.g. a switch). */
+export function InlineField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-1">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        {hint ? <p className="mt-0.5 text-xs text-muted-foreground">{hint}</p> : null}
+      </div>
+      <div className="shrink-0 pt-0.5">{children}</div>
+    </div>
+  );
+}
+
+/** A titled group of controls with a consistent header + divider. */
+export function PanelSection({
+  title,
+  subtitle,
+  action,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+          {subtitle ? <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p> : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/flow-diagram.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/flow-diagram.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import type { FormConfig, FormFieldType } from '@quill/engine';
+import type { EditorMessages } from './messages';
+
+const TYPE_TAG: Record<FormFieldType, string> = {
+  text: 'TXT',
+  name: 'NAME',
+  email: 'MAIL',
+  phone: 'TEL',
+  dropdown: 'LIST',
+  multiple_choice: 'PICK',
+  slider: 'SLDR',
+  textarea: 'LONG',
+  message: 'MSG',
+};
+
+function Arrow() {
+  return (
+    <div aria-hidden className="flex justify-center py-1 text-muted-foreground">
+      <i className="pi pi-arrow-down" style={{ fontSize: 12 }} />
+    </div>
+  );
+}
+
+function Node({
+  children,
+  tone = 'default',
+}: {
+  children: React.ReactNode;
+  tone?: 'default' | 'accent' | 'muted';
+}) {
+  const toneClass =
+    tone === 'accent'
+      ? 'border-primary bg-primary/10'
+      : tone === 'muted'
+        ? 'border-dashed border-border bg-card'
+        : 'border-border bg-card';
+  return (
+    <div className={`mx-auto w-full max-w-md rounded-lg border px-4 py-3 ${toneClass}`}>{children}</div>
+  );
+}
+
+/**
+ * A clean, read-only map of the whole form: cover → each step (with its type,
+ * question, flow group and any conditional-visibility summary) → end. No
+ * editing on the diagram (Track A brief §6) — it's an at-a-glance overview.
+ */
+export function FlowDiagram({ config, m }: { config: FormConfig; m: EditorMessages }) {
+  const coverOn = config.cover?.enabled !== false && config.cover != null;
+
+  if (config.steps.length === 0) {
+    return <p className="py-10 text-center text-sm text-muted-foreground">{m.flow.empty}</p>;
+  }
+
+  const fieldLabel = (key: string): string => {
+    const s = config.steps.find((x) => x.key === key);
+    return s?.question?.trim() || key;
+  };
+
+  return (
+    <div className="mx-auto max-w-[640px]">
+      {coverOn ? (
+        <>
+          <Node tone="accent">
+            <div className="flex items-center gap-2">
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-muted-foreground">
+                {m.flow.cover.toUpperCase()}
+              </span>
+              <span className="truncate text-sm font-medium">
+                {config.cover?.headline || m.flow.cover}
+              </span>
+            </div>
+          </Node>
+          <Arrow />
+        </>
+      ) : null}
+
+      {config.steps.map((step, i) => {
+        const conditions: string[] = [];
+        if (step.showWhen) conditions.push(`${m.logic.showWhen}: ${fieldLabel(step.showWhen.field)} = ${step.showWhen.values.join(', ')}`);
+        if (step.hideWhen) conditions.push(`${m.logic.hideWhen}: ${fieldLabel(step.hideWhen.field)} = ${step.hideWhen.values.join(', ')}`);
+        return (
+          <div key={step.key}>
+            <Node tone={conditions.length ? 'muted' : 'default'}>
+              <div className="flex items-center gap-2">
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-muted-foreground">
+                  {TYPE_TAG[step.type]}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {step.question?.trim() || m.steps.untitled}
+                </span>
+                {step.flowGroup === 'lead_capture' ? (
+                  <span className="shrink-0 rounded-full bg-secondary/20 px-2 py-0.5 text-[10px] font-semibold text-secondary">
+                    {m.props.leadCapture}
+                  </span>
+                ) : null}
+              </div>
+              {conditions.length ? (
+                <ul className="mt-1.5 flex flex-col gap-0.5 border-t border-border pt-1.5">
+                  {conditions.map((c, ci) => (
+                    <li key={ci} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <i aria-hidden className="pi pi-sitemap" style={{ fontSize: 10 }} />
+                      {c}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </Node>
+            <Arrow />
+            {i === config.steps.length - 1 ? (
+              <Node tone="muted">
+                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <i aria-hidden className="pi pi-flag" style={{ fontSize: 12 }} />
+                  {m.flow.end}
+                </div>
+              </Node>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormConfig, FormStep } from '@quill/engine';
+import { resolveQuestion } from '@quill/engine';
+import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
+import type { EditorMessages } from './messages';
+
+/**
+ * A faithful, read-only preview of the cover or a single step, styled with the
+ * form's branding accent so the editor reflects the public surface. Interactive
+ * within the preview (you can tap options / drag the slider) but never submits.
+ */
+export function LivePreview({
+  config,
+  selected,
+  m,
+}: {
+  config: FormConfig;
+  selected: number | 'cover';
+  m: EditorMessages['preview'];
+}) {
+  const accent = clampAccent(config.branding?.primaryColor || DEFAULT_ACCENT);
+  const accentText = onAccent(accent);
+  const step: FormStep | undefined = typeof selected === 'number' ? config.steps[selected] : undefined;
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-4">
+      {selected === 'cover' ? (
+        <CoverPreview config={config} accent={accent} accentText={accentText} m={m} />
+      ) : step ? (
+        <StepPreview step={step} accent={accent} accentText={accentText} m={m} index={selected} total={config.steps.length} />
+      ) : (
+        <p className="py-8 text-center text-sm text-muted-foreground">{m.empty}</p>
+      )}
+    </div>
+  );
+}
+
+function CoverPreview({
+  config,
+  accent,
+  accentText,
+  m,
+}: {
+  config: FormConfig;
+  accent: string;
+  accentText: string;
+  m: EditorMessages['preview'];
+}) {
+  const cover = config.cover ?? {};
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-md border border-border bg-card p-6 text-center">
+      {cover.bannerText ? (
+        <div
+          className="mb-1 w-full rounded-md px-3 py-1.5 text-xs font-medium"
+          style={{ background: accent, color: accentText }}
+        >
+          {cover.bannerText}
+        </div>
+      ) : null}
+      {cover.eyebrow ? (
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {cover.eyebrow}
+        </span>
+      ) : null}
+      <h1 className="text-2xl font-semibold tracking-tight">{cover.headline || m.coverTitle}</h1>
+      {cover.subheadline ? <p className="text-sm text-muted-foreground">{cover.subheadline}</p> : null}
+      <button
+        type="button"
+        className="mt-1 rounded-md px-5 py-2.5 text-sm font-semibold transition-transform active:scale-[0.98]"
+        style={{ background: accent, color: accentText }}
+      >
+        {cover.ctaText || 'Start'}
+      </button>
+      {cover.trustBadge ? <p className="text-xs text-muted-foreground">{cover.trustBadge}</p> : null}
+    </div>
+  );
+}
+
+function StepPreview({
+  step,
+  accent,
+  accentText,
+  index,
+  total,
+  m,
+}: {
+  step: FormStep;
+  accent: string;
+  accentText: string;
+  index: number;
+  total: number;
+  m: EditorMessages['preview'];
+}) {
+  const [value, setValue] = useState<string | number>('');
+  const question = resolveQuestion(step, {}) || step.key;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-md border border-border bg-card p-6">
+      <div className="flex items-center gap-1.5" aria-hidden>
+        {Array.from({ length: Math.max(total, 1) }).map((_, i) => (
+          <span
+            key={i}
+            className="h-1.5 flex-1 rounded-full"
+            style={{ background: i <= index ? accent : 'var(--muted)' }}
+          />
+        ))}
+      </div>
+
+      <p className="text-[11px] font-medium text-muted-foreground">
+        {m.step} {index + 1} {m.of} {total}
+      </p>
+
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold">
+          {question}
+          {step.required && step.type !== 'message' ? (
+            <span aria-hidden style={{ color: accent }} className="ml-0.5">
+              *
+            </span>
+          ) : null}
+        </h2>
+        {step.helper ? <p className="text-sm text-muted-foreground">{step.helper}</p> : null}
+      </div>
+
+      {step.type === 'message' ? null : step.type === 'dropdown' || step.type === 'multiple_choice' ? (
+        <div className="flex flex-col gap-2">
+          {(step.options ?? []).map((o) => {
+            const on = value === o.value;
+            return (
+              <button
+                key={o.value}
+                type="button"
+                onClick={() => setValue(o.value)}
+                className="rounded-md border px-4 py-3 text-left text-sm transition-colors"
+                style={
+                  on
+                    ? { borderColor: accent, background: 'color-mix(in srgb, ' + accent + ' 15%, transparent)' }
+                    : { borderColor: 'var(--border)' }
+                }
+              >
+                {o.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : step.type === 'slider' ? (
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={step.min ?? 0}
+            max={step.max ?? 100}
+            step={step.step ?? 1}
+            value={Number(value || step.default || step.min || 0)}
+            onChange={(e) => setValue(Number(e.target.value))}
+            className="flex-1 accent-[var(--primary)]"
+            style={{ accentColor: accent }}
+          />
+          <span className="w-12 text-right font-mono text-sm">
+            {String(value || step.default || step.min || 0)}
+          </span>
+        </div>
+      ) : step.type === 'textarea' ? (
+        <textarea
+          value={String(value)}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={step.placeholder ?? undefined}
+          rows={3}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      ) : (
+        <input
+          type={step.type === 'email' ? 'email' : step.type === 'phone' ? 'tel' : 'text'}
+          value={String(value)}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={step.placeholder ?? undefined}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          className="rounded-md px-5 py-2.5 text-sm font-semibold transition-transform active:scale-[0.98]"
+          style={{ background: accent, color: accentText }}
+        >
+          {step.buttonText || (index + 1 === total ? 'Submit' : 'Next')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/messages.ts
@@ -1,0 +1,4 @@
+import type { FormsMessages } from '@quill/shared';
+
+/** The editor message subtree passed from the server page into the client UI. */
+export type EditorMessages = FormsMessages['admin']['editor'];

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { FormOption } from '@quill/engine';
+import { slugify } from '@quill/engine';
+import { Button } from '@/components/ui/button';
+import { TextField, NumberField } from './fields';
+import { SortableList, SortableRow } from './sortable';
+import type { EditorMessages } from './messages';
+
+/**
+ * Editor for a choice/dropdown step's options: label, value, points and an
+ * optional icon, drag-reorderable. Value auto-fills from the label until the
+ * author edits it directly (then it's left alone). No native scrollbars; the
+ * whole panel scrolls with the page.
+ */
+export function OptionsEditor({
+  options,
+  onChange,
+  m,
+}: {
+  options: FormOption[];
+  onChange: (next: FormOption[]) => void;
+  m: EditorMessages['options'];
+}) {
+  const ids = options.map((_, i) => `opt-${i}`);
+
+  function update(index: number, patch: Partial<FormOption>) {
+    onChange(options.map((o, i) => (i === index ? { ...o, ...patch } : o)));
+  }
+  function remove(index: number) {
+    onChange(options.filter((_, i) => i !== index));
+  }
+  function add() {
+    const n = options.length + 1;
+    onChange([...options, { label: `Option ${n}`, value: slugify(`option ${n}`), points: 0 }]);
+  }
+  function reorder(from: number, to: number) {
+    const next = [...options];
+    const [moved] = next.splice(from, 1);
+    if (!moved) return;
+    next.splice(to, 0, moved);
+    onChange(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {options.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{m.empty}</p>
+      ) : (
+        <SortableList ids={ids} onReorder={reorder} className="flex flex-col gap-2">
+          {(id, index) => {
+            const o = options[index];
+            if (!o) return null;
+            return (
+              <SortableRow key={id} id={id}>
+                {({ handleProps }) => (
+                  <div className="flex items-end gap-2 rounded-md border border-border bg-background p-2">
+                    <button
+                      type="button"
+                      aria-label={m.title}
+                      className="mb-1.5 shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+                      {...handleProps}
+                    >
+                      <i aria-hidden className="pi pi-bars" style={{ fontSize: 13 }} />
+                    </button>
+                    <label className="flex min-w-0 flex-[2] flex-col gap-1">
+                      <span className="text-[11px] font-medium text-muted-foreground">{m.label}</span>
+                      <TextField
+                        value={o.label}
+                        onChange={(e) => {
+                          const label = e.target.value;
+                          const autoValue = !o.value || o.value === slugify(o.label ?? '');
+                          update(index, autoValue ? { label, value: slugify(label) } : { label });
+                        }}
+                      />
+                    </label>
+                    <label className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="text-[11px] font-medium text-muted-foreground">{m.value}</span>
+                      <TextField
+                        value={o.value}
+                        onChange={(e) => update(index, { value: e.target.value })}
+                      />
+                    </label>
+                    <label className="flex w-16 shrink-0 flex-col gap-1">
+                      <span className="text-[11px] font-medium text-muted-foreground">{m.points}</span>
+                      <NumberField
+                        value={o.points ?? 0}
+                        onChange={(e) => update(index, { points: Number(e.target.value) || 0 })}
+                      />
+                    </label>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={m.remove}
+                      onClick={() => remove(index)}
+                      className="mb-0.5 shrink-0 text-muted-foreground hover:text-destructive"
+                    >
+                      <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                    </Button>
+                  </div>
+                )}
+              </SortableRow>
+            );
+          }}
+        </SortableList>
+      )}
+      <div>
+        <Button variant="outline" size="sm" onClick={add}>
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/outcomes-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/outcomes-panel.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { FormConfig, FormOutcome } from '@quill/engine';
+import { createEmptyOutcome } from '@quill/engine';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Field, TextField, NumberField, InlineField, PanelSection } from './fields';
+import type { EditorMessages } from './messages';
+
+/**
+ * Outcomes editor — the generalized score-routing model. Each bucket has a
+ * label, a minimum score, and an optional redirect URL; at submit time the
+ * highest bucket the score clears wins. A master toggle mirrors
+ * `scoring.enabled`.
+ */
+export function OutcomesPanel({
+  config,
+  onScoringChange,
+  onOutcomesChange,
+  m,
+}: {
+  config: FormConfig;
+  onScoringChange: (enabled: boolean) => void;
+  onOutcomesChange: (next: FormOutcome[]) => void;
+  m: EditorMessages;
+}) {
+  const outcomes = config.outcomes ?? [];
+  const scoringOn = config.scoring?.enabled !== false;
+
+  function update(index: number, patch: Partial<FormOutcome>) {
+    onOutcomesChange(outcomes.map((o, i) => (i === index ? { ...o, ...patch } : o)));
+  }
+  function add() {
+    const taken = new Set(outcomes.map((o) => o.id));
+    onOutcomesChange([...outcomes, createEmptyOutcome(taken)]);
+  }
+
+  return (
+    <div className="mx-auto flex max-w-[760px] flex-col gap-4">
+      <PanelSection title={m.outcomes.title} subtitle={m.outcomes.subtitle}>
+        <InlineField label={m.outcomes.scoringEnabled} hint={m.outcomes.scoringHint}>
+          <Switch checked={scoringOn} onCheckedChange={onScoringChange} aria-label={m.outcomes.scoringEnabled} />
+        </InlineField>
+      </PanelSection>
+
+      <PanelSection
+        title={m.outcomes.title}
+        action={
+          <Button variant="outline" size="sm" onClick={add}>
+            <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.outcomes.add}
+          </Button>
+        }
+      >
+        {outcomes.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{m.outcomes.empty}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {outcomes.map((o, index) => (
+              <div key={o.id} className="flex flex-col gap-3 rounded-md border border-border bg-background p-3 sm:flex-row sm:items-end">
+                <Field label={m.outcomes.label} className="flex-[2]">
+                  <TextField
+                    value={o.label}
+                    placeholder={m.outcomes.labelPlaceholder}
+                    onChange={(e) => update(index, { label: e.target.value })}
+                  />
+                </Field>
+                <Field label={m.outcomes.minScore} className="sm:w-28">
+                  <NumberField
+                    value={o.minScore ?? 0}
+                    onChange={(e) => update(index, { minScore: Number(e.target.value) || 0 })}
+                  />
+                </Field>
+                <Field label={m.outcomes.redirectUrl} className="flex-[2]">
+                  <TextField
+                    type="url"
+                    value={o.redirectUrl ?? ''}
+                    placeholder={m.outcomes.redirectPlaceholder}
+                    onChange={(e) => update(index, { redirectUrl: e.target.value || null })}
+                  />
+                </Field>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={m.outcomes.remove}
+                  onClick={() => onOutcomesChange(outcomes.filter((_, i) => i !== index))}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </PanelSection>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-variants-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-variants-editor.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { FormStep } from '@quill/engine';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { SelectField, TextField, TextArea, InlineField } from './fields';
+import type { PriorField } from './condition-editor';
+import type { EditorMessages } from './messages';
+
+/**
+ * Dynamic-question editor: vary a step's question by the answer to an earlier
+ * field. Variants are stored as `questionVariants` (value → text), with `*` as
+ * the fallback. `[field]` interpolation is available in every variant.
+ */
+export function QuestionVariantsEditor({
+  step,
+  priorFields,
+  onUpdate,
+  m,
+}: {
+  step: FormStep;
+  priorFields: PriorField[];
+  onUpdate: (patch: Partial<FormStep>) => void;
+  m: EditorMessages['variants'];
+}) {
+  const enabled = !!step.questionField;
+  const variants = step.questionVariants ?? {};
+  // Editable pairs excluding the special `*` fallback key.
+  const pairs = Object.entries(variants).filter(([k]) => k !== '*');
+  const fallback = variants['*'] ?? '';
+
+  function setVariants(next: Record<string, string>) {
+    onUpdate({ questionVariants: next });
+  }
+  function enable(on: boolean) {
+    if (on) onUpdate({ questionField: priorFields[0]?.key ?? '', questionVariants: variants });
+    else onUpdate({ questionField: null, questionVariants: undefined });
+  }
+  function updateKey(oldKey: string, newKey: string) {
+    const next: Record<string, string> = {};
+    for (const [k, v] of Object.entries(variants)) next[k === oldKey ? newKey : k] = v;
+    setVariants(next);
+  }
+  function updateValue(key: string, text: string) {
+    setVariants({ ...variants, [key]: text });
+  }
+  function remove(key: string) {
+    const next = { ...variants };
+    delete next[key];
+    setVariants(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <InlineField label={m.enable} hint={m.hint}>
+        <Switch checked={enabled} onCheckedChange={enable} aria-label={m.enable} />
+      </InlineField>
+
+      {enabled ? (
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">{m.field}</span>
+            <SelectField
+              value={step.questionField ?? ''}
+              onChange={(e) => onUpdate({ questionField: e.target.value })}
+            >
+              {priorFields.length === 0 ? <option value="">—</option> : null}
+              {priorFields.map((f) => (
+                <option key={f.key} value={f.key}>
+                  {f.label}
+                </option>
+              ))}
+            </SelectField>
+          </label>
+
+          {pairs.map(([key, text], i) => (
+            <div key={i} className="flex flex-col gap-1.5 rounded-md border border-border bg-background p-2">
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] font-medium text-muted-foreground">{m.matchValue}</span>
+                <TextField
+                  value={key}
+                  placeholder={m.matchValuePlaceholder}
+                  onChange={(e) => updateKey(key, e.target.value)}
+                  className="flex-1"
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={m.remove}
+                  onClick={() => remove(key)}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                </Button>
+              </div>
+              <TextArea
+                value={text}
+                rows={2}
+                placeholder={m.variantQuestion}
+                onChange={(e) => updateValue(key, e.target.value)}
+              />
+            </div>
+          ))}
+
+          <div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setVariants({ ...variants, '': '' })}
+              disabled={'' in variants}
+            >
+              <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
+            </Button>
+          </div>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">{m.fallback}</span>
+            <TextArea
+              value={fallback}
+              rows={2}
+              onChange={(e) => updateValue('*', e.target.value)}
+            />
+          </label>
+          <p className="text-xs text-muted-foreground">{m.interpolationHint}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/slider-scoring-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/slider-scoring-editor.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { SliderScoringRange } from '@quill/engine';
+import { Button } from '@/components/ui/button';
+import { NumberField } from './fields';
+import type { EditorMessages } from './messages';
+
+/** Slider scoring ranges: value in [min,max] awards `points`. Add/remove rows. */
+export function SliderScoringEditor({
+  ranges,
+  onChange,
+  m,
+}: {
+  ranges: SliderScoringRange[];
+  onChange: (next: SliderScoringRange[]) => void;
+  m: EditorMessages['sliderScoring'];
+}) {
+  function update(index: number, patch: Partial<SliderScoringRange>) {
+    onChange(ranges.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {ranges.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{m.empty}</p>
+      ) : (
+        ranges.map((r, index) => (
+          <div
+            key={index}
+            className="flex items-end gap-2 rounded-md border border-border bg-background p-2"
+          >
+            <label className="flex flex-1 flex-col gap-1">
+              <span className="text-[11px] font-medium text-muted-foreground">{m.min}</span>
+              <NumberField value={r.min} onChange={(e) => update(index, { min: Number(e.target.value) || 0 })} />
+            </label>
+            <label className="flex flex-1 flex-col gap-1">
+              <span className="text-[11px] font-medium text-muted-foreground">{m.max}</span>
+              <NumberField value={r.max} onChange={(e) => update(index, { max: Number(e.target.value) || 0 })} />
+            </label>
+            <label className="flex w-16 shrink-0 flex-col gap-1">
+              <span className="text-[11px] font-medium text-muted-foreground">{m.points}</span>
+              <NumberField value={r.points} onChange={(e) => update(index, { points: Number(e.target.value) || 0 })} />
+            </label>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={m.remove}
+              onClick={() => onChange(ranges.filter((_, i) => i !== index))}
+              className="mb-0.5 shrink-0 text-muted-foreground hover:text-destructive"
+            >
+              <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+            </Button>
+          </div>
+        ))
+      )}
+      <div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onChange([...ranges, { min: 0, max: 0, points: 0 }])}
+        >
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { HTMLAttributes, ReactNode } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+/**
+ * A thin, reusable dnd-kit vertical sortable. Keyboard-accessible (grip is a
+ * focusable handle; arrows move a picked-up item), pointer needs a 4px intent
+ * so clicks on inner controls don't start a drag. Used for the step list and
+ * the option list so reorder behaves identically everywhere.
+ */
+export function SortableList({
+  ids,
+  onReorder,
+  children,
+  className,
+}: {
+  ids: string[];
+  onReorder: (from: number, to: number) => void;
+  children: (id: string, index: number) => ReactNode;
+  className?: string;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = ids.indexOf(String(active.id));
+    const to = ids.indexOf(String(over.id));
+    if (from >= 0 && to >= 0) onReorder(from, to);
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleEnd}>
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        <div className={className}>{ids.map((id, index) => children(id, index))}</div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+/** One sortable row. `children` receives the props to spread on the drag grip. */
+export function SortableRow({
+  id,
+  children,
+}: {
+  id: string;
+  children: (args: { handleProps: HTMLAttributes<HTMLElement>; isDragging: boolean }) => ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+    zIndex: isDragging ? 20 : undefined,
+    position: 'relative',
+  };
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ handleProps: { ...attributes, ...listeners }, isDragging })}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/step-list.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/step-list.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormStep, FormFieldType } from '@quill/engine';
+import { Button } from '@/components/ui/button';
+import { SelectField } from './fields';
+import { SortableList, SortableRow } from './sortable';
+import type { EditorMessages } from './messages';
+
+const STEP_TYPES: FormFieldType[] = [
+  'text',
+  'name',
+  'email',
+  'phone',
+  'dropdown',
+  'multiple_choice',
+  'slider',
+  'textarea',
+  'message',
+];
+
+const TYPE_TAG: Record<FormFieldType, string> = {
+  text: 'TXT',
+  name: 'NAME',
+  email: 'MAIL',
+  phone: 'TEL',
+  dropdown: 'LIST',
+  multiple_choice: 'PICK',
+  slider: 'SLDR',
+  textarea: 'LONG',
+  message: 'MSG',
+};
+
+/**
+ * The left rail: a drag-reorderable list of steps (dnd-kit) with a type-picker
+ * add control at the bottom. Selection drives the center properties panel and
+ * the live preview. The active row is unmistakable (accent border + fill).
+ */
+export function StepList({
+  steps,
+  selectedIndex,
+  onSelect,
+  onReorder,
+  onAdd,
+  m,
+}: {
+  steps: FormStep[];
+  selectedIndex: number | null;
+  onSelect: (index: number) => void;
+  onReorder: (from: number, to: number) => void;
+  onAdd: (type: FormFieldType) => void;
+  m: EditorMessages;
+}) {
+  const [addType, setAddType] = useState<FormFieldType>('text');
+  const ids = steps.map((s) => s.key);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-foreground">{m.steps.title}</h2>
+        <span className="text-xs text-muted-foreground">{steps.length}</span>
+      </div>
+
+      {steps.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+          {m.steps.empty}
+        </p>
+      ) : (
+        <SortableList ids={ids} onReorder={onReorder} className="flex flex-col gap-1.5">
+          {(id, index) => {
+            const step = steps[index];
+            if (!step) return null;
+            const active = index === selectedIndex;
+            return (
+              <SortableRow key={id} id={id}>
+                {({ handleProps }) => (
+                  <div
+                    className={
+                      'flex items-center gap-2 rounded-md border px-2 py-2 transition-colors ' +
+                      (active
+                        ? 'border-primary bg-primary/10'
+                        : 'border-border bg-card hover:border-muted-foreground')
+                    }
+                  >
+                    <button
+                      type="button"
+                      aria-label={m.steps.dragHint}
+                      className="shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+                      {...handleProps}
+                    >
+                      <i aria-hidden className="pi pi-bars" style={{ fontSize: 12 }} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onSelect(index)}
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    >
+                      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-muted-foreground">
+                        {TYPE_TAG[step.type]}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-sm">
+                        {step.question?.trim() || m.steps.untitled}
+                      </span>
+                      {step.showWhen || step.hideWhen ? (
+                        <i
+                          aria-hidden
+                          title={m.flow.conditional}
+                          className="pi pi-sitemap shrink-0 text-muted-foreground"
+                          style={{ fontSize: 11 }}
+                        />
+                      ) : null}
+                    </button>
+                  </div>
+                )}
+              </SortableRow>
+            );
+          }}
+        </SortableList>
+      )}
+
+      <div className="flex items-end gap-2 border-t border-border pt-3">
+        <label className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="text-[11px] font-medium text-muted-foreground">{m.steps.addType}</span>
+          <SelectField value={addType} onChange={(e) => setAddType(e.target.value as FormFieldType)}>
+            {STEP_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {m.types[t]}
+              </option>
+            ))}
+          </SelectField>
+        </label>
+        <Button variant="outline" size="sm" onClick={() => onAdd(addType)} className="shrink-0">
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.steps.add}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/step-properties.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/step-properties.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import type { FormStep, FormFieldType } from '@quill/engine';
+import { defaultFlowGroup } from '@quill/engine';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import {
+  Field,
+  TextField,
+  TextArea,
+  NumberField,
+  SelectField,
+  InlineField,
+  PanelSection,
+} from './fields';
+import { OptionsEditor } from './options-editor';
+import { SliderScoringEditor } from './slider-scoring-editor';
+import { ConditionEditor, type PriorField } from './condition-editor';
+import { QuestionVariantsEditor } from './question-variants-editor';
+import type { EditorMessages } from './messages';
+
+const STEP_TYPES: FormFieldType[] = [
+  'text',
+  'name',
+  'email',
+  'phone',
+  'dropdown',
+  'multiple_choice',
+  'slider',
+  'textarea',
+  'message',
+];
+
+const hasOptions = (t: FormFieldType) => t === 'dropdown' || t === 'multiple_choice';
+
+/**
+ * The center panel: every property of the selected step, for all 9 kinds.
+ * Common anatomy up top (type, question, helper, required, button, flow group),
+ * then kind-specific blocks (options, slider bounds+scoring, email/phone
+ * validation), then cross-cutting logic (dynamic question + conditional
+ * visibility). One vertical rhythm; the page scrolls (no inner scrollbar).
+ */
+export function StepProperties({
+  step,
+  index,
+  priorFields,
+  onUpdate,
+  onDelete,
+  m,
+}: {
+  step: FormStep;
+  index: number;
+  priorFields: PriorField[];
+  onUpdate: (patch: Partial<FormStep>) => void;
+  onDelete: () => void;
+  m: EditorMessages;
+}) {
+  const showButton = step.type === 'message';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelSection
+        title={m.steps.stepN.replace('{n}', String(index + 1))}
+        action={
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              if (confirm(m.steps.deleteConfirm)) onDelete();
+            }}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <i aria-hidden className="pi pi-trash" style={{ fontSize: 12 }} /> {m.steps.delete}
+          </Button>
+        }
+      >
+        <Field label={m.props.type}>
+          <SelectField
+            value={step.type}
+            onChange={(e) => {
+              const type = e.target.value as FormFieldType;
+              const patch: Partial<FormStep> = { type, flowGroup: defaultFlowGroup(type) };
+              if (hasOptions(type) && (step.options ?? []).length === 0) {
+                patch.options = [{ label: 'Option 1', value: 'option_1', points: 0 }];
+              }
+              if (type === 'slider' && step.min == null) {
+                patch.min = 0;
+                patch.max = 100;
+                patch.step = 1;
+                patch.default = 50;
+              }
+              onUpdate(patch);
+            }}
+          >
+            {STEP_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {m.types[t]}
+              </option>
+            ))}
+          </SelectField>
+        </Field>
+
+        <Field label={m.props.question}>
+          <TextArea
+            value={step.question ?? ''}
+            rows={2}
+            placeholder={m.props.questionPlaceholder}
+            onChange={(e) => onUpdate({ question: e.target.value })}
+          />
+        </Field>
+
+        <Field label={m.props.helper}>
+          <TextField
+            value={step.helper ?? ''}
+            onChange={(e) => onUpdate({ helper: e.target.value || null })}
+          />
+        </Field>
+
+        {step.type !== 'message' && step.type !== 'slider' && !hasOptions(step.type) ? (
+          <Field label={m.props.placeholder}>
+            <TextField
+              value={step.placeholder ?? ''}
+              onChange={(e) => onUpdate({ placeholder: e.target.value || null })}
+            />
+          </Field>
+        ) : null}
+
+        {showButton ? (
+          <Field label={m.props.buttonText}>
+            <TextField
+              value={step.buttonText ?? ''}
+              placeholder={m.props.buttonTextPlaceholder}
+              onChange={(e) => onUpdate({ buttonText: e.target.value || null })}
+            />
+          </Field>
+        ) : null}
+
+        {step.type !== 'message' ? (
+          <InlineField label={m.props.required}>
+            <Switch
+              checked={step.required !== false}
+              onCheckedChange={(v) => onUpdate({ required: v })}
+              aria-label={m.props.required}
+            />
+          </InlineField>
+        ) : null}
+
+        <Field label={m.props.flowGroup} hint={m.props.flowGroupHint}>
+          <SelectField
+            value={step.flowGroup ?? defaultFlowGroup(step.type)}
+            onChange={(e) => onUpdate({ flowGroup: e.target.value as FormStep['flowGroup'] })}
+          >
+            <option value="qualification">{m.props.qualification}</option>
+            <option value="lead_capture">{m.props.leadCapture}</option>
+          </SelectField>
+        </Field>
+      </PanelSection>
+
+      {hasOptions(step.type) ? (
+        <PanelSection title={m.options.title}>
+          <OptionsEditor
+            options={step.options ?? []}
+            onChange={(options) => onUpdate({ options })}
+            m={m.options}
+          />
+        </PanelSection>
+      ) : null}
+
+      {step.type === 'slider' ? (
+        <PanelSection title={m.types.slider}>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Field label={m.props.sliderMin}>
+              <NumberField value={step.min ?? 0} onChange={(e) => onUpdate({ min: Number(e.target.value) || 0 })} />
+            </Field>
+            <Field label={m.props.sliderMax}>
+              <NumberField value={step.max ?? 100} onChange={(e) => onUpdate({ max: Number(e.target.value) || 0 })} />
+            </Field>
+            <Field label={m.props.sliderStep}>
+              <NumberField value={step.step ?? 1} onChange={(e) => onUpdate({ step: Number(e.target.value) || 1 })} />
+            </Field>
+            <Field label={m.props.sliderDefault}>
+              <NumberField
+                value={step.default ?? 0}
+                onChange={(e) => onUpdate({ default: Number(e.target.value) || 0 })}
+              />
+            </Field>
+          </div>
+          <div className="mt-1">
+            <p className="mb-2 text-xs font-medium text-muted-foreground">{m.sliderScoring.hint}</p>
+            <SliderScoringEditor
+              ranges={step.sliderScoring ?? []}
+              onChange={(sliderScoring) => onUpdate({ sliderScoring })}
+              m={m.sliderScoring}
+            />
+          </div>
+        </PanelSection>
+      ) : null}
+
+      {step.type === 'email' ? (
+        <PanelSection title={m.types.email}>
+          <InlineField label={m.props.corporateEmailOnly} hint={m.props.corporateEmailHint}>
+            <Switch
+              checked={!!step.corporateEmailOnly}
+              onCheckedChange={(v) => onUpdate({ corporateEmailOnly: v || undefined })}
+              aria-label={m.props.corporateEmailOnly}
+            />
+          </InlineField>
+        </PanelSection>
+      ) : null}
+
+      {step.type === 'phone' ? (
+        <PanelSection title={m.types.phone}>
+          <Field label={m.props.phoneMinDigits}>
+            <NumberField
+              value={step.phoneMinDigits ?? 7}
+              min={1}
+              onChange={(e) => onUpdate({ phoneMinDigits: Number(e.target.value) || undefined })}
+            />
+          </Field>
+        </PanelSection>
+      ) : null}
+
+      <PanelSection title={m.variants.title}>
+        <QuestionVariantsEditor step={step} priorFields={priorFields} onUpdate={onUpdate} m={m.variants} />
+      </PanelSection>
+
+      <PanelSection title={m.logic.title}>
+        {priorFields.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{m.logic.noPriorFields}</p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <ConditionEditor
+              label={m.logic.showWhen}
+              condition={step.showWhen}
+              priorFields={priorFields}
+              onChange={(showWhen) => onUpdate({ showWhen })}
+              m={m.logic}
+            />
+            <ConditionEditor
+              label={m.logic.hideWhen}
+              condition={step.hideWhen}
+              priorFields={priorFields}
+              onChange={(hideWhen) => onUpdate({ hideWhen })}
+              m={m.logic}
+            />
+          </div>
+        )}
+      </PanelSection>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -1,84 +1,247 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import type { FormConfig, FormStep, FormCover, FormBranding, FormOutcome, FormFieldType } from '@quill/engine';
+import { createEmptyStep, normalizeConfig } from '@quill/engine';
 import { saveFormAction } from '@/app/admin/actions';
+import { useToast } from '@/components/toast';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/cn';
+import { StepList } from './_components/step-list';
+import { StepProperties } from './_components/step-properties';
+import { CoverPanel } from './_components/cover-panel';
+import { OutcomesPanel } from './_components/outcomes-panel';
+import { FlowDiagram } from './_components/flow-diagram';
+import { LivePreview } from './_components/live-preview';
+import { DevicePreviewModal } from './_components/device-preview-modal';
+import type { PriorField } from './_components/condition-editor';
+import type { EditorMessages } from './_components/messages';
+
+type Tab = 'build' | 'cover' | 'outcomes' | 'flow';
 
 /**
- * Placeholder editor (Phase 1 replaces this with a real step builder). It edits
- * the form name and the raw config JSON and saves via a server action — enough to
- * make the whole loop (edit → save → public render) work end to end.
+ * The form editor: a step builder (drag-reorder list · per-step properties ·
+ * live preview), a cover/branding tab, an outcomes/scoring tab and a read-only
+ * flow overview. Config is normalized on save (dedupe keys, canonical order,
+ * derived flags) via @quill/engine so the persisted blob is always canonical.
  */
 export function FormEditor({
   id,
   initialName,
   initialConfig,
+  publicPath,
+  m,
 }: {
   id: string;
   initialName: string;
-  initialConfig: string;
+  initialConfig: FormConfig;
+  publicPath: string;
+  m: EditorMessages;
 }) {
+  const toast = useToast();
   const [name, setName] = useState(initialName);
-  const [config, setConfig] = useState(initialConfig);
-  const [message, setMessage] = useState<string | null>(null);
+  const [config, setConfig] = useState<FormConfig>(initialConfig);
+  const [tab, setTab] = useState<Tab>('build');
+  const [selected, setSelected] = useState<number | null>(initialConfig.steps.length ? 0 : null);
+  const [deviceOpen, setDeviceOpen] = useState(false);
   const [pending, start] = useTransition();
 
-  function save() {
-    setMessage(null);
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(config);
-    } catch {
-      setMessage('Config is not valid JSON.');
-      return;
-    }
-    start(async () => {
-      const res = await saveFormAction(id, { name, config: parsed });
-      setMessage(res.ok ? 'Saved.' : (res.message ?? 'Failed to save.'));
+  /** Fields defined before `index` — the pool skip-logic / variants can read. */
+  const priorFieldsFor = (index: number): PriorField[] =>
+    config.steps.slice(0, index).map((s) => ({
+      key: s.key,
+      label: s.question?.trim() || s.key,
+      options: s.options?.map((o) => ({ label: o.label, value: o.value })),
+    }));
+
+  function patchStep(index: number, patch: Partial<FormStep>) {
+    setConfig((c) => ({ ...c, steps: c.steps.map((s, i) => (i === index ? { ...s, ...patch } : s)) }));
+  }
+
+  function addStep(type: FormFieldType) {
+    setConfig((c) => {
+      const step = createEmptyStep(type, new Set(c.steps.map((s) => s.key)));
+      const steps = [...c.steps, step];
+      setSelected(steps.length - 1);
+      return { ...c, steps };
     });
   }
 
+  function deleteStep(index: number) {
+    setConfig((c) => ({ ...c, steps: c.steps.filter((_, i) => i !== index) }));
+    setSelected((sel) => {
+      if (sel == null) return null;
+      const nextLen = config.steps.length - 1;
+      if (nextLen === 0) return null;
+      if (sel === index) return Math.max(0, index - 1);
+      return sel > index ? sel - 1 : sel;
+    });
+  }
+
+  function reorderSteps(from: number, to: number) {
+    setConfig((c) => {
+      const steps = [...c.steps];
+      const [moved] = steps.splice(from, 1);
+      if (!moved) return c;
+      steps.splice(to, 0, moved);
+      return { ...c, steps };
+    });
+    setSelected((sel) => {
+      if (sel == null) return null;
+      if (sel === from) return to;
+      if (from < sel && to >= sel) return sel - 1;
+      if (from > sel && to <= sel) return sel + 1;
+      return sel;
+    });
+  }
+
+  function patchCover(patch: Partial<FormCover>) {
+    setConfig((c) => ({ ...c, cover: { ...c.cover, ...patch } }));
+  }
+  function patchBranding(patch: Partial<FormBranding>) {
+    setConfig((c) => ({ ...c, branding: { ...c.branding, ...patch } }));
+  }
+  function setScoring(enabled: boolean) {
+    setConfig((c) => ({ ...c, scoring: { enabled } }));
+  }
+  function setOutcomes(outcomes: FormOutcome[]) {
+    setConfig((c) => ({ ...c, outcomes }));
+  }
+
+  function save() {
+    const normalized = normalizeConfig(config);
+    start(async () => {
+      const res = await saveFormAction(id, { name, config: normalized });
+      if (res.ok) {
+        setConfig(normalized);
+        // Selection index may shift if empty steps were reordered; clamp it.
+        setSelected((sel) => (sel == null ? null : Math.min(sel, normalized.steps.length - 1)));
+        toast.success(m.saved);
+      } else {
+        toast.error(res.message ?? m.saveError);
+      }
+    });
+  }
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'build', label: m.tabs.build },
+    { id: 'cover', label: m.tabs.cover },
+    { id: 'outcomes', label: m.tabs.outcomes },
+    { id: 'flow', label: m.tabs.flow },
+  ];
+
+  const selectedStep = selected != null ? config.steps[selected] : undefined;
+
   return (
-    <div className="mt-4 flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <label htmlFor="form-name" className="text-sm font-medium">
-          Form name
-        </label>
-        <input
-          id="form-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="rounded-md border border-border bg-background px-3 py-2"
-        />
+    <div className="min-h-dvh">
+      {/* Sticky header: back · name · preview + save (one primary CTA — R30). */}
+      <div className="sticky top-0 z-30 border-b border-border bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+        <div className="mx-auto flex max-w-[1520px] flex-col gap-3 px-4 pb-3 pt-4 sm:px-6">
+          <Link
+            href="/admin"
+            className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <i aria-hidden className="pi pi-chevron-left" style={{ fontSize: 12 }} />
+            {m.back}
+          </Link>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={m.formNamePlaceholder}
+              aria-label={m.formNamePlaceholder}
+              className="min-w-0 flex-1 rounded-md border border-transparent bg-transparent px-1 py-1 text-2xl font-semibold tracking-tight hover:border-border focus-visible:border-input focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <div className="flex shrink-0 items-center gap-2">
+              <Button variant="outline" onClick={() => setDeviceOpen(true)}>
+                <i aria-hidden className="pi pi-eye" style={{ fontSize: 13 }} /> {m.previewBtn}
+              </Button>
+              <Button onClick={save} disabled={pending} className="min-w-[92px]">
+                {pending ? m.saving : m.save}
+              </Button>
+            </div>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex gap-1 overflow-x-auto">
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                aria-current={tab === t.id}
+                className={cn(
+                  'whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                  tab === t.id
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
-      <div className="flex flex-col gap-1">
-        <label htmlFor="form-config" className="text-sm font-medium">
-          Config (JSON)
-        </label>
-        <textarea
-          id="form-config"
-          value={config}
-          onChange={(e) => setConfig(e.target.value)}
-          spellCheck={false}
-          rows={22}
-          className="rounded-md border border-border bg-background px-3 py-2 font-mono text-xs"
-        />
-        <p className="text-xs text-muted-foreground">
-          Placeholder editor — Phase 1 replaces this with a visual step builder.
-        </p>
+      <div className="mx-auto max-w-[1520px] px-4 py-6 sm:px-6">
+        {tab === 'build' ? (
+          <div className="grid gap-4 lg:grid-cols-[minmax(220px,260px)_minmax(0,1fr)_minmax(320px,400px)]">
+            <aside className="lg:sticky lg:top-[9.5rem] lg:self-start">
+              <StepList
+                steps={config.steps}
+                selectedIndex={selected}
+                onSelect={setSelected}
+                onReorder={reorderSteps}
+                onAdd={addStep}
+                m={m}
+              />
+            </aside>
+
+            <div className="min-w-0">
+              {selectedStep && selected != null ? (
+                <StepProperties
+                  step={selectedStep}
+                  index={selected}
+                  priorFields={priorFieldsFor(selected)}
+                  onUpdate={(patch) => patchStep(selected, patch)}
+                  onDelete={() => deleteStep(selected)}
+                  m={m}
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
+                  {m.steps.select}
+                </div>
+              )}
+            </div>
+
+            <aside className="lg:sticky lg:top-[9.5rem] lg:self-start">
+              <p className="mb-2 text-sm font-semibold text-foreground">{m.preview.title}</p>
+              <LivePreview config={config} selected={selected ?? 'cover'} m={m.preview} />
+            </aside>
+          </div>
+        ) : tab === 'cover' ? (
+          <CoverPanel config={config} onCoverChange={patchCover} onBrandingChange={patchBranding} m={m} />
+        ) : tab === 'outcomes' ? (
+          <OutcomesPanel config={config} onScoringChange={setScoring} onOutcomesChange={setOutcomes} m={m} />
+        ) : (
+          <div>
+            <div className="mb-4">
+              <h2 className="text-sm font-semibold text-foreground">{m.flow.title}</h2>
+              <p className="text-xs text-muted-foreground">{m.flow.subtitle}</p>
+            </div>
+            <FlowDiagram config={config} m={m} />
+          </div>
+        )}
       </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={save}
-          disabled={pending}
-          className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground active:scale-[0.98] disabled:opacity-50"
-        >
-          {pending ? 'Saving…' : 'Save'}
-        </button>
-        {message ? <span className="text-sm text-muted-foreground">{message}</span> : null}
-      </div>
+      <DevicePreviewModal
+        open={deviceOpen}
+        onClose={() => setDeviceOpen(false)}
+        publicPath={publicPath}
+        m={m.preview}
+      />
     </div>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/page.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/page.tsx
@@ -1,30 +1,34 @@
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 import { FormEditor } from './form-editor';
 
 export const dynamic = 'force-dynamic';
 
 export default async function EditFormPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const locale = await getLocale();
+  const m = getMessages(locale).admin.editor;
+
   let form: Awaited<ReturnType<typeof adminApi.getForm>>;
+  let me: Awaited<ReturnType<typeof adminApi.me>>;
   try {
-    form = await adminApi.getForm(id);
+    [form, me] = await Promise.all([adminApi.getForm(id), adminApi.me()]);
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) notFound();
     throw e;
   }
 
+  const publicPath = `/${me.accountCode}/${me.handle ?? 'me'}/${form.slug}`;
+
   return (
-    <div className="mx-auto max-w-[900px] px-8 py-10">
-      <Link href="/admin" className="text-sm text-muted-foreground hover:text-foreground">
-        ← Back to forms
-      </Link>
-      <FormEditor
-        id={form.id}
-        initialName={form.name}
-        initialConfig={JSON.stringify(form.config, null, 2)}
-      />
-    </div>
+    <FormEditor
+      id={form.id}
+      initialName={form.name}
+      initialConfig={form.config}
+      publicPath={publicPath}
+      m={m}
+    />
   );
 }

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,39 +1,46 @@
 import Link from 'next/link';
+import { getMessages, t } from '@quill/shared';
 import { adminApi } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 import { CopyLink } from '@/components/copy-link';
-import { createFormAction } from './actions';
+import { PageHeader } from '@/components/ui/page-header';
+import { CreateFormButton } from './create-form-button';
 import { FormRowActions } from './form-row-actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function AdminHome() {
+  const locale = await getLocale();
+  const m = getMessages(locale).admin.forms;
   const [me, forms] = await Promise.all([adminApi.me(), adminApi.listForms()]);
 
+  const createLabels = {
+    create: m.create,
+    createTitle: m.createTitle,
+    nameLabel: m.nameLabel,
+    namePlaceholder: m.namePlaceholder,
+    cancel: m.cancel,
+  };
+  const rowLabels = { duplicate: m.duplicate, delete: m.delete, deleteConfirm: m.deleteConfirm };
+
   return (
-    <div className="mx-auto max-w-[1100px] px-8 py-10">
-      <div className="mb-8 flex items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-semibold tracking-tight">Forms</h1>
-          <p className="text-muted-foreground">Build a form, share the public link, collect submissions.</p>
-        </div>
-        <form action={createFormAction} className="flex items-center gap-2">
-          <input
-            name="name"
-            placeholder="New form name"
-            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
-          />
-          <button
-            type="submit"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground active:scale-[0.98]"
-          >
-            Create form
-          </button>
-        </form>
-      </div>
+    <div className="mx-auto max-w-[1100px] px-6 py-10 sm:px-8">
+      <PageHeader
+        title={m.title}
+        subtitle={m.subtitle}
+        action={forms.length > 0 ? <CreateFormButton labels={createLabels} /> : undefined}
+      />
 
       {forms.length === 0 ? (
-        <div className="rounded-md border border-dashed border-border p-12 text-center text-muted-foreground">
-          No forms yet. Create your first form above.
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed border-border p-12 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <i aria-hidden className="pi pi-file-edit" style={{ fontSize: 20 }} />
+          </div>
+          <div>
+            <p className="font-medium text-foreground">{m.emptyTitle}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{m.emptyBody}</p>
+          </div>
+          <CreateFormButton labels={createLabels} />
         </div>
       ) : (
         <ul className="flex flex-col gap-3">
@@ -42,18 +49,21 @@ export default async function AdminHome() {
             return (
               <li
                 key={f.id}
-                className="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-4"
+                className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="flex min-w-0 flex-col gap-1">
-                  <Link href={`/admin/forms/${f.id}/edit`} className="font-medium hover:underline">
+                  <Link
+                    href={`/admin/forms/${f.id}/edit`}
+                    className="w-fit font-medium transition-colors hover:text-primary hover:underline"
+                  >
                     {f.name}
                   </Link>
-                  <CopyLink path={publicPath} labels={{ copy: 'Copy link', copied: 'Copied', open: 'Open' }} />
+                  <CopyLink path={publicPath} labels={{ copy: m.copy, copied: m.copied, open: m.open }} />
                   <span className="text-xs text-muted-foreground">
-                    Updated {new Date(f.updatedAt).toLocaleString()}
+                    {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
                   </span>
                 </div>
-                <FormRowActions id={f.id} />
+                <FormRowActions id={f.id} labels={rowLabels} />
               </li>
             );
           })}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@quill/engine": "workspace:*",
     "@quill/shared": "workspace:*",
     "@quill/types": "workspace:*",

--- a/packages/engine/src/form-config.spec.ts
+++ b/packages/engine/src/form-config.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import {
+  slugify,
+  uniqueKey,
+  defaultFlowGroup,
+  createEmptyStep,
+  createEmptyOutcome,
+  hasScoringSignal,
+  normalizeConfig,
+  interpolate,
+  resolveQuestion,
+} from './form-config';
+import type { FormConfig, FormStep } from './form-logic';
+
+const step = (p: Partial<FormStep> & Pick<FormStep, 'key' | 'type'>): FormStep => p;
+
+describe('slugify', () => {
+  it('lowercases, strips accents, and collapses non-alphanumerics', () => {
+    expect(slugify('¿Cuál es tu Rol?')).toBe('cual_es_tu_rol');
+    expect(slugify('  Hello  World  ')).toBe('hello_world');
+  });
+  it('falls back when nothing usable remains', () => {
+    expect(slugify('!!!', 'step')).toBe('step');
+    expect(slugify('')).toBe('item');
+  });
+});
+
+describe('uniqueKey', () => {
+  it('returns the base when free and suffixes on collision', () => {
+    const taken = new Set(['role', 'role_2']);
+    expect(uniqueKey('name', taken)).toBe('name');
+    expect(uniqueKey('role', taken)).toBe('role_3');
+  });
+});
+
+describe('defaultFlowGroup', () => {
+  it('marks lead-capture field types, qualification otherwise', () => {
+    expect(defaultFlowGroup('email')).toBe('lead_capture');
+    expect(defaultFlowGroup('phone')).toBe('lead_capture');
+    expect(defaultFlowGroup('name')).toBe('lead_capture');
+    expect(defaultFlowGroup('dropdown')).toBe('qualification');
+    expect(defaultFlowGroup('slider')).toBe('qualification');
+  });
+});
+
+describe('createEmptyStep', () => {
+  it('produces a valid step with a unique key and per-type defaults', () => {
+    const drop = createEmptyStep('dropdown', new Set(['dropdown_1']));
+    expect(drop.type).toBe('dropdown');
+    expect(drop.key).not.toBe('dropdown_1');
+    expect(drop.options).toHaveLength(1);
+    expect(drop.flowGroup).toBe('qualification');
+
+    const slider = createEmptyStep('slider');
+    expect(slider.min).toBe(0);
+    expect(slider.max).toBe(100);
+    expect(slider.default).toBe(50);
+
+    const msg = createEmptyStep('message');
+    expect(msg.required).toBe(false);
+    expect(msg.buttonText).toBeTruthy();
+
+    const email = createEmptyStep('email');
+    expect(email.flowGroup).toBe('lead_capture');
+  });
+});
+
+describe('createEmptyOutcome', () => {
+  it('mints a unique id', () => {
+    const o = createEmptyOutcome(new Set(['outcome_1']));
+    expect(o.id).toBeTruthy();
+    expect(o.label).toBe('');
+  });
+});
+
+describe('hasScoringSignal', () => {
+  it('detects points, ranges, and outcomes', () => {
+    expect(hasScoringSignal({ version: 1, steps: [] })).toBe(false);
+    expect(
+      hasScoringSignal({
+        version: 1,
+        steps: [step({ key: 'a', type: 'dropdown', options: [{ label: 'x', value: 'x', points: 3 }] })],
+      }),
+    ).toBe(true);
+    expect(
+      hasScoringSignal({ version: 1, steps: [], outcomes: [{ id: 'o', label: 'Hot', minScore: 5 }] }),
+    ).toBe(true);
+  });
+});
+
+describe('normalizeConfig', () => {
+  it('dedupes step keys and rewrites references to renamed keys', () => {
+    const config: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: 'dup', type: 'dropdown', options: [{ label: 'A', value: 'a', points: 1 }] }),
+        step({ key: 'dup', type: 'text' }), // collides → becomes dup_2
+        step({ key: 'q3', type: 'text', showWhen: { field: 'dup', values: ['a'] } }),
+      ],
+    };
+    const out = normalizeConfig(config);
+    expect(out.steps.map((s) => s.key)).toEqual(['dup', 'dup_2', 'q3']);
+    // The condition still points at the FIRST step (unchanged key).
+    expect(out.steps[2].showWhen).toEqual({ field: 'dup', values: ['a'] });
+  });
+
+  it('generates keys for blank ones from the question', () => {
+    const out = normalizeConfig({
+      version: 1,
+      steps: [step({ key: '', type: 'text', question: 'What is your budget?' })],
+    });
+    expect(out.steps[0].key).toBe('what_is_your_budget');
+  });
+
+  it('derives flowGroup and fills option values, and derives scoring', () => {
+    const out = normalizeConfig({
+      version: 1,
+      steps: [
+        step({ key: 'email', type: 'email' }),
+        step({
+          key: 'role',
+          type: 'dropdown',
+          options: [
+            { label: 'Founder', value: '', points: 10 },
+            { label: 'Founder', value: '', points: 0 }, // dup slug → founder_2
+          ],
+        }),
+      ],
+    });
+    expect(out.steps[0].flowGroup).toBe('lead_capture');
+    expect(out.steps[1].flowGroup).toBe('qualification');
+    expect(out.steps[1].options?.map((o) => o.value)).toEqual(['founder', 'founder_2']);
+    expect(out.scoring).toEqual({ enabled: true });
+  });
+
+  it('sorts outcomes by minScore ascending and keeps unique ids', () => {
+    const out = normalizeConfig({
+      version: 1,
+      steps: [],
+      outcomes: [
+        { id: 'hot', label: 'Hot', minScore: 20 },
+        { id: 'cold', label: 'Cold', minScore: 0 },
+      ],
+    });
+    expect(out.outcomes?.map((o) => o.minScore)).toEqual([0, 20]);
+  });
+
+  it('respects an explicit scoring flag and is idempotent', () => {
+    const config: FormConfig = {
+      version: 1,
+      scoring: { enabled: false },
+      steps: [step({ key: 'role', type: 'dropdown', options: [{ label: 'A', value: 'a', points: 5 }] })],
+    };
+    const once = normalizeConfig(config);
+    expect(once.scoring).toEqual({ enabled: false });
+    expect(normalizeConfig(once)).toEqual(once);
+  });
+});
+
+describe('interpolate', () => {
+  it('replaces [field] tokens with answers, joining arrays', () => {
+    expect(interpolate('Hi [name], budget [budget]?', { name: 'Ada', budget: 500 })).toBe(
+      'Hi Ada, budget 500?',
+    );
+    expect(interpolate('Picked [tools]', { tools: ['a', 'b'] })).toBe('Picked a, b');
+    expect(interpolate('Hi [missing]', {})).toBe('Hi ');
+  });
+});
+
+describe('resolveQuestion', () => {
+  const s = step({
+    key: 'detail',
+    type: 'text',
+    question: 'Tell us more',
+    questionField: 'role',
+    questionVariants: { founder: 'Tell us about [company]', '*': 'Tell us about your work' },
+  });
+  it('picks the variant matching the referenced answer, interpolated', () => {
+    expect(resolveQuestion(s, { role: 'founder', company: 'Acme' })).toBe('Tell us about Acme');
+  });
+  it('falls back to * then to the plain question', () => {
+    expect(resolveQuestion(s, { role: 'student' })).toBe('Tell us about your work');
+    expect(resolveQuestion({ ...s, questionVariants: { founder: 'x' } }, { role: 'student' })).toBe(
+      'Tell us more',
+    );
+  });
+});

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -1,0 +1,221 @@
+/**
+ * Pure config authoring helpers — the builder's counterpart to form-logic. No
+ * DB, no I/O, no framework. The admin editor and the API both lean on these so
+ * a saved config is always canonical: unique step keys, a stable derived flow
+ * group per step, sorted/id'd outcomes, and clean option values. Kept here (not
+ * in the UI) so it's fully unit-tested and identical on client and server.
+ */
+
+import type {
+  FormConfig,
+  FormStep,
+  FormFieldType,
+  FormOption,
+  FormOutcome,
+  Answers,
+  AnswerValue,
+} from './form-logic';
+
+/** Field kinds that capture the lead and therefore never score. */
+const LEAD_CAPTURE_TYPES: ReadonlySet<FormFieldType> = new Set<FormFieldType>([
+  'name',
+  'email',
+  'phone',
+]);
+
+/** slugify to a safe key/value token; falls back when nothing usable remains. */
+export function slugify(text: string, fallback = 'item'): string {
+  const slug = text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return slug || fallback;
+}
+
+/** Make `base` unique against `taken` by appending `_2`, `_3`, … (deterministic). */
+export function uniqueKey(base: string, taken: ReadonlySet<string>): string {
+  if (!taken.has(base)) return base;
+  let i = 2;
+  while (taken.has(`${base}_${i}`)) i += 1;
+  return `${base}_${i}`;
+}
+
+/** The default flow group for a step type when the author hasn't set one. */
+export function defaultFlowGroup(type: FormFieldType): FormStep['flowGroup'] {
+  return LEAD_CAPTURE_TYPES.has(type) ? 'lead_capture' : 'qualification';
+}
+
+let stepSeq = 0;
+/**
+ * A fresh, valid step of `type` with a unique key. Sensible per-type defaults
+ * mirror the pilot (choice steps start with one option; sliders get a 0–100
+ * range). `taken` guarantees the generated key doesn't collide.
+ */
+export function createEmptyStep(
+  type: FormFieldType,
+  taken: ReadonlySet<string> = new Set(),
+): FormStep {
+  stepSeq += 1;
+  const key = uniqueKey(`${type}_${stepSeq}`, taken);
+  const base: FormStep = {
+    key,
+    type,
+    question: '',
+    required: !(type === 'message'),
+    flowGroup: defaultFlowGroup(type),
+  };
+
+  if (type === 'dropdown' || type === 'multiple_choice') {
+    base.options = [{ label: 'Option 1', value: 'option_1', points: 0 }];
+  }
+  if (type === 'slider') {
+    base.min = 0;
+    base.max = 100;
+    base.step = 1;
+    base.default = 50;
+    base.sliderScoring = [];
+  }
+  if (type === 'message') {
+    base.buttonText = 'Continue';
+  }
+  return base;
+}
+
+/** A blank outcome bucket with a unique id. */
+export function createEmptyOutcome(taken: ReadonlySet<string> = new Set()): FormOutcome {
+  stepSeq += 1;
+  return { id: uniqueKey(`outcome_${stepSeq}`, taken), label: '', minScore: 0 };
+}
+
+/** Normalize a single step's options: fill values from labels, dedupe values. */
+function normalizeOptions(options: FormOption[] | undefined): FormOption[] | undefined {
+  if (!options || options.length === 0) return options;
+  const taken = new Set<string>();
+  return options.map((o, i) => {
+    const base = (o.value && o.value.trim()) || slugify(o.label ?? '', `option_${i + 1}`);
+    const value = uniqueKey(base, taken);
+    taken.add(value);
+    return {
+      label: o.label ?? value,
+      value,
+      ...(o.points != null ? { points: o.points } : {}),
+      ...(o.icon ? { icon: o.icon } : {}),
+    };
+  });
+}
+
+/** True when the config carries any scoring signal (points / ranges / outcomes). */
+export function hasScoringSignal(config: FormConfig): boolean {
+  if ((config.outcomes ?? []).length > 0) return true;
+  return config.steps.some(
+    (s) =>
+      (s.points ?? 0) !== 0 ||
+      (s.sliderScoring ?? []).length > 0 ||
+      (s.options ?? []).some((o) => (o.points ?? 0) !== 0),
+  );
+}
+
+/**
+ * Return a canonical, save-ready config:
+ *  - every step has a unique, non-empty `key` (collisions get `_2`, `_3`…),
+ *  - references (`showWhen`/`hideWhen`/`questionField`) are rewritten to follow
+ *    any key that had to change, so skip-logic never dangles,
+ *  - each step gets a derived `flowGroup` when absent (lead-capture fields
+ *    never score),
+ *  - options get filled/deduped values,
+ *  - outcomes are sorted by `minScore` ascending with unique ids,
+ *  - `scoring.enabled` is derived when the author left it unset but the form
+ *    clearly scores.
+ * Pure and idempotent: normalizing an already-canonical config is a no-op.
+ */
+export function normalizeConfig(config: FormConfig): FormConfig {
+  const taken = new Set<string>();
+  const assigned: string[] = [];
+  const preserved = new Set<string>();
+
+  const steps: FormStep[] = config.steps.map((step, i) => {
+    const desired =
+      (step.key && step.key.trim()) || slugify(step.question ?? '', `step_${i + 1}`);
+    const key = uniqueKey(desired, taken);
+    taken.add(key);
+    assigned.push(key);
+    if (step.key && step.key === key) preserved.add(step.key);
+    return { ...step, key };
+  });
+
+  // Build the rename map only for keys that actually changed and weren't kept
+  // by an earlier step (a reference to a duplicated key resolves to the first,
+  // preserved occurrence — never to the suffixed later one).
+  const rename = new Map<string, string>();
+  config.steps.forEach((step, i) => {
+    if (step.key && step.key !== assigned[i] && !preserved.has(step.key) && !rename.has(step.key)) {
+      rename.set(step.key, assigned[i]);
+    }
+  });
+
+  const remap = (field: string): string => rename.get(field) ?? field;
+
+  const normalized = steps.map((step) => {
+    const next: FormStep = {
+      ...step,
+      flowGroup: step.flowGroup ?? defaultFlowGroup(step.type),
+    };
+    if (step.options) next.options = normalizeOptions(step.options);
+    if (step.showWhen) next.showWhen = { ...step.showWhen, field: remap(step.showWhen.field) };
+    if (step.hideWhen) next.hideWhen = { ...step.hideWhen, field: remap(step.hideWhen.field) };
+    if (step.questionField) next.questionField = remap(step.questionField);
+    return next;
+  });
+
+  const outcomeIds = new Set<string>();
+  const outcomes = (config.outcomes ?? [])
+    .map((o, i) => {
+      const id = uniqueKey((o.id && o.id.trim()) || `outcome_${i + 1}`, outcomeIds);
+      outcomeIds.add(id);
+      return { ...o, id };
+    })
+    .sort((a, b) => (a.minScore ?? 0) - (b.minScore ?? 0));
+
+  const next: FormConfig = {
+    version: 1,
+    steps: normalized,
+    ...(config.cover != null ? { cover: config.cover } : {}),
+    ...(config.branding != null ? { branding: config.branding } : {}),
+    ...(outcomes.length ? { outcomes } : {}),
+  };
+
+  // Derive scoring only when the author never spoke to it.
+  if (config.scoring != null) {
+    next.scoring = config.scoring;
+  } else if (hasScoringSignal(next)) {
+    next.scoring = { enabled: true };
+  }
+
+  return next;
+}
+
+/** Replace `[field]` tokens with the respondent's answer to that field. */
+export function interpolate(template: string, answers: Answers): string {
+  return template.replace(/\[([a-zA-Z0-9_]+)\]/g, (_, field: string) => {
+    const value: AnswerValue = answers[field];
+    if (value == null) return '';
+    return Array.isArray(value) ? value.join(', ') : String(value);
+  });
+}
+
+/**
+ * The question to show for a step given the answers so far: a `questionVariants`
+ * match on `questionField` (falling back to `*` then the plain `question`), with
+ * `[field]` interpolation applied to the result.
+ */
+export function resolveQuestion(step: FormStep, answers: Answers): string {
+  let text = step.question ?? '';
+  if (step.questionField && step.questionVariants) {
+    const raw = answers[step.questionField];
+    const key = raw == null ? '' : Array.isArray(raw) ? raw.join(',') : String(raw);
+    text = step.questionVariants[key] ?? step.questionVariants['*'] ?? text;
+  }
+  return interpolate(text, answers);
+}

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -75,6 +75,14 @@ export interface FormStep {
   corporateEmailOnly?: boolean;
   /** Phone validation: minimum digit count. */
   phoneMinDigits?: number;
+  /**
+   * Dynamic question variants: pick the question text from the answer to
+   * `questionField`. `questionVariants[value]` overrides `question` when the
+   * respondent's answer to that earlier field matches a key; a `*` key (or the
+   * plain `question`) is the fallback. Lets one step ask a tailored question.
+   */
+  questionField?: string | null;
+  questionVariants?: Record<string, string>;
 }
 
 export interface FormOutcome {
@@ -87,6 +95,8 @@ export interface FormOutcome {
 
 export interface FormCover {
   enabled?: boolean;
+  /** A sticky banner line shown above the form throughout the flow. */
+  bannerText?: string | null;
   eyebrow?: string | null;
   headline?: string | null;
   subheadline?: string | null;
@@ -94,9 +104,15 @@ export interface FormCover {
   trustBadge?: string | null;
 }
 
+/** Per-form branding — the single accent color drives the public surface. */
+export interface FormBranding {
+  primaryColor?: string | null;
+}
+
 export interface FormConfig {
   version: 1;
   cover?: FormCover | null;
+  branding?: FormBranding | null;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,6 +3,7 @@
  * Fully unit-tested; portable across SQLite and Postgres deployments.
  */
 export * from './form-logic';
+export * from './form-config';
 export * from './short-links';
 export * from './manage-token';
 export * from './pg-errors';

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -30,6 +30,171 @@ export interface FormsMessages {
       error: string;
       retry: string;
     };
+    /** The forms list (index) page. */
+    forms: {
+      title: string;
+      subtitle: string;
+      create: string;
+      createTitle: string;
+      nameLabel: string;
+      namePlaceholder: string;
+      cancel: string;
+      emptyTitle: string;
+      emptyBody: string;
+      updated: string;
+      duplicate: string;
+      delete: string;
+      deleteConfirm: string;
+      copy: string;
+      copied: string;
+      open: string;
+    };
+    /** The form editor (builder). */
+    editor: {
+      back: string;
+      save: string;
+      saving: string;
+      saved: string;
+      saveError: string;
+      previewBtn: string;
+      formNamePlaceholder: string;
+      tabs: { build: string; cover: string; outcomes: string; flow: string };
+      steps: {
+        title: string;
+        add: string;
+        addType: string;
+        empty: string;
+        select: string;
+        delete: string;
+        deleteConfirm: string;
+        dragHint: string;
+        stepN: string;
+        untitled: string;
+      };
+      types: {
+        text: string;
+        name: string;
+        email: string;
+        phone: string;
+        dropdown: string;
+        multiple_choice: string;
+        slider: string;
+        textarea: string;
+        message: string;
+      };
+      props: {
+        type: string;
+        question: string;
+        questionPlaceholder: string;
+        helper: string;
+        placeholder: string;
+        required: string;
+        buttonText: string;
+        buttonTextPlaceholder: string;
+        flowGroup: string;
+        qualification: string;
+        leadCapture: string;
+        flowGroupHint: string;
+        corporateEmailOnly: string;
+        corporateEmailHint: string;
+        phoneMinDigits: string;
+        sliderMin: string;
+        sliderMax: string;
+        sliderStep: string;
+        sliderDefault: string;
+      };
+      options: {
+        title: string;
+        add: string;
+        label: string;
+        value: string;
+        points: string;
+        icon: string;
+        remove: string;
+        empty: string;
+      };
+      sliderScoring: {
+        title: string;
+        hint: string;
+        add: string;
+        min: string;
+        max: string;
+        points: string;
+        remove: string;
+        empty: string;
+      };
+      logic: {
+        title: string;
+        showWhen: string;
+        hideWhen: string;
+        none: string;
+        field: string;
+        values: string;
+        valuesHint: string;
+        clear: string;
+        noPriorFields: string;
+      };
+      variants: {
+        title: string;
+        hint: string;
+        enable: string;
+        field: string;
+        add: string;
+        matchValue: string;
+        matchValuePlaceholder: string;
+        variantQuestion: string;
+        fallback: string;
+        remove: string;
+        interpolationHint: string;
+      };
+      cover: {
+        title: string;
+        subtitle: string;
+        enabled: string;
+        bannerText: string;
+        eyebrow: string;
+        headline: string;
+        subheadline: string;
+        ctaText: string;
+        trustBadge: string;
+        branding: string;
+        primaryColor: string;
+        primaryColorHint: string;
+      };
+      outcomes: {
+        title: string;
+        subtitle: string;
+        scoringEnabled: string;
+        scoringHint: string;
+        add: string;
+        label: string;
+        labelPlaceholder: string;
+        minScore: string;
+        redirectUrl: string;
+        redirectPlaceholder: string;
+        remove: string;
+        empty: string;
+      };
+      flow: {
+        title: string;
+        subtitle: string;
+        cover: string;
+        end: string;
+        conditional: string;
+        empty: string;
+      };
+      preview: {
+        title: string;
+        empty: string;
+        coverTitle: string;
+        step: string;
+        of: string;
+        device: string;
+        mobile: string;
+        desktop: string;
+        close: string;
+      };
+    };
   };
 }
 
@@ -56,6 +221,169 @@ export const en: FormsMessages = {
       error: 'Something went wrong signing in. Please try again.',
       retry: 'Try again',
     },
+    forms: {
+      title: 'Forms',
+      subtitle: 'Build a form, share the public link, collect submissions.',
+      create: 'Create form',
+      createTitle: 'Create a new form',
+      nameLabel: 'Form name',
+      namePlaceholder: 'e.g. Lead qualification quiz',
+      cancel: 'Cancel',
+      emptyTitle: 'No forms yet',
+      emptyBody: 'Create your first form to start collecting responses.',
+      updated: 'Updated {when}',
+      duplicate: 'Duplicate',
+      delete: 'Delete',
+      deleteConfirm: 'Delete this form and all its submissions?',
+      copy: 'Copy link',
+      copied: 'Copied',
+      open: 'Open',
+    },
+    editor: {
+      back: 'Back to forms',
+      save: 'Save',
+      saving: 'Saving…',
+      saved: 'Saved.',
+      saveError: 'Could not save — please try again.',
+      previewBtn: 'Preview',
+      formNamePlaceholder: 'Form name',
+      tabs: { build: 'Build', cover: 'Cover', outcomes: 'Outcomes', flow: 'Flow' },
+      steps: {
+        title: 'Steps',
+        add: 'Add step',
+        addType: 'Step type',
+        empty: 'No steps yet. Add your first step.',
+        select: 'Select a step to edit it.',
+        delete: 'Delete step',
+        deleteConfirm: 'Delete this step?',
+        dragHint: 'Drag to reorder',
+        stepN: 'Step {n}',
+        untitled: 'Untitled step',
+      },
+      types: {
+        text: 'Text',
+        name: 'Full name',
+        email: 'Email',
+        phone: 'Phone',
+        dropdown: 'Dropdown',
+        multiple_choice: 'Multiple choice',
+        slider: 'Slider',
+        textarea: 'Long text',
+        message: 'Message (no input)',
+      },
+      props: {
+        type: 'Type',
+        question: 'Question',
+        questionPlaceholder: 'What do you want to ask?',
+        helper: 'Helper text',
+        placeholder: 'Placeholder',
+        required: 'Required',
+        buttonText: 'Button text',
+        buttonTextPlaceholder: 'Continue',
+        flowGroup: 'Flow group',
+        qualification: 'Qualification',
+        leadCapture: 'Lead capture',
+        flowGroupHint: 'Lead-capture fields (name, email, phone) never contribute to the score.',
+        corporateEmailOnly: 'Require work email',
+        corporateEmailHint: 'Blocks Gmail, Hotmail, Yahoo and other personal domains.',
+        phoneMinDigits: 'Minimum digits',
+        sliderMin: 'Min',
+        sliderMax: 'Max',
+        sliderStep: 'Step',
+        sliderDefault: 'Default',
+      },
+      options: {
+        title: 'Options',
+        add: 'Add option',
+        label: 'Label',
+        value: 'Value',
+        points: 'Points',
+        icon: 'Icon',
+        remove: 'Remove option',
+        empty: 'No options yet.',
+      },
+      sliderScoring: {
+        title: 'Slider scoring',
+        hint: 'Award points when the value falls inside a range.',
+        add: 'Add range',
+        min: 'From',
+        max: 'To',
+        points: 'Points',
+        remove: 'Remove range',
+        empty: 'No scoring ranges — the slider does not score.',
+      },
+      logic: {
+        title: 'Conditional visibility',
+        showWhen: 'Show when',
+        hideWhen: 'Hide when',
+        none: 'Always show',
+        field: 'Field',
+        values: 'Matches any of',
+        valuesHint: 'Comma-separated values from that field’s options.',
+        clear: 'Clear',
+        noPriorFields: 'Add a step before this one to branch on its answer.',
+      },
+      variants: {
+        title: 'Dynamic question',
+        hint: 'Ask a different question depending on an earlier answer.',
+        enable: 'Vary the question by a field',
+        field: 'Based on field',
+        add: 'Add variant',
+        matchValue: 'When answer is',
+        matchValuePlaceholder: 'e.g. founder',
+        variantQuestion: 'Ask instead',
+        fallback: 'Fallback (any other answer)',
+        remove: 'Remove variant',
+        interpolationHint: 'Use [field] to insert an earlier answer into the question.',
+      },
+      cover: {
+        title: 'Cover screen',
+        subtitle: 'The intro screen shown before the first step.',
+        enabled: 'Show a cover screen',
+        bannerText: 'Banner text',
+        eyebrow: 'Eyebrow',
+        headline: 'Headline',
+        subheadline: 'Subheadline',
+        ctaText: 'Start button text',
+        trustBadge: 'Trust badge',
+        branding: 'Branding',
+        primaryColor: 'Primary color',
+        primaryColorHint: 'Drives the accent on the public form. Auto-adjusted for contrast.',
+      },
+      outcomes: {
+        title: 'Outcomes',
+        subtitle: 'Route respondents by their score. The highest bucket they clear wins.',
+        scoringEnabled: 'Enable scoring',
+        scoringHint: 'When off, every submission scores 0 and no outcome is resolved.',
+        add: 'Add outcome',
+        label: 'Label',
+        labelPlaceholder: 'e.g. Hot lead',
+        minScore: 'Minimum score',
+        redirectUrl: 'Redirect URL',
+        redirectPlaceholder: 'https://…',
+        remove: 'Remove outcome',
+        empty: 'No outcomes yet. Add buckets to route by score.',
+      },
+      flow: {
+        title: 'Flow overview',
+        subtitle: 'A read-only map of the form, including conditional branches.',
+        cover: 'Cover',
+        end: 'End',
+        conditional: 'Conditional',
+        empty: 'Add steps to see the flow.',
+      },
+      preview: {
+        title: 'Live preview',
+        empty: 'Select a step to preview it.',
+        coverTitle: 'Cover',
+        step: 'Step',
+        of: 'of',
+        device: 'Device preview',
+        mobile: 'Mobile',
+        desktop: 'Desktop',
+        close: 'Close',
+      },
+    },
   },
 };
 
@@ -81,6 +409,169 @@ export const es: FormsMessages = {
       workosSubtitle: 'Te redirigiremos para iniciar sesión de forma segura.',
       error: 'Algo salió mal al iniciar sesión. Inténtalo de nuevo.',
       retry: 'Reintentar',
+    },
+    forms: {
+      title: 'Formularios',
+      subtitle: 'Crea un formulario, comparte el enlace público y recibe respuestas.',
+      create: 'Crear formulario',
+      createTitle: 'Crear un formulario nuevo',
+      nameLabel: 'Nombre del formulario',
+      namePlaceholder: 'p. ej. Cuestionario de calificación de leads',
+      cancel: 'Cancelar',
+      emptyTitle: 'Aún no hay formularios',
+      emptyBody: 'Crea tu primer formulario para empezar a recibir respuestas.',
+      updated: 'Actualizado {when}',
+      duplicate: 'Duplicar',
+      delete: 'Eliminar',
+      deleteConfirm: '¿Eliminar este formulario y todas sus respuestas?',
+      copy: 'Copiar enlace',
+      copied: 'Copiado',
+      open: 'Abrir',
+    },
+    editor: {
+      back: 'Volver a formularios',
+      save: 'Guardar',
+      saving: 'Guardando…',
+      saved: 'Guardado.',
+      saveError: 'No se pudo guardar — inténtalo de nuevo.',
+      previewBtn: 'Vista previa',
+      formNamePlaceholder: 'Nombre del formulario',
+      tabs: { build: 'Construir', cover: 'Portada', outcomes: 'Resultados', flow: 'Flujo' },
+      steps: {
+        title: 'Pasos',
+        add: 'Añadir paso',
+        addType: 'Tipo de paso',
+        empty: 'Aún no hay pasos. Añade el primero.',
+        select: 'Selecciona un paso para editarlo.',
+        delete: 'Eliminar paso',
+        deleteConfirm: '¿Eliminar este paso?',
+        dragHint: 'Arrastra para reordenar',
+        stepN: 'Paso {n}',
+        untitled: 'Paso sin título',
+      },
+      types: {
+        text: 'Texto',
+        name: 'Nombre completo',
+        email: 'Correo',
+        phone: 'Teléfono',
+        dropdown: 'Desplegable',
+        multiple_choice: 'Opción múltiple',
+        slider: 'Deslizador',
+        textarea: 'Texto largo',
+        message: 'Mensaje (sin campo)',
+      },
+      props: {
+        type: 'Tipo',
+        question: 'Pregunta',
+        questionPlaceholder: '¿Qué quieres preguntar?',
+        helper: 'Texto de ayuda',
+        placeholder: 'Marcador de posición',
+        required: 'Obligatorio',
+        buttonText: 'Texto del botón',
+        buttonTextPlaceholder: 'Continuar',
+        flowGroup: 'Grupo de flujo',
+        qualification: 'Calificación',
+        leadCapture: 'Captura de lead',
+        flowGroupHint: 'Los campos de captura (nombre, correo, teléfono) nunca suman al puntaje.',
+        corporateEmailOnly: 'Exigir correo corporativo',
+        corporateEmailHint: 'Bloquea Gmail, Hotmail, Yahoo y otros dominios personales.',
+        phoneMinDigits: 'Dígitos mínimos',
+        sliderMin: 'Mín',
+        sliderMax: 'Máx',
+        sliderStep: 'Paso',
+        sliderDefault: 'Predeterminado',
+      },
+      options: {
+        title: 'Opciones',
+        add: 'Añadir opción',
+        label: 'Etiqueta',
+        value: 'Valor',
+        points: 'Puntos',
+        icon: 'Ícono',
+        remove: 'Quitar opción',
+        empty: 'Aún no hay opciones.',
+      },
+      sliderScoring: {
+        title: 'Puntaje del deslizador',
+        hint: 'Otorga puntos cuando el valor cae dentro de un rango.',
+        add: 'Añadir rango',
+        min: 'Desde',
+        max: 'Hasta',
+        points: 'Puntos',
+        remove: 'Quitar rango',
+        empty: 'Sin rangos de puntaje — el deslizador no suma.',
+      },
+      logic: {
+        title: 'Visibilidad condicional',
+        showWhen: 'Mostrar cuando',
+        hideWhen: 'Ocultar cuando',
+        none: 'Mostrar siempre',
+        field: 'Campo',
+        values: 'Coincide con',
+        valuesHint: 'Valores separados por comas de las opciones de ese campo.',
+        clear: 'Limpiar',
+        noPriorFields: 'Añade un paso antes de este para ramificar por su respuesta.',
+      },
+      variants: {
+        title: 'Pregunta dinámica',
+        hint: 'Haz una pregunta distinta según una respuesta anterior.',
+        enable: 'Variar la pregunta según un campo',
+        field: 'Según el campo',
+        add: 'Añadir variante',
+        matchValue: 'Cuando la respuesta sea',
+        matchValuePlaceholder: 'p. ej. fundador',
+        variantQuestion: 'Preguntar en su lugar',
+        fallback: 'Alternativa (cualquier otra respuesta)',
+        remove: 'Quitar variante',
+        interpolationHint: 'Usa [campo] para insertar una respuesta anterior en la pregunta.',
+      },
+      cover: {
+        title: 'Portada',
+        subtitle: 'La pantalla de introducción antes del primer paso.',
+        enabled: 'Mostrar una portada',
+        bannerText: 'Texto del banner',
+        eyebrow: 'Antetítulo',
+        headline: 'Titular',
+        subheadline: 'Subtítulo',
+        ctaText: 'Texto del botón de inicio',
+        trustBadge: 'Sello de confianza',
+        branding: 'Marca',
+        primaryColor: 'Color primario',
+        primaryColorHint: 'Define el acento del formulario público. Se ajusta para contraste.',
+      },
+      outcomes: {
+        title: 'Resultados',
+        subtitle: 'Enruta según el puntaje. Gana el rango más alto que alcancen.',
+        scoringEnabled: 'Activar puntaje',
+        scoringHint: 'Si está desactivado, todo suma 0 y no se resuelve ningún resultado.',
+        add: 'Añadir resultado',
+        label: 'Etiqueta',
+        labelPlaceholder: 'p. ej. Lead caliente',
+        minScore: 'Puntaje mínimo',
+        redirectUrl: 'URL de redirección',
+        redirectPlaceholder: 'https://…',
+        remove: 'Quitar resultado',
+        empty: 'Aún no hay resultados. Añade rangos para enrutar por puntaje.',
+      },
+      flow: {
+        title: 'Vista del flujo',
+        subtitle: 'Un mapa de solo lectura del formulario, incluidas las ramas condicionales.',
+        cover: 'Portada',
+        end: 'Fin',
+        conditional: 'Condicional',
+        empty: 'Añade pasos para ver el flujo.',
+      },
+      preview: {
+        title: 'Vista previa en vivo',
+        empty: 'Selecciona un paso para previsualizarlo.',
+        coverTitle: 'Portada',
+        step: 'Paso',
+        of: 'de',
+        device: 'Vista por dispositivo',
+        mobile: 'Móvil',
+        desktop: 'Escritorio',
+        close: 'Cerrar',
+      },
     },
   },
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -74,16 +74,27 @@ export const formStepSchema = z.object({
   flowGroup: z.enum(['qualification', 'lead_capture']).optional(),
   corporateEmailOnly: z.boolean().optional(),
   phoneMinDigits: z.number().int().positive().optional(),
+  /** Dynamic question: pick the text from the answer to this earlier field. */
+  questionField: z.string().min(1).nullable().optional(),
+  /** value → question text (a `*` key is the fallback); `[field]` interpolated. */
+  questionVariants: z.record(z.string(), z.string().max(500)).optional(),
 });
 export type FormStepInput = z.infer<typeof formStepSchema>;
 
 export const formCoverSchema = z.object({
   enabled: z.boolean().optional(),
+  /** A sticky banner line shown above the form throughout the flow. */
+  bannerText: z.string().max(200).nullable().optional(),
   eyebrow: z.string().max(200).nullable().optional(),
   headline: z.string().max(300).nullable().optional(),
   subheadline: z.string().max(500).nullable().optional(),
   ctaText: z.string().max(80).nullable().optional(),
   trustBadge: z.string().max(200).nullable().optional(),
+});
+
+/** Per-form branding — the single accent color drives the public surface. */
+export const formBrandingSchema = z.object({
+  primaryColor: z.string().max(32).nullable().optional(),
 });
 
 export const formOutcomeSchema = z.object({
@@ -97,6 +108,7 @@ export const formOutcomeSchema = z.object({
 export const formConfigSchema = z.object({
   version: z.literal(1),
   cover: formCoverSchema.nullable().optional(),
+  branding: formBrandingSchema.nullable().optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@quill/engine':
         specifier: workspace:*
         version: link:../../packages/engine
@@ -343,6 +352,28 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
@@ -3010,6 +3041,31 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.2.0
       prettier: 2.8.8
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@emnapi/runtime@1.11.2':
     dependencies:


### PR DESCRIPTION
## What

Replaces the placeholder JSON editor at `apps/web/app/admin/forms/[id]/edit` with a full visual form builder (Track A — Builder UI).

### Build tab (3-pane)
- **Left:** dnd-kit drag-reorder step list (keyboard-accessible), type-picker add, delete.
- **Center:** per-step properties for all 9 types (text, name, email, phone, dropdown, multiple_choice, slider, textarea, message):
  - question / helper / placeholder / required / buttonText / flowGroup
  - options editor — label / value / points / icon, drag-reorderable
  - slider min/max/step/default + `sliderScoring` ranges
  - conditional visibility `showWhen` / `hideWhen` with a prior-field picker (option chips)
  - dynamic question variants (`questionField` + `questionVariants`) with `[field]` interpolation
  - `corporateEmailOnly`, `phoneMinDigits`
- **Right:** inline live preview of the current step, rendered with the form's branding accent.

### Cover tab
Enable toggle, banner text, eyebrow, headline, subheadline, CTA text, trust badge + branding `primaryColor` picker (shows the AA-clamped swatch) with a live cover preview.

### Outcomes tab
Generalized score buckets (label / minScore / redirectUrl) + scoring enable toggle.

### Flow tab
Read-only diagram of the whole form incl. conditional-branch annotations and lead-capture badges.

### Preview
Inline live preview + a device-preview modal (mobile/desktop iframes of the public route).

### Forms list polish
`PageHeader` + create dialog (list/create pattern, no inline form), empty state, i18n.

## Engine (pure logic + tests)
`normalizeConfig` (dedupe keys + reference remap, derived flowGroup, option-value fill, outcome sort, derived scoring), `createEmptyStep`, `createEmptyOutcome`, `resolveQuestion`, `interpolate`, `slugify` — added to `@quill/engine` with **15 new unit tests**.

## Schema (additive-only)
`formStepSchema`: `questionField`, `questionVariants`. `formCoverSchema`: `bannerText`. `formConfigSchema`: `branding.primaryColor`. EN/ES i18n for every new string. Public renderer minimally wired to render dynamic questions + the cover banner.

## Verification
- `pnpm lint / typecheck / test / build` all green (14 lint tasks, 13 test tasks incl. 27 engine specs, full Next build).
- Booted API (4401) + web (3401) on SQLite; logged in as the seeded user.
- Built a 4-step quiz (dropdown w/ points → conditional text w/ dynamic-question variant → slider w/ scoring → lead-capture email) with a cover + branding + 2 outcomes **through the UI**.
- Confirmed round-trip: `PUT` then `GET /v1/forms/:id` returns exactly the built config — all new fields (`questionField`, `questionVariants`, `cover.bannerText`, `branding.primaryColor`), `showWhen` branching, `sliderScoring`, and outcomes persist.
- Design self-review vs DESIGN-QUALITY-BAR via headless Chrome at 1520px and 360px: sticky header, tokens-only, inline required asterisk, no button wrap, no native scrollbars, one primary CTA per view, responsive to 360px, keyboard-accessible drag. Device-preview iframe renders the real public form.

## Out of scope (untouched)
analytics / submissions / integrations pages (sibling tracks); public renderer changed only minimally (dynamic-question + banner) to make the features real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)