### PR TITLE
feat(renderer): public form experience — steps, logic, events, outcomes, growth

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -2,11 +2,14 @@
 
 import { postSubmission, postFormEvent } from '@/lib/api';
 
-/** Submit a completed form (score recomputed server-side). */
+/**
+ * Submit a form — partial (past the lead-capture threshold) or complete. The
+ * score is always recomputed server-side; the client value is never trusted.
+ */
 export async function submitFormAction(
   accountCode: string,
   slug: string,
-  payload: { sessionId: string; data: Record<string, unknown> },
+  payload: { sessionId: string; data: Record<string, unknown>; partial?: boolean },
 ): Promise<{ ok: boolean; score?: number; outcome?: string | null; message?: string }> {
   const res = await postSubmission(accountCode, slug, payload);
   return { ok: res.ok, score: res.score, outcome: res.outcome, message: res.message };

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -1,21 +1,39 @@
 'use client';
 
 /**
- * Minimal public form renderer (ugly-but-working; Phase 1 brings the real UI).
- * Walks the visible steps with the engine (skip-logic + validation shared with
- * the server), posts funnel events, and submits via the server action. The
- * per-session id lives in sessionStorage so events + submission tie together.
+ * The public form experience — a mobile-first, one-question-per-screen flow
+ * driven entirely by `@quill/engine` (visibleSteps/runtimeSteps/validate/score/
+ * outcome), so the client and server agree on flow, score, and outcome. It walks
+ * the engine's ordered visible steps, records the funnel event stream, persists a
+ * partial submission past the lead-capture threshold and a complete one at the
+ * end, then resolves the outcome bucket to a redirect or a thank-you screen.
+ *
+ * User-visible copy comes from the form CONFIG (localizable per form); only the
+ * renderer chrome (buttons, errors, thank-you) is i18n'd via @quill/shared.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  visibleSteps,
-  validateAnswer,
-  resolveQuestion,
+  runtimeSteps,
+  validateAnswerCode,
+  resolveOutcome,
+  partialSubmitKey,
+  nameFields,
   type Answers,
+  type AnswerValue,
   type FormStep,
 } from '@quill/engine';
+import { onAccent, getMessages, t } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
+import { signupHref } from '@/lib/growth';
+import { FormLogo } from '@/components/public/form-logo';
+import { FormProgress } from '@/components/public/form-progress';
+import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
+import { StepInput } from '@/components/public/step-input';
 import { submitFormAction, recordEventAction } from './actions';
+import './public-form.css';
+
+type Phase = 'cover' | 'steps' | 'reveal' | 'submitting' | 'done';
+const REVEAL_MS = 2200;
 
 function useSessionId(key: string): string {
   const [id] = useState(() => {
@@ -29,205 +47,438 @@ function useSessionId(key: string): string {
   return id;
 }
 
+/** Read `utm_*` query params from the current URL into a flat string map. */
+function captureUtm(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  const utm: Record<string, string> = {};
+  for (const [k, v] of params.entries()) {
+    if (k.toLowerCase().startsWith('utm_') && v) utm[k] = v;
+  }
+  return utm;
+}
+
 export function FormRenderer({
   accountCode,
   slug,
   name,
   config,
+  locale = 'en',
 }: {
   accountCode: string;
   slug: string;
   name: string;
   config: FormConfig;
+  locale?: string;
 }) {
+  const m = getMessages(locale).renderer;
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
-  const cover = config.cover?.enabled ? config.cover : null;
-  const [started, setStarted] = useState(!cover);
+  const cover = config.cover && config.cover.enabled !== false ? config.cover : null;
+
+  const [phase, setPhase] = useState<Phase>(cover ? 'cover' : 'steps');
   const [answers, setAnswers] = useState<Answers>({});
   const [index, setIndex] = useState(0);
+  const [animKey, setAnimKey] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [done, setDone] = useState<{ score?: number; outcome?: string | null } | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState<{ score: number; outcome: string | null } | null>(null);
 
-  // The engine decides which steps are visible given the answers so far.
-  const steps = useMemo(
-    () => visibleSteps(config as never, answers) as FormStep[],
-    [config, answers],
+  const utmRef = useRef<Record<string, string>>({});
+  const viewTracked = useRef(false);
+  const partialSent = useRef(false);
+  const advancing = useRef(false);
+  const submitAfterReveal = useRef(false);
+  const lastStepViewKey = useRef<string | null>(null);
+  const engineConfig = config as unknown as Parameters<typeof runtimeSteps>[0];
+
+  // The engine decides the ordered, visible, display-resolved steps.
+  const steps = useMemo<FormStep[]>(
+    () => runtimeSteps(engineConfig, answers),
+    [engineConfig, answers],
   );
-  const step = steps[Math.min(index, Math.max(steps.length - 1, 0))];
+  const step = steps[index];
+  const thresholdKey = useMemo(() => partialSubmitKey(engineConfig), [engineConfig]);
 
+  // Accent branding (only override the local default when a color is configured).
+  const primary = config.branding?.primaryColor ?? null;
+  const accentVars = primary
+    ? ({ ['--pf-primary']: primary, ['--pf-primary-contrast']: onAccent(primary) } as React.CSSProperties)
+    : undefined;
+
+  const err = (code: string) => m.errors[code as keyof typeof m.errors] ?? m.errors.required;
+
+  const track = useCallback(
+    (type: string, stepIndex?: number) => {
+      if (!sessionId) return;
+      void recordEventAction(accountCode, slug, { sessionId, type, stepIndex: stepIndex ?? null });
+    },
+    [accountCode, slug, sessionId],
+  );
+
+  // Capture UTM once, and fire a single `view` per session per load.
   useEffect(() => {
-    if (sessionId) void recordEventAction(accountCode, slug, { sessionId, type: 'view' });
-  }, [sessionId, accountCode, slug]);
+    utmRef.current = captureUtm();
+  }, []);
+  useEffect(() => {
+    if (!sessionId || viewTracked.current) return;
+    viewTracked.current = true;
+    track('view');
+  }, [sessionId, track]);
+
+  // step_view once when a step becomes current — keyed by phase+index so an
+  // answer keystroke (which recomputes `step`) never re-fires the same view.
+  useEffect(() => {
+    if (phase !== 'steps' || !step) return;
+    const key = `${phase}:${index}`;
+    if (lastStepViewKey.current === key) return;
+    lastStepViewKey.current = key;
+    track('step_view', index);
+  }, [phase, index, step, track]);
+
+  // Clamp the index if the visible-step set shrinks (a branch closed).
+  useEffect(() => {
+    if (phase === 'steps' && steps.length > 0 && index >= steps.length) {
+      setIndex(steps.length - 1);
+    }
+  }, [phase, index, steps.length]);
+
+  function withData(a: Answers): Record<string, unknown> {
+    const utm = utmRef.current;
+    return Object.keys(utm).length > 0 ? { ...a, utm } : { ...a };
+  }
+
+  const finalize = useCallback(
+    async (finalAnswers: Answers) => {
+      setPhase('submitting');
+      const res = await submitFormAction(accountCode, slug, {
+        sessionId,
+        data: withData(finalAnswers),
+      });
+      if (!res.ok) {
+        setError(res.message ?? err('submit'));
+        setPhase('steps');
+        return;
+      }
+      track('submit');
+      const score = res.score ?? 0;
+      const outcome = resolveOutcome(engineConfig, score);
+      if (outcome?.redirectUrl) {
+        window.location.href = outcome.redirectUrl;
+        return;
+      }
+      setDone({ score, outcome: res.outcome ?? null });
+      setPhase('done');
+    },
+    [accountCode, slug, sessionId, engineConfig, track],
+  );
+
+  const advance = useCallback(
+    async (nextAnswers: Answers, completed: FormStep) => {
+      if (advancing.current) return;
+      advancing.current = true;
+      try {
+        const nextSteps = runtimeSteps(engineConfig, nextAnswers);
+        const completedIdx = nextSteps.findIndex((s) => s.key === completed.key);
+        const isLast = completedIdx >= 0 ? completedIdx >= nextSteps.length - 1 : index >= nextSteps.length - 1;
+
+        track('step_complete', index);
+
+        // Partial submit once past the configured lead-capture threshold.
+        if (thresholdKey && completed.key === thresholdKey && !partialSent.current) {
+          partialSent.current = true;
+          track('partial_submit', index);
+          void submitFormAction(accountCode, slug, {
+            sessionId,
+            data: withData(nextAnswers),
+            partial: true,
+          });
+        }
+
+        // Terminal (disqualify) step → finalize now, skip reveal/booking.
+        if (completed.terminal) {
+          await finalize(nextAnswers);
+          return;
+        }
+
+        // Optional processing/reveal interstitial after this step.
+        const reveal = config.reveal && config.reveal.enabled !== false;
+        if (reveal && completed.triggersReveal) {
+          submitAfterReveal.current = isLast;
+          if (!isLast) setIndex(completedIdx + 1);
+          setPhase('reveal');
+          return;
+        }
+
+        if (isLast) {
+          await finalize(nextAnswers);
+          return;
+        }
+
+        setAnimKey((k) => k + 1);
+        setError(null);
+        setIndex(completedIdx >= 0 ? completedIdx + 1 : Math.min(index + 1, nextSteps.length - 1));
+      } finally {
+        advancing.current = false;
+      }
+    },
+    [engineConfig, index, thresholdKey, accountCode, slug, sessionId, config.reveal, finalize, track],
+  );
+
+  function submitCurrent() {
+    if (!step) return;
+    const check = validateAnswerCode(step, answers[step.key], answers);
+    if (!check.ok) {
+      setError(err(check.code));
+      return;
+    }
+    setError(null);
+    void advance(answers, step);
+  }
+
+  // Choice/dropdown selection: record the answer and auto-advance.
+  function select(value: string) {
+    if (!step) return;
+    const next = { ...answers, [step.key]: value };
+    setAnswers(next);
+    setError(null);
+    void advance(next, step);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key !== 'Enter' || !step) return;
+    if (step.type === 'textarea' || step.type === 'dropdown' || step.type === 'multiple_choice') return;
+    // Name: hop to the second field if the first is filled and the second empty.
+    if (step.type === 'name') {
+      const [, second] = nameFields(step);
+      if (second && !String(answers[second] ?? '').trim()) {
+        const inputs = (e.currentTarget as HTMLElement).querySelectorAll<HTMLInputElement>('.pf-name-fields .pf-input');
+        if (document.activeElement === inputs[0] && inputs[1]) {
+          e.preventDefault();
+          inputs[1].focus();
+          return;
+        }
+      }
+    }
+    e.preventDefault();
+    submitCurrent();
+  }
 
   function start() {
-    setStarted(true);
-    void recordEventAction(accountCode, slug, { sessionId, type: 'start' });
+    track('start');
+    lastStepViewKey.current = null;
+    setPhase('steps');
+    setIndex(0);
+    setAnimKey((k) => k + 1);
   }
 
-  function setValue(value: string | number) {
-    if (!step) return;
-    setAnswers((a) => ({ ...a, [step.key]: value }));
+  function back() {
     setError(null);
+    if (phase === 'steps' && index > 0) {
+      setAnimKey((k) => k + 1);
+      setIndex((i) => i - 1);
+    } else if (phase === 'steps' && index === 0 && cover) {
+      setPhase('cover');
+    }
   }
 
-  async function next() {
-    if (!step) return;
-    const check = validateAnswer(step, answers[step.key]);
-    if (!check.ok) {
-      setError(check.error);
-      return;
-    }
-    void recordEventAction(accountCode, slug, { sessionId, type: 'step_complete', stepIndex: index });
-    if (index + 1 < steps.length) {
-      setIndex(index + 1);
-      void recordEventAction(accountCode, slug, { sessionId, type: 'step_view', stepIndex: index + 1 });
-      return;
-    }
-    // Final step → submit.
-    setSubmitting(true);
-    const res = await submitFormAction(accountCode, slug, { sessionId, data: answers as Record<string, unknown> });
-    setSubmitting(false);
-    if (!res.ok) {
-      setError(res.message ?? 'Could not submit — please try again.');
-      return;
-    }
-    void recordEventAction(accountCode, slug, { sessionId, type: 'submit' });
-    setDone({ score: res.score, outcome: res.outcome });
-  }
+  // Drive the reveal interstitial: after REVEAL_MS, continue or finalize.
+  useEffect(() => {
+    if (phase !== 'reveal') return;
+    const timer = setTimeout(() => {
+      if (submitAfterReveal.current) {
+        submitAfterReveal.current = false;
+        void finalize(answers);
+      } else {
+        setAnimKey((k) => k + 1);
+        setPhase('steps');
+      }
+    }, REVEAL_MS);
+    return () => clearTimeout(timer);
+  }, [phase]);
 
-  if (done) {
+  // --- Screens --------------------------------------------------------------
+
+  if (phase === 'done' && done) {
+    const outcome = resolveOutcome(engineConfig, done.score);
+    const cta = signupHref('confirmation', accountCode);
     return (
-      <div className="flex flex-col items-center gap-3 rounded-md border border-border bg-card p-8 text-center">
-        <h1 className="text-2xl font-semibold">Thank you!</h1>
-        <p className="text-muted-foreground">Your responses to “{name}” were recorded.</p>
+      <div className="pf pf--done" style={accentVars}>
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <div className="pf-done__inner pf-animate">
+          <div className="pf-done__check" aria-hidden="true">
+            ✓
+          </div>
+          <h1 className="pf-done__title">{outcome?.label ?? m.thankYouTitle}</h1>
+          <p className="pf-done__body">{t(m.thankYouBody, { name })}</p>
+          {cta ? (
+            <>
+              <p className="pf-done__cta-question">{m.ctaQuestion}</p>
+              <a className="pf-done__cta" href={cta} target="_blank" rel="noopener noreferrer">
+                {m.ctaAction}
+                <span className="sr-only"> {m.newTab}</span>
+              </a>
+            </>
+          ) : null}
+        </div>
       </div>
     );
   }
 
-  if (!started && cover) {
+  if (phase === 'reveal') {
+    const reveal = config.reveal ?? {};
     return (
-      <div className="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-8 text-center">
-        {cover.bannerText ? (
-          <div className="mb-1 w-full rounded-md bg-primary/15 px-3 py-1.5 text-xs font-medium text-foreground">
-            {cover.bannerText}
+      <div className="pf pf--reveal" style={accentVars} role="status" aria-live="polite">
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <RevealBody
+          headline={reveal.headline ?? m.revealHeadline}
+          subtitle={reveal.subtitle ?? m.revealSubtitle}
+        />
+      </div>
+    );
+  }
+
+  if (phase === 'submitting') {
+    return (
+      <div className="pf pf--reveal" style={accentVars} role="status" aria-live="polite">
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <div className="pf-reveal__inner">
+          <div className="pf-reveal__spinner" aria-hidden="true" />
+          <p className="pf-reveal__subtitle">{m.submitting}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'cover' && cover) {
+    const logo = cover.logo ?? config.branding?.logo ?? null;
+    const logos = cover.clientLogos ?? config.branding?.clientLogos ?? [];
+    return (
+      <div
+        className="pf pf--cover"
+        style={accentVars}
+        onKeyDown={(e) => e.key === 'Enter' && start()}
+        tabIndex={-1}
+      >
+        {cover.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <header className="pf__cover-header">
+          <FormLogo src={logo} name={name} />
+        </header>
+        <div className="pf__cover-main">
+          <div className="pf__cover-content pf-animate">
+            {cover.eyebrow || cover.badge ? (
+              <p className="pf__badge">{cover.eyebrow ?? cover.badge}</p>
+            ) : null}
+            <h1 className="pf__title">{cover.headline ?? name}</h1>
+            {cover.subheadline ? <p className="pf__subheadline">{cover.subheadline}</p> : null}
+            {cover.trustBadge ? <p className="pf__trust">{cover.trustBadge}</p> : null}
           </div>
-        ) : null}
-        {cover.eyebrow ? (
-          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            {cover.eyebrow}
-          </span>
-        ) : null}
-        <h1 className="text-3xl font-semibold tracking-tight">{cover.headline ?? name}</h1>
-        {cover.subheadline ? <p className="text-muted-foreground">{cover.subheadline}</p> : null}
-        <button
-          type="button"
-          onClick={start}
-          className="rounded-md bg-primary px-6 py-3 font-semibold text-primary-foreground active:scale-[0.98]"
-        >
-          {cover.ctaText ?? 'Start'}
-        </button>
-        {cover.trustBadge ? <p className="text-xs text-muted-foreground">{cover.trustBadge}</p> : null}
+          <ClientLogosMarquee logos={logos} label={m.trustedBy} />
+        </div>
+        <div className="pf__cover-footer">
+          <button type="button" className="pf__btn" onClick={start}>
+            {cover.ctaText ?? m.start}
+          </button>
+        </div>
       </div>
     );
   }
 
   if (!step) {
-    return <p className="text-center text-muted-foreground">This form has no steps yet.</p>;
+    return (
+      <div className="pf" style={accentVars}>
+        <div className="pf__body">
+          <p className="pf__helper">{m.noSteps}</p>
+        </div>
+      </div>
+    );
   }
 
-  const value = answers[step.key];
+  const showContinue = step.type !== 'multiple_choice' && step.type !== 'dropdown';
+  const logo = cover?.logo ?? config.branding?.logo ?? null;
 
   return (
-    <div className="flex flex-col gap-5 rounded-md border border-border bg-card p-8">
-      {/* Progress dots across the currently-visible steps. */}
-      <div
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={steps.length}
-        aria-valuenow={index + 1}
-        className="flex items-center gap-1.5"
-      >
-        {steps.map((s, i) => (
-          <span
-            key={s.key}
-            className={`h-1.5 flex-1 rounded-full ${i <= index ? 'bg-primary' : 'bg-muted'}`}
-          />
-        ))}
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <h2 className="text-xl font-semibold">{resolveQuestion(step, answers) || step.key}</h2>
-        {step.helper ? <p className="text-sm text-muted-foreground">{step.helper}</p> : null}
-      </div>
-
-      {step.type === 'message' ? null : step.type === 'dropdown' || step.type === 'multiple_choice' ? (
-        <div className="flex flex-col gap-2">
-          {(step.options ?? []).map((o) => (
-            <button
-              key={o.value}
-              type="button"
-              onClick={() => setValue(o.value)}
-              className={`rounded-md border px-4 py-3 text-left transition-colors ${
-                value === o.value ? 'border-primary bg-primary/10' : 'border-border hover:border-primary'
-              }`}
-            >
-              {o.label}
+    <div className="pf" style={accentVars} onKeyDown={onKeyDown}>
+      {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+      <header className="pf__topbar">
+        <div className="pf__topbar-inner">
+          {index > 0 || cover ? (
+            <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+              ←
             </button>
-          ))}
+          ) : (
+            <span className="pf__back pf__back--placeholder" />
+          )}
+          <FormLogo src={logo} name={name} />
+          <span className="pf__back pf__back--placeholder" />
         </div>
-      ) : step.type === 'slider' ? (
-        <div className="flex items-center gap-3">
-          <input
-            type="range"
-            min={step.min ?? 0}
-            max={step.max ?? 100}
-            step={step.step ?? 1}
-            value={Number(value ?? step.default ?? step.min ?? 0)}
-            onChange={(e) => setValue(Number(e.target.value))}
-            className="flex-1"
-          />
-          <span className="w-12 text-right font-mono text-sm">
-            {String(value ?? step.default ?? step.min ?? 0)}
-          </span>
+        <FormProgress total={steps.length} currentIndex={index} locale={locale} />
+      </header>
+
+      <div className="pf__body">
+        <div className="pf__inner">
+          <div className="pf__content pf-animate" key={animKey}>
+            <div className="pf__question-wrap">
+              <h2 className="pf__question">{step.question ?? step.key}</h2>
+              {step.helper && step.type !== 'message' ? (
+                <p className="pf__helper">{step.helper}</p>
+              ) : null}
+            </div>
+
+            <div className="pf__fields">
+              <StepInput
+                step={step}
+                value={answers[step.key]}
+                answers={answers}
+                onChange={(v: AnswerValue) => {
+                  setAnswers((a) => ({ ...a, [step.key]: v }));
+                  setError(null);
+                }}
+                onFieldChange={(field, v) => {
+                  setAnswers((a) => ({ ...a, [field]: v }));
+                  setError(null);
+                }}
+                onSelect={select}
+                dropdownPlaceholder={m.dropdownPlaceholder}
+                dropdownEmpty={m.dropdownEmpty}
+              />
+
+              {error ? (
+                <p className="pf__error" role="alert">
+                  {error}
+                </p>
+              ) : null}
+
+              {showContinue ? (
+                <button type="button" className="pf__btn pf__btn--inline" onClick={submitCurrent}>
+                  {step.buttonText ?? (index + 1 === steps.length ? m.submit : m.next)}
+                </button>
+              ) : null}
+            </div>
+          </div>
         </div>
-      ) : step.type === 'textarea' ? (
-        <textarea
-          value={String(value ?? '')}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={step.placeholder ?? undefined}
-          rows={4}
-          className="rounded-md border border-border bg-background px-3 py-2"
-        />
-      ) : (
-        <input
-          type={step.type === 'email' ? 'email' : step.type === 'phone' ? 'tel' : 'text'}
-          value={String(value ?? '')}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={step.placeholder ?? undefined}
-          className="rounded-md border border-border bg-background px-3 py-2"
-        />
-      )}
+      </div>
+    </div>
+  );
+}
 
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
-
-      <div className="flex items-center justify-between">
-        <button
-          type="button"
-          onClick={() => setIndex(Math.max(0, index - 1))}
-          disabled={index === 0 || submitting}
-          className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-40"
-        >
-          Back
-        </button>
-        <button
-          type="button"
-          onClick={() => void next()}
-          disabled={submitting}
-          className="rounded-md bg-primary px-5 py-2.5 font-semibold text-primary-foreground active:scale-[0.98] disabled:opacity-50"
-        >
-          {submitting ? 'Submitting…' : index + 1 === steps.length ? (step.buttonText ?? 'Submit') : (step.buttonText ?? 'Next')}
-        </button>
+/** Reveal interstitial body with an animated determinate bar (generic copy). */
+function RevealBody({ headline, subtitle }: { headline: string; subtitle: string }) {
+  const [pct, setPct] = useState(4);
+  useEffect(() => {
+    const startedAt = Date.now();
+    const id = setInterval(() => {
+      const p = Math.min(100, Math.round(((Date.now() - startedAt) / REVEAL_MS) * 100));
+      setPct(p);
+      if (p >= 100) clearInterval(id);
+    }, 60);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="pf-reveal__inner">
+      <div className="pf-reveal__spinner" aria-hidden="true" />
+      <h1 className="pf-reveal__headline">{headline}</h1>
+      <p className="pf-reveal__subtitle">{subtitle}</p>
+      <div className="pf-reveal__track">
+        <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />
       </div>
     </div>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -18,6 +18,7 @@ import {
   resolveOutcome,
   partialSubmitKey,
   nameFields,
+  isSafeHttpUrl,
   type Answers,
   type AnswerValue,
   type FormStep,
@@ -162,8 +163,14 @@ export function FormRenderer({
       const score = res.score ?? 0;
       const outcome = resolveOutcome(engineConfig, score);
       if (outcome?.redirectUrl) {
-        window.location.href = outcome.redirectUrl;
-        return;
+        // Runtime XSS guard: only navigate to http(s). A non-http(s) protocol
+        // (javascript:/data:) is ignored + logged, falling through to the
+        // thank-you screen (the schema also rejects it on save — belt-and-braces).
+        if (isSafeHttpUrl(outcome.redirectUrl)) {
+          window.location.href = outcome.redirectUrl;
+          return;
+        }
+        console.warn('[forms] ignored non-http(s) redirectUrl');
       }
       setDone({ score, outcome: res.outcome ?? null });
       setPhase('done');
@@ -280,13 +287,20 @@ export function FormRenderer({
     }
   }
 
+  // Latest finalize + answers via refs so the reveal timer arms once per
+  // reveal-phase entry (not on every answers change) without a stale closure.
+  const finalizeRef = useRef(finalize);
+  finalizeRef.current = finalize;
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
+
   // Drive the reveal interstitial: after REVEAL_MS, continue or finalize.
   useEffect(() => {
     if (phase !== 'reveal') return;
     const timer = setTimeout(() => {
       if (submitAfterReveal.current) {
         submitAfterReveal.current = false;
-        void finalize(answers);
+        void finalizeRef.current(answersRef.current);
       } else {
         setAnimKey((k) => k + 1);
         setPhase('steps');

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -2,18 +2,32 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getPublicForm } from '@/lib/api';
 import { publicLocale } from '@/lib/locale';
+import { getMessages, t } from '@quill/shared';
 import { MadeWithBadge } from '@/components/made-with-badge';
 import { FormRenderer } from './form-renderer';
 
+/**
+ * SEO/OG metadata for the public form — the form name as the title and a
+ * localized description (the form's cover subheadline when present, else a
+ * templated fallback). `noindex` support is deferred to a later phase.
+ */
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ accountCode: string; slug: string }>;
+  params: Promise<{ accountCode: string; slug: string; lang?: string }>;
 }): Promise<Metadata> {
   const { accountCode, slug } = await params;
   const form = await getPublicForm(accountCode, slug);
   if (!form) return {};
-  return { title: form.name, openGraph: { title: form.name, type: 'website' } };
+  const locale = await publicLocale();
+  const description =
+    form.config.cover?.subheadline ?? t(getMessages(locale).growth.seoForm, { name: form.name });
+  return {
+    title: form.name,
+    description,
+    openGraph: { title: form.name, description, type: 'website' },
+    twitter: { card: 'summary', title: form.name, description },
+  };
 }
 
 // Public form page. The Server Component fetches the published config; the
@@ -34,9 +48,13 @@ export default async function PublicFormPage({
 
   return (
     <>
-      <main className="mx-auto flex min-h-dvh max-w-xl flex-col justify-center px-6 py-12">
-        <FormRenderer accountCode={accountCode} slug={slug} name={form.name} config={form.config} />
-      </main>
+      <FormRenderer
+        accountCode={accountCode}
+        slug={slug}
+        name={form.name}
+        config={form.config}
+        locale={locale}
+      />
       <MadeWithBadge locale={locale} accountCode={accountCode} />
     </>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1,0 +1,838 @@
+/* -----------------------------------------------------------------------------
+ * Public form renderer — a self-contained, mobile-first "one question per screen"
+ * surface (the pilot's King-Kong/Typeform feel). It is intentionally a single
+ * LIGHT look regardless of the app theme: a public form is a branded landing
+ * surface, not app chrome. The one instance-level value is the accent, threaded
+ * through `--pf-primary` (set inline from `branding.primaryColor`, AA-clamped by
+ * the engine's accent helper); everything else is a fixed local token so the
+ * page reads as one system. All rules are scoped under `.pf`.
+ * -------------------------------------------------------------------------- */
+
+.pf {
+  --pf-primary: #cbe84f;
+  --pf-primary-contrast: #1a1a1c;
+  --pf-bg: #f5f5f5;
+  --pf-surface: #ffffff;
+  --pf-text: #111114;
+  --pf-muted: #6b6b73;
+  --pf-border: #d9dade;
+  --pf-focus: #2563eb;
+  --pf-danger: #dc2626;
+  --pf-radius: 12px;
+  --pf-radius-sm: 8px;
+  --pf-gap: 12px;
+  --pf-ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--pf-bg);
+  color: var(--pf-text);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Themed scrollbars for any inner overflow region on this light surface
+   (Design Quality Bar §1 — never a native/dark track on a light surface). */
+.pf *::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.pf *::-webkit-scrollbar-track {
+  background: transparent;
+}
+.pf *::-webkit-scrollbar-thumb {
+  background: var(--pf-border);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.pf *::-webkit-scrollbar-thumb:hover {
+  background: var(--pf-muted);
+  background-clip: padding-box;
+}
+.pf * {
+  scrollbar-width: thin;
+  scrollbar-color: var(--pf-border) transparent;
+}
+
+.pf :focus-visible {
+  outline: 2px solid var(--pf-focus);
+  outline-offset: 2px;
+}
+
+/* ── Sticky promo banner ── */
+.pf__banner {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: var(--pf-primary);
+  color: var(--pf-primary-contrast);
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  padding: 12px 20px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  flex-shrink: 0;
+}
+
+/* ── Top bar (back · logo · spacer) ── */
+.pf__topbar {
+  background: var(--pf-surface);
+  border-bottom: 1px solid #eee;
+  padding: 14px 20px 18px;
+  flex-shrink: 0;
+}
+.pf__topbar-inner {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  align-items: center;
+  max-width: 480px;
+  margin: 0 auto 16px;
+}
+.pf__back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  background: none;
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--pf-text);
+  cursor: pointer;
+  border-radius: var(--pf-radius-sm);
+  transition: background 0.12s var(--pf-ease);
+}
+.pf__back:hover {
+  background: var(--pf-bg);
+}
+.pf__back--placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+.pf__logo-img {
+  display: block;
+  height: 32px;
+  width: auto;
+  max-width: 150px;
+  margin: 0 auto;
+  object-fit: contain;
+}
+.pf__logo--fallback {
+  text-align: center;
+  font-size: 20px;
+  font-weight: 700;
+}
+.pf__logo-dot {
+  color: var(--pf-primary);
+}
+
+/* ── Progress ── */
+.pf-progress {
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 2px;
+}
+.pf-progress__track {
+  height: 4px;
+  width: 100%;
+  background: var(--pf-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pf-progress__fill {
+  height: 100%;
+  background: var(--pf-primary);
+  border-radius: 999px;
+  transition: width 0.3s var(--pf-ease);
+}
+
+/* ── Body ── */
+.pf__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 32px 20px 28px;
+}
+.pf__inner {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.pf__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.pf-animate {
+  animation: pfSlideIn 0.32s var(--pf-ease);
+}
+@keyframes pfSlideIn {
+  from {
+    transform: translateX(28px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pf-animate {
+    animation: none;
+  }
+}
+
+/* ── Question typography ── */
+.pf__question-wrap {
+  width: 100%;
+  max-width: 540px;
+  margin: 0 auto;
+  padding: 0 8px;
+}
+.pf__question {
+  text-align: center;
+  font-size: clamp(20px, 4.6vw, 27px);
+  font-weight: 800;
+  line-height: 1.3;
+  margin: 0;
+  text-wrap: balance;
+}
+.pf__helper {
+  text-align: center;
+  font-size: 16px;
+  color: var(--pf-muted);
+  margin: 10px 0 0;
+  line-height: 1.45;
+}
+.pf__fields {
+  margin-top: 36px;
+}
+
+/* ── Inputs ── */
+.pf-input {
+  width: 100%;
+  padding: 16px;
+  font-size: 17px;
+  font-family: inherit;
+  color: var(--pf-text);
+  background: var(--pf-surface);
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.12s var(--pf-ease), box-shadow 0.12s var(--pf-ease);
+}
+.pf-input:focus {
+  border-color: var(--pf-focus);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+.pf-name-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--pf-gap);
+}
+@media (max-width: 480px) {
+  .pf-name-fields {
+    grid-template-columns: 1fr;
+  }
+}
+.pf-textarea {
+  resize: vertical;
+  min-height: 120px;
+  line-height: 1.5;
+}
+.pf-message__body {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--pf-muted);
+  text-align: center;
+}
+
+/* ── Choices — list ── */
+.pf-choices--list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-gap);
+}
+.pf-choice-list {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-height: 56px;
+  padding: 16px 20px;
+  font-size: 16px;
+  font-family: inherit;
+  font-weight: 500;
+  text-align: left;
+  color: var(--pf-text);
+  background: var(--pf-surface);
+  border: 2px solid transparent;
+  border-radius: var(--pf-radius);
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: border-color 0.12s var(--pf-ease), transform 0.08s var(--pf-ease);
+}
+.pf-choice-list:hover {
+  border-color: var(--pf-border);
+}
+.pf-choice-list:active {
+  transform: scale(0.995);
+}
+.pf-choice-list--selected {
+  border-color: var(--pf-primary);
+  background: color-mix(in srgb, var(--pf-primary) 14%, var(--pf-surface));
+}
+.pf-choice-list__radio {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--pf-border);
+  background: var(--pf-bg);
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s;
+}
+.pf-choice-list--selected .pf-choice-list__radio {
+  background: var(--pf-primary);
+  border-color: var(--pf-primary);
+  box-shadow: inset 0 0 0 3px var(--pf-surface);
+}
+.pf-choice-list__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #f3f4f6;
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+}
+.pf-choice-list__text {
+  flex: 1;
+  line-height: 1.35;
+}
+
+/* ── Choices — icon grid ── */
+.pf-choices--icons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--pf-gap);
+}
+@media (max-width: 400px) {
+  .pf-choices--icons {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.pf-choice-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-height: 96px;
+  padding: 16px 8px;
+  background: var(--pf-surface);
+  border: 2px solid transparent;
+  border-radius: 16px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  transition: border-color 0.12s var(--pf-ease), transform 0.08s var(--pf-ease);
+  font-family: inherit;
+}
+.pf-choice-icon:hover {
+  border-color: var(--pf-border);
+}
+.pf-choice-icon:active {
+  transform: scale(0.98);
+}
+.pf-choice-icon--selected {
+  border-color: var(--pf-primary);
+  background: color-mix(in srgb, var(--pf-primary) 12%, var(--pf-surface));
+}
+.pf-choice-icon__circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #f3f4f6;
+  font-size: 24px;
+  line-height: 1;
+}
+.pf-choice-icon__label {
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.25;
+}
+
+/* ── Searchable dropdown ── */
+.pf-dropdown {
+  position: relative;
+}
+.pf-dropdown__list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  background: var(--pf-surface);
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  max-height: 240px;
+  overflow-y: auto;
+}
+.pf-dropdown__option {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 16px;
+  font-family: inherit;
+  text-align: left;
+  color: var(--pf-text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.pf-dropdown__option:hover,
+.pf-dropdown__option:focus-visible {
+  background: var(--pf-bg);
+}
+.pf-dropdown__option--selected {
+  background: color-mix(in srgb, var(--pf-primary) 18%, var(--pf-surface));
+  font-weight: 600;
+}
+.pf-dropdown__empty {
+  padding: 12px 16px;
+  font-size: 15px;
+  color: var(--pf-muted);
+  text-align: center;
+}
+
+/* ── Slider ── */
+.pf-slider {
+  padding: 8px 4px 4px;
+}
+.pf-slider__pill {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 10px;
+  width: fit-content;
+  margin: 0 auto 24px;
+  background: var(--pf-text);
+  border-radius: 999px;
+  padding: 16px 40px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  white-space: nowrap;
+}
+.pf-slider__pill-num {
+  font-size: 40px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--pf-primary);
+  letter-spacing: -0.02em;
+}
+.pf-slider__pill-label {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.75);
+}
+.pf-slider__input {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  cursor: pointer;
+  margin: 0;
+  padding: 10px 0;
+  display: block;
+}
+.pf-slider__input::-webkit-slider-runnable-track {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--pf-primary) 0%,
+    var(--pf-primary) var(--pf-progress, 0%),
+    #e5e7eb var(--pf-progress, 0%),
+    #e5e7eb 100%
+  );
+}
+.pf-slider__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid var(--pf-text);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  margin-top: -11px;
+  cursor: grab;
+}
+.pf-slider__input:active::-webkit-slider-thumb {
+  transform: scale(1.08);
+  cursor: grabbing;
+}
+.pf-slider__input::-moz-range-thumb {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid var(--pf-text);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  cursor: grab;
+}
+.pf-slider__input::-moz-range-track {
+  height: 12px;
+  border-radius: 999px;
+  background: #e5e7eb;
+}
+.pf-slider__input::-moz-range-progress {
+  height: 12px;
+  border-radius: 999px;
+  background: var(--pf-primary);
+}
+.pf-slider__scale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  padding: 0 2px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #9ca3af;
+  user-select: none;
+}
+
+/* ── Error ── */
+.pf__error {
+  text-align: center;
+  font-size: 14px;
+  color: var(--pf-danger);
+  margin-top: 14px;
+}
+
+/* ── Primary button ── */
+.pf__btn {
+  display: block;
+  width: 100%;
+  min-height: 56px;
+  padding: 0 24px;
+  font-size: 17px;
+  font-weight: 700;
+  font-family: inherit;
+  color: var(--pf-primary-contrast);
+  background: var(--pf-primary);
+  border: none;
+  border-radius: var(--pf-radius);
+  cursor: pointer;
+  transition: opacity 0.12s, transform 0.08s var(--pf-ease);
+}
+.pf__btn:hover {
+  opacity: 0.92;
+}
+.pf__btn:active {
+  transform: scale(0.99);
+}
+.pf__btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.pf__btn--inline {
+  margin-top: 28px;
+}
+
+/* ── Cover ── */
+.pf--cover .pf__cover-header {
+  flex-shrink: 0;
+  background: var(--pf-surface);
+  border-bottom: 1px solid #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 20px;
+}
+.pf__cover-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  text-align: center;
+  gap: 8px;
+}
+.pf__cover-content {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.pf__badge {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--pf-muted);
+  margin: 0 0 12px;
+}
+.pf__title {
+  font-size: clamp(26px, 6vw, 36px);
+  font-weight: 800;
+  line-height: 1.25;
+  margin: 0;
+  text-wrap: balance;
+}
+.pf__subheadline {
+  font-size: clamp(15px, 3.6vw, 17px);
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--pf-muted);
+  margin: 16px 0 0;
+  text-wrap: balance;
+}
+.pf__trust {
+  font-size: 13px;
+  color: var(--pf-muted);
+  margin: 18px 0 0;
+}
+.pf__cover-footer {
+  flex-shrink: 0;
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 0 24px calc(40px + env(safe-area-inset-bottom));
+}
+
+/* ── Client-logos marquee ── */
+.pf-logos {
+  width: 100%;
+  max-width: 640px;
+  margin: 28px auto 0;
+}
+.pf-logos__label {
+  margin: 0 0 12px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.5);
+}
+.pf-logos__viewport {
+  overflow: hidden;
+  width: 100%;
+  mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+.pf-logos__track {
+  display: flex;
+  gap: var(--pf-gap);
+  width: max-content;
+  animation: pf-logos-marquee 24s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pf-logos__track {
+    animation: none;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+  }
+}
+.pf-logos__chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  padding: 8px 16px;
+  height: 48px;
+  min-width: 88px;
+  flex-shrink: 0;
+  font-weight: 700;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.7);
+}
+.pf-logos__img {
+  height: 26px;
+  max-width: 100px;
+  object-fit: contain;
+}
+@keyframes pf-logos-marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* ── Reveal / processing interstitial (generic, templated) ── */
+.pf--reveal {
+  text-align: center;
+}
+.pf-reveal__inner {
+  flex: 1;
+  max-width: 420px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+}
+.pf-reveal__spinner {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-top-color: var(--pf-primary);
+  animation: pf-spin 0.9s linear infinite;
+  margin-bottom: 28px;
+}
+@keyframes pf-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.pf-reveal__headline {
+  font-size: clamp(22px, 5vw, 28px);
+  font-weight: 800;
+  line-height: 1.2;
+  margin: 0 0 12px;
+  text-wrap: balance;
+}
+.pf-reveal__subtitle {
+  font-size: 16px;
+  color: var(--pf-muted);
+  margin: 0 0 24px;
+  line-height: 1.5;
+  text-wrap: balance;
+}
+.pf-reveal__track {
+  width: 260px;
+  max-width: 100%;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pf-reveal__fill {
+  height: 100%;
+  background: var(--pf-primary);
+  border-radius: 999px;
+  transition: width 0.08s linear;
+}
+
+/* ── Thank-you / outcome screen ── */
+.pf--done {
+  text-align: center;
+}
+.pf-done__inner {
+  flex: 1;
+  max-width: 460px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+}
+.pf-done__check {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--pf-primary);
+  color: var(--pf-primary-contrast);
+  font-size: 34px;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+.pf-done__title {
+  font-size: clamp(24px, 5vw, 30px);
+  font-weight: 800;
+  margin: 0 0 10px;
+}
+.pf-done__body {
+  font-size: 16px;
+  color: var(--pf-muted);
+  margin: 0 0 28px;
+  line-height: 1.5;
+  text-wrap: balance;
+}
+.pf-done__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 24px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--pf-primary-contrast);
+  background: var(--pf-primary);
+  border-radius: var(--pf-radius);
+  text-decoration: none;
+  transition: opacity 0.12s, transform 0.08s var(--pf-ease);
+}
+.pf-done__cta:hover {
+  opacity: 0.92;
+}
+.pf-done__cta:active {
+  transform: scale(0.99);
+}
+.pf-done__cta-question {
+  font-size: 14px;
+  color: var(--pf-muted);
+  margin: 0 0 12px;
+}
+
+/* ── Desktop niceties ── */
+@media (min-width: 769px) {
+  /* Vertically center the single question on larger screens so the composition
+     stays balanced rather than top-heavy (Design Quality Bar §9). Mobile keeps
+     the natural top-aligned flow. */
+  .pf__body {
+    padding: 44px 24px 36px;
+    justify-content: center;
+  }
+  .pf__inner {
+    flex: 0 1 auto;
+  }
+  .pf__fields {
+    margin-top: 40px;
+  }
+}
+@media (max-width: 480px) {
+  .pf__banner {
+    font-size: 12px;
+    padding: 10px 14px;
+  }
+  .pf__body {
+    padding: 24px 16px;
+  }
+  .pf__fields {
+    margin-top: 24px;
+  }
+  .pf-input {
+    font-size: 16px;
+  }
+}

--- a/apps/web/components/public/client-logos-marquee.tsx
+++ b/apps/web/components/public/client-logos-marquee.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormClientLogo } from '@quill/engine';
+
+function LogoChip({ logo }: { logo: FormClientLogo }) {
+  const [failed, setFailed] = useState(false);
+  const showText = !logo.src || failed;
+  return (
+    <div className="pf-logos__chip">
+      {!showText && logo.src ? (
+        <img
+          src={logo.src}
+          alt={logo.name}
+          className="pf-logos__img"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <span>{logo.name}</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Optional "trusted by" marquee on the cover. Config-driven logos (image or text
+ * fallback); duplicated once for a seamless loop. Falls back to a static wrapped
+ * row when the viewer prefers reduced motion (handled in CSS).
+ */
+export function ClientLogosMarquee({
+  logos,
+  label,
+}: {
+  logos: FormClientLogo[];
+  label: string;
+}) {
+  if (!logos.length) return null;
+  const items = [...logos, ...logos];
+  return (
+    <div className="pf-logos">
+      {label ? <p className="pf-logos__label">{label}</p> : null}
+      <div className="pf-logos__viewport">
+        <div className="pf-logos__track">
+          {items.map((logo, i) => (
+            <LogoChip key={`${logo.name}-${i}`} logo={logo} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/public/form-logo.tsx
+++ b/apps/web/components/public/form-logo.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * The form's logo in the top bar. Uses the per-form logo URL when set, else a
+ * text fallback (the form name). No hardcoded tenant asset — the pilot's baked-in
+ * Dapta logo is generalized to config-driven branding.
+ */
+export function FormLogo({ src, name }: { src?: string | null; name: string }) {
+  const [failed, setFailed] = useState(false);
+  if (src && !failed) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className="pf__logo-img"
+        height={32}
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return (
+    <span className="pf__logo--fallback">
+      {name}
+      <span className="pf__logo-dot">.</span>
+    </span>
+  );
+}

--- a/apps/web/components/public/form-progress.tsx
+++ b/apps/web/components/public/form-progress.tsx
@@ -1,0 +1,37 @@
+import { getMessages, t } from '@quill/shared';
+
+/**
+ * Linear progress across the CURRENTLY-visible steps. A real `progressbar` with
+ * aria-valuenow/min/max + a localized accessible label; the fill advances as the
+ * respondent moves through steps (visible steps only — hidden branches don't
+ * inflate the bar).
+ */
+export function FormProgress({
+  total,
+  currentIndex,
+  locale = 'en',
+}: {
+  total: number;
+  currentIndex: number;
+  locale?: string;
+}) {
+  const fillPct = total <= 1 ? 100 : Math.round((currentIndex / (total - 1)) * 100);
+  const label = t(getMessages(locale).renderer.progressLabel, {
+    current: currentIndex + 1,
+    total,
+  });
+  return (
+    <div
+      className="pf-progress"
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={currentIndex + 1}
+      aria-valuemin={1}
+      aria-valuemax={total}
+    >
+      <div className="pf-progress__track">
+        <div className="pf-progress__fill" style={{ width: `${fillPct}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/public/searchable-dropdown.tsx
+++ b/apps/web/components/public/searchable-dropdown.tsx
@@ -7,6 +7,10 @@ import type { FormOption } from '@quill/engine';
  * A searchable single-select for `dropdown` steps — filters options as you type,
  * good for long lists (country, industry…). Combobox aria, click-outside to
  * close, and selecting an option advances the form (auto-next).
+ *
+ * Keyboard: ArrowDown/ArrowUp move focus through the listbox options (real DOM
+ * focus, so Enter/Space activate the focused option's native button), Escape
+ * closes and returns focus to the input.
  */
 export function SearchableDropdown({
   options,
@@ -23,6 +27,8 @@ export function SearchableDropdown({
 }) {
   const listId = useId();
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
 
@@ -50,9 +56,51 @@ export function SearchableDropdown({
     return options.filter((o) => o.label.toLowerCase().includes(q));
   }, [query, options]);
 
+  const focusOption = (i: number) => {
+    const el = optionRefs.current[i];
+    if (el) el.focus();
+  };
+
+  const closeAndReset = () => {
+    setOpen(false);
+    setQuery(selected?.label ?? '');
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      // Focus the first option once the list has rendered.
+      requestAnimationFrame(() => focusOption(0));
+    } else if (e.key === 'Escape') {
+      if (open) {
+        e.preventDefault();
+        closeAndReset();
+      }
+    }
+  };
+
+  const onOptionKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, i: number) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusOption(Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (i === 0) inputRef.current?.focus();
+      else focusOption(i - 1);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeAndReset();
+      inputRef.current?.focus();
+    }
+    // Enter/Space: the focused option is a native <button>, which fires its
+    // onClick on both keys — no extra handling needed to "select the focused option".
+  };
+
   return (
     <div className="pf-dropdown" ref={wrapperRef}>
       <input
+        ref={inputRef}
         type="text"
         className="pf-input"
         value={query}
@@ -62,6 +110,7 @@ export function SearchableDropdown({
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
+        onKeyDown={onInputKeyDown}
         autoComplete="off"
         role="combobox"
         aria-expanded={open}
@@ -75,12 +124,16 @@ export function SearchableDropdown({
               {emptyLabel}
             </li>
           ) : (
-            filtered.map((option) => (
+            filtered.map((option, i) => (
               <li key={option.value} role="option" aria-selected={value === option.value}>
                 <button
+                  ref={(el) => {
+                    optionRefs.current[i] = el;
+                  }}
                   type="button"
                   className={`pf-dropdown__option${value === option.value ? ' pf-dropdown__option--selected' : ''}`}
                   onMouseDown={(e) => e.preventDefault()}
+                  onKeyDown={(e) => onOptionKeyDown(e, i)}
                   onClick={() => {
                     setQuery(option.label);
                     setOpen(false);

--- a/apps/web/components/public/searchable-dropdown.tsx
+++ b/apps/web/components/public/searchable-dropdown.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { FormOption } from '@quill/engine';
+
+/**
+ * A searchable single-select for `dropdown` steps — filters options as you type,
+ * good for long lists (country, industry…). Combobox aria, click-outside to
+ * close, and selecting an option advances the form (auto-next).
+ */
+export function SearchableDropdown({
+  options,
+  value,
+  onSelect,
+  placeholder,
+  emptyLabel,
+}: {
+  options: FormOption[];
+  value: string;
+  onSelect: (value: string) => void;
+  placeholder: string;
+  emptyLabel: string;
+}) {
+  const listId = useId();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const selected = useMemo(() => options.find((o) => o.value === value), [options, value]);
+
+  useEffect(() => {
+    setQuery(selected?.label ?? '');
+    setOpen(false);
+  }, [selected?.label, value]);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery(selected?.label ?? '');
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [selected?.label]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [query, options]);
+
+  return (
+    <div className="pf-dropdown" ref={wrapperRef}>
+      <input
+        type="text"
+        className="pf-input"
+        value={query}
+        placeholder={placeholder}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        autoComplete="off"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+      />
+      {open && (
+        <ul id={listId} className="pf-dropdown__list" role="listbox">
+          {filtered.length === 0 ? (
+            <li className="pf-dropdown__empty" role="option" aria-disabled aria-selected={false}>
+              {emptyLabel}
+            </li>
+          ) : (
+            filtered.map((option) => (
+              <li key={option.value} role="option" aria-selected={value === option.value}>
+                <button
+                  type="button"
+                  className={`pf-dropdown__option${value === option.value ? ' pf-dropdown__option--selected' : ''}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    setQuery(option.label);
+                    setOpen(false);
+                    onSelect(option.value);
+                  }}
+                >
+                  {option.label}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { Answers, AnswerValue, FormStep } from '@quill/engine';
+import { nameFields } from '@quill/engine';
+import { SearchableDropdown } from './searchable-dropdown';
+
+interface StepInputProps {
+  step: FormStep;
+  value: AnswerValue;
+  answers: Answers;
+  onChange: (value: AnswerValue) => void;
+  onFieldChange: (field: string, value: AnswerValue) => void;
+  /** Choice/dropdown selection auto-advances the form. */
+  onSelect: (value: string) => void;
+  dropdownPlaceholder: string;
+  dropdownEmpty: string;
+}
+
+/** Renders the input for a single step. `message` renders info copy, no input. */
+export function StepInput({
+  step,
+  value,
+  answers,
+  onChange,
+  onFieldChange,
+  onSelect,
+  dropdownPlaceholder,
+  dropdownEmpty,
+}: StepInputProps) {
+  switch (step.type) {
+    case 'name': {
+      const [firstField, secondField] = nameFields(step);
+      return (
+        <div className="pf-name-fields">
+          {firstField && (
+            <input
+              type="text"
+              className="pf-input"
+              value={String(answers[firstField] ?? '')}
+              onChange={(e) => onFieldChange(firstField, e.target.value)}
+              placeholder={step.placeholders?.[firstField] ?? ''}
+              aria-label={step.placeholders?.[firstField] ?? firstField}
+              autoFocus
+            />
+          )}
+          {secondField && (
+            <input
+              type="text"
+              className="pf-input"
+              value={String(answers[secondField] ?? '')}
+              onChange={(e) => onFieldChange(secondField, e.target.value)}
+              placeholder={step.placeholders?.[secondField] ?? ''}
+              aria-label={step.placeholders?.[secondField] ?? secondField}
+            />
+          )}
+        </div>
+      );
+    }
+
+    case 'text':
+    case 'email':
+    case 'phone':
+      return (
+        <input
+          type={step.type === 'email' ? 'email' : step.type === 'phone' ? 'tel' : 'text'}
+          inputMode={step.type === 'phone' ? 'tel' : undefined}
+          className="pf-input"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={step.placeholder ?? ''}
+          aria-label={step.question ?? step.key}
+          autoFocus
+        />
+      );
+
+    case 'textarea':
+      return (
+        <textarea
+          className="pf-input pf-textarea"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={step.placeholder ?? ''}
+          aria-label={step.question ?? step.key}
+          rows={4}
+          autoFocus
+        />
+      );
+
+    case 'dropdown':
+      return (
+        <SearchableDropdown
+          options={step.options ?? []}
+          value={String(value ?? '')}
+          onSelect={onSelect}
+          placeholder={step.placeholder ?? dropdownPlaceholder}
+          emptyLabel={dropdownEmpty}
+        />
+      );
+
+    case 'multiple_choice':
+      if (step.showIcons) {
+        return (
+          <div className="pf-choices--icons" role="radiogroup" aria-label={step.question ?? step.key}>
+            {(step.options ?? []).map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                role="radio"
+                aria-checked={value === opt.value}
+                className={`pf-choice-icon${value === opt.value ? ' pf-choice-icon--selected' : ''}`}
+                onClick={() => onSelect(opt.value)}
+              >
+                <span className="pf-choice-icon__circle" aria-hidden="true">
+                  {opt.icon ?? opt.label.charAt(0).toUpperCase()}
+                </span>
+                <span className="pf-choice-icon__label">{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        );
+      }
+      return (
+        <div className="pf-choices--list" role="radiogroup" aria-label={step.question ?? step.key}>
+          {(step.options ?? []).map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={value === opt.value}
+              className={`pf-choice-list${value === opt.value ? ' pf-choice-list--selected' : ''}`}
+              onClick={() => onSelect(opt.value)}
+            >
+              {opt.icon ? (
+                <span className="pf-choice-list__icon" aria-hidden="true">
+                  {opt.icon}
+                </span>
+              ) : (
+                <span className="pf-choice-list__radio" aria-hidden="true" />
+              )}
+              <span className="pf-choice-list__text">{opt.label}</span>
+            </button>
+          ))}
+        </div>
+      );
+
+    case 'slider':
+      return <SliderInput step={step} value={value} onChange={onChange} />;
+
+    case 'message':
+      return step.helper ? <p className="pf-message__body">{step.helper}</p> : null;
+
+    default:
+      return null;
+  }
+}
+
+function SliderInput({
+  step,
+  value,
+  onChange,
+}: {
+  step: FormStep;
+  value: AnswerValue;
+  onChange: (value: AnswerValue) => void;
+}) {
+  const min = step.min ?? 0;
+  const max = step.max ?? 100;
+  const stepSize = step.step ?? 1;
+  const current = value != null && value !== '' ? Number(value) : (step.default ?? min);
+  const ref = useRef<HTMLInputElement>(null);
+  const pct = max > min ? ((current - min) / (max - min)) * 100 : 0;
+
+  useEffect(() => {
+    ref.current?.style.setProperty('--pf-progress', `${pct}%`);
+  }, [pct]);
+
+  // Seed the default answer so an untouched (optional) slider still submits a value.
+  useEffect(() => {
+    if (value == null || value === '') onChange(current);
+  }, []);
+
+  return (
+    <div className="pf-slider">
+      <div className="pf-slider__pill">
+        <span className="pf-slider__pill-num">{current}</span>
+        {step.sliderUnitLabel ? (
+          <span className="pf-slider__pill-label">{step.sliderUnitLabel}</span>
+        ) : null}
+      </div>
+      <input
+        ref={ref}
+        type="range"
+        className="pf-slider__input"
+        style={{ ['--pf-progress']: `${pct}%` } as React.CSSProperties}
+        min={min}
+        max={max}
+        step={stepSize}
+        value={current}
+        aria-label={step.question ?? step.key}
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          e.target.style.setProperty('--pf-progress', `${max > min ? ((v - min) / (max - min)) * 100 : 0}%`);
+          onChange(v);
+        }}
+      />
+      <div className="pf-slider__scale" aria-hidden="true">
+        <span>{min}</span>
+        <span>{max}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -348,13 +348,19 @@ export async function upsertSubmission(
   },
 ): Promise<SubmissionRow> {
   const now = input.now ?? Date.now();
-  const existing = await db.get<{ id: string; started_at: number }>(
-    sql`SELECT id, started_at FROM submission
+  const existing = await db.get<{ id: string; started_at: number; completed_at: number | null }>(
+    sql`SELECT id, started_at, completed_at FROM submission
         WHERE form_id = ${input.formId} AND session_id = ${input.sessionId} LIMIT 1`,
   );
   const completedAt = input.partial ? null : now;
   const partialAt = input.partial ? now : null;
   if (existing) {
+    // Reorder guard: a fire-and-forget partial can land AFTER the complete
+    // submit. Once a row is completed, only a complete submit may update it —
+    // a late partial must NOT overwrite the finalized data/score.
+    if (input.partial && existing.completed_at != null) {
+      return (await getSubmissionById(db, existing.id))!;
+    }
     await db.run(
       sql`UPDATE submission
           SET data = ${jsonParam(input.data)}, score = ${input.score},

--- a/packages/db/src/submission.spec.ts
+++ b/packages/db/src/submission.spec.ts
@@ -54,6 +54,32 @@ describe('submission upsert', () => {
     expect(rows[0]!.partialAt).not.toBeNull(); // earlier partial preserved
   });
 
+  it('ignores a late partial that arrives AFTER the complete submit', async () => {
+    // Reorder race: the fire-and-forget partial lands after the final submit.
+    // A completed row must NOT be overwritten by a partial payload.
+    const session = 'reorder';
+    await upsertSubmission(db, {
+      formId,
+      sessionId: session,
+      data: { a: 1, b: 2, done: true },
+      score: 9,
+    });
+    // Late partial with stale/lesser data + score — must be a no-op on data/score.
+    await upsertSubmission(db, {
+      formId,
+      sessionId: session,
+      data: { a: 1 },
+      score: 3,
+      partial: true,
+    });
+
+    const rows = await listSubmissions(db, formId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.score).toBe(9); // completed score preserved
+    expect(rows[0]!.data).toEqual({ a: 1, b: 2, done: true }); // completed data intact
+    expect(rows[0]!.completedAt).not.toBeNull();
+  });
+
   it('creates distinct rows for distinct sessions', async () => {
     await upsertSubmission(db, { formId, sessionId: 'a', data: {}, score: 0 });
     await upsertSubmission(db, { formId, sessionId: 'b', data: {}, score: 0 });

--- a/packages/engine/src/form-config.spec.ts
+++ b/packages/engine/src/form-config.spec.ts
@@ -7,9 +7,9 @@ import {
   createEmptyOutcome,
   hasScoringSignal,
   normalizeConfig,
-  interpolate,
-  resolveQuestion,
 } from './form-config';
+// interpolate + resolveQuestion are unified in ./form-logic (shared by builder + runtime).
+import { interpolate, resolveQuestion } from './form-logic';
 import type { FormConfig, FormStep } from './form-logic';
 
 const step = (p: Partial<FormStep> & Pick<FormStep, 'key' | 'type'>): FormStep => p;

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -12,8 +12,6 @@ import type {
   FormFieldType,
   FormOption,
   FormOutcome,
-  Answers,
-  AnswerValue,
 } from './form-logic';
 
 /** Field kinds that capture the lead and therefore never score. */
@@ -196,26 +194,5 @@ export function normalizeConfig(config: FormConfig): FormConfig {
   return next;
 }
 
-/** Replace `[field]` tokens with the respondent's answer to that field. */
-export function interpolate(template: string, answers: Answers): string {
-  return template.replace(/\[([a-zA-Z0-9_]+)\]/g, (_, field: string) => {
-    const value: AnswerValue = answers[field];
-    if (value == null) return '';
-    return Array.isArray(value) ? value.join(', ') : String(value);
-  });
-}
-
-/**
- * The question to show for a step given the answers so far: a `questionVariants`
- * match on `questionField` (falling back to `*` then the plain `question`), with
- * `[field]` interpolation applied to the result.
- */
-export function resolveQuestion(step: FormStep, answers: Answers): string {
-  let text = step.question ?? '';
-  if (step.questionField && step.questionVariants) {
-    const raw = answers[step.questionField];
-    const key = raw == null ? '' : Array.isArray(raw) ? raw.join(',') : String(raw);
-    text = step.questionVariants[key] ?? step.questionVariants['*'] ?? text;
-  }
-  return interpolate(text, answers);
-}
+// `interpolate` and `resolveQuestion` are unified in ./form-logic (the core the
+// runtime and the builder preview both call) — re-exported via the package index.

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -12,6 +12,8 @@ import {
   runtimeSteps,
   partialSubmitKey,
   nameFields,
+  isSafeHttpUrl,
+  isSafeImageUrl,
   type FormConfig,
   type FormStep,
 } from './form-logic';
@@ -249,5 +251,42 @@ describe('partialSubmitKey', () => {
   it('resolves the 1-based threshold step key or null', () => {
     expect(partialSubmitKey({ ...config, partialSubmitAfterStep: 4 })).toBe('email');
     expect(partialSubmitKey(config)).toBeNull();
+  });
+});
+
+describe('corporateEmailOnly validation parity (validateAnswer ⇄ validateAnswerCode)', () => {
+  // Both validators must agree on the SAME address — validateAnswer previously
+  // only checked PERSONAL_EMAIL_DOMAINS while validateAnswerCode used the fuller
+  // isPersonalEmail() (domain list + free-mail bases). Now both use isPersonalEmail().
+  const s = step({ key: 'e', type: 'email', corporateEmailOnly: true });
+  it.each([
+    ['user@msn.com', false], // free-mail base "msn"
+    ['user@hotmail.co.uk', false], // free-mail base "hotmail" on a cc-TLD
+    ['a@gmail.com', false], // exact personal domain
+    ['jane@acme.com', true], // corporate → accepted
+  ])('agrees on %s (accepted=%s)', (email, expectedOk) => {
+    expect(validateAnswer(s, email).ok).toBe(expectedOk);
+    expect(validateAnswerCode(s, email).ok).toBe(expectedOk);
+  });
+});
+
+describe('URL safety guards (XSS)', () => {
+  it('isSafeHttpUrl allows only http(s)', () => {
+    expect(isSafeHttpUrl('https://example.com/thanks')).toBe(true);
+    expect(isSafeHttpUrl('http://localhost:3000/x')).toBe(true);
+    expect(isSafeHttpUrl('  HTTPS://Example.com ')).toBe(true);
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeHttpUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeHttpUrl('/relative/path')).toBe(false);
+  });
+  it('isSafeImageUrl blocks script protocols but allows images/relative', () => {
+    expect(isSafeImageUrl('https://cdn.example.com/logo.png')).toBe(true);
+    expect(isSafeImageUrl('//cdn.example.com/logo.png')).toBe(true);
+    expect(isSafeImageUrl('/assets/logo.svg')).toBe(true);
+    expect(isSafeImageUrl('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+    expect(isSafeImageUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeImageUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeImageUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
   });
 });

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -2,8 +2,16 @@ import { describe, it, expect } from 'vitest';
 import {
   visibleSteps,
   validateAnswer,
+  validateAnswerCode,
   computeScore,
   resolveOutcome,
+  isPersonalEmail,
+  orderSteps,
+  interpolate,
+  resolveStepDisplay,
+  runtimeSteps,
+  partialSubmitKey,
+  nameFields,
   type FormConfig,
   type FormStep,
 } from './form-logic';
@@ -124,5 +132,122 @@ describe('resolveOutcome', () => {
   it('picks the highest bucket the score clears', () => {
     expect(resolveOutcome(config, 15)?.id).toBe('high');
     expect(resolveOutcome(config, 3)?.id).toBe('low');
+  });
+});
+
+describe('isPersonalEmail', () => {
+  it('flags free-mail domains and passes corporate ones', () => {
+    expect(isPersonalEmail('a@gmail.com')).toBe(true);
+    expect(isPersonalEmail('a@hotmail.co.uk')).toBe(true);
+    expect(isPersonalEmail('a@acme.io')).toBe(false);
+    expect(isPersonalEmail(null)).toBe(false);
+    expect(isPersonalEmail(123)).toBe(false);
+  });
+});
+
+describe('orderSteps', () => {
+  it('puts qualification before lead_capture, preserving order within a phase', () => {
+    const steps: FormStep[] = [
+      step({ key: 'email', type: 'email', flowGroup: 'lead_capture' }),
+      step({ key: 'q1', type: 'text', flowGroup: 'qualification' }),
+      step({ key: 'phone', type: 'phone', flowGroup: 'lead_capture' }),
+      step({ key: 'q2', type: 'text' }), // no group → qualification
+    ];
+    expect(orderSteps(steps).map((s) => s.key)).toEqual(['q1', 'q2', 'email', 'phone']);
+  });
+});
+
+describe('personal-email branch (showForPersonalEmailOnly)', () => {
+  const branchCfg: FormConfig = {
+    version: 1,
+    steps: [
+      step({ key: 'email', type: 'email', flowGroup: 'lead_capture' }),
+      step({ key: 'website', type: 'text', flowGroup: 'lead_capture', showForPersonalEmailOnly: true }),
+      step({ key: 'phone', type: 'phone', flowGroup: 'lead_capture' }),
+    ],
+  };
+  it('hides the branch for a corporate email and shows it for a personal one', () => {
+    expect(visibleSteps(branchCfg, { email: 'a@acme.io' }).map((s) => s.key)).toEqual(['email', 'phone']);
+    expect(visibleSteps(branchCfg, { email: 'a@gmail.com' }).map((s) => s.key)).toEqual([
+      'email',
+      'website',
+      'phone',
+    ]);
+  });
+});
+
+describe('interpolate + resolveStepDisplay', () => {
+  it('substitutes [key] tokens, removing unknown/empty tokens', () => {
+    expect(interpolate('Hi [firstname]!', { firstname: 'Ada' })).toBe('Hi Ada!');
+    expect(interpolate('Hi [firstname]!', {})).toBe('Hi !');
+  });
+  it('picks the dynamic question variant and slider unit label', () => {
+    const s = step({
+      key: 'volume',
+      type: 'slider',
+      question: 'How much?',
+      questionField: 'problem',
+      questionVariants: { leads: 'How many leads, [firstname]?' },
+      sliderLabelVariants: { leads: 'leads / mo' },
+    });
+    const resolved = resolveStepDisplay(s, { problem: 'leads', firstname: 'Sam' });
+    expect(resolved.question).toBe('How many leads, Sam?');
+    expect(resolved.sliderUnitLabel).toBe('leads / mo');
+  });
+});
+
+describe('runtimeSteps', () => {
+  it('orders two-phase, applies skip-logic, and resolves display', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: 'email', type: 'email', flowGroup: 'lead_capture' }),
+        step({
+          key: 'problem',
+          type: 'dropdown',
+          flowGroup: 'qualification',
+          question: 'What is the problem?',
+          options: [{ label: 'Leads', value: 'leads' }],
+        }),
+        step({
+          key: 'detail',
+          type: 'text',
+          flowGroup: 'qualification',
+          question: 'Tell us more about [problem].',
+          showWhen: { field: 'problem', values: ['leads'] },
+        }),
+      ],
+    };
+    const walked = runtimeSteps(cfg, { problem: 'leads' });
+    expect(walked.map((s) => s.key)).toEqual(['problem', 'detail', 'email']);
+    expect(walked[1].question).toBe('Tell us more about leads.');
+  });
+});
+
+describe('validateAnswerCode', () => {
+  it('returns stable codes for each failure', () => {
+    expect(validateAnswerCode(step({ key: 'x', type: 'text', required: true }), '')).toEqual({
+      ok: false,
+      code: 'required',
+    });
+    expect(validateAnswerCode(step({ key: 'e', type: 'email', required: true }), 'nope').code).toBe('email');
+    expect(
+      validateAnswerCode(step({ key: 'e', type: 'email', corporateEmailOnly: true }), 'a@gmail.com').code,
+    ).toBe('work_email');
+    expect(validateAnswerCode(step({ key: 'p', type: 'phone', phoneMinDigits: 8 }), '12').code).toBe('phone');
+    expect(validateAnswerCode(step({ key: 's', type: 'slider', min: 0, max: 5 }), 9).code).toBe('too_high');
+  });
+  it('checks both name sub-fields', () => {
+    const s = step({ key: 'name', type: 'name', required: true });
+    expect(validateAnswerCode(s, undefined, { firstname: 'Ada', lastname: '' }).ok).toBe(false);
+    expect(validateAnswerCode(s, undefined, { firstname: 'Ada', lastname: 'Lovelace' }).ok).toBe(true);
+    expect(nameFields(s)).toEqual(['firstname', 'lastname']);
+  });
+});
+
+describe('partialSubmitKey', () => {
+  it('resolves the 1-based threshold step key or null', () => {
+    expect(partialSubmitKey({ ...config, partialSubmitAfterStep: 4 })).toBe('email');
+    expect(partialSubmitKey(config)).toBeNull();
   });
 });

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -274,11 +274,10 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
     case 'email': {
       const email = String(value).trim().toLowerCase();
       if (!EMAIL_RE.test(email)) return { ok: false, error: 'Enter a valid email address.' };
-      if (step.corporateEmailOnly) {
-        const domain = email.split('@')[1] ?? '';
-        if (PERSONAL_EMAIL_DOMAINS.has(domain))
-          return { ok: false, error: 'Please use your work email address.' };
-      }
+      // Use the SAME personal-email test as validateAnswerCode (domain list +
+      // free-mail bases) so both validators agree on any given address.
+      if (step.corporateEmailOnly && isPersonalEmail(email))
+        return { ok: false, error: 'Please use your work email address.' };
       return { ok: true };
     }
     case 'phone': {
@@ -507,4 +506,32 @@ export function partialSubmitKey(config: FormConfig): string | null {
   const n = config.partialSubmitAfterStep;
   if (n == null || n < 1) return null;
   return config.steps[n - 1]?.key ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// URL safety (XSS). Shared by the zod config schema (server-side validation on
+// save) AND the public renderer (a runtime guard before navigating). Belt-and-
+// braces: a config could reach the renderer from an older/looser source, so the
+// sink is guarded too — never assign a non-http(s) URL to `window.location`.
+// ---------------------------------------------------------------------------
+
+/**
+ * True only for http(s) URLs — the allowlist for anything assigned to
+ * `window.location` (e.g. an outcome `redirectUrl`). Rejects `javascript:`,
+ * `data:`, `vbscript:`, etc., which `URL`/zod `.url()` would otherwise accept.
+ */
+export function isSafeHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
+}
+
+/**
+ * True for URLs safe to render into an `<img src>`: http(s), protocol-relative
+ * (`//host`), root/relative paths, and `data:image/…` URIs. Rejects script
+ * protocols (`javascript:`/`vbscript:`) and non-image `data:` payloads.
+ */
+export function isSafeImageUrl(url: string): boolean {
+  const s = url.trim().toLowerCase();
+  if (s.startsWith('javascript:') || s.startsWith('vbscript:')) return false;
+  if (s.startsWith('data:') && !s.startsWith('data:image/')) return false;
+  return true;
 }

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -75,6 +75,11 @@ export interface FormStep {
   corporateEmailOnly?: boolean;
   /** Phone validation: minimum digit count. */
   phoneMinDigits?: number;
+  // --- Builder + runtime extensions (all optional; back-compat) -------------
+  /** `name` step: the two fields collected on one slide (default firstname+lastname). */
+  fields?: string[];
+  /** `name` step: per-field placeholders keyed by field name. */
+  placeholders?: Record<string, string>;
   /**
    * Dynamic question variants: pick the question text from the answer to
    * `questionField`. `questionVariants[value]` overrides `question` when the
@@ -82,7 +87,26 @@ export interface FormStep {
    * plain `question`) is the fallback. Lets one step ask a tailored question.
    */
   questionField?: string | null;
+  /** Question text per value of `questionField` (falls back to `question`). */
   questionVariants?: Record<string, string>;
+  /** Slider unit label per value of `questionField` (falls back to `sliderUnitLabel`). */
+  sliderLabelVariants?: Record<string, string>;
+  /** Static unit label shown next to the slider value (e.g. "leads / mo"). */
+  sliderUnitLabel?: string | null;
+  /** `multiple_choice`: render as an icon grid instead of a radio list. */
+  showIcons?: boolean;
+  /**
+   * Branch insertion: show this step ONLY when the `email` answer is a personal/
+   * free-mail domain (the pilot's "ask for company/website when email is personal").
+   */
+  showForPersonalEmailOnly?: boolean;
+  /**
+   * Terminal step (disqualify path): completing it ends the flow — the submission
+   * is finalized and the outcome resolved, skipping any reveal/booking screen.
+   */
+  terminal?: boolean;
+  /** Show the processing/reveal interstitial after this step completes. */
+  triggersReveal?: boolean;
 }
 
 export interface FormOutcome {
@@ -93,32 +117,67 @@ export interface FormOutcome {
   redirectUrl?: string | null;
 }
 
+/** A client logo chip on the cover marquee (image `src`, or the `name` as text). */
+export interface FormClientLogo {
+  name: string;
+  src?: string | null;
+}
+
 export interface FormCover {
   enabled?: boolean;
-  /** A sticky banner line shown above the form throughout the flow. */
+  /** A sticky banner line (promo strip) shown above every screen throughout the flow. */
   bannerText?: string | null;
   eyebrow?: string | null;
+  /** Alias for eyebrow (pilot `badge`); eyebrow wins when both are set. */
+  badge?: string | null;
   headline?: string | null;
   subheadline?: string | null;
   ctaText?: string | null;
   trustBadge?: string | null;
+  /** Cover logo image URL (falls back to branding.logo, then the product mark). */
+  logo?: string | null;
+  /** Optional "trusted by" marquee shown on the cover. */
+  clientLogos?: FormClientLogo[];
 }
 
-/** Per-form branding — the single accent color drives the public surface. */
+/** Per-form branding — the accent color threads the banner/CTA/selected states. */
 export interface FormBranding {
   primaryColor?: string | null;
+  logo?: string | null;
+  clientLogos?: FormClientLogo[];
+}
+
+/** Optional processing/result-reveal interstitial (generic, templated copy). */
+export interface FormReveal {
+  enabled?: boolean;
+  headline?: string | null;
+  subtitle?: string | null;
 }
 
 export interface FormConfig {
   version: 1;
-  cover?: FormCover | null;
   branding?: FormBranding | null;
+  cover?: FormCover | null;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];
+  reveal?: FormReveal | null;
+  /**
+   * Persist a partial submission once the step at this 1-based position in
+   * `steps` is completed (typically just past the lead-capture email). Absent =
+   * no partial save.
+   */
+  partialSubmitAfterStep?: number;
 }
 
-export type AnswerValue = string | string[] | number | boolean | null | undefined;
+export type AnswerValue =
+  | string
+  | string[]
+  | number
+  | boolean
+  | Record<string, string>
+  | null
+  | undefined;
 export type Answers = Record<string, AnswerValue>;
 
 /** Normalize an answer to the set of string tokens it represents (for matching). */
@@ -136,14 +195,36 @@ function conditionHolds(cond: StepCondition, answers: Answers): boolean {
 
 /**
  * The steps to show given the answers so far, in config order. A step appears
- * when its `showWhen` holds (or is absent) AND its `hideWhen` does not hold.
+ * when its `showWhen` holds (or is absent) AND its `hideWhen` does not hold —
+ * and, for a personal-email-only branch step, only when the email is personal.
  */
 export function visibleSteps(config: FormConfig, answers: Answers): FormStep[] {
   return config.steps.filter((step) => {
     if (step.showWhen && !conditionHolds(step.showWhen, answers)) return false;
     if (step.hideWhen && conditionHolds(step.hideWhen, answers)) return false;
+    if (step.showForPersonalEmailOnly) {
+      const emailKey = findEmailKey(config);
+      if (!emailKey || !isPersonalEmail(answers[emailKey])) return false;
+    }
     return true;
   });
+}
+
+/** The first `email`-typed step's key (the branch pivot for personal-email logic). */
+function findEmailKey(config: FormConfig): string | null {
+  return config.steps.find((s) => s.type === 'email')?.key ?? null;
+}
+
+/**
+ * True when the answer looks like a personal/free-mail address. Accepts an
+ * answer value (or a raw string); non-strings and empties are never personal.
+ */
+export function isPersonalEmail(value: AnswerValue): boolean {
+  if (typeof value !== 'string') return false;
+  const domain = value.trim().toLowerCase().split('@')[1] ?? '';
+  if (!domain) return false;
+  const base = domain.split('.')[0] ?? '';
+  return PERSONAL_EMAIL_DOMAINS.has(domain) || FREE_EMAIL_BASES.has(base);
 }
 
 export type ValidationResult = { ok: true } | { ok: false; error: string };
@@ -160,6 +241,19 @@ const PERSONAL_EMAIL_DOMAINS = new Set([
   'aol.com',
   'proton.me',
   'protonmail.com',
+]);
+/** Domain "base" tokens (before the first dot) also treated as free-mail. */
+const FREE_EMAIL_BASES = new Set([
+  'gmail',
+  'hotmail',
+  'outlook',
+  'yahoo',
+  'icloud',
+  'live',
+  'aol',
+  'msn',
+  'proton',
+  'protonmail',
 ]);
 
 /** Validate one answer against its step. Pure; used on both client and server. */
@@ -257,4 +351,160 @@ export function resolveOutcome(config: FormConfig, score: number): FormOutcome |
     .filter((o) => (o.minScore ?? 0) <= score)
     .sort((a, b) => (b.minScore ?? 0) - (a.minScore ?? 0));
   return buckets[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Phase-1 runtime helpers (pure; unit-tested). The renderer walks these so the
+// public experience is fully engine-driven — client and server agree on flow,
+// score, and outcome. Existing signatures above are untouched; these are new.
+// ---------------------------------------------------------------------------
+
+/** Stable-code validation for localized inline errors (renderer maps code→copy). */
+export type ValidationCode =
+  | 'required'
+  | 'email'
+  | 'work_email'
+  | 'phone'
+  | 'number'
+  | 'too_low'
+  | 'too_high'
+  | 'option';
+
+export type ValidationCodeResult = { ok: true } | { ok: false; code: ValidationCode };
+
+/**
+ * Like `validateAnswer` but returns a stable machine code instead of English
+ * copy — the renderer resolves the code to a localized message. For a `name`
+ * step, pass the full answers object so both sub-fields are checked.
+ */
+export function validateAnswerCode(
+  step: FormStep,
+  value: AnswerValue,
+  answers: Answers = {},
+): ValidationCodeResult {
+  if (step.type === 'message') return { ok: true };
+
+  if (step.type === 'name') {
+    const fields = nameFields(step);
+    for (const f of fields) {
+      const v = answers[f];
+      const empty = v == null || String(v).trim() === '';
+      if (empty && step.required) return { ok: false, code: 'required' };
+    }
+    return { ok: true };
+  }
+
+  const empty =
+    value == null || value === '' || (Array.isArray(value) && value.length === 0);
+  if (empty) return step.required ? { ok: false, code: 'required' } : { ok: true };
+
+  switch (step.type) {
+    case 'email': {
+      const email = String(value).trim().toLowerCase();
+      if (!EMAIL_RE.test(email)) return { ok: false, code: 'email' };
+      if (step.corporateEmailOnly && isPersonalEmail(email))
+        return { ok: false, code: 'work_email' };
+      return { ok: true };
+    }
+    case 'phone': {
+      const digits = String(value).replace(/\D/g, '');
+      if (digits.length < (step.phoneMinDigits ?? 7)) return { ok: false, code: 'phone' };
+      return { ok: true };
+    }
+    case 'slider': {
+      const n = Number(value);
+      if (Number.isNaN(n)) return { ok: false, code: 'number' };
+      if (step.min != null && n < step.min) return { ok: false, code: 'too_low' };
+      if (step.max != null && n > step.max) return { ok: false, code: 'too_high' };
+      return { ok: true };
+    }
+    case 'dropdown':
+    case 'multiple_choice': {
+      const allowed = new Set((step.options ?? []).map((o) => o.value));
+      if (tokens(value).some((t) => !allowed.has(t))) return { ok: false, code: 'option' };
+      return { ok: true };
+    }
+    default:
+      return { ok: true };
+  }
+}
+
+/** The sub-fields a `name` step collects (default firstname + lastname). */
+export function nameFields(step: FormStep): string[] {
+  if (step.type === 'name') return step.fields ?? ['firstname', 'lastname'];
+  return [step.key];
+}
+
+/**
+ * Two-phase order: qualification steps first, then lead-capture — a stable
+ * partition that preserves each step's relative order within its phase. Steps
+ * with no `flowGroup` are treated as qualification.
+ */
+export function orderSteps(steps: FormStep[]): FormStep[] {
+  const qualification = steps.filter((s) => s.flowGroup !== 'lead_capture');
+  const leadCapture = steps.filter((s) => s.flowGroup === 'lead_capture');
+  return [...qualification, ...leadCapture];
+}
+
+/** Replace `[key]` tokens in copy with the corresponding answer (empty → left as-is). */
+export function interpolate(template: string, answers: Answers): string {
+  return template.replace(/\[([a-zA-Z0-9_]+)\]/g, (_m, field: string) => {
+    const value: AnswerValue = answers[field];
+    if (value == null) return '';
+    return Array.isArray(value) ? value.join(', ') : String(value);
+  });
+}
+
+/** The lookup token a `questionField` answer resolves to for variant selection. */
+function variantKey(raw: AnswerValue): string {
+  return raw == null ? '' : Array.isArray(raw) ? raw.join(',') : String(raw);
+}
+
+/**
+ * The question to show for a step given the answers so far: a `questionVariants`
+ * match on `questionField` (falling back to `*` then the plain `question`), with
+ * `[field]` interpolation applied to the result. Shared by the builder preview
+ * and the public renderer so both resolve dynamic questions identically.
+ */
+export function resolveQuestion(step: FormStep, answers: Answers): string {
+  let text = step.question ?? '';
+  if (step.questionField && step.questionVariants) {
+    const key = variantKey(answers[step.questionField]);
+    text = step.questionVariants[key] ?? step.questionVariants['*'] ?? text;
+  }
+  return interpolate(text, answers);
+}
+
+/**
+ * Resolve a step for display against the answers: pick the dynamic question
+ * variant (via `resolveQuestion`), interpolate `[key]` tokens in the question,
+ * and resolve the slider unit label variant. Returns a shallow copy — never
+ * mutates the config.
+ */
+export function resolveStepDisplay(step: FormStep, answers: Answers): FormStep {
+  const question = resolveQuestion(step, answers);
+  let sliderUnitLabel = step.sliderUnitLabel ?? null;
+  if (step.questionField && step.sliderLabelVariants) {
+    const key = variantKey(answers[step.questionField]);
+    if (step.sliderLabelVariants[key]) sliderUnitLabel = step.sliderLabelVariants[key];
+  }
+  return { ...step, question, sliderUnitLabel };
+}
+
+/**
+ * The ordered, visible, display-resolved steps the renderer walks — the single
+ * source of truth for the public flow. Composes `orderSteps` (two-phase) +
+ * `visibleSteps` (skip-logic + personal-email branch) + `resolveStepDisplay`
+ * (dynamic variants + interpolation).
+ */
+export function runtimeSteps(config: FormConfig, answers: Answers): FormStep[] {
+  const ordered: FormConfig = { ...config, steps: orderSteps(config.steps) };
+  return visibleSteps(ordered, answers).map((s) => resolveStepDisplay(s, answers));
+}
+
+/** The key of the step at `partialSubmitAfterStep` (1-based over `steps`), or null. */
+export function partialSubmitKey(config: FormConfig): string | null {
+  const n = config.partialSubmitAfterStep;
+  if (n == null || n < 1) return null;
+  return config.steps[n - 1]?.key ?? null;
 }

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -16,6 +16,37 @@ export interface FormsMessages {
     /** SEO/OG meta description for a public form page. */
     seoForm: string;
   };
+  /** Public form-renderer chrome (all user content comes from the form config). */
+  renderer: {
+    start: string;
+    back: string;
+    next: string;
+    submit: string;
+    submitting: string;
+    thankYouTitle: string;
+    thankYouBody: string; // {name}
+    ctaQuestion: string;
+    ctaAction: string;
+    progressLabel: string; // {current} {total}
+    revealHeadline: string;
+    revealSubtitle: string;
+    noSteps: string;
+    dropdownPlaceholder: string;
+    dropdownEmpty: string;
+    trustedBy: string;
+    newTab: string;
+    errors: {
+      required: string;
+      email: string;
+      work_email: string;
+      phone: string;
+      number: string;
+      too_low: string;
+      too_high: string;
+      option: string;
+      submit: string;
+    };
+  };
   admin: {
     login: {
       title: string;
@@ -309,6 +340,36 @@ export const en: FormsMessages = {
     ctaAction: 'Get Dapta Forms — free',
     seoForm: 'Fill out {name} online.',
   },
+  renderer: {
+    start: 'Start',
+    back: 'Back',
+    next: 'Next',
+    submit: 'Submit',
+    submitting: 'Submitting…',
+    thankYouTitle: 'Thank you!',
+    thankYouBody: 'Your responses to “{name}” were recorded.',
+    ctaQuestion: 'Want your own form?',
+    ctaAction: 'Get Dapta Forms — free',
+    progressLabel: 'Step {current} of {total}',
+    revealHeadline: 'Reviewing your answers…',
+    revealSubtitle: 'One moment while we match you with the best next step.',
+    noSteps: 'This form has no steps yet.',
+    dropdownPlaceholder: 'Type to search…',
+    dropdownEmpty: 'No results found',
+    trustedBy: 'Trusted by',
+    newTab: '(opens in a new tab)',
+    errors: {
+      required: 'This field is required.',
+      email: 'Enter a valid email address.',
+      work_email: 'Please use your work email address.',
+      phone: 'Enter a valid phone number.',
+      number: 'Enter a number.',
+      too_low: 'Value is too low.',
+      too_high: 'Value is too high.',
+      option: 'Choose one of the available options.',
+      submit: 'Could not submit — please try again.',
+    },
+  },
   admin: {
     login: {
       title: 'Sign in',
@@ -597,6 +658,36 @@ export const es: FormsMessages = {
     ctaQuestion: '¿Quieres tu propio formulario?',
     ctaAction: 'Consigue Dapta Forms — gratis',
     seoForm: 'Completa {name} en línea.',
+  },
+  renderer: {
+    start: 'Comenzar',
+    back: 'Atrás',
+    next: 'Siguiente',
+    submit: 'Enviar',
+    submitting: 'Enviando…',
+    thankYouTitle: '¡Gracias!',
+    thankYouBody: 'Tus respuestas a «{name}» quedaron registradas.',
+    ctaQuestion: '¿Quieres tu propio formulario?',
+    ctaAction: 'Consigue Dapta Forms — gratis',
+    progressLabel: 'Paso {current} de {total}',
+    revealHeadline: 'Revisando tus respuestas…',
+    revealSubtitle: 'Un momento mientras encontramos el mejor siguiente paso para ti.',
+    noSteps: 'Este formulario aún no tiene pasos.',
+    dropdownPlaceholder: 'Escribe para buscar…',
+    dropdownEmpty: 'No se encontraron resultados',
+    trustedBy: 'Confían en nosotros',
+    newTab: '(se abre en una pestaña nueva)',
+    errors: {
+      required: 'Este campo es obligatorio.',
+      email: 'Introduce un correo válido.',
+      work_email: 'Usa tu correo corporativo.',
+      phone: 'Introduce un número de teléfono válido.',
+      number: 'Introduce un número.',
+      too_low: 'El valor es muy bajo.',
+      too_high: 'El valor es muy alto.',
+      option: 'Elige una de las opciones disponibles.',
+      submit: 'No se pudo enviar. Inténtalo de nuevo.',
+    },
   },
   admin: {
     login: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,6 +54,11 @@ const sliderScoringSchema = z.object({
   points: z.number().int(),
 });
 
+const clientLogoSchema = z.object({
+  name: z.string().min(1).max(80),
+  src: z.string().max(2048).nullable().optional(),
+});
+
 export const formStepSchema = z.object({
   key: z.string().min(1).max(64),
   type: z.enum(formFieldType),
@@ -74,10 +79,19 @@ export const formStepSchema = z.object({
   flowGroup: z.enum(['qualification', 'lead_capture']).optional(),
   corporateEmailOnly: z.boolean().optional(),
   phoneMinDigits: z.number().int().positive().optional(),
+  // --- Builder + runtime extensions (all optional; back-compat) -------------
   /** Dynamic question: pick the text from the answer to this earlier field. */
-  questionField: z.string().min(1).nullable().optional(),
+  questionField: z.string().min(1).max(64).nullable().optional(),
   /** value → question text (a `*` key is the fallback); `[field]` interpolated. */
   questionVariants: z.record(z.string(), z.string().max(500)).optional(),
+  fields: z.array(z.string().min(1).max(64)).max(4).optional(),
+  placeholders: z.record(z.string(), z.string().max(200)).optional(),
+  sliderLabelVariants: z.record(z.string(), z.string().max(80)).optional(),
+  sliderUnitLabel: z.string().max(80).nullable().optional(),
+  showIcons: z.boolean().optional(),
+  showForPersonalEmailOnly: z.boolean().optional(),
+  terminal: z.boolean().optional(),
+  triggersReveal: z.boolean().optional(),
 });
 export type FormStepInput = z.infer<typeof formStepSchema>;
 
@@ -86,15 +100,25 @@ export const formCoverSchema = z.object({
   /** A sticky banner line shown above the form throughout the flow. */
   bannerText: z.string().max(200).nullable().optional(),
   eyebrow: z.string().max(200).nullable().optional(),
+  badge: z.string().max(200).nullable().optional(),
   headline: z.string().max(300).nullable().optional(),
   subheadline: z.string().max(500).nullable().optional(),
   ctaText: z.string().max(80).nullable().optional(),
   trustBadge: z.string().max(200).nullable().optional(),
+  logo: z.string().max(2048).nullable().optional(),
+  clientLogos: z.array(clientLogoSchema).max(24).optional(),
 });
 
-/** Per-form branding — the single accent color drives the public surface. */
 export const formBrandingSchema = z.object({
   primaryColor: z.string().max(32).nullable().optional(),
+  logo: z.string().max(2048).nullable().optional(),
+  clientLogos: z.array(clientLogoSchema).max(24).optional(),
+});
+
+export const formRevealSchema = z.object({
+  enabled: z.boolean().optional(),
+  headline: z.string().max(300).nullable().optional(),
+  subtitle: z.string().max(500).nullable().optional(),
 });
 
 export const formOutcomeSchema = z.object({
@@ -172,8 +196,8 @@ export type FormDestination = z.infer<typeof formDestinationSchema>;
 /** The versioned config blob. `version` gates future migrations of the shape. */
 export const formConfigSchema = z.object({
   version: z.literal(1),
-  cover: formCoverSchema.nullable().optional(),
   branding: formBrandingSchema.nullable().optional(),
+  cover: formCoverSchema.nullable().optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),
@@ -182,6 +206,8 @@ export const formConfigSchema = z.object({
    * ADDITIVE — absent on every legacy config; the renderer never receives it.
    */
   destinations: z.array(formDestinationSchema).optional(),
+  reveal: formRevealSchema.nullable().optional(),
+  partialSubmitAfterStep: z.number().int().positive().optional(),
 });
 export type FormConfig = z.infer<typeof formConfigSchema>;
 
@@ -219,10 +245,22 @@ export type PublicForm = z.infer<typeof publicFormSchema>;
 
 // --- Submissions -------------------------------------------------------------
 
-/** One submission's answers: fieldName -> value. */
+/**
+ * One submission's answers: fieldName -> value. Most values are scalars (or a
+ * string[] for multi-select); the reserved `utm` key carries a flat string map
+ * of the URL's `utm_*` params (additive — captured from the public URL, never a
+ * new column: it rides inside the free-form answers JSON).
+ */
 export const submissionAnswersSchema = z.record(
   z.string(),
-  z.union([z.string(), z.number(), z.boolean(), z.array(z.string()), z.null()]),
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(z.string()),
+    z.record(z.string(), z.string()),
+    z.null(),
+  ]),
 );
 export type SubmissionAnswers = z.infer<typeof submissionAnswersSchema>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,7 +5,13 @@
  * from the same schema (never trust the client; validate on both sides).
  */
 import { z } from 'zod';
-import { FORM_FIELD_TYPES } from '@quill/engine';
+import { FORM_FIELD_TYPES, isSafeHttpUrl, isSafeImageUrl } from '@quill/engine';
+
+/** A URL rendered into `<img src>` — reject script protocols (XSS defense-in-depth). */
+const safeImageUrl = z
+  .string()
+  .max(2048)
+  .refine(isSafeImageUrl, { message: 'Image URL protocol not allowed.' });
 
 // --- Identity enums (kept from the platform, portable across SQLite & PG) ----
 
@@ -56,7 +62,7 @@ const sliderScoringSchema = z.object({
 
 const clientLogoSchema = z.object({
   name: z.string().min(1).max(80),
-  src: z.string().max(2048).nullable().optional(),
+  src: safeImageUrl.nullable().optional(),
 });
 
 export const formStepSchema = z.object({
@@ -105,13 +111,13 @@ export const formCoverSchema = z.object({
   subheadline: z.string().max(500).nullable().optional(),
   ctaText: z.string().max(80).nullable().optional(),
   trustBadge: z.string().max(200).nullable().optional(),
-  logo: z.string().max(2048).nullable().optional(),
+  logo: safeImageUrl.nullable().optional(),
   clientLogos: z.array(clientLogoSchema).max(24).optional(),
 });
 
 export const formBrandingSchema = z.object({
   primaryColor: z.string().max(32).nullable().optional(),
-  logo: z.string().max(2048).nullable().optional(),
+  logo: safeImageUrl.nullable().optional(),
   clientLogos: z.array(clientLogoSchema).max(24).optional(),
 });
 
@@ -125,7 +131,15 @@ export const formOutcomeSchema = z.object({
   id: z.string().min(1).max(64),
   label: z.string().min(1).max(200),
   minScore: z.number().int().optional(),
-  redirectUrl: z.string().url().nullable().optional(),
+  // http(s) only: the renderer navigates here (`window.location`), so a
+  // `javascript:`/`data:` URL — which `.url()` alone would accept — is a stored
+  // XSS vector. Guarded again at the sink in the renderer (belt-and-braces).
+  redirectUrl: z
+    .string()
+    .url()
+    .refine(isSafeHttpUrl, { message: 'redirectUrl must use http(s).' })
+    .nullable()
+    .optional(),
 });
 
 // --- Submission destinations (pluggable CRM / webhook sync) ------------------


### PR DESCRIPTION
## Track B — Public Renderer

Replaces the minimal public renderer at `app/[accountCode]/[handle]/[slug]` with the full public form-filling experience, faithful to the pilot (`dapta_bookings`) and generalized for OSS. Engine-driven end to end so client and server agree on flow, score, and outcome.

### What's included
- **Cover screen** (when enabled): sticky promo banner, eyebrow/badge, headline, subheadline, trust badge, logo, client-logos marquee, branding `primaryColor` accent, mobile-first card that scales to desktop.
- **Multi-step runtime** for all 9 step types: text, name (first+last one slide), email, phone, dropdown (searchable), multiple_choice (icon grid / radio list), slider (min/max/step/default + unit label), textarea, message. Enter-to-advance; choice/dropdown auto-advance.
- **Engine-driven flow** (`@quill/engine`, new pure + unit-tested functions; existing signatures untouched): `runtimeSteps` (two-phase qualification→lead_capture ordering + skip-logic + personal-email branch + display resolution), `orderSteps`, `interpolate` (`[field]`), `resolveStepDisplay` (dynamic `questionVariants`/`sliderLabelVariants`), `isPersonalEmail`, `validateAnswerCode` (stable codes → localized errors), `partialSubmitKey`, `nameFields`. `visibleSteps` gains a `showForPersonalEmailOnly` branch gate.
- **aria progressbar** advancing across VISIBLE steps only.
- **Client-side per-step validation** with inline errors (required, email + corporateEmailOnly, phone min-digits, slider range).
- **Session id** in sessionStorage; **de-duplicated funnel events** (one `view`/session/load, no double `submit`): view/start/step_view/step_complete/partial_submit/submit.
- **Submissions**: partial submit once past the configurable lead-capture threshold, complete submit at the end; URL `utm_*` captured into `data.utm`. Server recomputes score.
- **Outcomes**: bucket → redirect URL or thank-you screen; optional processing/**reveal** interstitial (generic templated copy).
- **Growth loop**: "Made with Dapta Forms" badge (env-hideable) + thank-you signup CTA (`utm_source=dapta-forms`), SEO/OG metadata.
- **i18n EN/ES** for all renderer chrome (user content stays from config); not-found for unknown slug; R22/R27/R28 gates.

### Additive schema (no breaking / non-additive changes)
- `@quill/types` + engine interfaces gain optional fields (branding, cover banner/logo/clientLogos, reveal, partialSubmitAfterStep, name fields/placeholders, questionField/variants, showIcons, terminal, triggersReveal). Submission answers value union widened to accept the reserved nested `utm` string map — `data.utm` rides inside the free-form answers JSON, **no DB column/schema change**.
- Did **not** touch admin editor / analytics / submissions / integrations pages; `app.module.ts` untouched.

### Verification
- `pnpm lint / typecheck / test / build` all green (engine: 21 unit tests incl. new functions).
- Booted api:4402 + web:3402 on SQLite; created a form via API covering all 9 types + branching + disqualify + scoring + reveal.
- Walked the **entire** flow in a real browser (Chrome DevTools) at 1440px and 360px, EN and ES: cover → dynamic-variant slider → reveal → searchable dropdown → choices → optional textarea → name → email → **personal-email website branch** → interpolated phone → submit.
- Verified in SQLite: partial→complete on one row per session, `data.utm` nested object persisted, funnel events (view/start=1, step_view=one per step after dedup fix, partial_submit=1, submit=1), scores (8→thank-you, 22→redirect, 0→disqualify) and both outcome paths (redirect + thank-you), inline validation, growth badge/CTA UTMs.

### Deviations
- The public form is a deliberately **single light** branded surface (the pilot's King-Kong/Typeform look) with its own scoped `--pf-*` tokens + per-form branding accent — not the app's dark/light design tokens (which govern app chrome; the badge footer stays theme-aware). Documented at the top of `public-form.css`.
- `data.utm` object required a **1-line additive** widening of the submission Zod value union (the free-form JSON was strict-typed); no column/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)