### PR TITLE
release: Dapta Forms v1.0 MVP — builder, renderer, analytics, destinations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,14 @@ MAIL_FROM_NAME=Forms
 # EMAIL_HTTP_SIGNING_SECRET=
 # EMAIL_HTTP_CATEGORY=lifecycle
 
+# --- Submission destinations (CRM / webhook sync) ---------------------------
+# Webhook destinations are configured per form in the admin UI (URL + optional
+# HMAC secret) — nothing here. HubSpot destinations need a server-side private-
+# app token; unset -> the HubSpot destination + property picker report a clear
+# disabled state (a webhook-only deployment needs nothing here). Never sent to
+# the browser.
+# HUBSPOT_PRIVATE_APP_TOKEN=
+
 # --- Premium entitlements (vanity slug; Forms itself is always free) --------
 # open (default) -> every feature unlocked (a bare OSS fork gets everything).
 # locked         -> premium gates on the upstream entitlement service below.
@@ -93,7 +101,7 @@ MAIL_FROM_NAME=Forms
 # ENTITLEMENTS_API_URL=
 # ENTITLEMENTS_API_KEY=
 
-# --- Outbox worker (durable submission emails) ------------------------------
+# --- Outbox worker (durable submission emails + destination deliveries) -----
 # OUTBOX_WORKER_ENABLED=true
 # OUTBOX_POLL_MS=5000
 # OUTBOX_MAX_ATTEMPTS=5

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "@nestjs/platform-express": "^10.4.15",
     "@quill/config": "workspace:*",
     "@quill/db": "workspace:*",
+    "@quill/destinations": "workspace:*",
     "@quill/engine": "workspace:*",
     "@quill/notifications": "workspace:*",
     "@quill/shared": "workspace:*",

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -12,6 +12,7 @@ import {
   Patch,
   Post,
   Put,
+  Query,
   Req,
 } from '@nestjs/common';
 import type { Db } from '@quill/db';
@@ -34,8 +35,10 @@ import { formInputSchema, memberInviteSchema, memberPatchSchema } from '@quill/t
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
 import { SubmissionService } from './submission.service';
+import { AnalyticsService } from './analytics.service';
 import { AuthService, type ReqLike } from './auth.service';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
+import { parseBound, parseStatus } from './query-params';
 import { DB } from './tokens';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
@@ -62,6 +65,7 @@ export class AdminCrudController {
     @Inject(AuthService) private readonly auth: AuthService,
     @Inject(AdminService) private readonly admin: AdminService,
     @Inject(SubmissionService) private readonly submissions: SubmissionService,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
   ) {}
 
   // --- Identity ----------------------------------------------------------
@@ -132,12 +136,32 @@ export class AdminCrudController {
     await deleteForm(this.db, p.accountId, id);
   }
 
+  /**
+   * A page of a form's submissions. Optional query: `status`
+   * (all|completed|partial), `from`/`to` (epoch ms or YYYY-MM-DD, bound by
+   * startedAt), `limit`/`offset`. Returns a paginated envelope `{ items, total,
+   * limit, offset }` so the admin table can render page counts.
+   */
   @Get('forms/:id/submissions')
-  async formSubmissions(@Req() req: ReqLike, @Param('id') id: string) {
+  async formSubmissions(
+    @Req() req: ReqLike,
+    @Param('id') id: string,
+    @Query('status') status?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
     const p = await this.auth.resolveHost(req);
     const f = await getFormById(this.db, p.accountId, id);
     if (!f) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    return this.submissions.listSubmissions(id);
+    return this.analytics.submissionsPage(id, {
+      status: parseStatus(status),
+      from: parseBound(from, false),
+      to: parseBound(to, true),
+      limit: limit ? Number(limit) : undefined,
+      offset: offset ? Number(offset) : undefined,
+    });
   }
 
   // --- Members (workspace roster; admin/owner-only) ----------------------

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -38,7 +38,7 @@ import { SubmissionService } from './submission.service';
 import { AnalyticsService } from './analytics.service';
 import { AuthService, type ReqLike } from './auth.service';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
-import { parseBound, parseStatus } from './query-params';
+import { parseBound, parseIntParam, parseStatus } from './query-params';
 import { DB } from './tokens';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
@@ -159,8 +159,8 @@ export class AdminCrudController {
       status: parseStatus(status),
       from: parseBound(from, false),
       to: parseBound(to, true),
-      limit: limit ? Number(limit) : undefined,
-      offset: offset ? Number(offset) : undefined,
+      limit: parseIntParam(limit),
+      offset: parseIntParam(offset),
     });
   }
 

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -11,7 +11,7 @@ import {
   Res,
 } from '@nestjs/common';
 import type { Db } from '@quill/db';
-import { getFormById, querySubmissions } from '@quill/db';
+import { getFormById } from '@quill/db';
 import type { FormConfig } from '@quill/types';
 import { AuthService, type ReqLike } from './auth.service';
 import { AnalyticsService } from './analytics.service';
@@ -64,7 +64,9 @@ export class AnalyticsController {
   /**
    * Stream the form's submissions as CSV. Answers flatten to one column per
    * configured step key (form config order), after the fixed metadata columns.
-   * Paged internally so a large export never buffers the whole set in memory.
+   * Uses the un-paginated export query (`allSubmissionsForExport`) — the table
+   * query caps `limit` at 200, so paging through it would silently truncate and
+   * skip rows on large exports. Rows are still written incrementally.
    */
   @Get('forms/:id/submissions.csv')
   async exportCsv(
@@ -89,30 +91,25 @@ export class AnalyticsController {
 
     res.write(csvRow(['id', 'session_id', 'status', 'score', 'started_at', 'completed_at', ...stepKeys]));
 
-    const q = {
+    const rows = await this.analytics.exportSubmissions(id, {
       status: parseStatus(status),
       from: parseBound(from, false),
       to: parseBound(to, true),
-    };
-    const pageSize = 500;
-    for (let offset = 0; ; offset += pageSize) {
-      const page = await querySubmissions(this.db, id, { ...q, limit: pageSize, offset });
-      for (const s of page.items) {
-        const data = (s.data ?? {}) as Record<string, unknown>;
-        const st = s.completedAt != null ? 'completed' : s.partialAt != null ? 'partial' : 'in_progress';
-        res.write(
-          csvRow([
-            s.id,
-            s.sessionId,
-            st,
-            s.score,
-            iso(s.startedAt),
-            iso(s.completedAt),
-            ...stepKeys.map((k) => data[k]),
-          ]),
-        );
-      }
-      if (offset + pageSize >= page.total) break;
+    });
+    for (const s of rows) {
+      const data = (s.data ?? {}) as Record<string, unknown>;
+      const st = s.completedAt != null ? 'completed' : s.partialAt != null ? 'partial' : 'in_progress';
+      res.write(
+        csvRow([
+          s.id,
+          s.sessionId,
+          st,
+          s.score,
+          iso(s.startedAt),
+          iso(s.completedAt),
+          ...stepKeys.map((k) => data[k]),
+        ]),
+      );
     }
     res.end();
   }

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -1,0 +1,127 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Inject,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+  Res,
+} from '@nestjs/common';
+import type { Db } from '@quill/db';
+import { getFormById, querySubmissions } from '@quill/db';
+import type { FormConfig } from '@quill/types';
+import { AuthService, type ReqLike } from './auth.service';
+import { AnalyticsService } from './analytics.service';
+import { DB } from './tokens';
+import { csvRow } from './csv';
+import { parseBound, parseStatus } from './query-params';
+
+/** A minimal response shape (structurally satisfied by the express Response). */
+interface StreamRes {
+  setHeader(name: string, value: string): void;
+  write(chunk: string): void;
+  end(): void;
+}
+
+function iso(ms: number | null): string {
+  return ms == null ? '' : new Date(ms).toISOString();
+}
+
+/**
+ * Host-authed analytics + submissions read/export/delete surface. Kept separate
+ * from AdminCrudController so the analytics feature is self-contained (registered
+ * append-only in app.module). Every route resolves the host first, then scopes
+ * by the caller's account.
+ */
+@Controller('v1')
+export class AnalyticsController {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AuthService) private readonly auth: AuthService,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
+  ) {}
+
+  /** Funnel metrics + per-step drop-off for a form over an optional date range. */
+  @Get('forms/:id/analytics')
+  async formAnalytics(
+    @Req() req: ReqLike,
+    @Param('id') id: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    const p = await this.auth.resolveHost(req);
+    const result = await this.analytics.funnel(p.accountId, id, {
+      from: parseBound(from, false),
+      to: parseBound(to, true),
+    });
+    if (!result) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    return result;
+  }
+
+  /**
+   * Stream the form's submissions as CSV. Answers flatten to one column per
+   * configured step key (form config order), after the fixed metadata columns.
+   * Paged internally so a large export never buffers the whole set in memory.
+   */
+  @Get('forms/:id/submissions.csv')
+  async exportCsv(
+    @Req() req: ReqLike,
+    @Res() res: StreamRes,
+    @Param('id') id: string,
+    @Query('status') status?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ): Promise<void> {
+    const p = await this.auth.resolveHost(req);
+    const form = await getFormById(this.db, p.accountId, id);
+    if (!form) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+
+    const config = form.config as FormConfig;
+    const stepKeys = (config.steps ?? []).map((s) => s.key);
+    const filename = `${form.slug || 'submissions'}-submissions.csv`;
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Cache-Control', 'no-store');
+
+    res.write(csvRow(['id', 'session_id', 'status', 'score', 'started_at', 'completed_at', ...stepKeys]));
+
+    const q = {
+      status: parseStatus(status),
+      from: parseBound(from, false),
+      to: parseBound(to, true),
+    };
+    const pageSize = 500;
+    for (let offset = 0; ; offset += pageSize) {
+      const page = await querySubmissions(this.db, id, { ...q, limit: pageSize, offset });
+      for (const s of page.items) {
+        const data = (s.data ?? {}) as Record<string, unknown>;
+        const st = s.completedAt != null ? 'completed' : s.partialAt != null ? 'partial' : 'in_progress';
+        res.write(
+          csvRow([
+            s.id,
+            s.sessionId,
+            st,
+            s.score,
+            iso(s.startedAt),
+            iso(s.completedAt),
+            ...stepKeys.map((k) => data[k]),
+          ]),
+        );
+      }
+      if (offset + pageSize >= page.total) break;
+    }
+    res.end();
+  }
+
+  /** Delete a submission (account-scoped, idempotent → always 204). */
+  @Delete('submissions/:id')
+  @HttpCode(204)
+  async deleteSubmission(@Req() req: ReqLike, @Param('id') id: string): Promise<void> {
+    const p = await this.auth.resolveHost(req);
+    await this.analytics.deleteSubmission(p.accountId, id); // idempotent: absent/out-of-account → no-op
+  }
+}

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Analytics aggregation math, end to end on in-memory SQLite. Seeds a known set
+ * of funnel events + submissions and asserts the funnel summary + per-step
+ * drop-off table exactly (ground truth computed by hand in the comments). Also
+ * covers the date-range filter, submissions pagination/filter, and the
+ * account-scoped idempotent delete — the whole read surface's math.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createDb,
+  migrate,
+  seed,
+  recordFormEvent,
+  jsonParam,
+  querySubmissions,
+  deleteSubmissionForAccount,
+  sql,
+  type Db,
+} from '@quill/db';
+import { AnalyticsService } from './analytics.service';
+
+let db: Db;
+let svc: AnalyticsService;
+let accountId: string;
+let formId: string;
+
+/** Insert a submission row with explicit timestamps (bypasses upsert semantics). */
+async function insertSubmission(input: {
+  session: string;
+  data: Record<string, unknown>;
+  score: number;
+  startedAt: number;
+  completedAt?: number | null;
+  partialAt?: number | null;
+}) {
+  await db.run(
+    sql`INSERT INTO submission (id, form_id, session_id, data, score, started_at, completed_at, partial_at)
+        VALUES (${crypto.randomUUID()}, ${formId}, ${input.session}, ${jsonParam(input.data)},
+          ${input.score}, ${input.startedAt}, ${input.completedAt ?? null}, ${input.partialAt ?? null})`,
+  );
+}
+
+async function emit(type: string, count: number, stepIndex?: number, at?: number) {
+  for (let i = 0; i < count; i++) {
+    await recordFormEvent(db, {
+      formId,
+      sessionId: `${type}-${stepIndex ?? 'x'}-${i}`,
+      type,
+      stepIndex: stepIndex ?? null,
+      now: at,
+    });
+  }
+}
+
+const NOW = 1_800_000_000_000; // fixed instant so range math is deterministic
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db);
+  svc = new AnalyticsService(db);
+  const acc = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE code = 'acme' LIMIT 1`);
+  accountId = acc!.id;
+  const form = await db.get<{ id: string }>(sql`SELECT id FROM form WHERE slug = 'lead-qualifier' LIMIT 1`);
+  formId = form!.id;
+
+  // Funnel events (all at NOW): 10 views, 8 starts, step_views 8/6/4/3.
+  await emit('view', 10, undefined, NOW);
+  await emit('start', 8, undefined, NOW);
+  await emit('step_view', 8, 0, NOW);
+  await emit('step_view', 6, 1, NOW);
+  await emit('step_view', 4, 2, NOW);
+  await emit('step_view', 3, 3, NOW);
+
+  // 3 completed submissions with durations 30s / 60s / 90s → avg 60s.
+  await insertSubmission({ session: 'c1', data: { role: 'founder', email: 'a@x.io' }, score: 10, startedAt: NOW, completedAt: NOW + 30_000 });
+  await insertSubmission({ session: 'c2', data: { role: 'lead', email: 'b@x.io' }, score: 6, startedAt: NOW, completedAt: NOW + 60_000 });
+  await insertSubmission({ session: 'c3', data: { role: 'founder', email: 'c@x.io' }, score: 10, startedAt: NOW, completedAt: NOW + 90_000 });
+  // 2 partial-only submissions.
+  await insertSubmission({ session: 'p1', data: { role: 'individual' }, score: 2, startedAt: NOW, partialAt: NOW + 5_000 });
+  await insertSubmission({ session: 'p2', data: { role: 'lead' }, score: 6, startedAt: NOW, partialAt: NOW + 5_000 });
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('funnel aggregation', () => {
+  it('computes the funnel summary exactly', async () => {
+    const a = (await svc.funnel(accountId, formId, {}))!;
+    expect(a.views).toBe(10);
+    expect(a.starts).toBe(8);
+    expect(a.submissions).toBe(3); // completed
+    expect(a.partialSubmits).toBe(2);
+    expect(a.completionRate).toBe(37.5); // 3/8 = 37.5%
+    expect(a.avgTimeToComplete).toBe(60); // (30+60+90)/3 s
+  });
+
+  it('computes the per-step drop-off table (cover + one row per step)', async () => {
+    const a = (await svc.funnel(accountId, formId, {}))!;
+    // 4 configured steps + 1 cover row.
+    expect(a.dropoff).toHaveLength(5);
+
+    const [cover, s0, s1, s2, s3] = a.dropoff;
+    // Cover: views 10 → step0 8 ⇒ drop 2 (20%).
+    expect(cover).toMatchObject({ isCover: true, views: 10, dropoff: 2, dropoffPercent: 20 });
+    // role: 8 → 6 ⇒ drop 2 (25%).
+    expect(s0).toMatchObject({ key: 'role', views: 8, dropoff: 2, dropoffPercent: 25 });
+    // team_size: 6 → 4 ⇒ drop 2 (33.3%).
+    expect(s1).toMatchObject({ key: 'team_size', views: 6, dropoff: 2, dropoffPercent: 33.3 });
+    // company: 4 → 3 ⇒ drop 1 (25%).
+    expect(s2).toMatchObject({ key: 'company', views: 4, dropoff: 1, dropoffPercent: 25 });
+    // email: 3 → submissions 3 ⇒ drop 0 (0%).
+    expect(s3).toMatchObject({ key: 'email', views: 3, dropoff: 0, dropoffPercent: 0 });
+  });
+
+  it('applies the date-range filter (out-of-range rows excluded)', async () => {
+    // Everything was seeded at NOW; a window strictly before NOW sees nothing.
+    const empty = (await svc.funnel(accountId, formId, { from: NOW - 100_000, to: NOW - 1 }))!;
+    expect(empty.views).toBe(0);
+    expect(empty.starts).toBe(0);
+    expect(empty.submissions).toBe(0);
+    expect(empty.partialSubmits).toBe(0);
+
+    // A window covering NOW sees the full set again.
+    const full = (await svc.funnel(accountId, formId, { from: NOW - 1, to: NOW + 200_000 }))!;
+    expect(full.views).toBe(10);
+    expect(full.submissions).toBe(3);
+  });
+
+  it('returns null for a form the account does not own', async () => {
+    expect(await svc.funnel('someone-else', formId, {})).toBeNull();
+  });
+});
+
+describe('submissions query', () => {
+  it('paginates newest-first with a total', async () => {
+    const page = await querySubmissions(db, formId, { limit: 2, offset: 0 });
+    expect(page.total).toBe(5); // 3 completed + 2 partial
+    expect(page.items).toHaveLength(2);
+    expect(page.limit).toBe(2);
+  });
+
+  it('filters by status', async () => {
+    const completed = await querySubmissions(db, formId, { status: 'completed' });
+    expect(completed.total).toBe(3);
+    expect(completed.items.every((s) => s.completedAt != null)).toBe(true);
+
+    const partial = await querySubmissions(db, formId, { status: 'partial' });
+    expect(partial.total).toBe(2);
+    expect(partial.items.every((s) => s.completedAt == null && s.partialAt != null)).toBe(true);
+  });
+});
+
+describe('delete submission (account-scoped, idempotent)', () => {
+  it('deletes an owned submission and is a no-op on repeat / wrong account', async () => {
+    const one = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
+    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe(true);
+    // Idempotent second call.
+    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe(false);
+    // Wrong account never touches the row.
+    const other = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
+    expect(await deleteSubmissionForAccount(db, 'wrong-account', other.id)).toBe(false);
+    expect((await querySubmissions(db, formId, { status: 'completed' })).total).toBe(2);
+  });
+});

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -18,6 +18,10 @@ import {
   type Db,
 } from '@quill/db';
 import { AnalyticsService } from './analytics.service';
+import { AnalyticsController } from './analytics.controller';
+import type { AuthService } from './auth.service';
+import { csvField } from './csv';
+import { parseIntParam } from './query-params';
 
 let db: Db;
 let svc: AnalyticsService;
@@ -162,5 +166,103 @@ describe('delete submission (account-scoped, idempotent)', () => {
     const other = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
     expect(await deleteSubmissionForAccount(db, 'wrong-account', other.id)).toBe(false);
     expect((await querySubmissions(db, formId, { status: 'completed' })).total).toBe(2);
+  });
+});
+
+describe('CSV export (large sets, un-paginated)', () => {
+  /** Drive the real controller with a stub auth + capture-only response. */
+  async function runExport(): Promise<string[]> {
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: 'test-member', role: 'owner' as const }),
+    } as unknown as AuthService;
+    const ctrl = new AnalyticsController(db, auth, svc);
+    const chunks: string[] = [];
+    const res = {
+      setHeader: () => {},
+      write: (c: string) => {
+        chunks.push(c);
+      },
+      end: () => {},
+    };
+    await ctrl.exportCsv({ headers: {} }, res, formId, undefined, undefined, undefined);
+    return chunks.join('').trimEnd().split('\r\n');
+  }
+
+  it('exports EVERY row past the 200-row table cap (250 seeded → 250 CSV rows)', async () => {
+    // beforeEach seeded 5 submissions; add 245 more → exactly 250 total. The
+    // paginated table query caps limit at 200, so this proves the export path
+    // does NOT truncate or skip rows (OptiBot blocker).
+    for (let i = 0; i < 245; i++) {
+      await insertSubmission({
+        session: `bulk-${i}`,
+        data: { role: 'individual', email: `bulk${i}@x.io` },
+        score: 2,
+        startedAt: NOW + i,
+        completedAt: NOW + i + 1000,
+      });
+    }
+    expect((await querySubmissions(db, formId, {})).total).toBe(250);
+
+    const lines = await runExport();
+    expect(lines[0]).toMatch(/^id,session_id,status,score,started_at,completed_at/);
+    expect(lines.length - 1).toBe(250); // header + one row per submission
+  });
+
+  it('neutralizes a formula payload end-to-end in the exported CSV', async () => {
+    await insertSubmission({
+      session: 'inject-1',
+      data: { role: '=HYPERLINK("http://evil.example","click")', email: '@import' },
+      score: 0,
+      startedAt: NOW,
+      completedAt: NOW + 1,
+    });
+    const csv = (await runExport()).join('\n');
+    expect(csv).toContain(`'=HYPERLINK`);
+    expect(csv).toContain(`'@import`);
+    expect(csv).not.toMatch(/(^|,)=HYPERLINK/m); // no bare leading formula
+  });
+});
+
+describe('csvField formula-injection neutralization', () => {
+  it('prefixes a quote on formula-trigger strings', () => {
+    expect(csvField('=1+2')).toBe("'=1+2");
+    expect(csvField('+SUM(A1)')).toBe("'+SUM(A1)");
+    expect(csvField('-cmd')).toBe("'-cmd");
+    expect(csvField('@import')).toBe("'@import");
+    expect(csvField('\tpayload')).toBe("'\tpayload");
+  });
+
+  it('still RFC-4180-quotes when the neutralized value needs it', () => {
+    // Leading `=` AND a comma: neutralize first, then quote.
+    expect(csvField('=HYPERLINK("http://e.x","y")')).toBe('"\'=HYPERLINK(""http://e.x"",""y"")"');
+  });
+
+  it('leaves genuine numbers/booleans and plain strings untouched', () => {
+    expect(csvField(-5)).toBe('-5'); // negative score stays numeric
+    expect(csvField(true)).toBe('true');
+    expect(csvField('hello')).toBe('hello');
+    expect(csvField(null)).toBe('');
+  });
+
+  it('neutralizes an array whose flattened head is a trigger', () => {
+    expect(csvField(['=evil', 'b'])).toBe("'=evil; b");
+  });
+});
+
+describe('parseIntParam (NaN guard for limit/offset)', () => {
+  it('parses numeric strings and rejects everything else', () => {
+    expect(parseIntParam('50')).toBe(50);
+    expect(parseIntParam('0')).toBe(0);
+    expect(parseIntParam('12.9')).toBe(12); // truncated to an int
+    expect(parseIntParam('abc')).toBeUndefined(); // NaN must never reach SQL
+    expect(parseIntParam('1e309')).toBeUndefined(); // Infinity guarded too
+    expect(parseIntParam('')).toBeUndefined();
+    expect(parseIntParam(undefined)).toBeUndefined();
+  });
+
+  it('undefined falls back to the query default (no LIMIT NaN)', async () => {
+    const page = await querySubmissions(db, formId, { limit: parseIntParam('abc') });
+    expect(page.limit).toBe(25); // default, not NaN
+    expect(page.items.length).toBeGreaterThan(0);
   });
 });

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,0 +1,129 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Db } from '@quill/db';
+import {
+  eventTypeCounts,
+  stepViewCounts,
+  submissionAggregates,
+  querySubmissions,
+  allSubmissionsForExport,
+  deleteSubmissionForAccount,
+  getFormById,
+  type DateRange,
+  type SubmissionQuery,
+} from '@quill/db';
+import type {
+  AnalyticsResponse,
+  DropoffRow,
+  FormConfig,
+  SubmissionAnswers,
+  SubmissionsPage,
+} from '@quill/types';
+import { DB } from './tokens';
+
+/** Round to one decimal place (e.g. a completion/drop-off percentage). */
+function pct1(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+/**
+ * The admin analytics + submissions read surface. Aggregates are computed from
+ * `form_event` (funnel counts) + `submission` (completed/partial + timing) via
+ * the portable DB queries, then the funnel + per-step drop-off table is
+ * assembled here against the form's configured steps. All operations are
+ * account-scoped by the caller (the controller resolves the host first).
+ */
+@Injectable()
+export class AnalyticsService {
+  constructor(@Inject(DB) private readonly db: Db) {}
+
+  /** Funnel summary + question-by-question drop-off for a form over a range. */
+  async funnel(accountId: string, formId: string, range: DateRange): Promise<AnalyticsResponse | null> {
+    const form = await getFormById(this.db, accountId, formId);
+    if (!form) return null;
+    const config = form.config as FormConfig;
+    const steps = config.steps ?? [];
+
+    const [counts, stepViews, agg] = await Promise.all([
+      eventTypeCounts(this.db, formId, range),
+      stepViewCounts(this.db, formId, range),
+      submissionAggregates(this.db, formId, range),
+    ]);
+
+    const views = counts.view ?? 0;
+    const starts = counts.start ?? 0;
+    const submissions = agg.completed;
+    const partialSubmits = agg.partial;
+    const completionRate = pct1(submissions, starts);
+    const avgTimeToComplete =
+      agg.avgCompletionMs == null ? 0 : Math.round(agg.avgCompletionMs / 1000);
+
+    // rowViews[0] = form views (the cover/landing); rowViews[i+1] = views of step i.
+    const rowViews: number[] = [views];
+    for (let i = 0; i < steps.length; i++) rowViews.push(stepViews.get(i) ?? 0);
+
+    const dropoff: DropoffRow[] = [];
+
+    // Cover/landing row: drop between the landing and the first step.
+    const coverViews = rowViews[0] ?? 0;
+    const coverDrop = Math.max(0, coverViews - (rowViews[1] ?? 0));
+    dropoff.push({
+      stepIndex: -1,
+      key: null,
+      question: config.cover?.headline?.trim() || config.cover?.eyebrow?.trim() || 'Cover',
+      isCover: true,
+      views: coverViews,
+      dropoff: coverDrop,
+      dropoffPercent: pct1(coverDrop, coverViews),
+    });
+
+    // One row per configured step. The "next" for the last step is completed
+    // submissions (the true bottom of the funnel), matching the pilot semantics.
+    for (let i = 0; i < steps.length; i++) {
+      const viewsAtStep = rowViews[i + 1] ?? 0;
+      const viewsAtNext = i < steps.length - 1 ? (rowViews[i + 2] ?? 0) : submissions;
+      const drop = Math.max(0, viewsAtStep - viewsAtNext);
+      dropoff.push({
+        stepIndex: i,
+        key: steps[i]!.key,
+        question: steps[i]!.question?.trim() || steps[i]!.key,
+        isCover: false,
+        views: viewsAtStep,
+        dropoff: drop,
+        dropoffPercent: pct1(drop, viewsAtStep),
+      });
+    }
+
+    return {
+      views,
+      starts,
+      submissions,
+      completionRate,
+      avgTimeToComplete,
+      partialSubmits,
+      dropoff,
+      range: { from: range.from ?? null, to: range.to ?? null },
+    };
+  }
+
+  /** A page of a form's submissions (newest first) matching the filter. */
+  async submissionsPage(formId: string, q: SubmissionQuery): Promise<SubmissionsPage> {
+    const page = await querySubmissions(this.db, formId, q);
+    return {
+      items: page.items.map((r) => ({ ...r, data: (r.data ?? {}) as SubmissionAnswers })),
+      total: page.total,
+      limit: page.limit,
+      offset: page.offset,
+    };
+  }
+
+  /** Every submission matching the filter (CSV export — no pagination). */
+  exportSubmissions(formId: string, q: Omit<SubmissionQuery, 'limit' | 'offset'>) {
+    return allSubmissionsForExport(this.db, formId, q);
+  }
+
+  /** Delete a submission if it belongs to the account. Idempotent. */
+  deleteSubmission(accountId: string, submissionId: string): Promise<boolean> {
+    return deleteSubmissionForAccount(this.db, accountId, submissionId);
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,9 +15,11 @@ import type { Db } from '@quill/db';
 import { HealthController, DocsController } from './controllers';
 import { PublicController } from './public.controller';
 import { AdminCrudController } from './admin-crud.controller';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
 
 @Module({
-  controllers: [HealthController, DocsController, PublicController, AdminCrudController],
+  controllers: [HealthController, DocsController, PublicController, AdminCrudController, AnalyticsController],
   providers: [
     { provide: ENV, useFactory: () => loadServerEnv() },
     { provide: DB, useFactory: () => createDb() },
@@ -68,6 +70,7 @@ import { AdminCrudController } from './admin-crud.controller';
     { provide: RATE_LIMITER, useFactory: (env: ServerEnv) => createRateLimiter(env), inject: [ENV] },
     RateLimitGuard,
     SubmissionService,
+    AnalyticsService,
     AdminService,
     AuthService,
     EmailEffects,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -18,7 +18,11 @@ import { PublicController } from './public.controller';
 import { AdminCrudController } from './admin-crud.controller';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
-import { HubspotPropertiesService, IntegrationsController } from './integrations.controller';
+import {
+  FormDestinationsController,
+  HubspotPropertiesService,
+  IntegrationsController,
+} from './integrations.controller';
 
 @Module({
   controllers: [
@@ -28,6 +32,7 @@ import { HubspotPropertiesService, IntegrationsController } from './integrations
     AdminCrudController,
     AnalyticsController,
     IntegrationsController,
+    FormDestinationsController,
   ],
   providers: [
     { provide: ENV, useFactory: () => loadServerEnv() },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { SubmissionService } from './submission.service';
 import { AdminService } from './admin.service';
 import { AuthService } from './auth.service';
 import { EmailEffects } from './email-effects';
+import { DestinationEffects } from './destination-effects';
 import { OutboxWorker } from './outbox.worker';
 import { RateLimitGuard, createRateLimiter } from './rate-limit';
 import { resolveEntitlementsProvider } from './entitlements.provider';
@@ -17,9 +18,17 @@ import { PublicController } from './public.controller';
 import { AdminCrudController } from './admin-crud.controller';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
+import { HubspotPropertiesService, IntegrationsController } from './integrations.controller';
 
 @Module({
-  controllers: [HealthController, DocsController, PublicController, AdminCrudController, AnalyticsController],
+  controllers: [
+    HealthController,
+    DocsController,
+    PublicController,
+    AdminCrudController,
+    AnalyticsController,
+    IntegrationsController,
+  ],
   providers: [
     { provide: ENV, useFactory: () => loadServerEnv() },
     { provide: DB, useFactory: () => createDb() },
@@ -74,8 +83,18 @@ import { AnalyticsService } from './analytics.service';
     AdminService,
     AuthService,
     EmailEffects,
-    // Drains the durable outbox (submission emails) with retry+backoff — no
-    // silent loss on a provider outage (B1/B7/DM1).
+    // Fans submissions out to enabled destinations (webhook/HubSpot) via the
+    // durable outbox; delivery never blocks or fails submission handling.
+    DestinationEffects,
+    // Server-side HubSpot property lookup for the mapping UI (5-min cache, clear
+    // disabled state without a token). Factory so `fetch` isn't DI-reflected.
+    {
+      provide: HubspotPropertiesService,
+      useFactory: (env: ServerEnv) => new HubspotPropertiesService(env),
+      inject: [ENV],
+    },
+    // Drains the durable outbox (submission emails + destinations) with
+    // retry+backoff — no silent loss on a provider outage (B1/B7/DM1).
     OutboxWorker,
   ],
 })

--- a/apps/api/src/csv.ts
+++ b/apps/api/src/csv.ts
@@ -2,15 +2,30 @@
  * Minimal, dependency-free RFC-4180 CSV encoding for the submissions export.
  * Values are quoted when they contain a comma, quote, or newline; embedded
  * quotes are doubled. Arrays flatten to `a; b; c`; null/undefined to empty.
+ *
+ * Formula-injection hardening (OWASP CSV injection): a user-supplied value
+ * starting with `=`, `+`, `-`, `@`, tab, or CR would be executed as a formula
+ * by Excel/Sheets on open (e.g. `=HYPERLINK(...)`). Such fields are neutralized
+ * by prefixing a single quote AFTER stringification, BEFORE quoting. Genuine
+ * numbers/booleans can't carry a formula and are left untouched (so a negative
+ * score exports as `-5`, not `'-5`).
  */
 
-/** Escape a single CSV field. */
+/** Leading characters Excel/Sheets interpret as a formula trigger. */
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
+/** Escape a single CSV field (with formula-injection neutralization). */
 export function csvField(value: unknown): string {
   let s: string;
   if (value == null) s = '';
   else if (Array.isArray(value)) s = value.map((v) => (v == null ? '' : String(v))).join('; ');
   else if (typeof value === 'object') s = JSON.stringify(value);
   else s = String(value);
+  // Neutralize user-controlled strings that would execute as a spreadsheet
+  // formula; real numbers/booleans are inert and stay verbatim.
+  if (typeof value !== 'number' && typeof value !== 'boolean' && FORMULA_TRIGGER.test(s)) {
+    s = `'${s}`;
+  }
   if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
   return s;
 }

--- a/apps/api/src/csv.ts
+++ b/apps/api/src/csv.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal, dependency-free RFC-4180 CSV encoding for the submissions export.
+ * Values are quoted when they contain a comma, quote, or newline; embedded
+ * quotes are doubled. Arrays flatten to `a; b; c`; null/undefined to empty.
+ */
+
+/** Escape a single CSV field. */
+export function csvField(value: unknown): string {
+  let s: string;
+  if (value == null) s = '';
+  else if (Array.isArray(value)) s = value.map((v) => (v == null ? '' : String(v))).join('; ');
+  else if (typeof value === 'object') s = JSON.stringify(value);
+  else s = String(value);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Join a row of already-collected values into a CSV line (with CRLF). */
+export function csvRow(values: unknown[]): string {
+  return values.map(csvField).join(',') + '\r\n';
+}

--- a/apps/api/src/destination-effects.spec.ts
+++ b/apps/api/src/destination-effects.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Destinations end-to-end on in-memory SQLite: a submission to a form with an
+ * enabled webhook destination enqueues an outbox row (persist-first, never
+ * blocking submit), and the outbox worker drains it pending→done, POSTing the
+ * signed payload. Also asserts the public form NEVER leaks destination config.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createDb,
+  migrate,
+  seed,
+  listOutbox,
+  updateForm,
+  getAccountByCode,
+  listForms,
+  sql,
+  type Db,
+} from '@quill/db';
+import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
+import { signWebhookBody } from '@quill/destinations';
+import { SubmissionService } from './submission.service';
+import { EmailEffects } from './email-effects';
+import { DestinationEffects } from './destination-effects';
+import { OutboxWorker } from './outbox.worker';
+
+let db: Db;
+let svc: SubmissionService;
+let destinations: DestinationEffects;
+
+async function addWebhookDestination(secret?: string) {
+  const account = await getAccountByCode(db, 'acme');
+  const forms = await listForms(db, account!.id);
+  const form = forms.find((f) => f.slug === 'lead-qualifier')!;
+  const full = await db.get<{ config: string }>(sql`SELECT config FROM form WHERE id = ${form.id}`);
+  const config = JSON.parse(full!.config);
+  config.destinations = [
+    {
+      type: 'webhook',
+      enabled: true,
+      settings: { url: 'https://acme.io/hook', secret },
+    },
+  ];
+  await updateForm(db, account!.id, form.id, { config });
+}
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db);
+  const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
+  destinations = new DestinationEffects(db);
+  svc = new SubmissionService(db, email, destinations);
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('destination enqueue on submission', () => {
+  it('enqueues a pending webhook outbox row on a completed submission', async () => {
+    await addWebhookDestination('shh');
+    const out = await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-1',
+      data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+    });
+    expect('error' in out).toBe(false);
+
+    const rows = await listOutbox(db, { kind: 'webhook' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe('pending');
+    expect(rows[0]!.action).toBe('complete');
+    expect(rows[0]!.subjectUid).toBe((out as { id: string }).id);
+  });
+
+  it('extracts UTM from the NESTED data.utm object (renderer convention, PR #4), flat utm_* only as fallback', async () => {
+    // Exercised at the effects level: the renderer POSTs `data.utm` as an object;
+    // the widened submission union ships with the renderer track.
+    await destinations.enqueueSubmissionDeliveries({
+      formId: 'form-1',
+      formName: 'F',
+      accountId: 'acc-1',
+      submissionId: 'sub-utm',
+      sessionId: 's-utm',
+      score: 0,
+      outcomeLabel: null,
+      phase: 'complete',
+      submittedAt: Date.now(),
+      data: {
+        email: 'a@b.io',
+        // Nested convention (primary) …
+        utm: { utm_source: 'google', utm_medium: 'cpc' },
+        // … flat fallback: fills a gap, but NEVER overrides a nested value.
+        utm_source: 'flat-should-lose',
+        utm_campaign: 'q1-flat',
+      },
+      config: {
+        version: 1,
+        steps: [],
+        destinations: [{ type: 'webhook', enabled: true, settings: { url: 'https://x.io/h' } }],
+      },
+    });
+    const rows = await listOutbox(db, { kind: 'webhook', subjectUid: 'sub-utm' });
+    expect(rows).toHaveLength(1);
+    const payload = JSON.parse(rows[0]!.payload!) as { ctx: { utm: Record<string, string> } };
+    expect(payload.ctx.utm).toEqual({
+      utm_source: 'google', // nested wins over the flat clash
+      utm_medium: 'cpc',
+      utm_campaign: 'q1-flat', // flat fills the gap
+    });
+  });
+
+  it('does not enqueue a disabled destination', async () => {
+    const account = await getAccountByCode(db, 'acme');
+    const forms = await listForms(db, account!.id);
+    const form = forms.find((f) => f.slug === 'lead-qualifier')!;
+    const full = await db.get<{ config: string }>(sql`SELECT config FROM form WHERE id = ${form.id}`);
+    const config = JSON.parse(full!.config);
+    config.destinations = [{ type: 'webhook', enabled: false, settings: { url: 'https://x.io/h' } }];
+    await updateForm(db, account!.id, form.id, { config });
+
+    await svc.submit('acme', 'lead-qualifier', { sessionId: 's', data: { email: 'a@b.io' } });
+    expect(await listOutbox(db, { kind: 'webhook' })).toHaveLength(0);
+  });
+
+  it('drains the webhook row pending→done and POSTs a validly-signed payload', async () => {
+    await addWebhookDestination('shh');
+    const out = await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-2',
+      data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+    });
+
+    let received: { url: string; headers: Record<string, string>; body: string } | null = null;
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      received = {
+        url,
+        headers: init.headers as Record<string, string>,
+        body: init.body as string,
+      };
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    destinations.fetchImpl = fetchImpl;
+    const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
+    const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
+    const worker = new OutboxWorker(db, env, email, destinations);
+
+    const processed = await worker.drainOnce();
+    expect(processed).toBeGreaterThanOrEqual(1);
+
+    const rows = await listOutbox(db, { kind: 'webhook' });
+    expect(rows[0]!.status).toBe('done');
+
+    expect(received).not.toBeNull();
+    const got = received!;
+    expect(got.url).toBe('https://acme.io/hook');
+    // The signature validates against the exact body delivered.
+    expect(got.headers['x-quill-signature']).toBe(signWebhookBody(got.body, 'shh'));
+    const payload = JSON.parse(got.body);
+    expect(payload.submission.id).toBe((out as { id: string }).id);
+    expect(payload.submission.score).toBe(18);
+  });
+});
+
+describe('public form config', () => {
+  it('never leaks destination config to the public renderer', async () => {
+    await addWebhookDestination('shh');
+    const publicForm = await svc.publicForm('acme', 'lead-qualifier');
+    expect(publicForm).not.toBeNull();
+    expect((publicForm!.config as Record<string, unknown>).destinations).toBeUndefined();
+    // But the steps the renderer needs are still there.
+    expect(publicForm!.config.steps.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/destination-effects.spec.ts
+++ b/apps/api/src/destination-effects.spec.ts
@@ -72,6 +72,50 @@ describe('destination enqueue on submission', () => {
     expect(rows[0]!.subjectUid).toBe((out as { id: string }).id);
   });
 
+  it('TWO destinations of the SAME type both enqueue and both deliver (per-destination identity)', async () => {
+    const account = await getAccountByCode(db, 'acme');
+    const forms = await listForms(db, account!.id);
+    const form = forms.find((f) => f.slug === 'lead-qualifier')!;
+    const full = await db.get<{ config: string }>(sql`SELECT config FROM form WHERE id = ${form.id}`);
+    const config = JSON.parse(full!.config);
+    config.destinations = [
+      { type: 'webhook', enabled: true, settings: { url: 'https://first.example/hook' } },
+      { type: 'webhook', enabled: true, settings: { url: 'https://second.example/hook' } },
+    ];
+    await updateForm(db, account!.id, form.id, { config });
+
+    const out = await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-two',
+      data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+    });
+    expect('error' in out).toBe(false);
+
+    // Both rows survive enqueue (the per-loop delete used to cancel the first).
+    const rows = await listOutbox(db, { kind: 'webhook' });
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.status === 'pending')).toBe(true);
+    // Distinct per-destination idempotency keys (type alone is not an identity).
+    const keys = rows.map(
+      (r) => (JSON.parse(r.payload!) as { ctx: { idempotencyKey: string } }).ctx.idempotencyKey,
+    );
+    expect(new Set(keys).size).toBe(2);
+
+    // Drain: BOTH endpoints receive their delivery.
+    const urls: string[] = [];
+    destinations.fetchImpl = (async (url: string) => {
+      urls.push(url);
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
+    const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
+    const worker = new OutboxWorker(db, env, email, destinations);
+    await worker.drainOnce();
+
+    expect(urls.sort()).toEqual(['https://first.example/hook', 'https://second.example/hook']);
+    const after = await listOutbox(db, { kind: 'webhook' });
+    expect(after.every((r) => r.status === 'done')).toBe(true);
+  });
+
   it('extracts UTM from the NESTED data.utm object (renderer convention, PR #4), flat utm_* only as fallback', async () => {
     // Exercised at the effects level: the renderer POSTs `data.utm` as an object;
     // the widened submission union ships with the renderer track.

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -1,0 +1,192 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { deletePendingOutbox, enqueueOutbox, type Db, type OutboxKind } from '@quill/db';
+import {
+  createDestination,
+  type DestinationContext,
+  type DestinationSpec,
+} from '@quill/destinations';
+import { formConfigSchema, formDestinationSchema, type FormDestination } from '@quill/types';
+import type { ServerEnv } from '@quill/config/env';
+import { DB, ENV } from './tokens';
+
+/** The delivery snapshot serialized into an outbox row (config + context). */
+interface DestinationOutboxPayload {
+  destination: FormDestination;
+  ctx: DestinationContext;
+}
+
+/** What a persisted submission hands the effects layer to fan out to destinations. */
+export interface SubmissionDeliveryInput {
+  formId: string;
+  formName: string;
+  accountId: string;
+  submissionId: string;
+  sessionId: string;
+  score: number;
+  outcomeLabel: string | null;
+  phase: 'partial' | 'complete';
+  submittedAt: number;
+  /** The submission answers. */
+  data: Record<string, unknown>;
+  /** The stored form config (destinations are read from it). */
+  config: unknown;
+}
+
+/**
+ * Durable SUBMISSION DESTINATIONS (CRM/webhook sync). On a persisted submission
+ * every ENABLED destination is ENQUEUED as an `outbox` row (kind = the
+ * destination type) instead of delivered inline; the OutboxWorker drains it with
+ * retry+backoff. Delivery NEVER blocks or fails submission handling — enqueueing
+ * is wrapped so a bad config can't throw into the submit path, and the actual
+ * HTTP call happens later in the worker. Mirrors EmailEffects exactly.
+ */
+@Injectable()
+export class DestinationEffects {
+  private readonly log = new Logger('DestinationEffects');
+  /** Injectable for tests; defaults to global fetch for destination delivery. */
+  fetchImpl: typeof fetch = fetch;
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Optional() @Inject(ENV) private readonly env?: ServerEnv,
+  ) {}
+
+  /**
+   * Enqueue a delivery for every enabled destination on the form. Never rejects
+   * — the caller fire-and-forgets with `void`; a persisted submission is the
+   * durable fact, destination sync is best-effort-but-retried on top of it.
+   */
+  async enqueueSubmissionDeliveries(input: SubmissionDeliveryInput): Promise<void> {
+    try {
+      const destinations = extractDestinations(input.config);
+      for (const destination of destinations) {
+        if (destination.enabled === false) continue;
+        const kind = destination.type as OutboxKind;
+        const idempotencyKey = `submission:${input.submissionId}:${input.phase}:${destination.type}`;
+        const ctx: DestinationContext = {
+          idempotencyKey,
+          submissionId: input.submissionId,
+          formId: input.formId,
+          formName: input.formName,
+          accountId: input.accountId,
+          sessionId: input.sessionId,
+          score: input.score,
+          outcomeLabel: input.outcomeLabel,
+          phase: input.phase,
+          submittedAt: input.submittedAt,
+          data: input.data,
+          utm: extractUtm(input.data),
+        };
+        const payload: DestinationOutboxPayload = { destination, ctx };
+        // A re-submit of the same session+phase replaces a not-yet-sent delivery.
+        await deletePendingOutbox(this.db, {
+          subjectUid: input.submissionId,
+          kind,
+          action: input.phase,
+        });
+        await enqueueOutbox(this.db, {
+          kind,
+          action: input.phase,
+          subjectUid: input.submissionId,
+          accountId: input.accountId,
+          payload: JSON.stringify(payload),
+        });
+      }
+    } catch (err) {
+      this.log.error(`failed to enqueue submission destinations: ${String(err)}`);
+    }
+  }
+
+  /**
+   * The worker's executor for a destination outbox row (kind webhook/hubspot).
+   * Rebuilds the destination (injecting the server-side HubSpot token at delivery
+   * time — it is never stored in the payload) and delivers. A THROWN transport
+   * error propagates so the worker retries; a permanent no-op (delivered:false)
+   * resolves so the row is marked done.
+   */
+  async deliver(action: string, payloadJson: string): Promise<void> {
+    const { destination, ctx } = JSON.parse(payloadJson) as DestinationOutboxPayload;
+    const spec = this.toSpec(destination);
+    const dest = createDestination(spec, this.fetchImpl);
+    const result = await dest.deliver(ctx);
+    if (!result.delivered) {
+      this.log.warn(
+        `destination ${destination.type} (${ctx.submissionId}/${action}) no-op via ${result.driver}` +
+          (result.detail ? `: ${result.detail}` : ''),
+      );
+    } else {
+      this.log.log(
+        `destination ${destination.type} (${ctx.submissionId}/${action}) delivered` +
+          (result.detail ? `: ${result.detail}` : ''),
+      );
+    }
+  }
+
+  /** Resolve a stored destination config into a delivery spec (inject secrets). */
+  private toSpec(destination: FormDestination): DestinationSpec {
+    if (destination.type === 'webhook') {
+      return {
+        type: 'webhook',
+        webhook: {
+          url: destination.settings.url,
+          secret: destination.settings.secret ?? undefined,
+          signatureHeader: destination.settings.signatureHeader ?? undefined,
+          timeoutMs: destination.settings.timeoutMs,
+        },
+      };
+    }
+    return {
+      type: 'hubspot',
+      hubspot: {
+        // Server-side secret, injected at delivery time — never persisted.
+        token: this.env?.HUBSPOT_PRIVATE_APP_TOKEN ?? '',
+        fieldMappings: destination.fieldMappings ?? {},
+        utmMappings: destination.utmMappings ?? {},
+        scoreProperty: destination.scoreProperty ?? undefined,
+        dateProperty: destination.dateProperty ?? undefined,
+        note: destination.settings?.note,
+      },
+    };
+  }
+}
+
+/** Read the destinations array from a stored config, tolerating legacy/absent. */
+function extractDestinations(config: unknown): FormDestination[] {
+  const parsed = formConfigSchema.safeParse(config);
+  if (parsed.success) return parsed.data.destinations ?? [];
+  // A config that fails full validation still shouldn't break sync — best-effort:
+  // validate each destination entry on its own.
+  if (config && typeof config === 'object' && Array.isArray((config as { destinations?: unknown }).destinations)) {
+    const out: FormDestination[] = [];
+    for (const d of (config as { destinations: unknown[] }).destinations) {
+      const one = formDestinationSchema.safeParse(d);
+      if (one.success) out.push(one.data);
+    }
+    return out;
+  }
+  return [];
+}
+
+/**
+ * Pull UTM values from a submission. The renderer's convention (PR #4) is a
+ * NESTED `data.utm` object (`data: {..., utm: {utm_source, utm_medium, ...}}`) —
+ * that is the primary source. Flat top-level `utm_*` answer keys are accepted as
+ * a robustness fallback only; they never override a nested value.
+ */
+function extractUtm(data: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  const add = (key: string, value: unknown) => {
+    if (key in out) return; // first writer wins — nested is written first
+    if (value !== undefined && value !== null && String(value).trim() !== '') {
+      out[key] = String(value).trim();
+    }
+  };
+  const nested = data.utm;
+  if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+    for (const [key, value] of Object.entries(nested as Record<string, unknown>)) add(key, value);
+  }
+  for (const [key, value] of Object.entries(data)) {
+    if (/^utm_/i.test(key)) add(key, value);
+  }
+  return out;
+}

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -59,10 +59,32 @@ export class DestinationEffects {
   async enqueueSubmissionDeliveries(input: SubmissionDeliveryInput): Promise<void> {
     try {
       const destinations = extractDestinations(input.config);
-      for (const destination of destinations) {
-        if (destination.enabled === false) continue;
+      const enabled = destinations
+        .map((destination, index) => ({ destination, index }))
+        .filter(({ destination }) => destination.enabled !== false);
+
+      // A re-submit of the same session+phase replaces every not-yet-sent
+      // delivery: cancel pending rows ONCE per kind BEFORE the enqueue loop.
+      // Deleting inside the loop would cancel a sibling destination of the same
+      // type that was just enqueued (two webhooks are legal — only the last one
+      // would ever deliver).
+      const kinds = new Set<OutboxKind>(
+        enabled.map(({ destination }) => destination.type as OutboxKind),
+      );
+      for (const kind of kinds) {
+        await deletePendingOutbox(this.db, {
+          subjectUid: input.submissionId,
+          kind,
+          action: input.phase,
+        });
+      }
+
+      for (const { destination, index } of enabled) {
         const kind = destination.type as OutboxKind;
-        const idempotencyKey = `submission:${input.submissionId}:${input.phase}:${destination.type}`;
+        // Per-destination identity: the config-array index disambiguates two
+        // destinations of the same type, so each delivery carries its own
+        // idempotency key (receivers de-dup per destination, not per type).
+        const idempotencyKey = `submission:${input.submissionId}:${input.phase}:${destination.type}:${index}`;
         const ctx: DestinationContext = {
           idempotencyKey,
           submissionId: input.submissionId,
@@ -78,12 +100,6 @@ export class DestinationEffects {
           utm: extractUtm(input.data),
         };
         const payload: DestinationOutboxPayload = { destination, ctx };
-        // A re-submit of the same session+phase replaces a not-yet-sent delivery.
-        await deletePendingOutbox(this.db, {
-          subjectUid: input.submissionId,
-          kind,
-          action: input.phase,
-        });
         await enqueueOutbox(this.db, {
           kind,
           action: input.phase,

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -1,0 +1,89 @@
+import { Controller, Get, Inject, Injectable, Req } from '@nestjs/common';
+import type { ServerEnv } from '@quill/config/env';
+import { AuthService, type ReqLike } from './auth.service';
+import { ENV } from './tokens';
+
+/** A HubSpot contact property surfaced to the mapping UI. */
+export interface HubSpotPropertyDto {
+  name: string;
+  label: string;
+  type: string;
+}
+
+/** The property-picker response: disabled (no token) or the cached property list. */
+export type HubSpotPropertiesResponse =
+  | { enabled: false; reason: string }
+  | { enabled: true; cached: boolean; properties: HubSpotPropertyDto[] };
+
+const PLACEHOLDER_TOKENS = new Set(['', 'your_private_app_token_here', 'your_token_here']);
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const HUBSPOT_PROPERTIES_URL = 'https://api.hubapi.com/crm/v3/properties/contacts';
+
+interface HubSpotPropertiesApiResponse {
+  results?: Array<{ name: string; label?: string; type?: string }>;
+}
+
+/**
+ * Server-side HubSpot property lookup for the mapping UI. The private-app token
+ * lives only here (never in the browser); results are cached 5 minutes to stay
+ * well under HubSpot rate limits. Without a token it reports a clear disabled
+ * state instead of erroring — a webhook-only deployment needs no HubSpot config.
+ */
+@Injectable()
+export class HubspotPropertiesService {
+  private cache: { data: HubSpotPropertyDto[]; expires: number } | null = null;
+
+  constructor(
+    @Inject(ENV) private readonly env: ServerEnv,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  private token(): string | null {
+    const token = this.env.HUBSPOT_PRIVATE_APP_TOKEN;
+    if (!token || PLACEHOLDER_TOKENS.has(token.trim())) return null;
+    return token;
+  }
+
+  async listProperties(now = Date.now()): Promise<HubSpotPropertiesResponse> {
+    const token = this.token();
+    if (!token) {
+      return {
+        enabled: false,
+        reason: 'HUBSPOT_PRIVATE_APP_TOKEN is not configured on the server.',
+      };
+    }
+    if (this.cache && this.cache.expires > now) {
+      return { enabled: true, cached: true, properties: this.cache.data };
+    }
+    const res = await this.fetchImpl(HUBSPOT_PROPERTIES_URL, {
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    });
+    if (!res.ok) {
+      // Don't cache a failure; report disabled with the status so the UI can show it.
+      return { enabled: false, reason: `HubSpot rejected the request (HTTP ${res.status}).` };
+    }
+    const body = (await res.json().catch(() => ({}))) as HubSpotPropertiesApiResponse;
+    const properties = (body.results ?? [])
+      .map((p) => ({ name: p.name, label: p.label || p.name, type: p.type ?? 'string' }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    this.cache = { data: properties, expires: now + CACHE_TTL_MS };
+    return { enabled: true, cached: false, properties };
+  }
+}
+
+/** Auth-gated integration endpoints for the admin mapping UI. */
+@Controller('v1/integrations')
+export class IntegrationsController {
+  constructor(
+    @Inject(AuthService) private readonly auth: AuthService,
+    @Inject(HubspotPropertiesService) private readonly hubspot: HubspotPropertiesService,
+  ) {}
+
+  /** HubSpot contact-property picker (server-side token, 5-min cache). */
+  @Get('hubspot/properties')
+  async hubspotProperties(@Req() req: ReqLike): Promise<HubSpotPropertiesResponse> {
+    // Any authenticated host may read the property list (it drives their mapping UI).
+    await this.auth.resolveHost(req);
+    return this.hubspot.listProperties();
+  }
+}

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -1,7 +1,22 @@
-import { Controller, Get, Inject, Injectable, Req } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Inject,
+  Injectable,
+  NotFoundException,
+  Param,
+  Put,
+  Req,
+} from '@nestjs/common';
+import { z, ZodError } from 'zod';
+import type { Db } from '@quill/db';
+import { updateFormDestinations } from '@quill/db';
+import { formDestinationSchema } from '@quill/types';
 import type { ServerEnv } from '@quill/config/env';
 import { AuthService, type ReqLike } from './auth.service';
-import { ENV } from './tokens';
+import { DB, ENV } from './tokens';
 
 /** A HubSpot contact property surfaced to the mapping UI. */
 export interface HubSpotPropertyDto {
@@ -85,5 +100,38 @@ export class IntegrationsController {
     // Any authenticated host may read the property list (it drives their mapping UI).
     await this.auth.resolveHost(req);
     return this.hubspot.listProperties();
+  }
+}
+
+const destinationsBodySchema = z.object({ destinations: z.array(formDestinationSchema) });
+
+/**
+ * Auth-gated PARTIAL config write for the integrations screen: replaces ONLY the
+ * `destinations` key, merged against the row's fresh config server-side in one
+ * request — the web tier no longer reads the whole config and writes it back
+ * (which raced a concurrent editor save). See updateFormDestinations for the
+ * optimistic-locking caveat.
+ */
+@Controller('v1')
+export class FormDestinationsController {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AuthService) private readonly auth: AuthService,
+  ) {}
+
+  @Put('forms/:id/destinations')
+  async putDestinations(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    let destinations: unknown[];
+    try {
+      destinations = destinationsBodySchema.parse(body).destinations;
+    } catch (err) {
+      if (err instanceof ZodError)
+        throw new BadRequestException({ error: 'BAD_REQUEST', message: err.issues[0]?.message });
+      throw err;
+    }
+    const out = await updateFormDestinations(this.db, p.accountId, id, destinations);
+    if (!out.ok) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    return out.value;
   }
 }

--- a/apps/api/src/outbox.worker.ts
+++ b/apps/api/src/outbox.worker.ts
@@ -16,6 +16,7 @@ import {
 } from '@quill/db';
 import type { ServerEnv } from '@quill/config/env';
 import { EmailEffects, OutboxSkipError } from './email-effects';
+import { DestinationEffects } from './destination-effects';
 import { DB, ENV } from './tokens';
 
 /**
@@ -49,6 +50,7 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
     // reflected metadata for this class dep injects `undefined`. @Inject keeps
     // the class a value and gives Nest the token directly.
     @Inject(EmailEffects) private readonly email: EmailEffects,
+    @Inject(DestinationEffects) private readonly destinations: DestinationEffects,
   ) {}
 
   onModuleInit(): void {
@@ -126,8 +128,11 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       await this.email.deliver(row.action, row.payload, row.accountId);
       return;
     }
-    // Forms only enqueues `email` today; a future webhook/integration port can
-    // add its own kind here (reusing the same outbox + retry machinery).
+    if (row.kind === 'webhook' || row.kind === 'hubspot') {
+      if (row.payload == null) throw new Error(`${row.kind} outbox row missing payload`);
+      await this.destinations.deliver(row.action, row.payload);
+      return;
+    }
     throw new Error(`unknown outbox kind: ${String(row.kind)}`);
   }
 }

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -25,3 +25,14 @@ export function parseBound(v: string | undefined, endOfDay: boolean): number | n
 export function parseStatus(v: string | undefined): SubmissionStatus {
   return v === 'completed' || v === 'partial' ? v : 'all';
 }
+
+/**
+ * Parse a non-negative integer query param (limit/offset). Non-numeric input
+ * must resolve to `undefined` — a raw `Number('abc')` is NaN, which would reach
+ * SQL as `LIMIT NaN` (empty result on SQLite, ERROR on Postgres).
+ */
+export function parseIntParam(v: string | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : undefined;
+}

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared query-param parsers for the admin read surface (analytics +
+ * submissions). A date bound accepts epoch-ms passthrough or a YYYY-MM-DD / ISO
+ * string; a status narrows the submissions filter. Kept dialect- and
+ * framework-agnostic so both controllers parse identically.
+ */
+import type { SubmissionStatus } from '@quill/db';
+
+/** Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. */
+export function parseBound(v: string | undefined, endOfDay: boolean): number | null {
+  if (!v) return null;
+  if (/^\d+$/.test(v)) return Number(v);
+  const t = Date.parse(v);
+  if (Number.isNaN(t)) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+    const d = new Date(t);
+    if (endOfDay) d.setUTCHours(23, 59, 59, 999);
+    else d.setUTCHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+  return t;
+}
+
+/** Narrow a raw status query to the allowed filter (defaults to `all`). */
+export function parseStatus(v: string | undefined): SubmissionStatus {
+  return v === 'completed' || v === 'partial' ? v : 'all';
+}

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 import type { Db } from '@quill/db';
 import {
   getPublishedForm,
@@ -10,6 +10,7 @@ import {
 import { computeScore, resolveOutcome, type FormConfig } from '@quill/engine';
 import { submissionSchema, formEventSchema, type PublicForm } from '@quill/types';
 import { EmailEffects } from './email-effects';
+import { DestinationEffects } from './destination-effects';
 import { DB } from './tokens';
 
 export type ServiceError = { error: string; message: string; status: number };
@@ -24,13 +25,18 @@ export class SubmissionService {
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(EmailEffects) private readonly email: EmailEffects,
+    // Optional so existing direct constructions (tests) keep working; the module
+    // always provides it in the running app.
+    @Optional() @Inject(DestinationEffects) private readonly destinations?: DestinationEffects,
   ) {}
 
   /** The published form for a public code + slug (the renderer's config). */
   async publicForm(accountCode: string, slug: string): Promise<PublicForm | null> {
     const f = await getPublishedForm(this.db, accountCode, slug);
     if (!f) return null;
-    return { slug: f.slug, name: f.name, config: f.config as FormConfig };
+    // NEVER leak destination config (webhook URLs/secrets, CRM mappings) to the
+    // public renderer — it is server-only integration config.
+    return { slug: f.slug, name: f.name, config: toPublicConfig(f.config) };
   }
 
   /**
@@ -69,6 +75,25 @@ export class SubmissionService {
       });
     }
 
+    // Fan out to every enabled destination (CRM/webhook) via the durable outbox.
+    // Persist-first: this only ENQUEUES local outbox rows (cheap, never network,
+    // internally guarded so it cannot throw) — the actual delivery happens later
+    // in the worker, so the submission is never blocked or failed by a slow/failing
+    // destination. Enqueued for BOTH phases; adapters decide phase behavior.
+    await this.destinations?.enqueueSubmissionDeliveries({
+      formId: form.id,
+      formName: form.name,
+      accountId: form.accountId,
+      submissionId: row.id,
+      sessionId: input.sessionId,
+      score,
+      outcomeLabel: outcome?.label ?? null,
+      phase: input.partial ? 'partial' : 'complete',
+      submittedAt: Date.now(),
+      data: input.data,
+      config,
+    });
+
     return { id: row.id, score, outcome: outcome?.id ?? null };
   }
 
@@ -90,6 +115,17 @@ export class SubmissionService {
   listSubmissions(formId: string): Promise<SubmissionRow[]> {
     return listSubmissions(this.db, formId);
   }
+}
+
+/**
+ * Strip server-only sections (submission `destinations`: webhook URLs/secrets,
+ * CRM property mappings) from a stored config before it is served to the public
+ * renderer. The renderer only needs cover/steps/scoring/outcomes.
+ */
+function toPublicConfig(config: unknown): FormConfig {
+  const c = (config ?? { version: 1, steps: [] }) as Record<string, unknown>;
+  const { destinations: _destinations, ...rest } = c;
+  return rest as unknown as FormConfig;
 }
 
 /** Best-effort pick the respondent's email out of the answers for the receipt. */

--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -2,11 +2,14 @@
 
 import { postSubmission, postFormEvent } from '@/lib/api';
 
-/** Submit a completed form (score recomputed server-side). */
+/**
+ * Submit a form — partial (past the lead-capture threshold) or complete. The
+ * score is always recomputed server-side; the client value is never trusted.
+ */
 export async function submitFormAction(
   accountCode: string,
   slug: string,
-  payload: { sessionId: string; data: Record<string, unknown> },
+  payload: { sessionId: string; data: Record<string, unknown>; partial?: boolean },
 ): Promise<{ ok: boolean; score?: number; outcome?: string | null; message?: string }> {
   const res = await postSubmission(accountCode, slug, payload);
   return { ok: res.ok, score: res.score, outcome: res.outcome, message: res.message };

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   visibleSteps,
   validateAnswer,
+  resolveQuestion,
   type Answers,
   type FormStep,
 } from '@quill/engine';
@@ -107,6 +108,11 @@ export function FormRenderer({
   if (!started && cover) {
     return (
       <div className="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-8 text-center">
+        {cover.bannerText ? (
+          <div className="mb-1 w-full rounded-md bg-primary/15 px-3 py-1.5 text-xs font-medium text-foreground">
+            {cover.bannerText}
+          </div>
+        ) : null}
         {cover.eyebrow ? (
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {cover.eyebrow}
@@ -151,7 +157,7 @@ export function FormRenderer({
       </div>
 
       <div className="flex flex-col gap-1">
-        <h2 className="text-xl font-semibold">{step.question ?? step.key}</h2>
+        <h2 className="text-xl font-semibold">{resolveQuestion(step, answers) || step.key}</h2>
         {step.helper ? <p className="text-sm text-muted-foreground">{step.helper}</p> : null}
       </div>
 

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -1,21 +1,39 @@
 'use client';
 
 /**
- * Minimal public form renderer (ugly-but-working; Phase 1 brings the real UI).
- * Walks the visible steps with the engine (skip-logic + validation shared with
- * the server), posts funnel events, and submits via the server action. The
- * per-session id lives in sessionStorage so events + submission tie together.
+ * The public form experience — a mobile-first, one-question-per-screen flow
+ * driven entirely by `@quill/engine` (visibleSteps/runtimeSteps/validate/score/
+ * outcome), so the client and server agree on flow, score, and outcome. It walks
+ * the engine's ordered visible steps, records the funnel event stream, persists a
+ * partial submission past the lead-capture threshold and a complete one at the
+ * end, then resolves the outcome bucket to a redirect or a thank-you screen.
+ *
+ * User-visible copy comes from the form CONFIG (localizable per form); only the
+ * renderer chrome (buttons, errors, thank-you) is i18n'd via @quill/shared.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  visibleSteps,
-  validateAnswer,
-  resolveQuestion,
+  runtimeSteps,
+  validateAnswerCode,
+  resolveOutcome,
+  partialSubmitKey,
+  nameFields,
   type Answers,
+  type AnswerValue,
   type FormStep,
 } from '@quill/engine';
+import { onAccent, getMessages, t } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
+import { signupHref } from '@/lib/growth';
+import { FormLogo } from '@/components/public/form-logo';
+import { FormProgress } from '@/components/public/form-progress';
+import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
+import { StepInput } from '@/components/public/step-input';
 import { submitFormAction, recordEventAction } from './actions';
+import './public-form.css';
+
+type Phase = 'cover' | 'steps' | 'reveal' | 'submitting' | 'done';
+const REVEAL_MS = 2200;
 
 function useSessionId(key: string): string {
   const [id] = useState(() => {
@@ -29,205 +47,438 @@ function useSessionId(key: string): string {
   return id;
 }
 
+/** Read `utm_*` query params from the current URL into a flat string map. */
+function captureUtm(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  const utm: Record<string, string> = {};
+  for (const [k, v] of params.entries()) {
+    if (k.toLowerCase().startsWith('utm_') && v) utm[k] = v;
+  }
+  return utm;
+}
+
 export function FormRenderer({
   accountCode,
   slug,
   name,
   config,
+  locale = 'en',
 }: {
   accountCode: string;
   slug: string;
   name: string;
   config: FormConfig;
+  locale?: string;
 }) {
+  const m = getMessages(locale).renderer;
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
-  const cover = config.cover?.enabled ? config.cover : null;
-  const [started, setStarted] = useState(!cover);
+  const cover = config.cover && config.cover.enabled !== false ? config.cover : null;
+
+  const [phase, setPhase] = useState<Phase>(cover ? 'cover' : 'steps');
   const [answers, setAnswers] = useState<Answers>({});
   const [index, setIndex] = useState(0);
+  const [animKey, setAnimKey] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [done, setDone] = useState<{ score?: number; outcome?: string | null } | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState<{ score: number; outcome: string | null } | null>(null);
 
-  // The engine decides which steps are visible given the answers so far.
-  const steps = useMemo(
-    () => visibleSteps(config as never, answers) as FormStep[],
-    [config, answers],
+  const utmRef = useRef<Record<string, string>>({});
+  const viewTracked = useRef(false);
+  const partialSent = useRef(false);
+  const advancing = useRef(false);
+  const submitAfterReveal = useRef(false);
+  const lastStepViewKey = useRef<string | null>(null);
+  const engineConfig = config as unknown as Parameters<typeof runtimeSteps>[0];
+
+  // The engine decides the ordered, visible, display-resolved steps.
+  const steps = useMemo<FormStep[]>(
+    () => runtimeSteps(engineConfig, answers),
+    [engineConfig, answers],
   );
-  const step = steps[Math.min(index, Math.max(steps.length - 1, 0))];
+  const step = steps[index];
+  const thresholdKey = useMemo(() => partialSubmitKey(engineConfig), [engineConfig]);
 
+  // Accent branding (only override the local default when a color is configured).
+  const primary = config.branding?.primaryColor ?? null;
+  const accentVars = primary
+    ? ({ ['--pf-primary']: primary, ['--pf-primary-contrast']: onAccent(primary) } as React.CSSProperties)
+    : undefined;
+
+  const err = (code: string) => m.errors[code as keyof typeof m.errors] ?? m.errors.required;
+
+  const track = useCallback(
+    (type: string, stepIndex?: number) => {
+      if (!sessionId) return;
+      void recordEventAction(accountCode, slug, { sessionId, type, stepIndex: stepIndex ?? null });
+    },
+    [accountCode, slug, sessionId],
+  );
+
+  // Capture UTM once, and fire a single `view` per session per load.
   useEffect(() => {
-    if (sessionId) void recordEventAction(accountCode, slug, { sessionId, type: 'view' });
-  }, [sessionId, accountCode, slug]);
+    utmRef.current = captureUtm();
+  }, []);
+  useEffect(() => {
+    if (!sessionId || viewTracked.current) return;
+    viewTracked.current = true;
+    track('view');
+  }, [sessionId, track]);
+
+  // step_view once when a step becomes current — keyed by phase+index so an
+  // answer keystroke (which recomputes `step`) never re-fires the same view.
+  useEffect(() => {
+    if (phase !== 'steps' || !step) return;
+    const key = `${phase}:${index}`;
+    if (lastStepViewKey.current === key) return;
+    lastStepViewKey.current = key;
+    track('step_view', index);
+  }, [phase, index, step, track]);
+
+  // Clamp the index if the visible-step set shrinks (a branch closed).
+  useEffect(() => {
+    if (phase === 'steps' && steps.length > 0 && index >= steps.length) {
+      setIndex(steps.length - 1);
+    }
+  }, [phase, index, steps.length]);
+
+  function withData(a: Answers): Record<string, unknown> {
+    const utm = utmRef.current;
+    return Object.keys(utm).length > 0 ? { ...a, utm } : { ...a };
+  }
+
+  const finalize = useCallback(
+    async (finalAnswers: Answers) => {
+      setPhase('submitting');
+      const res = await submitFormAction(accountCode, slug, {
+        sessionId,
+        data: withData(finalAnswers),
+      });
+      if (!res.ok) {
+        setError(res.message ?? err('submit'));
+        setPhase('steps');
+        return;
+      }
+      track('submit');
+      const score = res.score ?? 0;
+      const outcome = resolveOutcome(engineConfig, score);
+      if (outcome?.redirectUrl) {
+        window.location.href = outcome.redirectUrl;
+        return;
+      }
+      setDone({ score, outcome: res.outcome ?? null });
+      setPhase('done');
+    },
+    [accountCode, slug, sessionId, engineConfig, track],
+  );
+
+  const advance = useCallback(
+    async (nextAnswers: Answers, completed: FormStep) => {
+      if (advancing.current) return;
+      advancing.current = true;
+      try {
+        const nextSteps = runtimeSteps(engineConfig, nextAnswers);
+        const completedIdx = nextSteps.findIndex((s) => s.key === completed.key);
+        const isLast = completedIdx >= 0 ? completedIdx >= nextSteps.length - 1 : index >= nextSteps.length - 1;
+
+        track('step_complete', index);
+
+        // Partial submit once past the configured lead-capture threshold.
+        if (thresholdKey && completed.key === thresholdKey && !partialSent.current) {
+          partialSent.current = true;
+          track('partial_submit', index);
+          void submitFormAction(accountCode, slug, {
+            sessionId,
+            data: withData(nextAnswers),
+            partial: true,
+          });
+        }
+
+        // Terminal (disqualify) step → finalize now, skip reveal/booking.
+        if (completed.terminal) {
+          await finalize(nextAnswers);
+          return;
+        }
+
+        // Optional processing/reveal interstitial after this step.
+        const reveal = config.reveal && config.reveal.enabled !== false;
+        if (reveal && completed.triggersReveal) {
+          submitAfterReveal.current = isLast;
+          if (!isLast) setIndex(completedIdx + 1);
+          setPhase('reveal');
+          return;
+        }
+
+        if (isLast) {
+          await finalize(nextAnswers);
+          return;
+        }
+
+        setAnimKey((k) => k + 1);
+        setError(null);
+        setIndex(completedIdx >= 0 ? completedIdx + 1 : Math.min(index + 1, nextSteps.length - 1));
+      } finally {
+        advancing.current = false;
+      }
+    },
+    [engineConfig, index, thresholdKey, accountCode, slug, sessionId, config.reveal, finalize, track],
+  );
+
+  function submitCurrent() {
+    if (!step) return;
+    const check = validateAnswerCode(step, answers[step.key], answers);
+    if (!check.ok) {
+      setError(err(check.code));
+      return;
+    }
+    setError(null);
+    void advance(answers, step);
+  }
+
+  // Choice/dropdown selection: record the answer and auto-advance.
+  function select(value: string) {
+    if (!step) return;
+    const next = { ...answers, [step.key]: value };
+    setAnswers(next);
+    setError(null);
+    void advance(next, step);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key !== 'Enter' || !step) return;
+    if (step.type === 'textarea' || step.type === 'dropdown' || step.type === 'multiple_choice') return;
+    // Name: hop to the second field if the first is filled and the second empty.
+    if (step.type === 'name') {
+      const [, second] = nameFields(step);
+      if (second && !String(answers[second] ?? '').trim()) {
+        const inputs = (e.currentTarget as HTMLElement).querySelectorAll<HTMLInputElement>('.pf-name-fields .pf-input');
+        if (document.activeElement === inputs[0] && inputs[1]) {
+          e.preventDefault();
+          inputs[1].focus();
+          return;
+        }
+      }
+    }
+    e.preventDefault();
+    submitCurrent();
+  }
 
   function start() {
-    setStarted(true);
-    void recordEventAction(accountCode, slug, { sessionId, type: 'start' });
+    track('start');
+    lastStepViewKey.current = null;
+    setPhase('steps');
+    setIndex(0);
+    setAnimKey((k) => k + 1);
   }
 
-  function setValue(value: string | number) {
-    if (!step) return;
-    setAnswers((a) => ({ ...a, [step.key]: value }));
+  function back() {
     setError(null);
+    if (phase === 'steps' && index > 0) {
+      setAnimKey((k) => k + 1);
+      setIndex((i) => i - 1);
+    } else if (phase === 'steps' && index === 0 && cover) {
+      setPhase('cover');
+    }
   }
 
-  async function next() {
-    if (!step) return;
-    const check = validateAnswer(step, answers[step.key]);
-    if (!check.ok) {
-      setError(check.error);
-      return;
-    }
-    void recordEventAction(accountCode, slug, { sessionId, type: 'step_complete', stepIndex: index });
-    if (index + 1 < steps.length) {
-      setIndex(index + 1);
-      void recordEventAction(accountCode, slug, { sessionId, type: 'step_view', stepIndex: index + 1 });
-      return;
-    }
-    // Final step → submit.
-    setSubmitting(true);
-    const res = await submitFormAction(accountCode, slug, { sessionId, data: answers as Record<string, unknown> });
-    setSubmitting(false);
-    if (!res.ok) {
-      setError(res.message ?? 'Could not submit — please try again.');
-      return;
-    }
-    void recordEventAction(accountCode, slug, { sessionId, type: 'submit' });
-    setDone({ score: res.score, outcome: res.outcome });
-  }
+  // Drive the reveal interstitial: after REVEAL_MS, continue or finalize.
+  useEffect(() => {
+    if (phase !== 'reveal') return;
+    const timer = setTimeout(() => {
+      if (submitAfterReveal.current) {
+        submitAfterReveal.current = false;
+        void finalize(answers);
+      } else {
+        setAnimKey((k) => k + 1);
+        setPhase('steps');
+      }
+    }, REVEAL_MS);
+    return () => clearTimeout(timer);
+  }, [phase]);
 
-  if (done) {
+  // --- Screens --------------------------------------------------------------
+
+  if (phase === 'done' && done) {
+    const outcome = resolveOutcome(engineConfig, done.score);
+    const cta = signupHref('confirmation', accountCode);
     return (
-      <div className="flex flex-col items-center gap-3 rounded-md border border-border bg-card p-8 text-center">
-        <h1 className="text-2xl font-semibold">Thank you!</h1>
-        <p className="text-muted-foreground">Your responses to “{name}” were recorded.</p>
+      <div className="pf pf--done" style={accentVars}>
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <div className="pf-done__inner pf-animate">
+          <div className="pf-done__check" aria-hidden="true">
+            ✓
+          </div>
+          <h1 className="pf-done__title">{outcome?.label ?? m.thankYouTitle}</h1>
+          <p className="pf-done__body">{t(m.thankYouBody, { name })}</p>
+          {cta ? (
+            <>
+              <p className="pf-done__cta-question">{m.ctaQuestion}</p>
+              <a className="pf-done__cta" href={cta} target="_blank" rel="noopener noreferrer">
+                {m.ctaAction}
+                <span className="sr-only"> {m.newTab}</span>
+              </a>
+            </>
+          ) : null}
+        </div>
       </div>
     );
   }
 
-  if (!started && cover) {
+  if (phase === 'reveal') {
+    const reveal = config.reveal ?? {};
     return (
-      <div className="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-8 text-center">
-        {cover.bannerText ? (
-          <div className="mb-1 w-full rounded-md bg-primary/15 px-3 py-1.5 text-xs font-medium text-foreground">
-            {cover.bannerText}
+      <div className="pf pf--reveal" style={accentVars} role="status" aria-live="polite">
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <RevealBody
+          headline={reveal.headline ?? m.revealHeadline}
+          subtitle={reveal.subtitle ?? m.revealSubtitle}
+        />
+      </div>
+    );
+  }
+
+  if (phase === 'submitting') {
+    return (
+      <div className="pf pf--reveal" style={accentVars} role="status" aria-live="polite">
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <div className="pf-reveal__inner">
+          <div className="pf-reveal__spinner" aria-hidden="true" />
+          <p className="pf-reveal__subtitle">{m.submitting}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'cover' && cover) {
+    const logo = cover.logo ?? config.branding?.logo ?? null;
+    const logos = cover.clientLogos ?? config.branding?.clientLogos ?? [];
+    return (
+      <div
+        className="pf pf--cover"
+        style={accentVars}
+        onKeyDown={(e) => e.key === 'Enter' && start()}
+        tabIndex={-1}
+      >
+        {cover.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        <header className="pf__cover-header">
+          <FormLogo src={logo} name={name} />
+        </header>
+        <div className="pf__cover-main">
+          <div className="pf__cover-content pf-animate">
+            {cover.eyebrow || cover.badge ? (
+              <p className="pf__badge">{cover.eyebrow ?? cover.badge}</p>
+            ) : null}
+            <h1 className="pf__title">{cover.headline ?? name}</h1>
+            {cover.subheadline ? <p className="pf__subheadline">{cover.subheadline}</p> : null}
+            {cover.trustBadge ? <p className="pf__trust">{cover.trustBadge}</p> : null}
           </div>
-        ) : null}
-        {cover.eyebrow ? (
-          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            {cover.eyebrow}
-          </span>
-        ) : null}
-        <h1 className="text-3xl font-semibold tracking-tight">{cover.headline ?? name}</h1>
-        {cover.subheadline ? <p className="text-muted-foreground">{cover.subheadline}</p> : null}
-        <button
-          type="button"
-          onClick={start}
-          className="rounded-md bg-primary px-6 py-3 font-semibold text-primary-foreground active:scale-[0.98]"
-        >
-          {cover.ctaText ?? 'Start'}
-        </button>
-        {cover.trustBadge ? <p className="text-xs text-muted-foreground">{cover.trustBadge}</p> : null}
+          <ClientLogosMarquee logos={logos} label={m.trustedBy} />
+        </div>
+        <div className="pf__cover-footer">
+          <button type="button" className="pf__btn" onClick={start}>
+            {cover.ctaText ?? m.start}
+          </button>
+        </div>
       </div>
     );
   }
 
   if (!step) {
-    return <p className="text-center text-muted-foreground">This form has no steps yet.</p>;
+    return (
+      <div className="pf" style={accentVars}>
+        <div className="pf__body">
+          <p className="pf__helper">{m.noSteps}</p>
+        </div>
+      </div>
+    );
   }
 
-  const value = answers[step.key];
+  const showContinue = step.type !== 'multiple_choice' && step.type !== 'dropdown';
+  const logo = cover?.logo ?? config.branding?.logo ?? null;
 
   return (
-    <div className="flex flex-col gap-5 rounded-md border border-border bg-card p-8">
-      {/* Progress dots across the currently-visible steps. */}
-      <div
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={steps.length}
-        aria-valuenow={index + 1}
-        className="flex items-center gap-1.5"
-      >
-        {steps.map((s, i) => (
-          <span
-            key={s.key}
-            className={`h-1.5 flex-1 rounded-full ${i <= index ? 'bg-primary' : 'bg-muted'}`}
-          />
-        ))}
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <h2 className="text-xl font-semibold">{resolveQuestion(step, answers) || step.key}</h2>
-        {step.helper ? <p className="text-sm text-muted-foreground">{step.helper}</p> : null}
-      </div>
-
-      {step.type === 'message' ? null : step.type === 'dropdown' || step.type === 'multiple_choice' ? (
-        <div className="flex flex-col gap-2">
-          {(step.options ?? []).map((o) => (
-            <button
-              key={o.value}
-              type="button"
-              onClick={() => setValue(o.value)}
-              className={`rounded-md border px-4 py-3 text-left transition-colors ${
-                value === o.value ? 'border-primary bg-primary/10' : 'border-border hover:border-primary'
-              }`}
-            >
-              {o.label}
+    <div className="pf" style={accentVars} onKeyDown={onKeyDown}>
+      {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+      <header className="pf__topbar">
+        <div className="pf__topbar-inner">
+          {index > 0 || cover ? (
+            <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+              ←
             </button>
-          ))}
+          ) : (
+            <span className="pf__back pf__back--placeholder" />
+          )}
+          <FormLogo src={logo} name={name} />
+          <span className="pf__back pf__back--placeholder" />
         </div>
-      ) : step.type === 'slider' ? (
-        <div className="flex items-center gap-3">
-          <input
-            type="range"
-            min={step.min ?? 0}
-            max={step.max ?? 100}
-            step={step.step ?? 1}
-            value={Number(value ?? step.default ?? step.min ?? 0)}
-            onChange={(e) => setValue(Number(e.target.value))}
-            className="flex-1"
-          />
-          <span className="w-12 text-right font-mono text-sm">
-            {String(value ?? step.default ?? step.min ?? 0)}
-          </span>
+        <FormProgress total={steps.length} currentIndex={index} locale={locale} />
+      </header>
+
+      <div className="pf__body">
+        <div className="pf__inner">
+          <div className="pf__content pf-animate" key={animKey}>
+            <div className="pf__question-wrap">
+              <h2 className="pf__question">{step.question ?? step.key}</h2>
+              {step.helper && step.type !== 'message' ? (
+                <p className="pf__helper">{step.helper}</p>
+              ) : null}
+            </div>
+
+            <div className="pf__fields">
+              <StepInput
+                step={step}
+                value={answers[step.key]}
+                answers={answers}
+                onChange={(v: AnswerValue) => {
+                  setAnswers((a) => ({ ...a, [step.key]: v }));
+                  setError(null);
+                }}
+                onFieldChange={(field, v) => {
+                  setAnswers((a) => ({ ...a, [field]: v }));
+                  setError(null);
+                }}
+                onSelect={select}
+                dropdownPlaceholder={m.dropdownPlaceholder}
+                dropdownEmpty={m.dropdownEmpty}
+              />
+
+              {error ? (
+                <p className="pf__error" role="alert">
+                  {error}
+                </p>
+              ) : null}
+
+              {showContinue ? (
+                <button type="button" className="pf__btn pf__btn--inline" onClick={submitCurrent}>
+                  {step.buttonText ?? (index + 1 === steps.length ? m.submit : m.next)}
+                </button>
+              ) : null}
+            </div>
+          </div>
         </div>
-      ) : step.type === 'textarea' ? (
-        <textarea
-          value={String(value ?? '')}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={step.placeholder ?? undefined}
-          rows={4}
-          className="rounded-md border border-border bg-background px-3 py-2"
-        />
-      ) : (
-        <input
-          type={step.type === 'email' ? 'email' : step.type === 'phone' ? 'tel' : 'text'}
-          value={String(value ?? '')}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={step.placeholder ?? undefined}
-          className="rounded-md border border-border bg-background px-3 py-2"
-        />
-      )}
+      </div>
+    </div>
+  );
+}
 
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
-
-      <div className="flex items-center justify-between">
-        <button
-          type="button"
-          onClick={() => setIndex(Math.max(0, index - 1))}
-          disabled={index === 0 || submitting}
-          className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-40"
-        >
-          Back
-        </button>
-        <button
-          type="button"
-          onClick={() => void next()}
-          disabled={submitting}
-          className="rounded-md bg-primary px-5 py-2.5 font-semibold text-primary-foreground active:scale-[0.98] disabled:opacity-50"
-        >
-          {submitting ? 'Submitting…' : index + 1 === steps.length ? (step.buttonText ?? 'Submit') : (step.buttonText ?? 'Next')}
-        </button>
+/** Reveal interstitial body with an animated determinate bar (generic copy). */
+function RevealBody({ headline, subtitle }: { headline: string; subtitle: string }) {
+  const [pct, setPct] = useState(4);
+  useEffect(() => {
+    const startedAt = Date.now();
+    const id = setInterval(() => {
+      const p = Math.min(100, Math.round(((Date.now() - startedAt) / REVEAL_MS) * 100));
+      setPct(p);
+      if (p >= 100) clearInterval(id);
+    }, 60);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="pf-reveal__inner">
+      <div className="pf-reveal__spinner" aria-hidden="true" />
+      <h1 className="pf-reveal__headline">{headline}</h1>
+      <p className="pf-reveal__subtitle">{subtitle}</p>
+      <div className="pf-reveal__track">
+        <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />
       </div>
     </div>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -18,6 +18,7 @@ import {
   resolveOutcome,
   partialSubmitKey,
   nameFields,
+  isSafeHttpUrl,
   type Answers,
   type AnswerValue,
   type FormStep,
@@ -162,8 +163,14 @@ export function FormRenderer({
       const score = res.score ?? 0;
       const outcome = resolveOutcome(engineConfig, score);
       if (outcome?.redirectUrl) {
-        window.location.href = outcome.redirectUrl;
-        return;
+        // Runtime XSS guard: only navigate to http(s). A non-http(s) protocol
+        // (javascript:/data:) is ignored + logged, falling through to the
+        // thank-you screen (the schema also rejects it on save — belt-and-braces).
+        if (isSafeHttpUrl(outcome.redirectUrl)) {
+          window.location.href = outcome.redirectUrl;
+          return;
+        }
+        console.warn('[forms] ignored non-http(s) redirectUrl');
       }
       setDone({ score, outcome: res.outcome ?? null });
       setPhase('done');
@@ -280,13 +287,20 @@ export function FormRenderer({
     }
   }
 
+  // Latest finalize + answers via refs so the reveal timer arms once per
+  // reveal-phase entry (not on every answers change) without a stale closure.
+  const finalizeRef = useRef(finalize);
+  finalizeRef.current = finalize;
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
+
   // Drive the reveal interstitial: after REVEAL_MS, continue or finalize.
   useEffect(() => {
     if (phase !== 'reveal') return;
     const timer = setTimeout(() => {
       if (submitAfterReveal.current) {
         submitAfterReveal.current = false;
-        void finalize(answers);
+        void finalizeRef.current(answersRef.current);
       } else {
         setAnimKey((k) => k + 1);
         setPhase('steps');

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -2,18 +2,32 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getPublicForm } from '@/lib/api';
 import { publicLocale } from '@/lib/locale';
+import { getMessages, t } from '@quill/shared';
 import { MadeWithBadge } from '@/components/made-with-badge';
 import { FormRenderer } from './form-renderer';
 
+/**
+ * SEO/OG metadata for the public form — the form name as the title and a
+ * localized description (the form's cover subheadline when present, else a
+ * templated fallback). `noindex` support is deferred to a later phase.
+ */
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ accountCode: string; slug: string }>;
+  params: Promise<{ accountCode: string; slug: string; lang?: string }>;
 }): Promise<Metadata> {
   const { accountCode, slug } = await params;
   const form = await getPublicForm(accountCode, slug);
   if (!form) return {};
-  return { title: form.name, openGraph: { title: form.name, type: 'website' } };
+  const locale = await publicLocale();
+  const description =
+    form.config.cover?.subheadline ?? t(getMessages(locale).growth.seoForm, { name: form.name });
+  return {
+    title: form.name,
+    description,
+    openGraph: { title: form.name, description, type: 'website' },
+    twitter: { card: 'summary', title: form.name, description },
+  };
 }
 
 // Public form page. The Server Component fetches the published config; the
@@ -34,9 +48,13 @@ export default async function PublicFormPage({
 
   return (
     <>
-      <main className="mx-auto flex min-h-dvh max-w-xl flex-col justify-center px-6 py-12">
-        <FormRenderer accountCode={accountCode} slug={slug} name={form.name} config={form.config} />
-      </main>
+      <FormRenderer
+        accountCode={accountCode}
+        slug={slug}
+        name={form.name}
+        config={form.config}
+        locale={locale}
+      />
       <MadeWithBadge locale={locale} accountCode={accountCode} />
     </>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1,0 +1,838 @@
+/* -----------------------------------------------------------------------------
+ * Public form renderer — a self-contained, mobile-first "one question per screen"
+ * surface (the pilot's King-Kong/Typeform feel). It is intentionally a single
+ * LIGHT look regardless of the app theme: a public form is a branded landing
+ * surface, not app chrome. The one instance-level value is the accent, threaded
+ * through `--pf-primary` (set inline from `branding.primaryColor`, AA-clamped by
+ * the engine's accent helper); everything else is a fixed local token so the
+ * page reads as one system. All rules are scoped under `.pf`.
+ * -------------------------------------------------------------------------- */
+
+.pf {
+  --pf-primary: #cbe84f;
+  --pf-primary-contrast: #1a1a1c;
+  --pf-bg: #f5f5f5;
+  --pf-surface: #ffffff;
+  --pf-text: #111114;
+  --pf-muted: #6b6b73;
+  --pf-border: #d9dade;
+  --pf-focus: #2563eb;
+  --pf-danger: #dc2626;
+  --pf-radius: 12px;
+  --pf-radius-sm: 8px;
+  --pf-gap: 12px;
+  --pf-ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--pf-bg);
+  color: var(--pf-text);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Themed scrollbars for any inner overflow region on this light surface
+   (Design Quality Bar §1 — never a native/dark track on a light surface). */
+.pf *::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.pf *::-webkit-scrollbar-track {
+  background: transparent;
+}
+.pf *::-webkit-scrollbar-thumb {
+  background: var(--pf-border);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.pf *::-webkit-scrollbar-thumb:hover {
+  background: var(--pf-muted);
+  background-clip: padding-box;
+}
+.pf * {
+  scrollbar-width: thin;
+  scrollbar-color: var(--pf-border) transparent;
+}
+
+.pf :focus-visible {
+  outline: 2px solid var(--pf-focus);
+  outline-offset: 2px;
+}
+
+/* ── Sticky promo banner ── */
+.pf__banner {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: var(--pf-primary);
+  color: var(--pf-primary-contrast);
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  padding: 12px 20px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  flex-shrink: 0;
+}
+
+/* ── Top bar (back · logo · spacer) ── */
+.pf__topbar {
+  background: var(--pf-surface);
+  border-bottom: 1px solid #eee;
+  padding: 14px 20px 18px;
+  flex-shrink: 0;
+}
+.pf__topbar-inner {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  align-items: center;
+  max-width: 480px;
+  margin: 0 auto 16px;
+}
+.pf__back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  background: none;
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--pf-text);
+  cursor: pointer;
+  border-radius: var(--pf-radius-sm);
+  transition: background 0.12s var(--pf-ease);
+}
+.pf__back:hover {
+  background: var(--pf-bg);
+}
+.pf__back--placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+.pf__logo-img {
+  display: block;
+  height: 32px;
+  width: auto;
+  max-width: 150px;
+  margin: 0 auto;
+  object-fit: contain;
+}
+.pf__logo--fallback {
+  text-align: center;
+  font-size: 20px;
+  font-weight: 700;
+}
+.pf__logo-dot {
+  color: var(--pf-primary);
+}
+
+/* ── Progress ── */
+.pf-progress {
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 2px;
+}
+.pf-progress__track {
+  height: 4px;
+  width: 100%;
+  background: var(--pf-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pf-progress__fill {
+  height: 100%;
+  background: var(--pf-primary);
+  border-radius: 999px;
+  transition: width 0.3s var(--pf-ease);
+}
+
+/* ── Body ── */
+.pf__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 32px 20px 28px;
+}
+.pf__inner {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.pf__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.pf-animate {
+  animation: pfSlideIn 0.32s var(--pf-ease);
+}
+@keyframes pfSlideIn {
+  from {
+    transform: translateX(28px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pf-animate {
+    animation: none;
+  }
+}
+
+/* ── Question typography ── */
+.pf__question-wrap {
+  width: 100%;
+  max-width: 540px;
+  margin: 0 auto;
+  padding: 0 8px;
+}
+.pf__question {
+  text-align: center;
+  font-size: clamp(20px, 4.6vw, 27px);
+  font-weight: 800;
+  line-height: 1.3;
+  margin: 0;
+  text-wrap: balance;
+}
+.pf__helper {
+  text-align: center;
+  font-size: 16px;
+  color: var(--pf-muted);
+  margin: 10px 0 0;
+  line-height: 1.45;
+}
+.pf__fields {
+  margin-top: 36px;
+}
+
+/* ── Inputs ── */
+.pf-input {
+  width: 100%;
+  padding: 16px;
+  font-size: 17px;
+  font-family: inherit;
+  color: var(--pf-text);
+  background: var(--pf-surface);
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.12s var(--pf-ease), box-shadow 0.12s var(--pf-ease);
+}
+.pf-input:focus {
+  border-color: var(--pf-focus);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+.pf-name-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--pf-gap);
+}
+@media (max-width: 480px) {
+  .pf-name-fields {
+    grid-template-columns: 1fr;
+  }
+}
+.pf-textarea {
+  resize: vertical;
+  min-height: 120px;
+  line-height: 1.5;
+}
+.pf-message__body {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--pf-muted);
+  text-align: center;
+}
+
+/* ── Choices — list ── */
+.pf-choices--list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-gap);
+}
+.pf-choice-list {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-height: 56px;
+  padding: 16px 20px;
+  font-size: 16px;
+  font-family: inherit;
+  font-weight: 500;
+  text-align: left;
+  color: var(--pf-text);
+  background: var(--pf-surface);
+  border: 2px solid transparent;
+  border-radius: var(--pf-radius);
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: border-color 0.12s var(--pf-ease), transform 0.08s var(--pf-ease);
+}
+.pf-choice-list:hover {
+  border-color: var(--pf-border);
+}
+.pf-choice-list:active {
+  transform: scale(0.995);
+}
+.pf-choice-list--selected {
+  border-color: var(--pf-primary);
+  background: color-mix(in srgb, var(--pf-primary) 14%, var(--pf-surface));
+}
+.pf-choice-list__radio {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--pf-border);
+  background: var(--pf-bg);
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s;
+}
+.pf-choice-list--selected .pf-choice-list__radio {
+  background: var(--pf-primary);
+  border-color: var(--pf-primary);
+  box-shadow: inset 0 0 0 3px var(--pf-surface);
+}
+.pf-choice-list__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #f3f4f6;
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+}
+.pf-choice-list__text {
+  flex: 1;
+  line-height: 1.35;
+}
+
+/* ── Choices — icon grid ── */
+.pf-choices--icons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--pf-gap);
+}
+@media (max-width: 400px) {
+  .pf-choices--icons {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.pf-choice-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-height: 96px;
+  padding: 16px 8px;
+  background: var(--pf-surface);
+  border: 2px solid transparent;
+  border-radius: 16px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  transition: border-color 0.12s var(--pf-ease), transform 0.08s var(--pf-ease);
+  font-family: inherit;
+}
+.pf-choice-icon:hover {
+  border-color: var(--pf-border);
+}
+.pf-choice-icon:active {
+  transform: scale(0.98);
+}
+.pf-choice-icon--selected {
+  border-color: var(--pf-primary);
+  background: color-mix(in srgb, var(--pf-primary) 12%, var(--pf-surface));
+}
+.pf-choice-icon__circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #f3f4f6;
+  font-size: 24px;
+  line-height: 1;
+}
+.pf-choice-icon__label {
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.25;
+}
+
+/* ── Searchable dropdown ── */
+.pf-dropdown {
+  position: relative;
+}
+.pf-dropdown__list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  background: var(--pf-surface);
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  max-height: 240px;
+  overflow-y: auto;
+}
+.pf-dropdown__option {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 16px;
+  font-family: inherit;
+  text-align: left;
+  color: var(--pf-text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.pf-dropdown__option:hover,
+.pf-dropdown__option:focus-visible {
+  background: var(--pf-bg);
+}
+.pf-dropdown__option--selected {
+  background: color-mix(in srgb, var(--pf-primary) 18%, var(--pf-surface));
+  font-weight: 600;
+}
+.pf-dropdown__empty {
+  padding: 12px 16px;
+  font-size: 15px;
+  color: var(--pf-muted);
+  text-align: center;
+}
+
+/* ── Slider ── */
+.pf-slider {
+  padding: 8px 4px 4px;
+}
+.pf-slider__pill {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 10px;
+  width: fit-content;
+  margin: 0 auto 24px;
+  background: var(--pf-text);
+  border-radius: 999px;
+  padding: 16px 40px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  white-space: nowrap;
+}
+.pf-slider__pill-num {
+  font-size: 40px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--pf-primary);
+  letter-spacing: -0.02em;
+}
+.pf-slider__pill-label {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.75);
+}
+.pf-slider__input {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  cursor: pointer;
+  margin: 0;
+  padding: 10px 0;
+  display: block;
+}
+.pf-slider__input::-webkit-slider-runnable-track {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--pf-primary) 0%,
+    var(--pf-primary) var(--pf-progress, 0%),
+    #e5e7eb var(--pf-progress, 0%),
+    #e5e7eb 100%
+  );
+}
+.pf-slider__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid var(--pf-text);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  margin-top: -11px;
+  cursor: grab;
+}
+.pf-slider__input:active::-webkit-slider-thumb {
+  transform: scale(1.08);
+  cursor: grabbing;
+}
+.pf-slider__input::-moz-range-thumb {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid var(--pf-text);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  cursor: grab;
+}
+.pf-slider__input::-moz-range-track {
+  height: 12px;
+  border-radius: 999px;
+  background: #e5e7eb;
+}
+.pf-slider__input::-moz-range-progress {
+  height: 12px;
+  border-radius: 999px;
+  background: var(--pf-primary);
+}
+.pf-slider__scale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  padding: 0 2px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #9ca3af;
+  user-select: none;
+}
+
+/* ── Error ── */
+.pf__error {
+  text-align: center;
+  font-size: 14px;
+  color: var(--pf-danger);
+  margin-top: 14px;
+}
+
+/* ── Primary button ── */
+.pf__btn {
+  display: block;
+  width: 100%;
+  min-height: 56px;
+  padding: 0 24px;
+  font-size: 17px;
+  font-weight: 700;
+  font-family: inherit;
+  color: var(--pf-primary-contrast);
+  background: var(--pf-primary);
+  border: none;
+  border-radius: var(--pf-radius);
+  cursor: pointer;
+  transition: opacity 0.12s, transform 0.08s var(--pf-ease);
+}
+.pf__btn:hover {
+  opacity: 0.92;
+}
+.pf__btn:active {
+  transform: scale(0.99);
+}
+.pf__btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.pf__btn--inline {
+  margin-top: 28px;
+}
+
+/* ── Cover ── */
+.pf--cover .pf__cover-header {
+  flex-shrink: 0;
+  background: var(--pf-surface);
+  border-bottom: 1px solid #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 20px;
+}
+.pf__cover-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  text-align: center;
+  gap: 8px;
+}
+.pf__cover-content {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.pf__badge {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--pf-muted);
+  margin: 0 0 12px;
+}
+.pf__title {
+  font-size: clamp(26px, 6vw, 36px);
+  font-weight: 800;
+  line-height: 1.25;
+  margin: 0;
+  text-wrap: balance;
+}
+.pf__subheadline {
+  font-size: clamp(15px, 3.6vw, 17px);
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--pf-muted);
+  margin: 16px 0 0;
+  text-wrap: balance;
+}
+.pf__trust {
+  font-size: 13px;
+  color: var(--pf-muted);
+  margin: 18px 0 0;
+}
+.pf__cover-footer {
+  flex-shrink: 0;
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 0 24px calc(40px + env(safe-area-inset-bottom));
+}
+
+/* ── Client-logos marquee ── */
+.pf-logos {
+  width: 100%;
+  max-width: 640px;
+  margin: 28px auto 0;
+}
+.pf-logos__label {
+  margin: 0 0 12px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.5);
+}
+.pf-logos__viewport {
+  overflow: hidden;
+  width: 100%;
+  mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+.pf-logos__track {
+  display: flex;
+  gap: var(--pf-gap);
+  width: max-content;
+  animation: pf-logos-marquee 24s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pf-logos__track {
+    animation: none;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+  }
+}
+.pf-logos__chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  padding: 8px 16px;
+  height: 48px;
+  min-width: 88px;
+  flex-shrink: 0;
+  font-weight: 700;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.7);
+}
+.pf-logos__img {
+  height: 26px;
+  max-width: 100px;
+  object-fit: contain;
+}
+@keyframes pf-logos-marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* ── Reveal / processing interstitial (generic, templated) ── */
+.pf--reveal {
+  text-align: center;
+}
+.pf-reveal__inner {
+  flex: 1;
+  max-width: 420px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+}
+.pf-reveal__spinner {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-top-color: var(--pf-primary);
+  animation: pf-spin 0.9s linear infinite;
+  margin-bottom: 28px;
+}
+@keyframes pf-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.pf-reveal__headline {
+  font-size: clamp(22px, 5vw, 28px);
+  font-weight: 800;
+  line-height: 1.2;
+  margin: 0 0 12px;
+  text-wrap: balance;
+}
+.pf-reveal__subtitle {
+  font-size: 16px;
+  color: var(--pf-muted);
+  margin: 0 0 24px;
+  line-height: 1.5;
+  text-wrap: balance;
+}
+.pf-reveal__track {
+  width: 260px;
+  max-width: 100%;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pf-reveal__fill {
+  height: 100%;
+  background: var(--pf-primary);
+  border-radius: 999px;
+  transition: width 0.08s linear;
+}
+
+/* ── Thank-you / outcome screen ── */
+.pf--done {
+  text-align: center;
+}
+.pf-done__inner {
+  flex: 1;
+  max-width: 460px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+}
+.pf-done__check {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--pf-primary);
+  color: var(--pf-primary-contrast);
+  font-size: 34px;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+.pf-done__title {
+  font-size: clamp(24px, 5vw, 30px);
+  font-weight: 800;
+  margin: 0 0 10px;
+}
+.pf-done__body {
+  font-size: 16px;
+  color: var(--pf-muted);
+  margin: 0 0 28px;
+  line-height: 1.5;
+  text-wrap: balance;
+}
+.pf-done__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 24px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--pf-primary-contrast);
+  background: var(--pf-primary);
+  border-radius: var(--pf-radius);
+  text-decoration: none;
+  transition: opacity 0.12s, transform 0.08s var(--pf-ease);
+}
+.pf-done__cta:hover {
+  opacity: 0.92;
+}
+.pf-done__cta:active {
+  transform: scale(0.99);
+}
+.pf-done__cta-question {
+  font-size: 14px;
+  color: var(--pf-muted);
+  margin: 0 0 12px;
+}
+
+/* ── Desktop niceties ── */
+@media (min-width: 769px) {
+  /* Vertically center the single question on larger screens so the composition
+     stays balanced rather than top-heavy (Design Quality Bar §9). Mobile keeps
+     the natural top-aligned flow. */
+  .pf__body {
+    padding: 44px 24px 36px;
+    justify-content: center;
+  }
+  .pf__inner {
+    flex: 0 1 auto;
+  }
+  .pf__fields {
+    margin-top: 40px;
+  }
+}
+@media (max-width: 480px) {
+  .pf__banner {
+    font-size: 12px;
+    padding: 10px 14px;
+  }
+  .pf__body {
+    padding: 24px 16px;
+  }
+  .pf__fields {
+    margin-top: 24px;
+  }
+  .pf-input {
+    font-size: 16px;
+  }
+}

--- a/apps/web/app/admin/create-form-button.tsx
+++ b/apps/web/app/admin/create-form-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { createFormAction } from './actions';
+
+interface Labels {
+  create: string;
+  createTitle: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  cancel: string;
+}
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} className="min-w-[110px]">
+      {label}
+    </Button>
+  );
+}
+
+/**
+ * Create-form entry point following the list/create pattern (Design Quality
+ * Bar): a primary button that opens a dedicated create surface (a dialog),
+ * never an inline form under the list. Submits to the create server action,
+ * which redirects into the new form's editor.
+ */
+export function CreateFormButton({ labels, variant = 'default' }: { labels: Labels; variant?: 'default' | 'outline' }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant={variant} onClick={() => setOpen(true)}>
+        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {labels.create}
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)} title={labels.createTitle} labelId="create-form-title">
+        <form action={createFormAction} className="flex flex-col gap-4">
+          <label className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">{labels.nameLabel}</span>
+            <input
+              name="name"
+              required
+              autoComplete="off"
+              placeholder={labels.namePlaceholder}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </label>
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+              {labels.cancel}
+            </Button>
+            <SubmitButton label={labels.create} />
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/apps/web/app/admin/form-row-actions.tsx
+++ b/apps/web/app/admin/form-row-actions.tsx
@@ -4,7 +4,13 @@ import { useTransition } from 'react';
 import { duplicateFormAction, deleteFormAction } from './actions';
 
 /** Duplicate / delete buttons for a form row (client → server actions). */
-export function FormRowActions({ id }: { id: string }) {
+export function FormRowActions({
+  id,
+  labels,
+}: {
+  id: string;
+  labels: { duplicate: string; delete: string; deleteConfirm: string };
+}) {
   const [pending, start] = useTransition();
   return (
     <div className="flex items-center gap-3 text-sm">
@@ -12,21 +18,21 @@ export function FormRowActions({ id }: { id: string }) {
         type="button"
         disabled={pending}
         onClick={() => start(() => void duplicateFormAction(id))}
-        className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+        className="text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
       >
-        Duplicate
+        {labels.duplicate}
       </button>
       <button
         type="button"
         disabled={pending}
         onClick={() => {
-          if (confirm('Delete this form and all its submissions?')) {
+          if (confirm(labels.deleteConfirm)) {
             start(() => void deleteFormAction(id));
           }
         }}
-        className="text-destructive hover:opacity-80 disabled:opacity-50"
+        className="text-destructive transition-opacity hover:opacity-80 disabled:opacity-50"
       >
-        Delete
+        {labels.delete}
       </button>
     </div>
   );

--- a/apps/web/app/admin/form-row-actions.tsx
+++ b/apps/web/app/admin/form-row-actions.tsx
@@ -6,7 +6,8 @@ import { duplicateFormAction, deleteFormAction } from './actions';
 
 /**
  * Per-row actions for a form: cross-links to its Analytics + Submissions pages
- * (analytics track — additive) plus localized Duplicate / Delete (builder track).
+ * (analytics track) and Integrations page (destinations track — additive), plus
+ * localized Duplicate / Delete (builder track).
  */
 export function FormRowActions({
   id,
@@ -15,7 +16,7 @@ export function FormRowActions({
 }: {
   id: string;
   labels: { duplicate: string; delete: string; deleteConfirm: string };
-  nav?: { analytics: string; submissions: string };
+  nav?: { analytics: string; submissions: string; integrations?: string };
 }) {
   const [pending, start] = useTransition();
   return (
@@ -34,6 +35,14 @@ export function FormRowActions({
           >
             {nav.submissions}
           </Link>
+          {nav.integrations ? (
+            <Link
+              href={`/admin/forms/${id}/integrations`}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {nav.integrations}
+            </Link>
+          ) : null}
         </>
       ) : null}
       <button

--- a/apps/web/app/admin/form-row-actions.tsx
+++ b/apps/web/app/admin/form-row-actions.tsx
@@ -1,19 +1,41 @@
 'use client';
 
+import Link from 'next/link';
 import { useTransition } from 'react';
 import { duplicateFormAction, deleteFormAction } from './actions';
 
-/** Duplicate / delete buttons for a form row (client → server actions). */
+/**
+ * Per-row actions for a form: cross-links to its Analytics + Submissions pages
+ * (analytics track — additive) plus localized Duplicate / Delete (builder track).
+ */
 export function FormRowActions({
   id,
   labels,
+  nav,
 }: {
   id: string;
   labels: { duplicate: string; delete: string; deleteConfirm: string };
+  nav?: { analytics: string; submissions: string };
 }) {
   const [pending, start] = useTransition();
   return (
     <div className="flex items-center gap-3 text-sm">
+      {nav ? (
+        <>
+          <Link
+            href={`/admin/forms/${id}/analytics`}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {nav.analytics}
+          </Link>
+          <Link
+            href={`/admin/forms/${id}/submissions`}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {nav.submissions}
+          </Link>
+        </>
+      ) : null}
       <button
         type="button"
         disabled={pending}

--- a/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, useTransition } from 'react';
+
+type Preset = '7' | '30' | '90' | 'all' | 'custom';
+
+/**
+ * Date-range control for the analytics dashboard: presets (7/30/90 days + all)
+ * plus a custom from/to. Writes the choice to the URL query so the server
+ * component re-fetches; a Suspense boundary shows the skeleton while it does
+ * (R22). Tokens-only; 44px hit targets (R28).
+ */
+export function AnalyticsFilter({
+  labels,
+}: {
+  labels: {
+    last7: string;
+    last30: string;
+    last90: string;
+    all: string;
+    custom: string;
+    from: string;
+    to: string;
+    apply: string;
+  };
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, start] = useTransition();
+
+  const current = (params.get('preset') as Preset | null) ?? 'all';
+  const [from, setFrom] = useState(params.get('from') ?? '');
+  const [to, setTo] = useState(params.get('to') ?? '');
+  const [showCustom, setShowCustom] = useState(current === 'custom');
+
+  const push = (next: URLSearchParams) => start(() => router.push(`?${next.toString()}`, { scroll: false }));
+
+  const selectPreset = (preset: Preset) => {
+    if (preset === 'custom') {
+      setShowCustom(true);
+      return;
+    }
+    setShowCustom(false);
+    const next = new URLSearchParams();
+    if (preset !== 'all') next.set('preset', preset);
+    push(next);
+  };
+
+  const applyCustom = () => {
+    if (!from && !to) return;
+    const next = new URLSearchParams();
+    next.set('preset', 'custom');
+    if (from) next.set('from', from);
+    if (to) next.set('to', to);
+    push(next);
+  };
+
+  const presets: { key: Preset; label: string }[] = [
+    { key: '7', label: labels.last7 },
+    { key: '30', label: labels.last30 },
+    { key: '90', label: labels.last90 },
+    { key: 'all', label: labels.all },
+    { key: 'custom', label: labels.custom },
+  ];
+
+  return (
+    <div className="flex flex-col gap-3" aria-busy={pending}>
+      <div className="flex flex-wrap items-center gap-2">
+        {presets.map((p) => {
+          const active = p.key === 'custom' ? showCustom : !showCustom && current === p.key;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              disabled={pending}
+              onClick={() => selectPreset(p.key)}
+              aria-pressed={active}
+              className={
+                active
+                  ? 'inline-flex h-9 items-center rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60'
+                  : 'inline-flex h-9 items-center rounded-md border border-border bg-transparent px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60'
+              }
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {showCustom ? (
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            {labels.from}
+            <input
+              type="date"
+              value={from}
+              max={to || undefined}
+              onChange={(e) => setFrom(e.target.value)}
+              className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            {labels.to}
+            <input
+              type="date"
+              value={to}
+              min={from || undefined}
+              onChange={(e) => setTo(e.target.value)}
+              className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+            />
+          </label>
+          <button
+            type="button"
+            disabled={pending || (!from && !to)}
+            onClick={applyCustom}
+            className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60"
+          >
+            {labels.apply}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/analytics/error.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/error.tsx
@@ -2,11 +2,7 @@
 
 import { getMessages } from '@quill/shared';
 
-/** Read the persisted admin locale on the client (mirrors the server cookie). */
-function clientLocale(): 'en' | 'es' {
-  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
-  return 'en';
-}
+import { clientLocale } from '@/lib/client-locale';
 
 export default function AnalyticsError({ reset }: { error: Error; reset: () => void }) {
   const m = getMessages(clientLocale()).admin.analytics;

--- a/apps/web/app/admin/forms/[id]/analytics/error.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { getMessages } from '@quill/shared';
+
+/** Read the persisted admin locale on the client (mirrors the server cookie). */
+function clientLocale(): 'en' | 'es' {
+  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
+  return 'en';
+}
+
+export default function AnalyticsError({ reset }: { error: Error; reset: () => void }) {
+  const m = getMessages(clientLocale()).admin.analytics;
+  return (
+    <div className="mx-auto max-w-md px-8 py-16 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">{m.error}</h1>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-primary px-5 py-2 font-semibold text-primary-foreground transition-transform active:scale-[0.98]"
+      >
+        {m.retry}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/analytics/loading.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/skeleton';
+
+export default function AnalyticsLoading() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <Skeleton className="mb-6 h-9 w-64" />
+      <Skeleton className="mb-6 h-9 w-80" />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" />
+        ))}
+      </div>
+      <Skeleton className="mt-8 h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/analytics/page.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/page.tsx
@@ -1,0 +1,194 @@
+import { Suspense } from 'react';
+import { notFound } from 'next/navigation';
+import type { AnalyticsResponse } from '@quill/types';
+import { getMessages, type FormsMessages } from '@quill/shared';
+import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
+import { FormTabs } from '@/components/ui/form-tabs';
+import { Skeleton } from '@/components/skeleton';
+import { AnalyticsFilter } from './analytics-filter';
+
+export const dynamic = 'force-dynamic';
+
+const DAY_MS = 86_400_000;
+
+type SP = { preset?: string; from?: string; to?: string };
+
+/** Resolve the URL query into an epoch-ms range the API understands. */
+function resolveRange(sp: SP): { from?: number; to?: number } {
+  if (sp.preset === 'custom') {
+    const from = sp.from ? Date.parse(`${sp.from}T00:00:00.000Z`) : NaN;
+    const to = sp.to ? Date.parse(`${sp.to}T23:59:59.999Z`) : NaN;
+    return {
+      from: Number.isNaN(from) ? undefined : from,
+      to: Number.isNaN(to) ? undefined : to,
+    };
+  }
+  const days = sp.preset === '7' ? 7 : sp.preset === '30' ? 30 : sp.preset === '90' ? 90 : null;
+  if (days) return { from: Date.now() - days * DAY_MS };
+  return {};
+}
+
+export default async function AnalyticsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<SP>;
+}) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const m = getMessages(await getLocale()).admin;
+  const range = resolveRange(sp);
+  const rangeKey = `${sp.preset ?? 'all'}:${sp.from ?? ''}:${sp.to ?? ''}`;
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <FormTabs formId={id} active="analytics" labels={m.nav} />
+      <div className="mb-6 flex flex-col gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">{m.analytics.title}</h1>
+          <p className="mt-1 text-muted-foreground">{m.analytics.subtitle}</p>
+        </div>
+        <AnalyticsFilter
+          labels={{
+            last7: m.analytics.rangeLast7,
+            last30: m.analytics.rangeLast30,
+            last90: m.analytics.rangeLast90,
+            all: m.analytics.rangeAll,
+            custom: m.analytics.rangeCustom,
+            from: m.analytics.rangeFrom,
+            to: m.analytics.rangeTo,
+            apply: m.analytics.rangeApply,
+          }}
+        />
+      </div>
+
+      <Suspense key={rangeKey} fallback={<AnalyticsSkeleton />}>
+        <AnalyticsData id={id} range={range} m={m.analytics} />
+      </Suspense>
+    </div>
+  );
+}
+
+/** Format seconds as `Ns` or `Nm Ss`. */
+function formatDuration(seconds: number, unit: string): string {
+  if (seconds < 60) return `${seconds}${unit}`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s === 0 ? `${m}m` : `${m}m ${s}${unit}`;
+}
+
+async function AnalyticsData({
+  id,
+  range,
+  m,
+}: {
+  id: string;
+  range: { from?: number; to?: number };
+  m: FormsMessages['admin']['analytics'];
+}) {
+  let a: AnalyticsResponse;
+  try {
+    a = await adminApi.getAnalytics(id, range);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+
+  const hasActivity = a.views + a.starts + a.submissions + a.partialSubmits > 0;
+  if (!hasActivity) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/40 p-12 text-center">
+        <p className="text-lg font-medium">{m.emptyTitle}</p>
+        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">{m.emptyBody}</p>
+      </div>
+    );
+  }
+
+  const cards = [
+    { label: m.metricViews, value: String(a.views) },
+    { label: m.metricStarts, value: String(a.starts) },
+    { label: m.metricSubmissions, value: String(a.submissions) },
+    { label: m.metricCompletionRate, value: `${a.completionRate}%` },
+    { label: m.metricAvgTime, value: formatDuration(a.avgTimeToComplete, m.seconds) },
+    { label: m.metricPartials, value: String(a.partialSubmits) },
+  ];
+
+  const maxViews = Math.max(1, ...a.dropoff.map((r) => r.views));
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {cards.map((c) => (
+          <div key={c.label} className="rounded-lg border border-border bg-card p-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{c.label}</div>
+            <div className="mt-2 text-2xl font-semibold tabular-nums">{c.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <section>
+        <h2 className="text-lg font-semibold">{m.dropoffTitle}</h2>
+        <p className="mb-3 text-sm text-muted-foreground">{m.dropoffSubtitle}</p>
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3 font-medium">{m.colStep}</th>
+                <th className="w-[45%] px-4 py-3 font-medium">{m.colViews}</th>
+                <th className="px-4 py-3 text-right font-medium">{m.colDropoff}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {a.dropoff.map((row) => (
+                <tr key={row.stepIndex} className="border-b border-border last:border-b-0">
+                  <td className="px-4 py-3">
+                    <span className="font-medium">{row.isCover ? m.coverRow : row.question}</span>
+                    {!row.isCover ? (
+                      <span className="ml-2 text-xs text-muted-foreground">#{row.stepIndex + 1}</span>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="relative h-6 w-full overflow-hidden rounded bg-muted">
+                      <div
+                        className="absolute inset-y-0 left-0 rounded bg-primary/25"
+                        style={{ width: `${Math.round((row.views / maxViews) * 100)}%` }}
+                      />
+                      <span className="absolute inset-0 flex items-center px-2 text-xs font-medium tabular-nums">
+                        {row.views}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {row.dropoff > 0 ? (
+                      <span className="text-destructive">
+                        −{row.dropoff}{' '}
+                        <span className="text-muted-foreground">({row.dropoffPercent}%)</span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function AnalyticsSkeleton() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" />
+        ))}
+      </div>
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/condition-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/condition-editor.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { StepCondition } from '@quill/engine';
+import { SelectField, TextField } from './fields';
+import type { EditorMessages } from './messages';
+
+/** A prior step the current step can branch on. */
+export interface PriorField {
+  key: string;
+  label: string;
+  options?: { label: string; value: string }[];
+}
+
+/**
+ * One condition row (used for both `showWhen` and `hideWhen`): pick an earlier
+ * field, then the values that trigger it. When that field has options they
+ * render as checkboxes; otherwise a comma-separated text input.
+ */
+export function ConditionEditor({
+  label,
+  condition,
+  priorFields,
+  onChange,
+  m,
+}: {
+  label: string;
+  condition: StepCondition | null | undefined;
+  priorFields: PriorField[];
+  onChange: (next: StepCondition | null) => void;
+  m: EditorMessages['logic'];
+}) {
+  const selected = priorFields.find((f) => f.key === condition?.field);
+  const values = condition?.values ?? [];
+
+  function pickField(key: string) {
+    if (!key) return onChange(null);
+    onChange({ field: key, values: [] });
+  }
+  function toggleValue(value: string) {
+    const next = values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+    onChange({ field: condition!.field, values: next });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <SelectField value={condition?.field ?? ''} onChange={(e) => pickField(e.target.value)}>
+        <option value="">{m.none}</option>
+        {priorFields.map((f) => (
+          <option key={f.key} value={f.key}>
+            {f.label}
+          </option>
+        ))}
+      </SelectField>
+
+      {condition ? (
+        selected?.options && selected.options.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {selected.options.map((o) => {
+              const on = values.includes(o.value);
+              return (
+                <button
+                  key={o.value}
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => toggleValue(o.value)}
+                  className={
+                    'rounded-full border px-3 py-1 text-xs transition-colors ' +
+                    (on
+                      ? 'border-primary bg-primary/15 text-foreground'
+                      : 'border-border text-muted-foreground hover:border-primary')
+                  }
+                >
+                  {o.label || o.value}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <TextField
+            value={values.join(', ')}
+            placeholder={m.valuesHint}
+            onChange={(e) =>
+              onChange({
+                field: condition.field,
+                values: e.target.value
+                  .split(',')
+                  .map((v) => v.trim())
+                  .filter(Boolean),
+              })
+            }
+          />
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import type { FormConfig, FormCover, FormBranding } from '@quill/engine';
+import { clampAccent, accentWasAdjusted, DEFAULT_ACCENT } from '@quill/shared';
+import { Switch } from '@/components/ui/switch';
+import { Field, TextField, TextArea, InlineField, PanelSection } from './fields';
+import { LivePreview } from './live-preview';
+import type { EditorMessages } from './messages';
+
+/**
+ * Cover / intro editor + per-form branding. The color picker feeds
+ * `branding.primaryColor`; the swatch shows the AA-clamped accent the public
+ * page will actually use, warning when the raw pick had to be nudged lighter.
+ * A live cover preview sits alongside so edits are visible immediately.
+ */
+export function CoverPanel({
+  config,
+  onCoverChange,
+  onBrandingChange,
+  m,
+}: {
+  config: FormConfig;
+  onCoverChange: (patch: Partial<FormCover>) => void;
+  onBrandingChange: (patch: Partial<FormBranding>) => void;
+  m: EditorMessages;
+}) {
+  const cover = config.cover ?? {};
+  const raw = config.branding?.primaryColor || DEFAULT_ACCENT;
+  const clamped = clampAccent(raw);
+  const adjusted = accentWasAdjusted(raw);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+      <div className="flex flex-col gap-4">
+        <PanelSection title={m.cover.title} subtitle={m.cover.subtitle}>
+          <InlineField label={m.cover.enabled}>
+            <Switch
+              checked={cover.enabled !== false}
+              onCheckedChange={(v) => onCoverChange({ enabled: v })}
+              aria-label={m.cover.enabled}
+            />
+          </InlineField>
+          <Field label={m.cover.bannerText}>
+            <TextField value={cover.bannerText ?? ''} onChange={(e) => onCoverChange({ bannerText: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.eyebrow}>
+            <TextField value={cover.eyebrow ?? ''} onChange={(e) => onCoverChange({ eyebrow: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.headline}>
+            <TextField value={cover.headline ?? ''} onChange={(e) => onCoverChange({ headline: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.subheadline}>
+            <TextArea value={cover.subheadline ?? ''} rows={2} onChange={(e) => onCoverChange({ subheadline: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.ctaText}>
+            <TextField value={cover.ctaText ?? ''} onChange={(e) => onCoverChange({ ctaText: e.target.value || null })} />
+          </Field>
+          <Field label={m.cover.trustBadge}>
+            <TextField value={cover.trustBadge ?? ''} onChange={(e) => onCoverChange({ trustBadge: e.target.value || null })} />
+          </Field>
+        </PanelSection>
+
+        <PanelSection title={m.cover.branding}>
+          <Field label={m.cover.primaryColor} hint={m.cover.primaryColorHint}>
+            <div className="flex items-center gap-3">
+              <input
+                type="color"
+                aria-label={m.cover.primaryColor}
+                value={/^#[0-9a-fA-F]{6}$/.test(raw) ? raw : DEFAULT_ACCENT}
+                onChange={(e) => onBrandingChange({ primaryColor: e.target.value })}
+                className="h-10 w-14 shrink-0 cursor-pointer rounded-md border border-input bg-background p-1"
+              />
+              <TextField
+                value={raw}
+                onChange={(e) => onBrandingChange({ primaryColor: e.target.value })}
+                className="max-w-[10rem] font-mono"
+              />
+              <span
+                aria-hidden
+                title={clamped}
+                className="h-8 w-8 shrink-0 rounded-full border border-border"
+                style={{ background: clamped }}
+              />
+            </div>
+          </Field>
+          {adjusted ? (
+            <p className="text-xs text-muted-foreground">
+              <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} />{' '}
+              {clamped}
+            </p>
+          ) : null}
+        </PanelSection>
+      </div>
+
+      <div className="lg:sticky lg:top-[7.5rem] lg:self-start">
+        <p className="mb-2 text-sm font-semibold text-foreground">{m.preview.title}</p>
+        <LivePreview config={config} selected="cover" m={m.preview} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/cn';
+import type { EditorMessages } from './messages';
+
+type Device = 'mobile' | 'desktop';
+
+/**
+ * Device preview: renders the live public form route inside a framed iframe at
+ * mobile (390px) or desktop widths. Backdrop + Esc close, focus restore. Save
+ * before opening so the iframe reflects the latest config.
+ */
+export function DevicePreviewModal({
+  open,
+  onClose,
+  publicPath,
+  m,
+}: {
+  open: boolean;
+  onClose: () => void;
+  publicPath: string;
+  m: EditorMessages['preview'];
+}) {
+  const [device, setDevice] = useState<Device>('mobile');
+  const restoreRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    restoreRef.current = document.activeElement as HTMLElement | null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      restoreRef.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center p-4">
+      <button type="button" aria-hidden tabIndex={-1} onClick={onClose} className="absolute inset-0 bg-background/85" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={m.device}
+        className="relative flex h-[90vh] w-full max-w-5xl flex-col rounded-xl border border-border bg-popover shadow-lg"
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="inline-flex rounded-md border border-border p-0.5">
+            {(['mobile', 'desktop'] as const).map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => setDevice(d)}
+                aria-pressed={device === d}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm transition-colors',
+                  device === d ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <i aria-hidden className={d === 'mobile' ? 'pi pi-mobile' : 'pi pi-desktop'} style={{ fontSize: 13 }} />
+                {d === 'mobile' ? m.mobile : m.desktop}
+              </button>
+            ))}
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label={m.close}>
+            <i aria-hidden className="pi pi-times" style={{ fontSize: 13 }} /> {m.close}
+          </Button>
+        </div>
+
+        <div className="flex flex-1 items-start justify-center overflow-auto bg-muted/30 p-4">
+          <div
+            className={cn(
+              'overflow-hidden rounded-lg border border-border bg-background shadow-sm transition-all',
+              device === 'mobile' ? 'h-[780px] w-[390px] max-w-full' : 'h-full w-full',
+            )}
+          >
+            <iframe
+              key={device}
+              src={publicPath}
+              title={m.device}
+              className="h-full w-full border-0"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+/**
+ * Small form-anatomy primitives shared by every editor panel so spacing,
+ * labels, and the inline required marker stay identical across the builder
+ * (Design Quality Bar §7/§8). Tokens only — no raw hex/px.
+ */
+
+export function Field({
+  label,
+  htmlFor,
+  required,
+  hint,
+  children,
+  className,
+}: {
+  label: string;
+  htmlFor?: string;
+  required?: boolean;
+  hint?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <label htmlFor={htmlFor} className="text-sm font-medium text-foreground">
+        {label}
+        {required ? (
+          <span aria-hidden className="ml-0.5 text-destructive">
+            *
+          </span>
+        ) : null}
+      </label>
+      {children}
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+const controlBase =
+  'w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors ' +
+  'placeholder:text-muted-foreground hover:border-muted-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+export function TextField(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  const { className, ...rest } = props;
+  return <input {...rest} className={cn(controlBase, className)} />;
+}
+
+export function TextArea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  const { className, rows = 3, ...rest } = props;
+  return <textarea {...rest} rows={rows} className={cn(controlBase, 'resize-y', className)} />;
+}
+
+export function NumberField(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  const { className, ...rest } = props;
+  return <input type="number" {...rest} className={cn(controlBase, className)} />;
+}
+
+export function SelectField(props: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  const { className, children, ...rest } = props;
+  return (
+    <select {...rest} className={cn(controlBase, 'cursor-pointer', className)}>
+      {children}
+    </select>
+  );
+}
+
+/** A row that pairs a label with an inline control (e.g. a switch). */
+export function InlineField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-1">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        {hint ? <p className="mt-0.5 text-xs text-muted-foreground">{hint}</p> : null}
+      </div>
+      <div className="shrink-0 pt-0.5">{children}</div>
+    </div>
+  );
+}
+
+/** A titled group of controls with a consistent header + divider. */
+export function PanelSection({
+  title,
+  subtitle,
+  action,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+          {subtitle ? <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p> : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/flow-diagram.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/flow-diagram.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import type { FormConfig, FormFieldType } from '@quill/engine';
+import type { EditorMessages } from './messages';
+
+const TYPE_TAG: Record<FormFieldType, string> = {
+  text: 'TXT',
+  name: 'NAME',
+  email: 'MAIL',
+  phone: 'TEL',
+  dropdown: 'LIST',
+  multiple_choice: 'PICK',
+  slider: 'SLDR',
+  textarea: 'LONG',
+  message: 'MSG',
+};
+
+function Arrow() {
+  return (
+    <div aria-hidden className="flex justify-center py-1 text-muted-foreground">
+      <i className="pi pi-arrow-down" style={{ fontSize: 12 }} />
+    </div>
+  );
+}
+
+function Node({
+  children,
+  tone = 'default',
+}: {
+  children: React.ReactNode;
+  tone?: 'default' | 'accent' | 'muted';
+}) {
+  const toneClass =
+    tone === 'accent'
+      ? 'border-primary bg-primary/10'
+      : tone === 'muted'
+        ? 'border-dashed border-border bg-card'
+        : 'border-border bg-card';
+  return (
+    <div className={`mx-auto w-full max-w-md rounded-lg border px-4 py-3 ${toneClass}`}>{children}</div>
+  );
+}
+
+/**
+ * A clean, read-only map of the whole form: cover → each step (with its type,
+ * question, flow group and any conditional-visibility summary) → end. No
+ * editing on the diagram (Track A brief §6) — it's an at-a-glance overview.
+ */
+export function FlowDiagram({ config, m }: { config: FormConfig; m: EditorMessages }) {
+  const coverOn = config.cover?.enabled !== false && config.cover != null;
+
+  if (config.steps.length === 0) {
+    return <p className="py-10 text-center text-sm text-muted-foreground">{m.flow.empty}</p>;
+  }
+
+  const fieldLabel = (key: string): string => {
+    const s = config.steps.find((x) => x.key === key);
+    return s?.question?.trim() || key;
+  };
+
+  return (
+    <div className="mx-auto max-w-[640px]">
+      {coverOn ? (
+        <>
+          <Node tone="accent">
+            <div className="flex items-center gap-2">
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-muted-foreground">
+                {m.flow.cover.toUpperCase()}
+              </span>
+              <span className="truncate text-sm font-medium">
+                {config.cover?.headline || m.flow.cover}
+              </span>
+            </div>
+          </Node>
+          <Arrow />
+        </>
+      ) : null}
+
+      {config.steps.map((step, i) => {
+        const conditions: string[] = [];
+        if (step.showWhen) conditions.push(`${m.logic.showWhen}: ${fieldLabel(step.showWhen.field)} = ${step.showWhen.values.join(', ')}`);
+        if (step.hideWhen) conditions.push(`${m.logic.hideWhen}: ${fieldLabel(step.hideWhen.field)} = ${step.hideWhen.values.join(', ')}`);
+        return (
+          <div key={step.key}>
+            <Node tone={conditions.length ? 'muted' : 'default'}>
+              <div className="flex items-center gap-2">
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-muted-foreground">
+                  {TYPE_TAG[step.type]}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {step.question?.trim() || m.steps.untitled}
+                </span>
+                {step.flowGroup === 'lead_capture' ? (
+                  <span className="shrink-0 rounded-full bg-secondary/20 px-2 py-0.5 text-[10px] font-semibold text-secondary">
+                    {m.props.leadCapture}
+                  </span>
+                ) : null}
+              </div>
+              {conditions.length ? (
+                <ul className="mt-1.5 flex flex-col gap-0.5 border-t border-border pt-1.5">
+                  {conditions.map((c, ci) => (
+                    <li key={ci} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <i aria-hidden className="pi pi-sitemap" style={{ fontSize: 10 }} />
+                      {c}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </Node>
+            <Arrow />
+            {i === config.steps.length - 1 ? (
+              <Node tone="muted">
+                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <i aria-hidden className="pi pi-flag" style={{ fontSize: 12 }} />
+                  {m.flow.end}
+                </div>
+              </Node>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormConfig, FormStep } from '@quill/engine';
+import { resolveQuestion } from '@quill/engine';
+import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
+import type { EditorMessages } from './messages';
+
+/**
+ * A faithful, read-only preview of the cover or a single step, styled with the
+ * form's branding accent so the editor reflects the public surface. Interactive
+ * within the preview (you can tap options / drag the slider) but never submits.
+ */
+export function LivePreview({
+  config,
+  selected,
+  m,
+}: {
+  config: FormConfig;
+  selected: number | 'cover';
+  m: EditorMessages['preview'];
+}) {
+  const accent = clampAccent(config.branding?.primaryColor || DEFAULT_ACCENT);
+  const accentText = onAccent(accent);
+  const step: FormStep | undefined = typeof selected === 'number' ? config.steps[selected] : undefined;
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-4">
+      {selected === 'cover' ? (
+        <CoverPreview config={config} accent={accent} accentText={accentText} m={m} />
+      ) : step ? (
+        <StepPreview step={step} accent={accent} accentText={accentText} m={m} index={selected} total={config.steps.length} />
+      ) : (
+        <p className="py-8 text-center text-sm text-muted-foreground">{m.empty}</p>
+      )}
+    </div>
+  );
+}
+
+function CoverPreview({
+  config,
+  accent,
+  accentText,
+  m,
+}: {
+  config: FormConfig;
+  accent: string;
+  accentText: string;
+  m: EditorMessages['preview'];
+}) {
+  const cover = config.cover ?? {};
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-md border border-border bg-card p-6 text-center">
+      {cover.bannerText ? (
+        <div
+          className="mb-1 w-full rounded-md px-3 py-1.5 text-xs font-medium"
+          style={{ background: accent, color: accentText }}
+        >
+          {cover.bannerText}
+        </div>
+      ) : null}
+      {cover.eyebrow ? (
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {cover.eyebrow}
+        </span>
+      ) : null}
+      <h1 className="text-2xl font-semibold tracking-tight">{cover.headline || m.coverTitle}</h1>
+      {cover.subheadline ? <p className="text-sm text-muted-foreground">{cover.subheadline}</p> : null}
+      <button
+        type="button"
+        className="mt-1 rounded-md px-5 py-2.5 text-sm font-semibold transition-transform active:scale-[0.98]"
+        style={{ background: accent, color: accentText }}
+      >
+        {cover.ctaText || 'Start'}
+      </button>
+      {cover.trustBadge ? <p className="text-xs text-muted-foreground">{cover.trustBadge}</p> : null}
+    </div>
+  );
+}
+
+function StepPreview({
+  step,
+  accent,
+  accentText,
+  index,
+  total,
+  m,
+}: {
+  step: FormStep;
+  accent: string;
+  accentText: string;
+  index: number;
+  total: number;
+  m: EditorMessages['preview'];
+}) {
+  const [value, setValue] = useState<string | number>('');
+  const question = resolveQuestion(step, {}) || step.key;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-md border border-border bg-card p-6">
+      <div className="flex items-center gap-1.5" aria-hidden>
+        {Array.from({ length: Math.max(total, 1) }).map((_, i) => (
+          <span
+            key={i}
+            className="h-1.5 flex-1 rounded-full"
+            style={{ background: i <= index ? accent : 'var(--muted)' }}
+          />
+        ))}
+      </div>
+
+      <p className="text-[11px] font-medium text-muted-foreground">
+        {m.step} {index + 1} {m.of} {total}
+      </p>
+
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold">
+          {question}
+          {step.required && step.type !== 'message' ? (
+            <span aria-hidden style={{ color: accent }} className="ml-0.5">
+              *
+            </span>
+          ) : null}
+        </h2>
+        {step.helper ? <p className="text-sm text-muted-foreground">{step.helper}</p> : null}
+      </div>
+
+      {step.type === 'message' ? null : step.type === 'dropdown' || step.type === 'multiple_choice' ? (
+        <div className="flex flex-col gap-2">
+          {(step.options ?? []).map((o) => {
+            const on = value === o.value;
+            return (
+              <button
+                key={o.value}
+                type="button"
+                onClick={() => setValue(o.value)}
+                className="rounded-md border px-4 py-3 text-left text-sm transition-colors"
+                style={
+                  on
+                    ? { borderColor: accent, background: 'color-mix(in srgb, ' + accent + ' 15%, transparent)' }
+                    : { borderColor: 'var(--border)' }
+                }
+              >
+                {o.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : step.type === 'slider' ? (
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={step.min ?? 0}
+            max={step.max ?? 100}
+            step={step.step ?? 1}
+            value={Number(value || step.default || step.min || 0)}
+            onChange={(e) => setValue(Number(e.target.value))}
+            className="flex-1 accent-[var(--primary)]"
+            style={{ accentColor: accent }}
+          />
+          <span className="w-12 text-right font-mono text-sm">
+            {String(value || step.default || step.min || 0)}
+          </span>
+        </div>
+      ) : step.type === 'textarea' ? (
+        <textarea
+          value={String(value)}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={step.placeholder ?? undefined}
+          rows={3}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      ) : (
+        <input
+          type={step.type === 'email' ? 'email' : step.type === 'phone' ? 'tel' : 'text'}
+          value={String(value)}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={step.placeholder ?? undefined}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          className="rounded-md px-5 py-2.5 text-sm font-semibold transition-transform active:scale-[0.98]"
+          style={{ background: accent, color: accentText }}
+        >
+          {step.buttonText || (index + 1 === total ? 'Submit' : 'Next')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/messages.ts
@@ -1,0 +1,4 @@
+import type { FormsMessages } from '@quill/shared';
+
+/** The editor message subtree passed from the server page into the client UI. */
+export type EditorMessages = FormsMessages['admin']['editor'];

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { FormOption } from '@quill/engine';
+import { slugify } from '@quill/engine';
+import { Button } from '@/components/ui/button';
+import { TextField, NumberField } from './fields';
+import { SortableList, SortableRow } from './sortable';
+import type { EditorMessages } from './messages';
+
+/**
+ * Editor for a choice/dropdown step's options: label, value, points and an
+ * optional icon, drag-reorderable. Value auto-fills from the label until the
+ * author edits it directly (then it's left alone). No native scrollbars; the
+ * whole panel scrolls with the page.
+ */
+export function OptionsEditor({
+  options,
+  onChange,
+  m,
+}: {
+  options: FormOption[];
+  onChange: (next: FormOption[]) => void;
+  m: EditorMessages['options'];
+}) {
+  const ids = options.map((_, i) => `opt-${i}`);
+
+  function update(index: number, patch: Partial<FormOption>) {
+    onChange(options.map((o, i) => (i === index ? { ...o, ...patch } : o)));
+  }
+  function remove(index: number) {
+    onChange(options.filter((_, i) => i !== index));
+  }
+  function add() {
+    const n = options.length + 1;
+    onChange([...options, { label: `Option ${n}`, value: slugify(`option ${n}`), points: 0 }]);
+  }
+  function reorder(from: number, to: number) {
+    const next = [...options];
+    const [moved] = next.splice(from, 1);
+    if (!moved) return;
+    next.splice(to, 0, moved);
+    onChange(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {options.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{m.empty}</p>
+      ) : (
+        <SortableList ids={ids} onReorder={reorder} className="flex flex-col gap-2">
+          {(id, index) => {
+            const o = options[index];
+            if (!o) return null;
+            return (
+              <SortableRow key={id} id={id}>
+                {({ handleProps }) => (
+                  <div className="flex items-end gap-2 rounded-md border border-border bg-background p-2">
+                    <button
+                      type="button"
+                      aria-label={m.title}
+                      className="mb-1.5 shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+                      {...handleProps}
+                    >
+                      <i aria-hidden className="pi pi-bars" style={{ fontSize: 13 }} />
+                    </button>
+                    <label className="flex min-w-0 flex-[2] flex-col gap-1">
+                      <span className="text-[11px] font-medium text-muted-foreground">{m.label}</span>
+                      <TextField
+                        value={o.label}
+                        onChange={(e) => {
+                          const label = e.target.value;
+                          const autoValue = !o.value || o.value === slugify(o.label ?? '');
+                          update(index, autoValue ? { label, value: slugify(label) } : { label });
+                        }}
+                      />
+                    </label>
+                    <label className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="text-[11px] font-medium text-muted-foreground">{m.value}</span>
+                      <TextField
+                        value={o.value}
+                        onChange={(e) => update(index, { value: e.target.value })}
+                      />
+                    </label>
+                    <label className="flex w-16 shrink-0 flex-col gap-1">
+                      <span className="text-[11px] font-medium text-muted-foreground">{m.points}</span>
+                      <NumberField
+                        value={o.points ?? 0}
+                        onChange={(e) => update(index, { points: Number(e.target.value) || 0 })}
+                      />
+                    </label>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={m.remove}
+                      onClick={() => remove(index)}
+                      className="mb-0.5 shrink-0 text-muted-foreground hover:text-destructive"
+                    >
+                      <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                    </Button>
+                  </div>
+                )}
+              </SortableRow>
+            );
+          }}
+        </SortableList>
+      )}
+      <div>
+        <Button variant="outline" size="sm" onClick={add}>
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/outcomes-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/outcomes-panel.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { FormConfig, FormOutcome } from '@quill/engine';
+import { createEmptyOutcome } from '@quill/engine';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Field, TextField, NumberField, InlineField, PanelSection } from './fields';
+import type { EditorMessages } from './messages';
+
+/**
+ * Outcomes editor — the generalized score-routing model. Each bucket has a
+ * label, a minimum score, and an optional redirect URL; at submit time the
+ * highest bucket the score clears wins. A master toggle mirrors
+ * `scoring.enabled`.
+ */
+export function OutcomesPanel({
+  config,
+  onScoringChange,
+  onOutcomesChange,
+  m,
+}: {
+  config: FormConfig;
+  onScoringChange: (enabled: boolean) => void;
+  onOutcomesChange: (next: FormOutcome[]) => void;
+  m: EditorMessages;
+}) {
+  const outcomes = config.outcomes ?? [];
+  const scoringOn = config.scoring?.enabled !== false;
+
+  function update(index: number, patch: Partial<FormOutcome>) {
+    onOutcomesChange(outcomes.map((o, i) => (i === index ? { ...o, ...patch } : o)));
+  }
+  function add() {
+    const taken = new Set(outcomes.map((o) => o.id));
+    onOutcomesChange([...outcomes, createEmptyOutcome(taken)]);
+  }
+
+  return (
+    <div className="mx-auto flex max-w-[760px] flex-col gap-4">
+      <PanelSection title={m.outcomes.title} subtitle={m.outcomes.subtitle}>
+        <InlineField label={m.outcomes.scoringEnabled} hint={m.outcomes.scoringHint}>
+          <Switch checked={scoringOn} onCheckedChange={onScoringChange} aria-label={m.outcomes.scoringEnabled} />
+        </InlineField>
+      </PanelSection>
+
+      <PanelSection
+        title={m.outcomes.title}
+        action={
+          <Button variant="outline" size="sm" onClick={add}>
+            <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.outcomes.add}
+          </Button>
+        }
+      >
+        {outcomes.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{m.outcomes.empty}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {outcomes.map((o, index) => (
+              <div key={o.id} className="flex flex-col gap-3 rounded-md border border-border bg-background p-3 sm:flex-row sm:items-end">
+                <Field label={m.outcomes.label} className="flex-[2]">
+                  <TextField
+                    value={o.label}
+                    placeholder={m.outcomes.labelPlaceholder}
+                    onChange={(e) => update(index, { label: e.target.value })}
+                  />
+                </Field>
+                <Field label={m.outcomes.minScore} className="sm:w-28">
+                  <NumberField
+                    value={o.minScore ?? 0}
+                    onChange={(e) => update(index, { minScore: Number(e.target.value) || 0 })}
+                  />
+                </Field>
+                <Field label={m.outcomes.redirectUrl} className="flex-[2]">
+                  <TextField
+                    type="url"
+                    value={o.redirectUrl ?? ''}
+                    placeholder={m.outcomes.redirectPlaceholder}
+                    onChange={(e) => update(index, { redirectUrl: e.target.value || null })}
+                  />
+                </Field>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={m.outcomes.remove}
+                  onClick={() => onOutcomesChange(outcomes.filter((_, i) => i !== index))}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </PanelSection>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-variants-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-variants-editor.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { FormStep } from '@quill/engine';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { SelectField, TextField, TextArea, InlineField } from './fields';
+import type { PriorField } from './condition-editor';
+import type { EditorMessages } from './messages';
+
+/**
+ * Dynamic-question editor: vary a step's question by the answer to an earlier
+ * field. Variants are stored as `questionVariants` (value → text), with `*` as
+ * the fallback. `[field]` interpolation is available in every variant.
+ */
+export function QuestionVariantsEditor({
+  step,
+  priorFields,
+  onUpdate,
+  m,
+}: {
+  step: FormStep;
+  priorFields: PriorField[];
+  onUpdate: (patch: Partial<FormStep>) => void;
+  m: EditorMessages['variants'];
+}) {
+  const enabled = !!step.questionField;
+  const variants = step.questionVariants ?? {};
+  // Editable pairs excluding the special `*` fallback key.
+  const pairs = Object.entries(variants).filter(([k]) => k !== '*');
+  const fallback = variants['*'] ?? '';
+
+  function setVariants(next: Record<string, string>) {
+    onUpdate({ questionVariants: next });
+  }
+  function enable(on: boolean) {
+    if (on) onUpdate({ questionField: priorFields[0]?.key ?? '', questionVariants: variants });
+    else onUpdate({ questionField: null, questionVariants: undefined });
+  }
+  function updateKey(oldKey: string, newKey: string) {
+    const next: Record<string, string> = {};
+    for (const [k, v] of Object.entries(variants)) next[k === oldKey ? newKey : k] = v;
+    setVariants(next);
+  }
+  function updateValue(key: string, text: string) {
+    setVariants({ ...variants, [key]: text });
+  }
+  function remove(key: string) {
+    const next = { ...variants };
+    delete next[key];
+    setVariants(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <InlineField label={m.enable} hint={m.hint}>
+        <Switch checked={enabled} onCheckedChange={enable} aria-label={m.enable} />
+      </InlineField>
+
+      {enabled ? (
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">{m.field}</span>
+            <SelectField
+              value={step.questionField ?? ''}
+              onChange={(e) => onUpdate({ questionField: e.target.value })}
+            >
+              {priorFields.length === 0 ? <option value="">—</option> : null}
+              {priorFields.map((f) => (
+                <option key={f.key} value={f.key}>
+                  {f.label}
+                </option>
+              ))}
+            </SelectField>
+          </label>
+
+          {pairs.map(([key, text], i) => (
+            <div key={i} className="flex flex-col gap-1.5 rounded-md border border-border bg-background p-2">
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] font-medium text-muted-foreground">{m.matchValue}</span>
+                <TextField
+                  value={key}
+                  placeholder={m.matchValuePlaceholder}
+                  onChange={(e) => updateKey(key, e.target.value)}
+                  className="flex-1"
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={m.remove}
+                  onClick={() => remove(key)}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                </Button>
+              </div>
+              <TextArea
+                value={text}
+                rows={2}
+                placeholder={m.variantQuestion}
+                onChange={(e) => updateValue(key, e.target.value)}
+              />
+            </div>
+          ))}
+
+          <div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setVariants({ ...variants, '': '' })}
+              disabled={'' in variants}
+            >
+              <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
+            </Button>
+          </div>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">{m.fallback}</span>
+            <TextArea
+              value={fallback}
+              rows={2}
+              onChange={(e) => updateValue('*', e.target.value)}
+            />
+          </label>
+          <p className="text-xs text-muted-foreground">{m.interpolationHint}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/slider-scoring-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/slider-scoring-editor.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { SliderScoringRange } from '@quill/engine';
+import { Button } from '@/components/ui/button';
+import { NumberField } from './fields';
+import type { EditorMessages } from './messages';
+
+/** Slider scoring ranges: value in [min,max] awards `points`. Add/remove rows. */
+export function SliderScoringEditor({
+  ranges,
+  onChange,
+  m,
+}: {
+  ranges: SliderScoringRange[];
+  onChange: (next: SliderScoringRange[]) => void;
+  m: EditorMessages['sliderScoring'];
+}) {
+  function update(index: number, patch: Partial<SliderScoringRange>) {
+    onChange(ranges.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {ranges.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{m.empty}</p>
+      ) : (
+        ranges.map((r, index) => (
+          <div
+            key={index}
+            className="flex items-end gap-2 rounded-md border border-border bg-background p-2"
+          >
+            <label className="flex flex-1 flex-col gap-1">
+              <span className="text-[11px] font-medium text-muted-foreground">{m.min}</span>
+              <NumberField value={r.min} onChange={(e) => update(index, { min: Number(e.target.value) || 0 })} />
+            </label>
+            <label className="flex flex-1 flex-col gap-1">
+              <span className="text-[11px] font-medium text-muted-foreground">{m.max}</span>
+              <NumberField value={r.max} onChange={(e) => update(index, { max: Number(e.target.value) || 0 })} />
+            </label>
+            <label className="flex w-16 shrink-0 flex-col gap-1">
+              <span className="text-[11px] font-medium text-muted-foreground">{m.points}</span>
+              <NumberField value={r.points} onChange={(e) => update(index, { points: Number(e.target.value) || 0 })} />
+            </label>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={m.remove}
+              onClick={() => onChange(ranges.filter((_, i) => i !== index))}
+              className="mb-0.5 shrink-0 text-muted-foreground hover:text-destructive"
+            >
+              <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+            </Button>
+          </div>
+        ))
+      )}
+      <div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onChange([...ranges, { min: 0, max: 0, points: 0 }])}
+        >
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { HTMLAttributes, ReactNode } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+/**
+ * A thin, reusable dnd-kit vertical sortable. Keyboard-accessible (grip is a
+ * focusable handle; arrows move a picked-up item), pointer needs a 4px intent
+ * so clicks on inner controls don't start a drag. Used for the step list and
+ * the option list so reorder behaves identically everywhere.
+ */
+export function SortableList({
+  ids,
+  onReorder,
+  children,
+  className,
+}: {
+  ids: string[];
+  onReorder: (from: number, to: number) => void;
+  children: (id: string, index: number) => ReactNode;
+  className?: string;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = ids.indexOf(String(active.id));
+    const to = ids.indexOf(String(over.id));
+    if (from >= 0 && to >= 0) onReorder(from, to);
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleEnd}>
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        <div className={className}>{ids.map((id, index) => children(id, index))}</div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+/** One sortable row. `children` receives the props to spread on the drag grip. */
+export function SortableRow({
+  id,
+  children,
+}: {
+  id: string;
+  children: (args: { handleProps: HTMLAttributes<HTMLElement>; isDragging: boolean }) => ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+    zIndex: isDragging ? 20 : undefined,
+    position: 'relative',
+  };
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ handleProps: { ...attributes, ...listeners }, isDragging })}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/step-list.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/step-list.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormStep, FormFieldType } from '@quill/engine';
+import { Button } from '@/components/ui/button';
+import { SelectField } from './fields';
+import { SortableList, SortableRow } from './sortable';
+import type { EditorMessages } from './messages';
+
+const STEP_TYPES: FormFieldType[] = [
+  'text',
+  'name',
+  'email',
+  'phone',
+  'dropdown',
+  'multiple_choice',
+  'slider',
+  'textarea',
+  'message',
+];
+
+const TYPE_TAG: Record<FormFieldType, string> = {
+  text: 'TXT',
+  name: 'NAME',
+  email: 'MAIL',
+  phone: 'TEL',
+  dropdown: 'LIST',
+  multiple_choice: 'PICK',
+  slider: 'SLDR',
+  textarea: 'LONG',
+  message: 'MSG',
+};
+
+/**
+ * The left rail: a drag-reorderable list of steps (dnd-kit) with a type-picker
+ * add control at the bottom. Selection drives the center properties panel and
+ * the live preview. The active row is unmistakable (accent border + fill).
+ */
+export function StepList({
+  steps,
+  selectedIndex,
+  onSelect,
+  onReorder,
+  onAdd,
+  m,
+}: {
+  steps: FormStep[];
+  selectedIndex: number | null;
+  onSelect: (index: number) => void;
+  onReorder: (from: number, to: number) => void;
+  onAdd: (type: FormFieldType) => void;
+  m: EditorMessages;
+}) {
+  const [addType, setAddType] = useState<FormFieldType>('text');
+  const ids = steps.map((s) => s.key);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-foreground">{m.steps.title}</h2>
+        <span className="text-xs text-muted-foreground">{steps.length}</span>
+      </div>
+
+      {steps.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+          {m.steps.empty}
+        </p>
+      ) : (
+        <SortableList ids={ids} onReorder={onReorder} className="flex flex-col gap-1.5">
+          {(id, index) => {
+            const step = steps[index];
+            if (!step) return null;
+            const active = index === selectedIndex;
+            return (
+              <SortableRow key={id} id={id}>
+                {({ handleProps }) => (
+                  <div
+                    className={
+                      'flex items-center gap-2 rounded-md border px-2 py-2 transition-colors ' +
+                      (active
+                        ? 'border-primary bg-primary/10'
+                        : 'border-border bg-card hover:border-muted-foreground')
+                    }
+                  >
+                    <button
+                      type="button"
+                      aria-label={m.steps.dragHint}
+                      className="shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+                      {...handleProps}
+                    >
+                      <i aria-hidden className="pi pi-bars" style={{ fontSize: 12 }} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onSelect(index)}
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    >
+                      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-muted-foreground">
+                        {TYPE_TAG[step.type]}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-sm">
+                        {step.question?.trim() || m.steps.untitled}
+                      </span>
+                      {step.showWhen || step.hideWhen ? (
+                        <i
+                          aria-hidden
+                          title={m.flow.conditional}
+                          className="pi pi-sitemap shrink-0 text-muted-foreground"
+                          style={{ fontSize: 11 }}
+                        />
+                      ) : null}
+                    </button>
+                  </div>
+                )}
+              </SortableRow>
+            );
+          }}
+        </SortableList>
+      )}
+
+      <div className="flex items-end gap-2 border-t border-border pt-3">
+        <label className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="text-[11px] font-medium text-muted-foreground">{m.steps.addType}</span>
+          <SelectField value={addType} onChange={(e) => setAddType(e.target.value as FormFieldType)}>
+            {STEP_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {m.types[t]}
+              </option>
+            ))}
+          </SelectField>
+        </label>
+        <Button variant="outline" size="sm" onClick={() => onAdd(addType)} className="shrink-0">
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.steps.add}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/step-properties.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/step-properties.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import type { FormStep, FormFieldType } from '@quill/engine';
+import { defaultFlowGroup } from '@quill/engine';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import {
+  Field,
+  TextField,
+  TextArea,
+  NumberField,
+  SelectField,
+  InlineField,
+  PanelSection,
+} from './fields';
+import { OptionsEditor } from './options-editor';
+import { SliderScoringEditor } from './slider-scoring-editor';
+import { ConditionEditor, type PriorField } from './condition-editor';
+import { QuestionVariantsEditor } from './question-variants-editor';
+import type { EditorMessages } from './messages';
+
+const STEP_TYPES: FormFieldType[] = [
+  'text',
+  'name',
+  'email',
+  'phone',
+  'dropdown',
+  'multiple_choice',
+  'slider',
+  'textarea',
+  'message',
+];
+
+const hasOptions = (t: FormFieldType) => t === 'dropdown' || t === 'multiple_choice';
+
+/**
+ * The center panel: every property of the selected step, for all 9 kinds.
+ * Common anatomy up top (type, question, helper, required, button, flow group),
+ * then kind-specific blocks (options, slider bounds+scoring, email/phone
+ * validation), then cross-cutting logic (dynamic question + conditional
+ * visibility). One vertical rhythm; the page scrolls (no inner scrollbar).
+ */
+export function StepProperties({
+  step,
+  index,
+  priorFields,
+  onUpdate,
+  onDelete,
+  m,
+}: {
+  step: FormStep;
+  index: number;
+  priorFields: PriorField[];
+  onUpdate: (patch: Partial<FormStep>) => void;
+  onDelete: () => void;
+  m: EditorMessages;
+}) {
+  const showButton = step.type === 'message';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelSection
+        title={m.steps.stepN.replace('{n}', String(index + 1))}
+        action={
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              if (confirm(m.steps.deleteConfirm)) onDelete();
+            }}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <i aria-hidden className="pi pi-trash" style={{ fontSize: 12 }} /> {m.steps.delete}
+          </Button>
+        }
+      >
+        <Field label={m.props.type}>
+          <SelectField
+            value={step.type}
+            onChange={(e) => {
+              const type = e.target.value as FormFieldType;
+              const patch: Partial<FormStep> = { type, flowGroup: defaultFlowGroup(type) };
+              if (hasOptions(type) && (step.options ?? []).length === 0) {
+                patch.options = [{ label: 'Option 1', value: 'option_1', points: 0 }];
+              }
+              if (type === 'slider' && step.min == null) {
+                patch.min = 0;
+                patch.max = 100;
+                patch.step = 1;
+                patch.default = 50;
+              }
+              onUpdate(patch);
+            }}
+          >
+            {STEP_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {m.types[t]}
+              </option>
+            ))}
+          </SelectField>
+        </Field>
+
+        <Field label={m.props.question}>
+          <TextArea
+            value={step.question ?? ''}
+            rows={2}
+            placeholder={m.props.questionPlaceholder}
+            onChange={(e) => onUpdate({ question: e.target.value })}
+          />
+        </Field>
+
+        <Field label={m.props.helper}>
+          <TextField
+            value={step.helper ?? ''}
+            onChange={(e) => onUpdate({ helper: e.target.value || null })}
+          />
+        </Field>
+
+        {step.type !== 'message' && step.type !== 'slider' && !hasOptions(step.type) ? (
+          <Field label={m.props.placeholder}>
+            <TextField
+              value={step.placeholder ?? ''}
+              onChange={(e) => onUpdate({ placeholder: e.target.value || null })}
+            />
+          </Field>
+        ) : null}
+
+        {showButton ? (
+          <Field label={m.props.buttonText}>
+            <TextField
+              value={step.buttonText ?? ''}
+              placeholder={m.props.buttonTextPlaceholder}
+              onChange={(e) => onUpdate({ buttonText: e.target.value || null })}
+            />
+          </Field>
+        ) : null}
+
+        {step.type !== 'message' ? (
+          <InlineField label={m.props.required}>
+            <Switch
+              checked={step.required !== false}
+              onCheckedChange={(v) => onUpdate({ required: v })}
+              aria-label={m.props.required}
+            />
+          </InlineField>
+        ) : null}
+
+        <Field label={m.props.flowGroup} hint={m.props.flowGroupHint}>
+          <SelectField
+            value={step.flowGroup ?? defaultFlowGroup(step.type)}
+            onChange={(e) => onUpdate({ flowGroup: e.target.value as FormStep['flowGroup'] })}
+          >
+            <option value="qualification">{m.props.qualification}</option>
+            <option value="lead_capture">{m.props.leadCapture}</option>
+          </SelectField>
+        </Field>
+      </PanelSection>
+
+      {hasOptions(step.type) ? (
+        <PanelSection title={m.options.title}>
+          <OptionsEditor
+            options={step.options ?? []}
+            onChange={(options) => onUpdate({ options })}
+            m={m.options}
+          />
+        </PanelSection>
+      ) : null}
+
+      {step.type === 'slider' ? (
+        <PanelSection title={m.types.slider}>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Field label={m.props.sliderMin}>
+              <NumberField value={step.min ?? 0} onChange={(e) => onUpdate({ min: Number(e.target.value) || 0 })} />
+            </Field>
+            <Field label={m.props.sliderMax}>
+              <NumberField value={step.max ?? 100} onChange={(e) => onUpdate({ max: Number(e.target.value) || 0 })} />
+            </Field>
+            <Field label={m.props.sliderStep}>
+              <NumberField value={step.step ?? 1} onChange={(e) => onUpdate({ step: Number(e.target.value) || 1 })} />
+            </Field>
+            <Field label={m.props.sliderDefault}>
+              <NumberField
+                value={step.default ?? 0}
+                onChange={(e) => onUpdate({ default: Number(e.target.value) || 0 })}
+              />
+            </Field>
+          </div>
+          <div className="mt-1">
+            <p className="mb-2 text-xs font-medium text-muted-foreground">{m.sliderScoring.hint}</p>
+            <SliderScoringEditor
+              ranges={step.sliderScoring ?? []}
+              onChange={(sliderScoring) => onUpdate({ sliderScoring })}
+              m={m.sliderScoring}
+            />
+          </div>
+        </PanelSection>
+      ) : null}
+
+      {step.type === 'email' ? (
+        <PanelSection title={m.types.email}>
+          <InlineField label={m.props.corporateEmailOnly} hint={m.props.corporateEmailHint}>
+            <Switch
+              checked={!!step.corporateEmailOnly}
+              onCheckedChange={(v) => onUpdate({ corporateEmailOnly: v || undefined })}
+              aria-label={m.props.corporateEmailOnly}
+            />
+          </InlineField>
+        </PanelSection>
+      ) : null}
+
+      {step.type === 'phone' ? (
+        <PanelSection title={m.types.phone}>
+          <Field label={m.props.phoneMinDigits}>
+            <NumberField
+              value={step.phoneMinDigits ?? 7}
+              min={1}
+              onChange={(e) => onUpdate({ phoneMinDigits: Number(e.target.value) || undefined })}
+            />
+          </Field>
+        </PanelSection>
+      ) : null}
+
+      <PanelSection title={m.variants.title}>
+        <QuestionVariantsEditor step={step} priorFields={priorFields} onUpdate={onUpdate} m={m.variants} />
+      </PanelSection>
+
+      <PanelSection title={m.logic.title}>
+        {priorFields.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{m.logic.noPriorFields}</p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <ConditionEditor
+              label={m.logic.showWhen}
+              condition={step.showWhen}
+              priorFields={priorFields}
+              onChange={(showWhen) => onUpdate({ showWhen })}
+              m={m.logic}
+            />
+            <ConditionEditor
+              label={m.logic.hideWhen}
+              condition={step.hideWhen}
+              priorFields={priorFields}
+              onChange={(hideWhen) => onUpdate({ hideWhen })}
+              m={m.logic}
+            />
+          </div>
+        )}
+      </PanelSection>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -1,84 +1,247 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import type { FormConfig, FormStep, FormCover, FormBranding, FormOutcome, FormFieldType } from '@quill/engine';
+import { createEmptyStep, normalizeConfig } from '@quill/engine';
 import { saveFormAction } from '@/app/admin/actions';
+import { useToast } from '@/components/toast';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/cn';
+import { StepList } from './_components/step-list';
+import { StepProperties } from './_components/step-properties';
+import { CoverPanel } from './_components/cover-panel';
+import { OutcomesPanel } from './_components/outcomes-panel';
+import { FlowDiagram } from './_components/flow-diagram';
+import { LivePreview } from './_components/live-preview';
+import { DevicePreviewModal } from './_components/device-preview-modal';
+import type { PriorField } from './_components/condition-editor';
+import type { EditorMessages } from './_components/messages';
+
+type Tab = 'build' | 'cover' | 'outcomes' | 'flow';
 
 /**
- * Placeholder editor (Phase 1 replaces this with a real step builder). It edits
- * the form name and the raw config JSON and saves via a server action — enough to
- * make the whole loop (edit → save → public render) work end to end.
+ * The form editor: a step builder (drag-reorder list · per-step properties ·
+ * live preview), a cover/branding tab, an outcomes/scoring tab and a read-only
+ * flow overview. Config is normalized on save (dedupe keys, canonical order,
+ * derived flags) via @quill/engine so the persisted blob is always canonical.
  */
 export function FormEditor({
   id,
   initialName,
   initialConfig,
+  publicPath,
+  m,
 }: {
   id: string;
   initialName: string;
-  initialConfig: string;
+  initialConfig: FormConfig;
+  publicPath: string;
+  m: EditorMessages;
 }) {
+  const toast = useToast();
   const [name, setName] = useState(initialName);
-  const [config, setConfig] = useState(initialConfig);
-  const [message, setMessage] = useState<string | null>(null);
+  const [config, setConfig] = useState<FormConfig>(initialConfig);
+  const [tab, setTab] = useState<Tab>('build');
+  const [selected, setSelected] = useState<number | null>(initialConfig.steps.length ? 0 : null);
+  const [deviceOpen, setDeviceOpen] = useState(false);
   const [pending, start] = useTransition();
 
-  function save() {
-    setMessage(null);
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(config);
-    } catch {
-      setMessage('Config is not valid JSON.');
-      return;
-    }
-    start(async () => {
-      const res = await saveFormAction(id, { name, config: parsed });
-      setMessage(res.ok ? 'Saved.' : (res.message ?? 'Failed to save.'));
+  /** Fields defined before `index` — the pool skip-logic / variants can read. */
+  const priorFieldsFor = (index: number): PriorField[] =>
+    config.steps.slice(0, index).map((s) => ({
+      key: s.key,
+      label: s.question?.trim() || s.key,
+      options: s.options?.map((o) => ({ label: o.label, value: o.value })),
+    }));
+
+  function patchStep(index: number, patch: Partial<FormStep>) {
+    setConfig((c) => ({ ...c, steps: c.steps.map((s, i) => (i === index ? { ...s, ...patch } : s)) }));
+  }
+
+  function addStep(type: FormFieldType) {
+    setConfig((c) => {
+      const step = createEmptyStep(type, new Set(c.steps.map((s) => s.key)));
+      const steps = [...c.steps, step];
+      setSelected(steps.length - 1);
+      return { ...c, steps };
     });
   }
 
+  function deleteStep(index: number) {
+    setConfig((c) => ({ ...c, steps: c.steps.filter((_, i) => i !== index) }));
+    setSelected((sel) => {
+      if (sel == null) return null;
+      const nextLen = config.steps.length - 1;
+      if (nextLen === 0) return null;
+      if (sel === index) return Math.max(0, index - 1);
+      return sel > index ? sel - 1 : sel;
+    });
+  }
+
+  function reorderSteps(from: number, to: number) {
+    setConfig((c) => {
+      const steps = [...c.steps];
+      const [moved] = steps.splice(from, 1);
+      if (!moved) return c;
+      steps.splice(to, 0, moved);
+      return { ...c, steps };
+    });
+    setSelected((sel) => {
+      if (sel == null) return null;
+      if (sel === from) return to;
+      if (from < sel && to >= sel) return sel - 1;
+      if (from > sel && to <= sel) return sel + 1;
+      return sel;
+    });
+  }
+
+  function patchCover(patch: Partial<FormCover>) {
+    setConfig((c) => ({ ...c, cover: { ...c.cover, ...patch } }));
+  }
+  function patchBranding(patch: Partial<FormBranding>) {
+    setConfig((c) => ({ ...c, branding: { ...c.branding, ...patch } }));
+  }
+  function setScoring(enabled: boolean) {
+    setConfig((c) => ({ ...c, scoring: { enabled } }));
+  }
+  function setOutcomes(outcomes: FormOutcome[]) {
+    setConfig((c) => ({ ...c, outcomes }));
+  }
+
+  function save() {
+    const normalized = normalizeConfig(config);
+    start(async () => {
+      const res = await saveFormAction(id, { name, config: normalized });
+      if (res.ok) {
+        setConfig(normalized);
+        // Selection index may shift if empty steps were reordered; clamp it.
+        setSelected((sel) => (sel == null ? null : Math.min(sel, normalized.steps.length - 1)));
+        toast.success(m.saved);
+      } else {
+        toast.error(res.message ?? m.saveError);
+      }
+    });
+  }
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'build', label: m.tabs.build },
+    { id: 'cover', label: m.tabs.cover },
+    { id: 'outcomes', label: m.tabs.outcomes },
+    { id: 'flow', label: m.tabs.flow },
+  ];
+
+  const selectedStep = selected != null ? config.steps[selected] : undefined;
+
   return (
-    <div className="mt-4 flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <label htmlFor="form-name" className="text-sm font-medium">
-          Form name
-        </label>
-        <input
-          id="form-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="rounded-md border border-border bg-background px-3 py-2"
-        />
+    <div className="min-h-dvh">
+      {/* Sticky header: back · name · preview + save (one primary CTA — R30). */}
+      <div className="sticky top-0 z-30 border-b border-border bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+        <div className="mx-auto flex max-w-[1520px] flex-col gap-3 px-4 pb-3 pt-4 sm:px-6">
+          <Link
+            href="/admin"
+            className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <i aria-hidden className="pi pi-chevron-left" style={{ fontSize: 12 }} />
+            {m.back}
+          </Link>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={m.formNamePlaceholder}
+              aria-label={m.formNamePlaceholder}
+              className="min-w-0 flex-1 rounded-md border border-transparent bg-transparent px-1 py-1 text-2xl font-semibold tracking-tight hover:border-border focus-visible:border-input focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <div className="flex shrink-0 items-center gap-2">
+              <Button variant="outline" onClick={() => setDeviceOpen(true)}>
+                <i aria-hidden className="pi pi-eye" style={{ fontSize: 13 }} /> {m.previewBtn}
+              </Button>
+              <Button onClick={save} disabled={pending} className="min-w-[92px]">
+                {pending ? m.saving : m.save}
+              </Button>
+            </div>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex gap-1 overflow-x-auto">
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                aria-current={tab === t.id}
+                className={cn(
+                  'whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                  tab === t.id
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
-      <div className="flex flex-col gap-1">
-        <label htmlFor="form-config" className="text-sm font-medium">
-          Config (JSON)
-        </label>
-        <textarea
-          id="form-config"
-          value={config}
-          onChange={(e) => setConfig(e.target.value)}
-          spellCheck={false}
-          rows={22}
-          className="rounded-md border border-border bg-background px-3 py-2 font-mono text-xs"
-        />
-        <p className="text-xs text-muted-foreground">
-          Placeholder editor — Phase 1 replaces this with a visual step builder.
-        </p>
+      <div className="mx-auto max-w-[1520px] px-4 py-6 sm:px-6">
+        {tab === 'build' ? (
+          <div className="grid gap-4 lg:grid-cols-[minmax(220px,260px)_minmax(0,1fr)_minmax(320px,400px)]">
+            <aside className="lg:sticky lg:top-[9.5rem] lg:self-start">
+              <StepList
+                steps={config.steps}
+                selectedIndex={selected}
+                onSelect={setSelected}
+                onReorder={reorderSteps}
+                onAdd={addStep}
+                m={m}
+              />
+            </aside>
+
+            <div className="min-w-0">
+              {selectedStep && selected != null ? (
+                <StepProperties
+                  step={selectedStep}
+                  index={selected}
+                  priorFields={priorFieldsFor(selected)}
+                  onUpdate={(patch) => patchStep(selected, patch)}
+                  onDelete={() => deleteStep(selected)}
+                  m={m}
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
+                  {m.steps.select}
+                </div>
+              )}
+            </div>
+
+            <aside className="lg:sticky lg:top-[9.5rem] lg:self-start">
+              <p className="mb-2 text-sm font-semibold text-foreground">{m.preview.title}</p>
+              <LivePreview config={config} selected={selected ?? 'cover'} m={m.preview} />
+            </aside>
+          </div>
+        ) : tab === 'cover' ? (
+          <CoverPanel config={config} onCoverChange={patchCover} onBrandingChange={patchBranding} m={m} />
+        ) : tab === 'outcomes' ? (
+          <OutcomesPanel config={config} onScoringChange={setScoring} onOutcomesChange={setOutcomes} m={m} />
+        ) : (
+          <div>
+            <div className="mb-4">
+              <h2 className="text-sm font-semibold text-foreground">{m.flow.title}</h2>
+              <p className="text-xs text-muted-foreground">{m.flow.subtitle}</p>
+            </div>
+            <FlowDiagram config={config} m={m} />
+          </div>
+        )}
       </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={save}
-          disabled={pending}
-          className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground active:scale-[0.98] disabled:opacity-50"
-        >
-          {pending ? 'Saving…' : 'Save'}
-        </button>
-        {message ? <span className="text-sm text-muted-foreground">{message}</span> : null}
-      </div>
+      <DevicePreviewModal
+        open={deviceOpen}
+        onClose={() => setDeviceOpen(false)}
+        publicPath={publicPath}
+        m={m.preview}
+      />
     </div>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/page.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/page.tsx
@@ -1,30 +1,34 @@
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 import { FormEditor } from './form-editor';
 
 export const dynamic = 'force-dynamic';
 
 export default async function EditFormPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const locale = await getLocale();
+  const m = getMessages(locale).admin.editor;
+
   let form: Awaited<ReturnType<typeof adminApi.getForm>>;
+  let me: Awaited<ReturnType<typeof adminApi.me>>;
   try {
-    form = await adminApi.getForm(id);
+    [form, me] = await Promise.all([adminApi.getForm(id), adminApi.me()]);
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) notFound();
     throw e;
   }
 
+  const publicPath = `/${me.accountCode}/${me.handle ?? 'me'}/${form.slug}`;
+
   return (
-    <div className="mx-auto max-w-[900px] px-8 py-10">
-      <Link href="/admin" className="text-sm text-muted-foreground hover:text-foreground">
-        ← Back to forms
-      </Link>
-      <FormEditor
-        id={form.id}
-        initialName={form.name}
-        initialConfig={JSON.stringify(form.config, null, 2)}
-      />
-    </div>
+    <FormEditor
+      id={form.id}
+      initialName={form.name}
+      initialConfig={form.config}
+      publicPath={publicPath}
+      m={m}
+    />
   );
 }

--- a/apps/web/app/admin/forms/[id]/integrations/actions.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/actions.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { adminApi } from '@/lib/admin-api';
+import type { FormDestination } from '@quill/types';
+
+/**
+ * Merge the integrations (destinations) into the form's existing config WITHOUT
+ * clobbering steps/cover/scoring/outcomes (those are owned by the editor). Reads
+ * the current config, replaces only `destinations`, and saves.
+ */
+export async function saveIntegrationsAction(
+  id: string,
+  destinations: FormDestination[],
+): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const form = await adminApi.getForm(id);
+    const config = { ...(form.config as Record<string, unknown>), destinations };
+    await adminApi.updateForm(id, { config });
+    revalidatePath(`/admin/forms/${id}/integrations`);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : 'Failed to save.' };
+  }
+}

--- a/apps/web/app/admin/forms/[id]/integrations/actions.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/actions.ts
@@ -5,18 +5,23 @@ import { adminApi } from '@/lib/admin-api';
 import type { FormDestination } from '@quill/types';
 
 /**
- * Merge the integrations (destinations) into the form's existing config WITHOUT
- * clobbering steps/cover/scoring/outcomes (those are owned by the editor). Reads
- * the current config, replaces only `destinations`, and saves.
+ * Save the integrations (destinations) for a form. Uses the API's PARTIAL
+ * `destinations` write (PUT /v1/forms/:id/destinations) which merges only that
+ * key against the form's fresh config server-side in ONE request — a concurrent
+ * editor save of steps/cover/scoring is never clobbered by this screen (the old
+ * shape read the whole config here and wrote it back across two requests,
+ * racing the editor).
+ *
+ * NOTE (optimistic locking): true write-write safety on the SAME key (e.g. two
+ * integrations tabs) still needs config versioning / compare-and-set — a general
+ * question for every config writer, tracked separately and out of scope here.
  */
 export async function saveIntegrationsAction(
   id: string,
   destinations: FormDestination[],
 ): Promise<{ ok: boolean; message?: string }> {
   try {
-    const form = await adminApi.getForm(id);
-    const config = { ...(form.config as Record<string, unknown>), destinations };
-    await adminApi.updateForm(id, { config });
+    await adminApi.updateFormDestinations(id, destinations);
     revalidatePath(`/admin/forms/${id}/integrations`);
     return { ok: true };
   } catch (e) {

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import type { FormsMessages } from '@quill/shared';
+import type { FormDestination } from '@quill/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/toast';
+import type { HubSpotPropertiesResponse } from '@/lib/admin-api';
+import { saveIntegrationsAction } from './actions';
+
+type Msgs = FormsMessages['admin']['integrations'];
+
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const;
+
+interface Pair {
+  key: string;
+  property: string;
+}
+
+interface WebhookState {
+  enabled: boolean;
+  url: string;
+  secret: string;
+}
+interface HubspotState {
+  enabled: boolean;
+  fieldMappings: Pair[];
+  utmMappings: Record<string, string>;
+  scoreProperty: string;
+  dateProperty: string;
+  note: boolean;
+}
+
+function initialWebhook(destinations: FormDestination[]): WebhookState {
+  const w = destinations.find((d) => d.type === 'webhook');
+  if (w && w.type === 'webhook') {
+    return { enabled: w.enabled, url: w.settings.url ?? '', secret: w.settings.secret ?? '' };
+  }
+  return { enabled: false, url: '', secret: '' };
+}
+
+function initialHubspot(destinations: FormDestination[]): HubspotState {
+  const h = destinations.find((d) => d.type === 'hubspot');
+  if (h && h.type === 'hubspot') {
+    return {
+      enabled: h.enabled,
+      fieldMappings: Object.entries(h.fieldMappings ?? {}).map(([key, property]) => ({ key, property })),
+      utmMappings: { ...(h.utmMappings ?? {}) },
+      scoreProperty: h.scoreProperty ?? '',
+      dateProperty: h.dateProperty ?? '',
+      note: h.settings?.note !== false,
+    };
+  }
+  return { enabled: false, fieldMappings: [], utmMappings: {}, scoreProperty: '', dateProperty: '', note: true };
+}
+
+const isHttpsUrl = (v: string): boolean => {
+  try {
+    return new URL(v).protocol === 'https:' || new URL(v).protocol === 'http:';
+  } catch {
+    return false;
+  }
+};
+
+export function IntegrationsEditor({
+  id,
+  initialDestinations,
+  hubspot: hubspotProps,
+  messages: m,
+}: {
+  id: string;
+  initialDestinations: FormDestination[];
+  hubspot: HubSpotPropertiesResponse;
+  messages: Msgs;
+}) {
+  const { success, error } = useToast();
+  const [pending, start] = useTransition();
+  const [webhook, setWebhook] = useState<WebhookState>(() => initialWebhook(initialDestinations));
+  const [hs, setHs] = useState<HubspotState>(() => initialHubspot(initialDestinations));
+  const [webhookError, setWebhookError] = useState<string | null>(null);
+
+  const properties = hubspotProps.enabled ? hubspotProps.properties : [];
+
+  function buildDestinations(): FormDestination[] | { error: string } {
+    const out: FormDestination[] = [];
+    if (webhook.enabled || webhook.url.trim()) {
+      if (!isHttpsUrl(webhook.url.trim())) return { error: m.webhookUrlInvalid };
+      out.push({
+        type: 'webhook',
+        enabled: webhook.enabled,
+        settings: {
+          url: webhook.url.trim(),
+          secret: webhook.secret.trim() || null,
+        },
+      });
+    }
+    const fieldMappings: Record<string, string> = {};
+    for (const p of hs.fieldMappings) {
+      if (p.key.trim() && p.property.trim()) fieldMappings[p.key.trim()] = p.property.trim();
+    }
+    const utmMappings: Record<string, string> = {};
+    for (const [k, v] of Object.entries(hs.utmMappings)) {
+      if (v && v.trim()) utmMappings[k] = v.trim();
+    }
+    const hasHubspotConfig =
+      hs.enabled ||
+      Object.keys(fieldMappings).length > 0 ||
+      Object.keys(utmMappings).length > 0 ||
+      hs.scoreProperty.trim() ||
+      hs.dateProperty.trim();
+    if (hasHubspotConfig) {
+      out.push({
+        type: 'hubspot',
+        enabled: hs.enabled,
+        settings: { note: hs.note },
+        fieldMappings,
+        utmMappings,
+        scoreProperty: hs.scoreProperty.trim() || null,
+        dateProperty: hs.dateProperty.trim() || null,
+      });
+    }
+    return out;
+  }
+
+  function save() {
+    setWebhookError(null);
+    const built = buildDestinations();
+    if ('error' in built) {
+      setWebhookError(built.error);
+      error(built.error);
+      return;
+    }
+    start(async () => {
+      const res = await saveIntegrationsAction(id, built);
+      if (res.ok) success(m.saved);
+      else error(res.message ?? m.saveError);
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <WebhookCard
+        state={webhook}
+        onChange={setWebhook}
+        urlError={webhookError}
+        clearUrlError={() => setWebhookError(null)}
+        m={m}
+      />
+      <HubspotCard state={hs} onChange={setHs} properties={properties} hubspotMeta={hubspotProps} m={m} />
+
+      <div className="sticky bottom-0 flex items-center gap-3 border-t border-border bg-background/95 py-4 backdrop-blur">
+        <Button onClick={save} disabled={pending}>
+          {pending ? m.saving : m.save}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** A property picker: a <select> of live properties, or a free-text fallback. */
+function PropertyField({
+  value,
+  onChange,
+  properties,
+  enabled,
+  allowNone,
+  m,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  properties: { name: string; label: string }[];
+  enabled: boolean;
+  allowNone?: boolean;
+  m: Msgs;
+  ariaLabel: string;
+}) {
+  if (!enabled) {
+    return (
+      <Input
+        value={value}
+        aria-label={ariaLabel}
+        placeholder={m.property}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  return (
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <option value="">{allowNone ? m.noProperty : m.selectProperty}</option>
+      {properties.map((p) => (
+        <option key={p.name} value={p.name}>
+          {p.label} ({p.name})
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function Card({
+  title,
+  desc,
+  enabled,
+  onToggle,
+  m,
+  children,
+}: {
+  title: string;
+  desc: string;
+  enabled: boolean;
+  onToggle: (v: boolean) => void;
+  m: Msgs;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">{desc}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-xs text-muted-foreground">{enabled ? m.enabled : m.disabled}</span>
+          <Switch checked={enabled} onCheckedChange={onToggle} aria-label={title} />
+        </div>
+      </div>
+      {enabled ? <div className="mt-5 flex flex-col gap-4">{children}</div> : null}
+    </section>
+  );
+}
+
+function Field({ label, help, children }: { label: string; help?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">{label}</label>
+      {children}
+      {help ? <p className="text-xs text-muted-foreground">{help}</p> : null}
+    </div>
+  );
+}
+
+function WebhookCard({
+  state,
+  onChange,
+  urlError,
+  clearUrlError,
+  m,
+}: {
+  state: WebhookState;
+  onChange: (s: WebhookState) => void;
+  urlError: string | null;
+  clearUrlError: () => void;
+  m: Msgs;
+}) {
+  return (
+    <Card
+      title={m.webhookTitle}
+      desc={m.webhookDesc}
+      enabled={state.enabled}
+      onToggle={(enabled) => onChange({ ...state, enabled })}
+      m={m}
+    >
+      <Field label={m.webhookUrl}>
+        <Input
+          type="url"
+          value={state.url}
+          placeholder={m.webhookUrlPlaceholder}
+          aria-invalid={urlError ? true : undefined}
+          onChange={(e) => {
+            clearUrlError();
+            onChange({ ...state, url: e.target.value });
+          }}
+        />
+        {urlError ? <p className="text-xs text-destructive">{urlError}</p> : null}
+      </Field>
+      <Field label={m.webhookSecret} help={m.webhookSecretHelp}>
+        <Input
+          type="text"
+          value={state.secret}
+          autoComplete="off"
+          onChange={(e) => onChange({ ...state, secret: e.target.value })}
+        />
+      </Field>
+    </Card>
+  );
+}
+
+function HubspotCard({
+  state,
+  onChange,
+  properties,
+  hubspotMeta,
+  m,
+}: {
+  state: HubspotState;
+  onChange: (s: HubspotState) => void;
+  properties: { name: string; label: string }[];
+  hubspotMeta: HubSpotPropertiesResponse;
+  m: Msgs;
+}) {
+  const pickerEnabled = hubspotMeta.enabled;
+  const utmValues = useMemo(() => state.utmMappings, [state.utmMappings]);
+
+  return (
+    <Card
+      title={m.hubspotTitle}
+      desc={m.hubspotDesc}
+      enabled={state.enabled}
+      onToggle={(enabled) => onChange({ ...state, enabled })}
+      m={m}
+    >
+      {!pickerEnabled ? (
+        <div className="rounded-md border border-dashed border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+          {hubspotMeta.enabled ? m.hubspotLoading : hubspotMeta.reason || m.hubspotDisabled}
+        </div>
+      ) : null}
+
+      {/* Field mappings */}
+      <Field label={m.fieldMappings} help={m.fieldMappingsHelp}>
+        <div className="flex flex-col gap-2">
+          {state.fieldMappings.length === 0 ? (
+            <p className="text-xs text-muted-foreground">{m.emptyMappings}</p>
+          ) : (
+            state.fieldMappings.map((pair, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <Input
+                  value={pair.key}
+                  aria-label={m.stepKey}
+                  placeholder={m.stepKey}
+                  className="flex-1"
+                  onChange={(e) => {
+                    const next = [...state.fieldMappings];
+                    next[i] = { ...pair, key: e.target.value };
+                    onChange({ ...state, fieldMappings: next });
+                  }}
+                />
+                <span aria-hidden className="text-muted-foreground">→</span>
+                <div className="flex-1">
+                  <PropertyField
+                    value={pair.property}
+                    ariaLabel={m.property}
+                    properties={properties}
+                    enabled={pickerEnabled}
+                    m={m}
+                    onChange={(v) => {
+                      const next = [...state.fieldMappings];
+                      next[i] = { ...pair, property: v };
+                      onChange({ ...state, fieldMappings: next });
+                    }}
+                  />
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={m.remove}
+                  onClick={() =>
+                    onChange({
+                      ...state,
+                      fieldMappings: state.fieldMappings.filter((_, j) => j !== i),
+                    })
+                  }
+                >
+                  {m.remove}
+                </Button>
+              </div>
+            ))
+          )}
+          <div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                onChange({ ...state, fieldMappings: [...state.fieldMappings, { key: '', property: '' }] })
+              }
+            >
+              {m.addMapping}
+            </Button>
+          </div>
+        </div>
+      </Field>
+
+      {/* UTM mappings */}
+      <Field label={m.utmMappings} help={m.utmMappingsHelp}>
+        <div className="flex flex-col gap-2">
+          {UTM_KEYS.map((k) => (
+            <div key={k} className="flex items-center gap-2">
+              <code className="w-32 shrink-0 text-xs text-muted-foreground">{k}</code>
+              <span aria-hidden className="text-muted-foreground">→</span>
+              <div className="flex-1">
+                <PropertyField
+                  value={utmValues[k] ?? ''}
+                  ariaLabel={`${k} ${m.property}`}
+                  properties={properties}
+                  enabled={pickerEnabled}
+                  allowNone
+                  m={m}
+                  onChange={(v) => onChange({ ...state, utmMappings: { ...state.utmMappings, [k]: v } })}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </Field>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label={m.scoreProperty}>
+          <PropertyField
+            value={state.scoreProperty}
+            ariaLabel={m.scoreProperty}
+            properties={properties}
+            enabled={pickerEnabled}
+            allowNone
+            m={m}
+            onChange={(v) => onChange({ ...state, scoreProperty: v })}
+          />
+        </Field>
+        <Field label={m.dateProperty}>
+          <PropertyField
+            value={state.dateProperty}
+            ariaLabel={m.dateProperty}
+            properties={properties}
+            enabled={pickerEnabled}
+            allowNone
+            m={m}
+            onChange={(v) => onChange({ ...state, dateProperty: v })}
+          />
+        </Field>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <label className="text-sm font-medium">{m.createNote}</label>
+          <p className="text-xs text-muted-foreground">{m.createNoteHelp}</p>
+        </div>
+        <Switch
+          checked={state.note}
+          onCheckedChange={(note) => onChange({ ...state, note })}
+          aria-label={m.createNote}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -56,9 +56,17 @@ function initialHubspot(destinations: FormDestination[]): HubspotState {
   return { enabled: false, fieldMappings: [], utmMappings: {}, scoreProperty: '', dateProperty: '', note: true };
 }
 
-const isHttpsUrl = (v: string): boolean => {
+/**
+ * https-only, with ONE documented exception: plain http is allowed for
+ * localhost/127.0.0.1 so a developer can point a form at a local catcher while
+ * testing. Any other http host is rejected (mirrors the server-side zod refine
+ * on the webhook settings URL — keep the two in sync).
+ */
+const isHttpsOrLocalhostUrl = (v: string): boolean => {
   try {
-    return new URL(v).protocol === 'https:' || new URL(v).protocol === 'http:';
+    const u = new URL(v);
+    if (u.protocol === 'https:') return true;
+    return u.protocol === 'http:' && (u.hostname === 'localhost' || u.hostname === '127.0.0.1');
   } catch {
     return false;
   }
@@ -86,7 +94,7 @@ export function IntegrationsEditor({
   function buildDestinations(): FormDestination[] | { error: string } {
     const out: FormDestination[] = [];
     if (webhook.enabled || webhook.url.trim()) {
-      if (!isHttpsUrl(webhook.url.trim())) return { error: m.webhookUrlInvalid };
+      if (!isHttpsOrLocalhostUrl(webhook.url.trim())) return { error: m.webhookUrlInvalid };
       out.push({
         type: 'webhook',
         enabled: webhook.enabled,

--- a/apps/web/app/admin/forms/[id]/integrations/page.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { adminApi, ApiError, type HubSpotPropertiesResponse } from '@/lib/admin-api';
+import { getMessages } from '@quill/shared';
+import { getLocale } from '@/lib/locale';
+import type { FormDestination } from '@quill/types';
+import { IntegrationsEditor } from './integrations-editor';
+
+export const dynamic = 'force-dynamic';
+
+export default async function IntegrationsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const locale = await getLocale();
+  const m = getMessages(locale).admin.integrations;
+
+  let form: Awaited<ReturnType<typeof adminApi.getForm>>;
+  try {
+    form = await adminApi.getForm(id);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+
+  // The property picker degrades gracefully — a lookup failure must not 500 the
+  // whole page; the editor shows a disabled state and still lets you save.
+  let hubspot: HubSpotPropertiesResponse;
+  try {
+    hubspot = await adminApi.hubspotProperties();
+  } catch {
+    hubspot = { enabled: false, reason: m.loadError };
+  }
+
+  const destinations = (form.config.destinations ?? []) as FormDestination[];
+
+  return (
+    <div className="mx-auto max-w-[900px] px-8 py-10">
+      <Link href="/admin" className="text-sm text-muted-foreground hover:text-foreground">
+        {m.back}
+      </Link>
+      <div className="mt-4 mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">{m.title}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {form.name} — {m.subtitle}
+        </p>
+      </div>
+      <IntegrationsEditor
+        id={id}
+        initialDestinations={destinations}
+        hubspot={hubspot}
+        messages={m}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/actions.ts
+++ b/apps/web/app/admin/forms/[id]/submissions/actions.ts
@@ -1,0 +1,10 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { adminApi } from '@/lib/admin-api';
+
+/** Delete a submission, then refresh the form's submissions table. */
+export async function deleteSubmissionAction(formId: string, submissionId: string): Promise<void> {
+  await adminApi.deleteSubmission(submissionId);
+  revalidatePath(`/admin/forms/${formId}/submissions`);
+}

--- a/apps/web/app/admin/forms/[id]/submissions/error.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/error.tsx
@@ -2,11 +2,7 @@
 
 import { getMessages } from '@quill/shared';
 
-/** Read the persisted admin locale on the client (mirrors the server cookie). */
-function clientLocale(): 'en' | 'es' {
-  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
-  return 'en';
-}
+import { clientLocale } from '@/lib/client-locale';
 
 export default function SubmissionsError({ reset }: { error: Error; reset: () => void }) {
   const m = getMessages(clientLocale()).admin.submissions;

--- a/apps/web/app/admin/forms/[id]/submissions/error.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { getMessages } from '@quill/shared';
+
+/** Read the persisted admin locale on the client (mirrors the server cookie). */
+function clientLocale(): 'en' | 'es' {
+  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
+  return 'en';
+}
+
+export default function SubmissionsError({ reset }: { error: Error; reset: () => void }) {
+  const m = getMessages(clientLocale()).admin.submissions;
+  return (
+    <div className="mx-auto max-w-md px-8 py-16 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">{m.error}</h1>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-primary px-5 py-2 font-semibold text-primary-foreground transition-transform active:scale-[0.98]"
+      >
+        {m.retry}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/export/route.ts
+++ b/apps/web/app/admin/forms/[id]/submissions/export/route.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server';
+import { hostFetch } from '@/lib/auth-session';
+
+/**
+ * CSV export proxy. The API's `/submissions.csv` needs the caller's identity
+ * headers, which live in the httpOnly session cookie — a plain `<a download>` to
+ * the API can't carry them. This server route attaches identity via `hostFetch`
+ * and streams the CSV straight back (no buffering), preserving the filter query.
+ */
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await ctx.params;
+  const search = req.nextUrl.searchParams.toString();
+  const upstream = await hostFetch(`/v1/forms/${id}/submissions.csv${search ? `?${search}` : ''}`);
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response('Export failed.', { status: upstream.status || 502 });
+  }
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': upstream.headers.get('content-type') ?? 'text/csv; charset=utf-8',
+      'Content-Disposition':
+        upstream.headers.get('content-disposition') ?? 'attachment; filename="submissions.csv"',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/apps/web/app/admin/forms/[id]/submissions/loading.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/loading.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from '@/components/skeleton';
+
+export default function SubmissionsLoading() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <Skeleton className="mb-6 h-9 w-64" />
+      <Skeleton className="mb-6 h-9 w-72" />
+      <Skeleton className="h-80 w-full" />
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/page.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.tsx
@@ -1,0 +1,222 @@
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { FormConfig, SubmissionsPage } from '@quill/types';
+import { getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
+import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
+import { FormTabs } from '@/components/ui/form-tabs';
+import { Skeleton } from '@/components/skeleton';
+import { SubmissionsFilter } from './submissions-filter';
+import { DeleteSubmissionButton } from './row-actions';
+
+export const dynamic = 'force-dynamic';
+
+const PAGE_SIZE = 25;
+
+type SP = { status?: string; offset?: string };
+
+function parseStatus(v: string | undefined): 'all' | 'completed' | 'partial' {
+  return v === 'completed' || v === 'partial' ? v : 'all';
+}
+
+export default async function SubmissionsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<SP>;
+}) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const locale = await getLocale();
+  const m = getMessages(locale).admin;
+  const status = parseStatus(sp.status);
+  const offset = Math.max(0, Number(sp.offset ?? 0) || 0);
+  const key = `${status}:${offset}`;
+
+  const exportQuery = status === 'all' ? '' : `?status=${status}`;
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-8">
+      <FormTabs formId={id} active="submissions" labels={m.nav} />
+      <div className="mb-6 flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{m.submissions.title}</h1>
+            <p className="mt-1 text-muted-foreground">{m.submissions.subtitle}</p>
+          </div>
+          <a
+            href={`/admin/forms/${id}/submissions/export${exportQuery}`}
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-border bg-transparent px-4 text-sm font-semibold text-foreground transition-colors hover:bg-accent"
+          >
+            <i aria-hidden className="pi pi-download" style={{ fontSize: 13 }} />
+            {m.submissions.export}
+          </a>
+        </div>
+        <SubmissionsFilter
+          labels={{
+            all: m.submissions.statusAll,
+            completed: m.submissions.statusCompleted,
+            partial: m.submissions.statusPartial,
+          }}
+        />
+      </div>
+
+      <Suspense key={key} fallback={<Skeleton className="h-80 w-full" />}>
+        <SubmissionsData id={id} status={status} offset={offset} locale={locale} m={m} />
+      </Suspense>
+    </div>
+  );
+}
+
+/** Flatten one answer value for a table cell. */
+function formatCell(v: unknown, na: string): string {
+  if (v == null || v === '') return na;
+  if (Array.isArray(v)) return v.length ? v.join(', ') : na;
+  if (typeof v === 'boolean') return v ? '✓' : '—';
+  return String(v);
+}
+
+async function SubmissionsData({
+  id,
+  status,
+  offset,
+  locale,
+  m,
+}: {
+  id: string;
+  status: 'all' | 'completed' | 'partial';
+  offset: number;
+  locale: Locale;
+  m: FormsMessages['admin'];
+}) {
+  let form: Awaited<ReturnType<typeof adminApi.getForm>>;
+  let page: SubmissionsPage;
+  try {
+    [form, page] = await Promise.all([
+      adminApi.getForm(id),
+      adminApi.listSubmissions(id, { status, limit: PAGE_SIZE, offset }),
+    ]);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+
+  const steps = (form.config as FormConfig).steps ?? [];
+
+  if (page.total === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/40 p-12 text-center">
+        <p className="text-lg font-medium">{m.submissions.emptyTitle}</p>
+        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">{m.submissions.emptyBody}</p>
+      </div>
+    );
+  }
+
+  const from = offset + 1;
+  const to = Math.min(offset + page.items.length, page.total);
+  const hasPrev = offset > 0;
+  const hasNext = offset + page.limit < page.total;
+  const statusParam = status === 'all' ? '' : `status=${status}&`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Horizontal scroll lives INSIDE this container (themed scrollbar, global);
+          the page body never scrolls sideways even with many step columns. */}
+      <div className="overflow-x-auto rounded-lg border border-border bg-card">
+        <table className="w-full min-w-[720px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="whitespace-nowrap px-4 py-3 font-medium">{m.submissions.colSubmitted}</th>
+              <th className="whitespace-nowrap px-4 py-3 font-medium">{m.submissions.colStatus}</th>
+              <th className="whitespace-nowrap px-4 py-3 text-right font-medium">{m.submissions.colScore}</th>
+              {steps.map((s) => (
+                <th key={s.key} className="whitespace-nowrap px-4 py-3 font-medium">
+                  {s.question?.trim() || s.key}
+                </th>
+              ))}
+              <th className="px-4 py-3" aria-label="actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {page.items.map((row) => {
+              const completed = row.completedAt != null;
+              const when = row.completedAt ?? row.partialAt ?? row.startedAt;
+              const data = (row.data ?? {}) as Record<string, unknown>;
+              return (
+                <tr key={row.id} className="border-b border-border last:border-b-0 align-top">
+                  <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
+                    {new Date(when).toLocaleString(locale)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3">
+                    <span
+                      className={
+                        completed
+                          ? 'inline-flex items-center gap-1.5 rounded-full bg-primary/20 px-2.5 py-0.5 text-xs font-medium text-foreground'
+                          : 'inline-flex items-center gap-1.5 rounded-full bg-secondary/20 px-2.5 py-0.5 text-xs font-medium text-foreground'
+                      }
+                    >
+                      <span
+                        aria-hidden
+                        className={`h-1.5 w-1.5 rounded-full ${completed ? 'bg-primary' : 'bg-secondary'}`}
+                      />
+                      {completed ? m.submissions.badgeCompleted : m.submissions.badgePartial}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums">{row.score}</td>
+                  {steps.map((s) => (
+                    <td key={s.key} className="max-w-[240px] truncate px-4 py-3" title={formatCell(data[s.key], '')}>
+                      {formatCell(data[s.key], m.submissions.na)}
+                    </td>
+                  ))}
+                  <td className="whitespace-nowrap px-4 py-3 text-right">
+                    <DeleteSubmissionButton
+                      formId={id}
+                      submissionId={row.id}
+                      labels={{ delete: m.submissions.delete, confirm: m.submissions.deleteConfirm }}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span className="text-muted-foreground tabular-nums">
+          {t(m.submissions.showing, { from, to, total: page.total })}
+        </span>
+        <div className="flex items-center gap-2">
+          {hasPrev ? (
+            <Link
+              href={`?${statusParam}offset=${Math.max(0, offset - page.limit)}`}
+              scroll={false}
+              className="inline-flex h-9 items-center rounded-md border border-border px-3 font-medium text-foreground transition-colors hover:bg-accent"
+            >
+              {m.submissions.prev}
+            </Link>
+          ) : (
+            <span className="inline-flex h-9 cursor-not-allowed items-center rounded-md border border-border px-3 font-medium text-muted-foreground opacity-50">
+              {m.submissions.prev}
+            </span>
+          )}
+          {hasNext ? (
+            <Link
+              href={`?${statusParam}offset=${offset + page.limit}`}
+              scroll={false}
+              className="inline-flex h-9 items-center rounded-md border border-border px-3 font-medium text-foreground transition-colors hover:bg-accent"
+            >
+              {m.submissions.next}
+            </Link>
+          ) : (
+            <span className="inline-flex h-9 cursor-not-allowed items-center rounded-md border border-border px-3 font-medium text-muted-foreground opacity-50">
+              {m.submissions.next}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/row-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/row-actions.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useTransition } from 'react';
+import { deleteSubmissionAction } from './actions';
+
+/** Delete-with-confirm for a submission row (client → server action). */
+export function DeleteSubmissionButton({
+  formId,
+  submissionId,
+  labels,
+}: {
+  formId: string;
+  submissionId: string;
+  labels: { delete: string; confirm: string };
+}) {
+  const [pending, start] = useTransition();
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() => {
+        if (confirm(labels.confirm)) {
+          start(() => void deleteSubmissionAction(formId, submissionId));
+        }
+      }}
+      className="text-sm text-destructive transition-opacity hover:opacity-80 disabled:opacity-50"
+    >
+      {labels.delete}
+    </button>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/submissions-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/submissions-filter.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+type Status = 'all' | 'completed' | 'partial';
+
+/**
+ * Status filter for the submissions table (all / completed / partial). Writes
+ * the choice to the URL query (resetting pagination) so the server component
+ * re-fetches; the Suspense boundary shows the skeleton meanwhile (R22).
+ */
+export function SubmissionsFilter({
+  labels,
+}: {
+  labels: { all: string; completed: string; partial: string };
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, start] = useTransition();
+  const current = (params.get('status') as Status | null) ?? 'all';
+
+  const select = (status: Status) => {
+    const next = new URLSearchParams(params.toString());
+    next.delete('offset'); // new filter → back to page 1
+    if (status === 'all') next.delete('status');
+    else next.set('status', status);
+    start(() => router.push(`?${next.toString()}`, { scroll: false }));
+  };
+
+  const options: { key: Status; label: string }[] = [
+    { key: 'all', label: labels.all },
+    { key: 'completed', label: labels.completed },
+    { key: 'partial', label: labels.partial },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" aria-busy={pending}>
+      {options.map((o) => {
+        const active = o.key === current;
+        return (
+          <button
+            key={o.key}
+            type="button"
+            disabled={pending}
+            onClick={() => select(o.key)}
+            aria-pressed={active}
+            className={
+              active
+                ? 'inline-flex h-9 items-center rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60'
+                : 'inline-flex h-9 items-center rounded-md border border-border bg-transparent px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60'
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -68,7 +68,11 @@ export default async function AdminHome() {
                 <FormRowActions
                   id={f.id}
                   labels={rowLabels}
-                  nav={{ analytics: nav.analytics, submissions: nav.submissions }}
+                  nav={{
+                    analytics: nav.analytics,
+                    submissions: nav.submissions,
+                    integrations: nav.integrations,
+                  }}
                 />
               </li>
             );

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,39 +1,46 @@
 import Link from 'next/link';
+import { getMessages, t } from '@quill/shared';
 import { adminApi } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 import { CopyLink } from '@/components/copy-link';
-import { createFormAction } from './actions';
+import { PageHeader } from '@/components/ui/page-header';
+import { CreateFormButton } from './create-form-button';
 import { FormRowActions } from './form-row-actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function AdminHome() {
+  const locale = await getLocale();
+  const m = getMessages(locale).admin.forms;
   const [me, forms] = await Promise.all([adminApi.me(), adminApi.listForms()]);
 
+  const createLabels = {
+    create: m.create,
+    createTitle: m.createTitle,
+    nameLabel: m.nameLabel,
+    namePlaceholder: m.namePlaceholder,
+    cancel: m.cancel,
+  };
+  const rowLabels = { duplicate: m.duplicate, delete: m.delete, deleteConfirm: m.deleteConfirm };
+
   return (
-    <div className="mx-auto max-w-[1100px] px-8 py-10">
-      <div className="mb-8 flex items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-semibold tracking-tight">Forms</h1>
-          <p className="text-muted-foreground">Build a form, share the public link, collect submissions.</p>
-        </div>
-        <form action={createFormAction} className="flex items-center gap-2">
-          <input
-            name="name"
-            placeholder="New form name"
-            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
-          />
-          <button
-            type="submit"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground active:scale-[0.98]"
-          >
-            Create form
-          </button>
-        </form>
-      </div>
+    <div className="mx-auto max-w-[1100px] px-6 py-10 sm:px-8">
+      <PageHeader
+        title={m.title}
+        subtitle={m.subtitle}
+        action={forms.length > 0 ? <CreateFormButton labels={createLabels} /> : undefined}
+      />
 
       {forms.length === 0 ? (
-        <div className="rounded-md border border-dashed border-border p-12 text-center text-muted-foreground">
-          No forms yet. Create your first form above.
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed border-border p-12 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <i aria-hidden className="pi pi-file-edit" style={{ fontSize: 20 }} />
+          </div>
+          <div>
+            <p className="font-medium text-foreground">{m.emptyTitle}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{m.emptyBody}</p>
+          </div>
+          <CreateFormButton labels={createLabels} />
         </div>
       ) : (
         <ul className="flex flex-col gap-3">
@@ -42,18 +49,21 @@ export default async function AdminHome() {
             return (
               <li
                 key={f.id}
-                className="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-4"
+                className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="flex min-w-0 flex-col gap-1">
-                  <Link href={`/admin/forms/${f.id}/edit`} className="font-medium hover:underline">
+                  <Link
+                    href={`/admin/forms/${f.id}/edit`}
+                    className="w-fit font-medium transition-colors hover:text-primary hover:underline"
+                  >
                     {f.name}
                   </Link>
-                  <CopyLink path={publicPath} labels={{ copy: 'Copy link', copied: 'Copied', open: 'Open' }} />
+                  <CopyLink path={publicPath} labels={{ copy: m.copy, copied: m.copied, open: m.open }} />
                   <span className="text-xs text-muted-foreground">
-                    Updated {new Date(f.updatedAt).toLocaleString()}
+                    {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
                   </span>
                 </div>
-                <FormRowActions id={f.id} />
+                <FormRowActions id={f.id} labels={rowLabels} />
               </li>
             );
           })}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -11,7 +11,9 @@ export const dynamic = 'force-dynamic';
 
 export default async function AdminHome() {
   const locale = await getLocale();
-  const m = getMessages(locale).admin.forms;
+  const messages = getMessages(locale).admin;
+  const m = messages.forms;
+  const nav = messages.nav;
   const [me, forms] = await Promise.all([adminApi.me(), adminApi.listForms()]);
 
   const createLabels = {
@@ -63,7 +65,11 @@ export default async function AdminHome() {
                     {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
                   </span>
                 </div>
-                <FormRowActions id={f.id} labels={rowLabels} />
+                <FormRowActions
+                  id={f.id}
+                  labels={rowLabels}
+                  nav={{ analytics: nav.analytics, submissions: nav.submissions }}
+                />
               </li>
             );
           })}

--- a/apps/web/components/public/client-logos-marquee.tsx
+++ b/apps/web/components/public/client-logos-marquee.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormClientLogo } from '@quill/engine';
+
+function LogoChip({ logo }: { logo: FormClientLogo }) {
+  const [failed, setFailed] = useState(false);
+  const showText = !logo.src || failed;
+  return (
+    <div className="pf-logos__chip">
+      {!showText && logo.src ? (
+        <img
+          src={logo.src}
+          alt={logo.name}
+          className="pf-logos__img"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <span>{logo.name}</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Optional "trusted by" marquee on the cover. Config-driven logos (image or text
+ * fallback); duplicated once for a seamless loop. Falls back to a static wrapped
+ * row when the viewer prefers reduced motion (handled in CSS).
+ */
+export function ClientLogosMarquee({
+  logos,
+  label,
+}: {
+  logos: FormClientLogo[];
+  label: string;
+}) {
+  if (!logos.length) return null;
+  const items = [...logos, ...logos];
+  return (
+    <div className="pf-logos">
+      {label ? <p className="pf-logos__label">{label}</p> : null}
+      <div className="pf-logos__viewport">
+        <div className="pf-logos__track">
+          {items.map((logo, i) => (
+            <LogoChip key={`${logo.name}-${i}`} logo={logo} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/public/form-logo.tsx
+++ b/apps/web/components/public/form-logo.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * The form's logo in the top bar. Uses the per-form logo URL when set, else a
+ * text fallback (the form name). No hardcoded tenant asset — the pilot's baked-in
+ * Dapta logo is generalized to config-driven branding.
+ */
+export function FormLogo({ src, name }: { src?: string | null; name: string }) {
+  const [failed, setFailed] = useState(false);
+  if (src && !failed) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className="pf__logo-img"
+        height={32}
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return (
+    <span className="pf__logo--fallback">
+      {name}
+      <span className="pf__logo-dot">.</span>
+    </span>
+  );
+}

--- a/apps/web/components/public/form-progress.tsx
+++ b/apps/web/components/public/form-progress.tsx
@@ -1,0 +1,37 @@
+import { getMessages, t } from '@quill/shared';
+
+/**
+ * Linear progress across the CURRENTLY-visible steps. A real `progressbar` with
+ * aria-valuenow/min/max + a localized accessible label; the fill advances as the
+ * respondent moves through steps (visible steps only — hidden branches don't
+ * inflate the bar).
+ */
+export function FormProgress({
+  total,
+  currentIndex,
+  locale = 'en',
+}: {
+  total: number;
+  currentIndex: number;
+  locale?: string;
+}) {
+  const fillPct = total <= 1 ? 100 : Math.round((currentIndex / (total - 1)) * 100);
+  const label = t(getMessages(locale).renderer.progressLabel, {
+    current: currentIndex + 1,
+    total,
+  });
+  return (
+    <div
+      className="pf-progress"
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={currentIndex + 1}
+      aria-valuemin={1}
+      aria-valuemax={total}
+    >
+      <div className="pf-progress__track">
+        <div className="pf-progress__fill" style={{ width: `${fillPct}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/public/searchable-dropdown.tsx
+++ b/apps/web/components/public/searchable-dropdown.tsx
@@ -7,6 +7,10 @@ import type { FormOption } from '@quill/engine';
  * A searchable single-select for `dropdown` steps — filters options as you type,
  * good for long lists (country, industry…). Combobox aria, click-outside to
  * close, and selecting an option advances the form (auto-next).
+ *
+ * Keyboard: ArrowDown/ArrowUp move focus through the listbox options (real DOM
+ * focus, so Enter/Space activate the focused option's native button), Escape
+ * closes and returns focus to the input.
  */
 export function SearchableDropdown({
   options,
@@ -23,6 +27,8 @@ export function SearchableDropdown({
 }) {
   const listId = useId();
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
 
@@ -50,9 +56,51 @@ export function SearchableDropdown({
     return options.filter((o) => o.label.toLowerCase().includes(q));
   }, [query, options]);
 
+  const focusOption = (i: number) => {
+    const el = optionRefs.current[i];
+    if (el) el.focus();
+  };
+
+  const closeAndReset = () => {
+    setOpen(false);
+    setQuery(selected?.label ?? '');
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      // Focus the first option once the list has rendered.
+      requestAnimationFrame(() => focusOption(0));
+    } else if (e.key === 'Escape') {
+      if (open) {
+        e.preventDefault();
+        closeAndReset();
+      }
+    }
+  };
+
+  const onOptionKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, i: number) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusOption(Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (i === 0) inputRef.current?.focus();
+      else focusOption(i - 1);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeAndReset();
+      inputRef.current?.focus();
+    }
+    // Enter/Space: the focused option is a native <button>, which fires its
+    // onClick on both keys — no extra handling needed to "select the focused option".
+  };
+
   return (
     <div className="pf-dropdown" ref={wrapperRef}>
       <input
+        ref={inputRef}
         type="text"
         className="pf-input"
         value={query}
@@ -62,6 +110,7 @@ export function SearchableDropdown({
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
+        onKeyDown={onInputKeyDown}
         autoComplete="off"
         role="combobox"
         aria-expanded={open}
@@ -75,12 +124,16 @@ export function SearchableDropdown({
               {emptyLabel}
             </li>
           ) : (
-            filtered.map((option) => (
+            filtered.map((option, i) => (
               <li key={option.value} role="option" aria-selected={value === option.value}>
                 <button
+                  ref={(el) => {
+                    optionRefs.current[i] = el;
+                  }}
                   type="button"
                   className={`pf-dropdown__option${value === option.value ? ' pf-dropdown__option--selected' : ''}`}
                   onMouseDown={(e) => e.preventDefault()}
+                  onKeyDown={(e) => onOptionKeyDown(e, i)}
                   onClick={() => {
                     setQuery(option.label);
                     setOpen(false);

--- a/apps/web/components/public/searchable-dropdown.tsx
+++ b/apps/web/components/public/searchable-dropdown.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { FormOption } from '@quill/engine';
+
+/**
+ * A searchable single-select for `dropdown` steps — filters options as you type,
+ * good for long lists (country, industry…). Combobox aria, click-outside to
+ * close, and selecting an option advances the form (auto-next).
+ */
+export function SearchableDropdown({
+  options,
+  value,
+  onSelect,
+  placeholder,
+  emptyLabel,
+}: {
+  options: FormOption[];
+  value: string;
+  onSelect: (value: string) => void;
+  placeholder: string;
+  emptyLabel: string;
+}) {
+  const listId = useId();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const selected = useMemo(() => options.find((o) => o.value === value), [options, value]);
+
+  useEffect(() => {
+    setQuery(selected?.label ?? '');
+    setOpen(false);
+  }, [selected?.label, value]);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery(selected?.label ?? '');
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [selected?.label]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [query, options]);
+
+  return (
+    <div className="pf-dropdown" ref={wrapperRef}>
+      <input
+        type="text"
+        className="pf-input"
+        value={query}
+        placeholder={placeholder}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        autoComplete="off"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+      />
+      {open && (
+        <ul id={listId} className="pf-dropdown__list" role="listbox">
+          {filtered.length === 0 ? (
+            <li className="pf-dropdown__empty" role="option" aria-disabled aria-selected={false}>
+              {emptyLabel}
+            </li>
+          ) : (
+            filtered.map((option) => (
+              <li key={option.value} role="option" aria-selected={value === option.value}>
+                <button
+                  type="button"
+                  className={`pf-dropdown__option${value === option.value ? ' pf-dropdown__option--selected' : ''}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    setQuery(option.label);
+                    setOpen(false);
+                    onSelect(option.value);
+                  }}
+                >
+                  {option.label}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { Answers, AnswerValue, FormStep } from '@quill/engine';
+import { nameFields } from '@quill/engine';
+import { SearchableDropdown } from './searchable-dropdown';
+
+interface StepInputProps {
+  step: FormStep;
+  value: AnswerValue;
+  answers: Answers;
+  onChange: (value: AnswerValue) => void;
+  onFieldChange: (field: string, value: AnswerValue) => void;
+  /** Choice/dropdown selection auto-advances the form. */
+  onSelect: (value: string) => void;
+  dropdownPlaceholder: string;
+  dropdownEmpty: string;
+}
+
+/** Renders the input for a single step. `message` renders info copy, no input. */
+export function StepInput({
+  step,
+  value,
+  answers,
+  onChange,
+  onFieldChange,
+  onSelect,
+  dropdownPlaceholder,
+  dropdownEmpty,
+}: StepInputProps) {
+  switch (step.type) {
+    case 'name': {
+      const [firstField, secondField] = nameFields(step);
+      return (
+        <div className="pf-name-fields">
+          {firstField && (
+            <input
+              type="text"
+              className="pf-input"
+              value={String(answers[firstField] ?? '')}
+              onChange={(e) => onFieldChange(firstField, e.target.value)}
+              placeholder={step.placeholders?.[firstField] ?? ''}
+              aria-label={step.placeholders?.[firstField] ?? firstField}
+              autoFocus
+            />
+          )}
+          {secondField && (
+            <input
+              type="text"
+              className="pf-input"
+              value={String(answers[secondField] ?? '')}
+              onChange={(e) => onFieldChange(secondField, e.target.value)}
+              placeholder={step.placeholders?.[secondField] ?? ''}
+              aria-label={step.placeholders?.[secondField] ?? secondField}
+            />
+          )}
+        </div>
+      );
+    }
+
+    case 'text':
+    case 'email':
+    case 'phone':
+      return (
+        <input
+          type={step.type === 'email' ? 'email' : step.type === 'phone' ? 'tel' : 'text'}
+          inputMode={step.type === 'phone' ? 'tel' : undefined}
+          className="pf-input"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={step.placeholder ?? ''}
+          aria-label={step.question ?? step.key}
+          autoFocus
+        />
+      );
+
+    case 'textarea':
+      return (
+        <textarea
+          className="pf-input pf-textarea"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={step.placeholder ?? ''}
+          aria-label={step.question ?? step.key}
+          rows={4}
+          autoFocus
+        />
+      );
+
+    case 'dropdown':
+      return (
+        <SearchableDropdown
+          options={step.options ?? []}
+          value={String(value ?? '')}
+          onSelect={onSelect}
+          placeholder={step.placeholder ?? dropdownPlaceholder}
+          emptyLabel={dropdownEmpty}
+        />
+      );
+
+    case 'multiple_choice':
+      if (step.showIcons) {
+        return (
+          <div className="pf-choices--icons" role="radiogroup" aria-label={step.question ?? step.key}>
+            {(step.options ?? []).map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                role="radio"
+                aria-checked={value === opt.value}
+                className={`pf-choice-icon${value === opt.value ? ' pf-choice-icon--selected' : ''}`}
+                onClick={() => onSelect(opt.value)}
+              >
+                <span className="pf-choice-icon__circle" aria-hidden="true">
+                  {opt.icon ?? opt.label.charAt(0).toUpperCase()}
+                </span>
+                <span className="pf-choice-icon__label">{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        );
+      }
+      return (
+        <div className="pf-choices--list" role="radiogroup" aria-label={step.question ?? step.key}>
+          {(step.options ?? []).map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={value === opt.value}
+              className={`pf-choice-list${value === opt.value ? ' pf-choice-list--selected' : ''}`}
+              onClick={() => onSelect(opt.value)}
+            >
+              {opt.icon ? (
+                <span className="pf-choice-list__icon" aria-hidden="true">
+                  {opt.icon}
+                </span>
+              ) : (
+                <span className="pf-choice-list__radio" aria-hidden="true" />
+              )}
+              <span className="pf-choice-list__text">{opt.label}</span>
+            </button>
+          ))}
+        </div>
+      );
+
+    case 'slider':
+      return <SliderInput step={step} value={value} onChange={onChange} />;
+
+    case 'message':
+      return step.helper ? <p className="pf-message__body">{step.helper}</p> : null;
+
+    default:
+      return null;
+  }
+}
+
+function SliderInput({
+  step,
+  value,
+  onChange,
+}: {
+  step: FormStep;
+  value: AnswerValue;
+  onChange: (value: AnswerValue) => void;
+}) {
+  const min = step.min ?? 0;
+  const max = step.max ?? 100;
+  const stepSize = step.step ?? 1;
+  const current = value != null && value !== '' ? Number(value) : (step.default ?? min);
+  const ref = useRef<HTMLInputElement>(null);
+  const pct = max > min ? ((current - min) / (max - min)) * 100 : 0;
+
+  useEffect(() => {
+    ref.current?.style.setProperty('--pf-progress', `${pct}%`);
+  }, [pct]);
+
+  // Seed the default answer so an untouched (optional) slider still submits a value.
+  useEffect(() => {
+    if (value == null || value === '') onChange(current);
+  }, []);
+
+  return (
+    <div className="pf-slider">
+      <div className="pf-slider__pill">
+        <span className="pf-slider__pill-num">{current}</span>
+        {step.sliderUnitLabel ? (
+          <span className="pf-slider__pill-label">{step.sliderUnitLabel}</span>
+        ) : null}
+      </div>
+      <input
+        ref={ref}
+        type="range"
+        className="pf-slider__input"
+        style={{ ['--pf-progress']: `${pct}%` } as React.CSSProperties}
+        min={min}
+        max={max}
+        step={stepSize}
+        value={current}
+        aria-label={step.question ?? step.key}
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          e.target.style.setProperty('--pf-progress', `${max > min ? ((v - min) / (max - min)) * 100 : 0}%`);
+          onChange(v);
+        }}
+      />
+      <div className="pf-slider__scale" aria-hidden="true">
+        <span>{min}</span>
+        <span>{max}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/form-tabs.tsx
+++ b/apps/web/components/ui/form-tabs.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+
+/**
+ * Cross-page tabs for a single form's admin surfaces (Edit / Analytics /
+ * Submissions) plus a back-to-list affordance. A NEW shared component so the
+ * analytics + submissions pages get consistent navigation WITHOUT touching the
+ * editor page internals. Tokens-only styling; the active tab is unmistakable
+ * (Design Quality Bar #5).
+ */
+export type FormTab = 'edit' | 'analytics' | 'submissions';
+
+export function FormTabs({
+  formId,
+  active,
+  labels,
+}: {
+  formId: string;
+  active: FormTab;
+  labels: { edit: string; analytics: string; submissions: string; backToForms: string };
+}) {
+  const tabs: { key: FormTab; href: string; label: string }[] = [
+    { key: 'edit', href: `/admin/forms/${formId}/edit`, label: labels.edit },
+    { key: 'analytics', href: `/admin/forms/${formId}/analytics`, label: labels.analytics },
+    { key: 'submissions', href: `/admin/forms/${formId}/submissions`, label: labels.submissions },
+  ];
+  return (
+    <div className="mb-6">
+      <Link
+        href="/admin"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <i aria-hidden className="pi pi-chevron-left" style={{ fontSize: 12 }} />
+        {labels.backToForms}
+      </Link>
+      <nav className="mt-3 flex items-center gap-1 border-b border-border" aria-label="Form sections">
+        {tabs.map((t) => {
+          const isActive = t.key === active;
+          return (
+            <Link
+              key={t.key}
+              href={t.href}
+              aria-current={isActive ? 'page' : undefined}
+              className={
+                isActive
+                  ? 'relative -mb-px border-b-2 border-primary px-3 py-2 text-sm font-semibold text-foreground'
+                  : 'relative -mb-px border-b-2 border-transparent px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground'
+              }
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -5,7 +5,7 @@
  * into a redirect to /login.
  */
 import { redirect } from 'next/navigation';
-import type { FormConfig } from '@quill/types';
+import type { AnalyticsResponse, FormConfig, SubmissionsPage } from '@quill/types';
 import { getSession, clearSession, authProvider } from './auth-session';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
@@ -107,6 +107,27 @@ export interface AccountMember {
   createdAt: number;
 }
 
+export type { AnalyticsResponse, SubmissionsPage } from '@quill/types';
+
+export interface SubmissionsQuery {
+  status?: 'all' | 'completed' | 'partial';
+  from?: number;
+  to?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/** Build a `?a=b&…` string from defined params only. */
+function qs(params: Record<string, string | number | undefined | null>): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === '') continue;
+    sp.set(k, String(v));
+  }
+  const s = sp.toString();
+  return s ? `?${s}` : '';
+}
+
 export const isAdminRole = (role: AccountRole): boolean => role === 'owner' || role === 'admin';
 
 export const adminApi = {
@@ -122,7 +143,13 @@ export const adminApi = {
     req<FormDetail>('PUT', `/v1/forms/${id}`, b),
   duplicateForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/duplicate`),
   deleteForm: (id: string) => req<void>('DELETE', `/v1/forms/${id}`),
-  listSubmissions: (id: string) => req<Submission[]>('GET', `/v1/forms/${id}/submissions`),
+
+  // Analytics + submissions (this track)
+  getAnalytics: (id: string, range: { from?: number; to?: number } = {}) =>
+    req<AnalyticsResponse>('GET', `/v1/forms/${id}/analytics${qs(range)}`),
+  listSubmissions: (id: string, q: SubmissionsQuery = {}) =>
+    req<SubmissionsPage>('GET', `/v1/forms/${id}/submissions${qs({ ...q })}`),
+  deleteSubmission: (id: string) => req<void>('DELETE', `/v1/submissions/${id}`),
 
   // Members (workspace roster — admin/owner only)
   listMembers: () => req<AccountMember[]>('GET', '/v1/members'),

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -5,7 +5,7 @@
  * into a redirect to /login.
  */
 import { redirect } from 'next/navigation';
-import type { AnalyticsResponse, FormConfig, SubmissionsPage } from '@quill/types';
+import type { AnalyticsResponse, FormConfig, FormDestination, SubmissionsPage } from '@quill/types';
 import { getSession, clearSession, authProvider } from './auth-session';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
@@ -130,6 +130,20 @@ function qs(params: Record<string, string | number | undefined | null>): string 
 
 export const isAdminRole = (role: AccountRole): boolean => role === 'owner' || role === 'admin';
 
+/** A HubSpot contact property surfaced to the mapping UI. */
+export interface HubSpotProperty {
+  name: string;
+  label: string;
+  type: string;
+}
+
+/** The property-picker response: disabled (no server token) or the property list. */
+export type HubSpotPropertiesResponse =
+  | { enabled: false; reason: string }
+  | { enabled: true; cached: boolean; properties: HubSpotProperty[] };
+
+export type { FormDestination };
+
 export const adminApi = {
   me: () => req<Me>('GET', '/v1/me'),
   vanityStatus: () =>
@@ -150,6 +164,10 @@ export const adminApi = {
   listSubmissions: (id: string, q: SubmissionsQuery = {}) =>
     req<SubmissionsPage>('GET', `/v1/forms/${id}/submissions${qs({ ...q })}`),
   deleteSubmission: (id: string) => req<void>('DELETE', `/v1/submissions/${id}`),
+
+  // Integrations
+  hubspotProperties: () =>
+    req<HubSpotPropertiesResponse>('GET', '/v1/integrations/hubspot/properties'),
 
   // Members (workspace roster — admin/owner only)
   listMembers: () => req<AccountMember[]>('GET', '/v1/members'),

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -168,6 +168,9 @@ export const adminApi = {
   // Integrations
   hubspotProperties: () =>
     req<HubSpotPropertiesResponse>('GET', '/v1/integrations/hubspot/properties'),
+  /** Partial write: replaces ONLY the config's `destinations` key server-side. */
+  updateFormDestinations: (id: string, destinations: FormDestination[]) =>
+    req<FormDetail>('PUT', `/v1/forms/${id}/destinations`, { destinations }),
 
   // Members (workspace roster — admin/owner only)
   listMembers: () => req<AccountMember[]>('GET', '/v1/members'),

--- a/apps/web/lib/client-locale.ts
+++ b/apps/web/lib/client-locale.ts
@@ -1,0 +1,11 @@
+import type { Locale } from '@quill/shared';
+
+/**
+ * Client-side twin of lib/locale.ts#getLocale (that one reads next/headers and
+ * is server-only): the persisted admin locale from the document cookie.
+ * Defaults to English so a bare fork renders with no cookie.
+ */
+export function clientLocale(): Locale {
+  if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
+  return 'en';
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@quill/engine": "workspace:*",
     "@quill/shared": "workspace:*",
     "@quill/types": "workspace:*",

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -55,6 +55,12 @@ export const serverEnvSchema = z.object({
   // Message category for `transactional-v1` (defaults to `lifecycle`).
   EMAIL_HTTP_CATEGORY: z.string().optional(),
 
+  // Submission destinations (CRM/webhook sync). Webhook destinations are fully
+  // self-configured per form; HubSpot needs a server-side private-app token.
+  // Unset = the HubSpot destination + property picker report a disabled state
+  // (a webhook-only fork needs nothing here). Never sent to the browser.
+  HUBSPOT_PRIVATE_APP_TOKEN: z.string().optional(),
+
   // Premium features (vanity slug + future perks). Forms is ALWAYS free —
   // `locked` gates premium on the customer's Dapta AI subscription via the
   // entitlement service below; `open` (default) unlocks everything, so a bare

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -1,0 +1,202 @@
+/**
+ * Analytics + submissions querying — the read side that powers the admin
+ * dashboard (funnel + per-step drop-off) and the submissions table (paginated,
+ * filtered, exportable). Everything goes through the portable `Db` port and
+ * `sql` templates so the identical code runs on SQLite (clone-and-run) and
+ * Postgres (prod): no dialect-specific SQL (no FILTER, no window fns) — only
+ * COUNT / SUM(CASE…) / AVG(CASE…) which behave the same on both engines.
+ */
+import { type SQL } from 'drizzle-orm';
+import { sql, type Db } from './client';
+import { parseJsonColumn } from './forms';
+import type { SubmissionRow } from './forms';
+
+/** An optional epoch-ms date window applied to the query. */
+export interface DateRange {
+  from?: number | null;
+  to?: number | null;
+}
+
+/**
+ * Build the `AND col >= from AND col <= to` fragment for an optional range.
+ * Each bound is independent; an empty range contributes no SQL. `col` is a
+ * fixed internal identifier fragment (never user input).
+ */
+function andRange(col: SQL, range?: DateRange): SQL {
+  const parts: SQL[] = [];
+  if (range?.from != null) parts.push(sql`AND ${col} >= ${range.from}`);
+  if (range?.to != null) parts.push(sql`AND ${col} <= ${range.to}`);
+  return parts.length ? sql.join(parts, sql` `) : sql``;
+}
+
+// --- Raw aggregates (the primitives the service composes) --------------------
+
+/** Count of funnel events by type within the range: `{ view: 12, start: 9, … }`. */
+export async function eventTypeCounts(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<Record<string, number>> {
+  const rows = await db.all<{ type: string; n: number | string }>(
+    sql`SELECT type, COUNT(*) AS n FROM form_event
+        WHERE form_id = ${formId} ${andRange(sql`created_at`, range)}
+        GROUP BY type`,
+  );
+  const out: Record<string, number> = {};
+  for (const r of rows) out[String(r.type)] = Number(r.n);
+  return out;
+}
+
+/** Count of `step_view` events per step index within the range. */
+export async function stepViewCounts(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<Map<number, number>> {
+  const rows = await db.all<{ step_index: number | string | null; n: number | string }>(
+    sql`SELECT step_index, COUNT(*) AS n FROM form_event
+        WHERE form_id = ${formId} AND type = 'step_view' AND step_index IS NOT NULL
+        ${andRange(sql`created_at`, range)}
+        GROUP BY step_index`,
+  );
+  const out = new Map<number, number>();
+  for (const r of rows) {
+    if (r.step_index == null) continue;
+    out.set(Number(r.step_index), Number(r.n));
+  }
+  return out;
+}
+
+export interface SubmissionAggregate {
+  /** Completed submissions (completed_at set). */
+  completed: number;
+  /** Partial-only submissions (partial_at set, completed_at null). */
+  partial: number;
+  /** Average ms from started_at→completed_at over completed rows (null if none). */
+  avgCompletionMs: number | null;
+}
+
+/**
+ * Submission counts + average completion time within the range (bounded by
+ * `started_at`). SUM(CASE…) and AVG(CASE…) are portable; AVG ignores the NULLs
+ * the CASE emits for non-completed rows, so it averages only completed sessions.
+ */
+export async function submissionAggregates(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<SubmissionAggregate> {
+  const row = await db.get<{
+    completed: number | string | null;
+    partial: number | string | null;
+    avg_ms: number | string | null;
+  }>(
+    sql`SELECT
+          SUM(CASE WHEN completed_at IS NOT NULL THEN 1 ELSE 0 END) AS completed,
+          SUM(CASE WHEN completed_at IS NULL AND partial_at IS NOT NULL THEN 1 ELSE 0 END) AS partial,
+          AVG(CASE WHEN completed_at IS NOT NULL THEN (completed_at - started_at) ELSE NULL END) AS avg_ms
+        FROM submission
+        WHERE form_id = ${formId} ${andRange(sql`started_at`, range)}`,
+  );
+  return {
+    completed: Number(row?.completed ?? 0),
+    partial: Number(row?.partial ?? 0),
+    avgCompletionMs: row?.avg_ms == null ? null : Number(row.avg_ms),
+  };
+}
+
+// --- Submissions table (paginated + filtered) --------------------------------
+
+export type SubmissionStatus = 'all' | 'completed' | 'partial';
+
+export interface SubmissionQuery extends DateRange {
+  status?: SubmissionStatus;
+  limit?: number;
+  offset?: number;
+}
+
+/** The status predicate for the submissions table (portable). */
+function statusClause(status?: SubmissionStatus): SQL {
+  if (status === 'completed') return sql`AND completed_at IS NOT NULL`;
+  if (status === 'partial') return sql`AND completed_at IS NULL AND partial_at IS NOT NULL`;
+  return sql``;
+}
+
+function mapSubmission(r: Record<string, unknown>): SubmissionRow {
+  return {
+    id: String(r.id),
+    formId: String(r.form_id),
+    sessionId: String(r.session_id),
+    data: parseJsonColumn(r.data, {}),
+    score: Number(r.score),
+    startedAt: Number(r.started_at),
+    completedAt: r.completed_at == null ? null : Number(r.completed_at),
+    partialAt: r.partial_at == null ? null : Number(r.partial_at),
+  };
+}
+
+/**
+ * A page of a form's submissions, newest first, with the total matching the
+ * filter (before pagination) so the UI can render page counts. `status` narrows
+ * to complete/partial; `from`/`to` bound `started_at`.
+ */
+export async function querySubmissions(
+  db: Db,
+  formId: string,
+  q: SubmissionQuery = {},
+): Promise<{ items: SubmissionRow[]; total: number; limit: number; offset: number }> {
+  const limit = Math.min(Math.max(q.limit ?? 25, 1), 200);
+  const offset = Math.max(q.offset ?? 0, 0);
+  const where = sql`WHERE form_id = ${formId} ${statusClause(q.status)} ${andRange(sql`started_at`, q)}`;
+
+  const totalRow = await db.get<{ n: number | string }>(
+    sql`SELECT COUNT(*) AS n FROM submission ${where}`,
+  );
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT * FROM submission ${where}
+        ORDER BY started_at DESC
+        LIMIT ${limit} OFFSET ${offset}`,
+  );
+  return { items: rows.map(mapSubmission), total: Number(totalRow?.n ?? 0), limit, offset };
+}
+
+/**
+ * Every submission for a form matching the filter, newest first — no pagination
+ * (used by the CSV export, which must include the full result set). Bounded by
+ * the same status/date filter as the table.
+ */
+export async function allSubmissionsForExport(
+  db: Db,
+  formId: string,
+  q: Omit<SubmissionQuery, 'limit' | 'offset'> = {},
+): Promise<SubmissionRow[]> {
+  const where = sql`WHERE form_id = ${formId} ${statusClause(q.status)} ${andRange(sql`started_at`, q)}`;
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT * FROM submission ${where} ORDER BY started_at DESC`,
+  );
+  return rows.map(mapSubmission);
+}
+
+// --- Account-scoped submission delete ----------------------------------------
+
+/**
+ * Delete a submission, but ONLY if it belongs to a form the account owns.
+ * Idempotent: returns false when the row is absent or out-of-account (both
+ * indistinguishable to the caller — no cross-account existence leak). The
+ * account scope is enforced in SQL via the form join, so a forged id can't
+ * touch another tenant's data.
+ */
+export async function deleteSubmissionForAccount(
+  db: Db,
+  accountId: string,
+  submissionId: string,
+): Promise<boolean> {
+  const owned = await db.get<{ id: string }>(
+    sql`SELECT s.id FROM submission s
+        JOIN form f ON f.id = s.form_id
+        WHERE s.id = ${submissionId} AND f.account_id = ${accountId} LIMIT 1`,
+  );
+  if (!owned) return false;
+  await db.run(sql`DELETE FROM submission WHERE id = ${submissionId}`);
+  return true;
+}

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -231,6 +231,33 @@ export async function updateForm(
   return { ok: true, value: (await getFormById(db, accountId, id))! };
 }
 
+/**
+ * Replace ONLY the `destinations` key of a form's config, merging against the
+ * row's FRESH config in one server-side call — so the integrations screen never
+ * clobbers steps/cover/scoring saved by a concurrent editor session (the web
+ * tier no longer does its own read-then-write across two requests).
+ *
+ * NOTE (optimistic locking): without a config version / compare-and-set, a
+ * concurrent FULL-config save can still interleave between this read and write.
+ * That general problem applies to every config writer and is out of scope here;
+ * full config versioning is tracked separately.
+ */
+export async function updateFormDestinations(
+  db: Db,
+  accountId: string,
+  id: string,
+  destinations: unknown[],
+): Promise<CrudResult<FormRow>> {
+  const existing = await getFormById(db, accountId, id);
+  if (!existing) return { ok: false, reason: 'NOT_FOUND' };
+  const config = { ...(existing.config as Record<string, unknown>), destinations };
+  await db.run(
+    sql`UPDATE form SET config = ${jsonParam(config)}, updated_at = ${Date.now()}
+        WHERE account_id = ${accountId} AND id = ${id}`,
+  );
+  return { ok: true, value: (await getFormById(db, accountId, id))! };
+}
+
 export async function duplicateForm(
   db: Db,
   accountId: string,

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -348,13 +348,19 @@ export async function upsertSubmission(
   },
 ): Promise<SubmissionRow> {
   const now = input.now ?? Date.now();
-  const existing = await db.get<{ id: string; started_at: number }>(
-    sql`SELECT id, started_at FROM submission
+  const existing = await db.get<{ id: string; started_at: number; completed_at: number | null }>(
+    sql`SELECT id, started_at, completed_at FROM submission
         WHERE form_id = ${input.formId} AND session_id = ${input.sessionId} LIMIT 1`,
   );
   const completedAt = input.partial ? null : now;
   const partialAt = input.partial ? now : null;
   if (existing) {
+    // Reorder guard: a fire-and-forget partial can land AFTER the complete
+    // submit. Once a row is completed, only a complete submit may update it —
+    // a late partial must NOT overwrite the finalized data/score.
+    if (input.partial && existing.completed_at != null) {
+      return (await getSubmissionById(db, existing.id))!;
+    }
     await db.run(
       sql`UPDATE submission
           SET data = ${jsonParam(input.data)}, score = ${input.score},

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,6 +6,7 @@
 export * from './client';
 export * from './crud';
 export * from './forms';
+export * from './analytics';
 export * from './members';
 export * from './short-links';
 export * from './outbox';

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -26,7 +26,13 @@ import { randomUUID } from 'node:crypto';
 import { sql } from 'drizzle-orm';
 import type { Db } from './client';
 
-export type OutboxKind = 'webhook' | 'email';
+/**
+ * `email` = submission lifecycle emails; `webhook`/`hubspot` = pluggable
+ * submission destinations (drained by the same worker + retry machinery). Adding
+ * a destination kind here is all the queue needs — the delivery logic lives in
+ * the API's DestinationEffects.
+ */
+export type OutboxKind = 'webhook' | 'email' | 'hubspot';
 /**
  * `skipped` = deliberately not performed (e.g. an email row whose tenant
  * context is unrecoverable on a transport that requires it) — recorded ONCE

--- a/packages/db/src/submission.spec.ts
+++ b/packages/db/src/submission.spec.ts
@@ -54,6 +54,32 @@ describe('submission upsert', () => {
     expect(rows[0]!.partialAt).not.toBeNull(); // earlier partial preserved
   });
 
+  it('ignores a late partial that arrives AFTER the complete submit', async () => {
+    // Reorder race: the fire-and-forget partial lands after the final submit.
+    // A completed row must NOT be overwritten by a partial payload.
+    const session = 'reorder';
+    await upsertSubmission(db, {
+      formId,
+      sessionId: session,
+      data: { a: 1, b: 2, done: true },
+      score: 9,
+    });
+    // Late partial with stale/lesser data + score — must be a no-op on data/score.
+    await upsertSubmission(db, {
+      formId,
+      sessionId: session,
+      data: { a: 1 },
+      score: 3,
+      partial: true,
+    });
+
+    const rows = await listSubmissions(db, formId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.score).toBe(9); // completed score preserved
+    expect(rows[0]!.data).toEqual({ a: 1, b: 2, done: true }); // completed data intact
+    expect(rows[0]!.completedAt).not.toBeNull();
+  });
+
   it('creates distinct rows for distinct sessions', async () => {
     await upsertSubmission(db, { formId, sessionId: 'a', data: {}, score: 0 });
     await upsertSubmission(db, { formId, sessionId: 'b', data: {}, score: 0 });

--- a/packages/destinations/eslint.config.js
+++ b/packages/destinations/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from '@quill/config/eslint';

--- a/packages/destinations/package.json
+++ b/packages/destinations/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@quill/destinations",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Pluggable submission destinations — a SubmissionDestination port with adapters (log-only default, webhook with optional HMAC, HubSpot contact upsert). A bare fork 'delivers' to the log. Failures never crash submission handling.",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@quill/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@quill/config": "workspace:*",
+    "@types/node": "^22.10.2",
+    "eslint": "^9.17.0",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/destinations/src/adapters/hubspot.spec.ts
+++ b/packages/destinations/src/adapters/hubspot.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { HubspotDestination, toHubSpotDateMs, buildSubmissionNoteBody } from './hubspot';
+import type { DestinationContext } from '../destination.port';
+
+function ctx(over: Partial<DestinationContext> = {}): DestinationContext {
+  return {
+    idempotencyKey: 'submission:sub-1:complete:hubspot',
+    submissionId: 'sub-1',
+    formId: 'form-1',
+    formName: 'Lead Qualifier',
+    accountId: 'acc-1',
+    sessionId: 'sess-1',
+    score: 18,
+    outcomeLabel: 'Qualified',
+    phase: 'complete',
+    submittedAt: Date.UTC(2026, 0, 15, 22, 30), // 15 Jan 2026 22:30 UTC
+    data: {
+      contact_email: 'lead@acme.io',
+      first: 'Ada',
+      company: 'Acme',
+      empty: '   ',
+    },
+    utm: { utm_source: 'google', utm_campaign: 'q1' },
+    ...over,
+  };
+}
+
+const MAPPING = {
+  fieldMappings: { contact_email: 'email', first: 'firstname', company: 'company', empty: 'notes' },
+  utmMappings: { utm_source: 'hs_analytics_source', utm_campaign: 'utm_campaign_prop' },
+  scoreProperty: 'lead_score',
+  dateProperty: 'submitted_date',
+};
+
+describe('toHubSpotDateMs', () => {
+  it('truncates an instant to UTC midnight (date property contract)', () => {
+    expect(toHubSpotDateMs(Date.UTC(2026, 0, 15, 22, 30))).toBe(String(Date.UTC(2026, 0, 15)));
+  });
+});
+
+describe('HubspotDestination.buildProperties', () => {
+  it('maps fields + UTM + score + date, dropping empty values', () => {
+    const dest = new HubspotDestination({ token: 't', ...MAPPING });
+    const props = dest.buildProperties(ctx());
+    expect(props.firstname).toBe('Ada');
+    expect(props.company).toBe('Acme');
+    expect(props.notes).toBeUndefined(); // whitespace-only dropped
+    expect(props.hs_analytics_source).toBe('google');
+    expect(props.utm_campaign_prop).toBe('q1');
+    expect(props.lead_score).toBe('18');
+    expect(props.submitted_date).toBe(String(Date.UTC(2026, 0, 15)));
+  });
+
+  it('omits the score property on a partial submission', () => {
+    const dest = new HubspotDestination({ token: 't', ...MAPPING });
+    expect(dest.buildProperties(ctx({ phase: 'partial' })).lead_score).toBeUndefined();
+  });
+
+  it('resolves email from the mapping, then from raw data', () => {
+    const dest = new HubspotDestination({ token: 't', ...MAPPING });
+    expect(dest.resolveEmail(ctx())).toBe('lead@acme.io');
+    const dest2 = new HubspotDestination({ token: 't', fieldMappings: {} });
+    expect(dest2.resolveEmail(ctx({ data: { email: 'x@y.io' } }))).toBe('x@y.io');
+    expect(dest2.resolveEmail(ctx({ data: {} }))).toBeNull();
+  });
+});
+
+describe('HubspotDestination.deliver', () => {
+  it('upserts the contact and creates a Note on a completed submission', async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      calls.push({ url, body: JSON.parse(init.body as string) });
+      if (url.includes('/contacts/batch/upsert'))
+        return new Response(JSON.stringify({ results: [{ id: '501' }] }), { status: 200 });
+      if (url.includes('/objects/notes')) return new Response('{}', { status: 201 });
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const dest = new HubspotDestination({ token: 't', ...MAPPING }, fetchImpl);
+    const res = await dest.deliver(ctx());
+    expect(res.delivered).toBe(true);
+    expect(res.detail).toContain('contact=501');
+    expect(res.detail).toContain('+note');
+
+    const upsert = calls.find((c) => c.url.includes('upsert'))!;
+    const input = (upsert.body as { inputs: Array<{ idProperty: string; id: string; properties: Record<string, string> }> }).inputs[0]!;
+    expect(input.idProperty).toBe('email');
+    expect(input.id).toBe('lead@acme.io');
+    expect(input.properties.email).toBe('lead@acme.io');
+    expect(input.properties.lead_score).toBe('18');
+
+    const note = calls.find((c) => c.url.includes('notes'))!;
+    const noteBody = (note.body as { properties: { hs_note_body: string } }).properties.hs_note_body;
+    expect(noteBody).toContain('Lead Qualifier');
+    expect(noteBody).toContain('Qualified');
+  });
+
+  it('does NOT create a Note on a partial submission', async () => {
+    const urls: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      urls.push(url);
+      return new Response(JSON.stringify({ results: [{ id: '9' }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await new HubspotDestination({ token: 't', ...MAPPING }, fetchImpl).deliver(ctx({ phase: 'partial' }));
+    expect(urls.some((u) => u.includes('/notes'))).toBe(false);
+  });
+
+  it('strips a portal-rejected property and retries the upsert', async () => {
+    let attempt = 0;
+    const bodies: Record<string, string>[] = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      if (!url.includes('upsert')) return new Response('{}', { status: 201 });
+      attempt++;
+      const input = JSON.parse(init.body as string).inputs[0];
+      bodies.push(input.properties);
+      if (attempt === 1) {
+        return new Response(
+          JSON.stringify({
+            errors: [{ code: 'PROPERTY_DOESNT_EXIST', context: { propertyName: ['lead_score'] } }],
+          }),
+          { status: 400 },
+        );
+      }
+      return new Response(JSON.stringify({ results: [{ id: '7' }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const res = await new HubspotDestination({ token: 't', ...MAPPING }, fetchImpl).deliver(ctx());
+    expect(attempt).toBe(2);
+    expect(bodies[0]!.lead_score).toBe('18'); // first attempt included it
+    expect(bodies[1]!.lead_score).toBeUndefined(); // retry stripped it
+    expect(res.detail).toContain('skipped=[lead_score]');
+  });
+
+  it('is a permanent no-op (delivered:false) when the submission has no email', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('should not be called');
+    }) as unknown as typeof fetch;
+    const dest = new HubspotDestination({ token: 't', fieldMappings: {} }, fetchImpl);
+    const res = await dest.deliver(ctx({ data: { first: 'Ada' } }));
+    expect(res.delivered).toBe(false);
+    expect(res.detail).toContain('no email');
+  });
+
+  it('THROWS on a non-recoverable upsert failure so the outbox retries', async () => {
+    const fetchImpl = (async () => new Response('boom', { status: 503 })) as unknown as typeof fetch;
+    await expect(
+      new HubspotDestination({ token: 't', ...MAPPING }, fetchImpl).deliver(ctx()),
+    ).rejects.toThrow(/HTTP 503/);
+  });
+});
+
+describe('buildSubmissionNoteBody', () => {
+  it('HTML-escapes user values (no injection into the note)', () => {
+    const body = buildSubmissionNoteBody(
+      { firstname: '<script>alert(1)</script>' },
+      { formName: 'F', score: 1, outcomeLabel: null, submittedAt: 0 },
+    );
+    expect(body).not.toContain('<script>');
+    expect(body).toContain('&lt;script&gt;');
+  });
+});

--- a/packages/destinations/src/adapters/hubspot.ts
+++ b/packages/destinations/src/adapters/hubspot.ts
@@ -1,0 +1,314 @@
+import type {
+  DestinationContext,
+  DestinationResult,
+  SubmissionDestination,
+} from '../destination.port';
+
+/** HubSpot public API base (overridable in tests). */
+export const HUBSPOT_API_BASE = 'https://api.hubapi.com';
+/** HUBSPOT_DEFINED note→contact association type id (v3). */
+const NOTE_TO_CONTACT_ASSOCIATION_TYPE_ID = 202;
+/** Upsert retries: strip an invalid property the portal rejected, then retry. */
+const MAX_UPSERT_ATTEMPTS = 15;
+
+export interface HubspotDestinationOptions {
+  /** HubSpot private-app token (server-side only; never sent to the browser). */
+  token: string;
+  /** stepKey -> contact property. One mapping's property SHOULD be `email`. */
+  fieldMappings: Record<string, string>;
+  /** utmKey (utm_source…) -> contact property. */
+  utmMappings?: Record<string, string>;
+  /** Contact property to write the server-computed score to (complete only). */
+  scoreProperty?: string;
+  /** Contact date property to write the submitted date to (UTC-midnight ms). */
+  dateProperty?: string;
+  /** Create a Note engagement on a completed submission (default true). */
+  note?: boolean;
+}
+
+interface HubSpotUpsertResponse {
+  results?: Array<{ id: string }>;
+}
+interface HubSpotValidationError {
+  code?: string;
+  context?: { propertyName?: string[] };
+}
+interface HubSpotErrorResponse {
+  errors?: HubSpotValidationError[];
+}
+
+/**
+ * HUBSPOT destination — upserts the respondent as a contact (keyed by email),
+ * maps configured form fields + UTM values to contact properties, writes the
+ * score and submitted-date to configurable properties, and (on a completed
+ * submission) attaches a Note engagement summarizing the submission. Port of the
+ * pilot's HubSpot sync (`hubspotUpsert`/`hubspotSync`/`note`) generalized behind
+ * the destination interface — no property names are baked in.
+ *
+ * Reliability: a transport failure (network, non-2xx after invalid-property
+ * stripping) THROWS so the durable outbox retries. A submission with no email to
+ * key on is a permanent no-op (`delivered:false`, marked done — retrying can't
+ * conjure an email). A Note failure is logged but never fails the delivery (the
+ * contact upsert already succeeded — the durable part).
+ */
+export class HubspotDestination implements SubmissionDestination {
+  readonly type = 'hubspot' as const;
+
+  constructor(
+    private readonly opts: HubspotDestinationOptions,
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly baseUrl: string = HUBSPOT_API_BASE,
+    private readonly logger: Pick<Console, 'warn'> = console,
+  ) {}
+
+  /**
+   * Build the contact properties exactly as sent to HubSpot (pure — exported
+   * shape for tests). Empty/whitespace values are dropped; email is guaranteed
+   * present in the returned object only when resolvable (caller checks).
+   */
+  buildProperties(ctx: DestinationContext): Record<string, string> {
+    const props: Record<string, string> = {};
+
+    // Field mappings: stepKey -> contact property.
+    for (const [stepKey, property] of Object.entries(this.opts.fieldMappings)) {
+      if (!property?.trim()) continue;
+      const value = ctx.data[stepKey];
+      if (value !== undefined && value !== null && String(value).trim() !== '') {
+        props[property.trim()] = String(value).trim();
+      }
+    }
+
+    // UTM mappings: utmKey -> contact property.
+    for (const [utmKey, property] of Object.entries(this.opts.utmMappings ?? {})) {
+      if (!property?.trim()) continue;
+      const value = ctx.utm[utmKey];
+      if (value !== undefined && value !== null && String(value).trim() !== '') {
+        props[property.trim()] = String(value).trim();
+      }
+    }
+
+    // Submitted-date → configurable date property (HubSpot date = UTC-midnight ms).
+    if (this.opts.dateProperty?.trim()) {
+      props[this.opts.dateProperty.trim()] = toHubSpotDateMs(ctx.submittedAt);
+    }
+
+    // Score → configurable property (complete submissions only, mirroring the pilot).
+    if (this.opts.scoreProperty?.trim() && ctx.phase === 'complete') {
+      props[this.opts.scoreProperty.trim()] = String(ctx.score);
+    }
+
+    return props;
+  }
+
+  /** Resolve the respondent email from the field mappings, then the raw data. */
+  resolveEmail(ctx: DestinationContext): string | null {
+    for (const [stepKey, property] of Object.entries(this.opts.fieldMappings)) {
+      if (property?.trim() === 'email' && ctx.data[stepKey]) {
+        return String(ctx.data[stepKey]).trim();
+      }
+    }
+    if (typeof ctx.data.email === 'string' && ctx.data.email.trim()) return ctx.data.email.trim();
+    return null;
+  }
+
+  async deliver(ctx: DestinationContext): Promise<DestinationResult> {
+    const email = this.resolveEmail(ctx);
+    if (!email) {
+      // No key to upsert on — a permanent no-op, not a retryable failure.
+      return { delivered: false, driver: 'hubspot', detail: 'no email in submission' };
+    }
+    const properties = this.buildProperties(ctx);
+    properties.email = email;
+
+    const upsert = await this.upsertContact(properties);
+    const contactId = upsert.contactId;
+
+    let noteDetail = '';
+    if (ctx.phase === 'complete' && this.opts.note !== false && contactId) {
+      const noteOk = await this.createNote(contactId, ctx, properties);
+      noteDetail = noteOk ? ' +note' : ' (note failed)';
+    }
+
+    const skipped = upsert.skippedProperties?.length
+      ? ` skipped=[${upsert.skippedProperties.join(', ')}]`
+      : '';
+    return {
+      delivered: true,
+      driver: 'hubspot',
+      detail: `contact=${contactId ?? '?'}${noteDetail}${skipped}`,
+    };
+  }
+
+  /**
+   * Upsert a contact by email. On a 400 that names non-existent/invalid
+   * properties, strip them and retry (the portal may not have every mapped
+   * property) — mirrors the pilot. Any other non-2xx THROWS so the outbox
+   * retries.
+   */
+  private async upsertContact(
+    properties: Record<string, string>,
+  ): Promise<{ contactId?: string; skippedProperties?: string[] }> {
+    const props = { ...properties };
+    const skippedProperties: string[] = [];
+
+    for (let attempt = 0; attempt < MAX_UPSERT_ATTEMPTS; attempt++) {
+      const res = await this.fetchImpl(`${this.baseUrl}/crm/v3/objects/contacts/batch/upsert`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${this.opts.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          inputs: [{ idProperty: 'email', id: props.email, properties: props }],
+        }),
+      });
+
+      if (res.ok) {
+        const body = (await res.json().catch(() => ({}))) as HubSpotUpsertResponse;
+        return {
+          contactId: body.results?.[0]?.id,
+          skippedProperties: skippedProperties.length ? skippedProperties : undefined,
+        };
+      }
+
+      const errorText = await res.text().catch(() => '');
+      if (res.status === 400) {
+        const retryable = extractRetryablePropertyNames(errorText);
+        const removed = retryable.filter((name) => name in props && name !== 'email');
+        if (removed.length > 0) {
+          for (const name of removed) {
+            delete props[name];
+            skippedProperties.push(name);
+          }
+          continue;
+        }
+      }
+      // Non-recoverable transport/validation failure — retry via the outbox.
+      throw new Error(`hubspot upsert failed: HTTP ${res.status} ${errorText.slice(0, 300)}`);
+    }
+    throw new Error('hubspot upsert failed: too many invalid-property retries');
+  }
+
+  /** Attach a Note engagement (v3, falling back to legacy v1). Never throws. */
+  private async createNote(
+    contactId: string,
+    ctx: DestinationContext,
+    properties: Record<string, string>,
+  ): Promise<boolean> {
+    const body = buildSubmissionNoteBody(properties, {
+      formName: ctx.formName,
+      score: ctx.score,
+      outcomeLabel: ctx.outcomeLabel,
+      submittedAt: ctx.submittedAt,
+    });
+    try {
+      const res = await this.fetchImpl(`${this.baseUrl}/crm/v3/objects/notes`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${this.opts.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          properties: { hs_note_body: body, hs_timestamp: String(ctx.submittedAt) },
+          associations: [
+            {
+              to: { id: contactId },
+              types: [
+                {
+                  associationCategory: 'HUBSPOT_DEFINED',
+                  associationTypeId: NOTE_TO_CONTACT_ASSOCIATION_TYPE_ID,
+                },
+              ],
+            },
+          ],
+        }),
+      });
+      if (res.ok) return true;
+      this.logger.warn(`[destination:hubspot] note v3 failed: HTTP ${res.status}`);
+    } catch (err) {
+      this.logger.warn(`[destination:hubspot] note v3 error: ${String(err)}`);
+    }
+    // Legacy v1 fallback.
+    const contactIdNum = Number.parseInt(contactId, 10);
+    if (Number.isNaN(contactIdNum)) return false;
+    try {
+      const res = await this.fetchImpl(`${this.baseUrl}/engagements/v1/engagements`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${this.opts.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          engagement: { active: true, type: 'NOTE', timestamp: ctx.submittedAt },
+          associations: { contactIds: [contactIdNum], companyIds: [], dealIds: [], ownerIds: [] },
+          metadata: { body },
+        }),
+      });
+      if (res.ok) return true;
+      this.logger.warn(`[destination:hubspot] note v1 failed: HTTP ${res.status}`);
+      return false;
+    } catch (err) {
+      this.logger.warn(`[destination:hubspot] note v1 error: ${String(err)}`);
+      return false;
+    }
+  }
+}
+
+/** Names of properties HubSpot rejected as non-existent/invalid (retry-strippable). */
+export function extractRetryablePropertyNames(errorText: string): string[] {
+  try {
+    const parsed = JSON.parse(errorText) as HubSpotErrorResponse;
+    const names = new Set<string>();
+    const retryableCodes = new Set(['PROPERTY_DOESNT_EXIST', 'INVALID_OPTION', 'INVALID_DATE']);
+    for (const err of parsed.errors ?? []) {
+      if (err.code && retryableCodes.has(err.code)) {
+        for (const name of err.context?.propertyName ?? []) names.add(name);
+      }
+    }
+    return [...names];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * A HubSpot date property expects UTC-midnight epoch-ms. Truncate the instant to
+ * its UTC calendar day so the date isn't shifted by the time-of-day. Exported for
+ * testing.
+ */
+export function toHubSpotDateMs(epochMs: number): string {
+  const d = new Date(epochMs);
+  return String(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** The Note engagement body: form name, submitted date, score/outcome, fields. */
+export function buildSubmissionNoteBody(
+  properties: Record<string, string>,
+  opts: { formName: string; score: number; outcomeLabel: string | null; submittedAt: number },
+): string {
+  const submittedAt = new Date(opts.submittedAt).toISOString();
+  const qualification = opts.outcomeLabel ?? String(opts.score);
+  const fieldLines = Object.entries(properties)
+    .filter(([key]) => key !== 'email')
+    .map(
+      ([key, value]) =>
+        `<p style="margin:0 0 6px 0;">• <strong>${escapeHtml(key)}:</strong> ${escapeHtml(value)}</p>`,
+    )
+    .join('');
+  return [
+    `<p style="margin:0 0 8px 0;"><strong>Form submission — ${escapeHtml(opts.formName)}</strong></p>`,
+    `<p style="margin:0 0 6px 0;"><strong>Submitted:</strong> ${escapeHtml(submittedAt)}</p>`,
+    `<p style="margin:0 0 6px 0;"><strong>Score:</strong> ${escapeHtml(String(opts.score))}</p>`,
+    `<p style="margin:0 0 6px 0;"><strong>Outcome:</strong> ${escapeHtml(qualification)}</p>`,
+    `<p style="margin:8px 0 8px 0;"><strong>Submitted data:</strong></p>`,
+    fieldLines || `<p style="margin:0;">—</p>`,
+  ].join('\n');
+}

--- a/packages/destinations/src/adapters/log-only.ts
+++ b/packages/destinations/src/adapters/log-only.ts
@@ -1,0 +1,30 @@
+import type {
+  DestinationContext,
+  DestinationResult,
+  SubmissionDestination,
+} from '../destination.port';
+
+/**
+ * The default destination. Logs that a submission *would* have been delivered,
+ * without any transport — so a bare clone runs submission flows end-to-end with
+ * nothing configured, and a destination whose required settings are missing
+ * (no webhook URL, no HubSpot token) degrades here instead of crashing. Logs the
+ * form + submission id and answer KEYS only, never values (avoids dumping PII).
+ */
+export class LogOnlyDestination implements SubmissionDestination {
+  readonly type = 'log-only' as const;
+
+  constructor(
+    private readonly reason: string = 'no destination configured',
+    private readonly logger: Pick<Console, 'log'> = console,
+  ) {}
+
+  deliver(ctx: DestinationContext): Promise<DestinationResult> {
+    const keys = Object.keys(ctx.data);
+    this.logger.log(
+      `[destination:log-only] not delivered (${this.reason}) → form="${ctx.formName}" ` +
+        `submission=${ctx.submissionId} phase=${ctx.phase} fields=[${keys.join(', ')}]`,
+    );
+    return Promise.resolve({ delivered: false, driver: 'log-only', detail: this.reason });
+  }
+}

--- a/packages/destinations/src/adapters/webhook.spec.ts
+++ b/packages/destinations/src/adapters/webhook.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { WebhookDestination, signWebhookBody } from './webhook';
+import type { DestinationContext } from '../destination.port';
+
+function ctx(over: Partial<DestinationContext> = {}): DestinationContext {
+  return {
+    idempotencyKey: 'submission:sub-1:complete:webhook',
+    submissionId: 'sub-1',
+    formId: 'form-1',
+    formName: 'Lead Qualifier',
+    accountId: 'acc-1',
+    sessionId: 'sess-1',
+    score: 18,
+    outcomeLabel: 'Qualified',
+    phase: 'complete',
+    submittedAt: 1_700_000_000_000,
+    data: { email: 'lead@acme.io', role: 'founder' },
+    utm: { utm_source: 'google' },
+    ...over,
+  };
+}
+
+describe('signWebhookBody', () => {
+  it('produces a sha256-prefixed HMAC a receiver can recompute', () => {
+    const sig = signWebhookBody('{"a":1}', 'secret');
+    const expected = `sha256=${createHmac('sha256', 'secret').update('{"a":1}').digest('hex')}`;
+    expect(sig).toBe(expected);
+  });
+});
+
+describe('WebhookDestination', () => {
+  it('POSTs the envelope and signs it with the configured secret + header', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const dest = new WebhookDestination(
+      { url: 'https://acme.io/hook', secret: 'shh', signatureHeader: 'X-Sig' },
+      fetchImpl,
+    );
+    const c = ctx();
+    const res = await dest.deliver(c);
+    expect(res.delivered).toBe(true);
+    expect(res.driver).toBe('webhook');
+
+    const { init } = calls[0]!;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-quill-delivery']).toBe(c.idempotencyKey);
+    expect(headers['x-quill-event']).toBe('form.submission');
+    // The signature validates against the exact body sent.
+    const body = init.body as string;
+    expect(headers['x-sig']).toBe(signWebhookBody(body, 'shh'));
+    const parsed = JSON.parse(body);
+    expect(parsed.submission.score).toBe(18);
+    expect(parsed.submission.outcome).toBe('Qualified');
+    expect(parsed.utm.utm_source).toBe('google');
+    expect(parsed.phase).toBe('complete');
+  });
+
+  it('omits the signature header when no secret is set', async () => {
+    let headers: Record<string, string> = {};
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      headers = init.headers as Record<string, string>;
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    await new WebhookDestination({ url: 'https://acme.io/hook' }, fetchImpl).deliver(ctx());
+    expect(headers['x-quill-signature']).toBeUndefined();
+  });
+
+  it('THROWS on a non-2xx response so the outbox retries', async () => {
+    const fetchImpl = (async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    await expect(
+      new WebhookDestination({ url: 'https://acme.io/hook' }, fetchImpl).deliver(ctx()),
+    ).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('refuses to follow a redirect (3xx is a failure, never a hop)', async () => {
+    const fetchImpl = (async () =>
+      new Response(null, { status: 302 })) as unknown as typeof fetch;
+    await expect(
+      new WebhookDestination({ url: 'https://acme.io/hook' }, fetchImpl).deliver(ctx()),
+    ).rejects.toThrow(/redirect/i);
+  });
+
+  it('aborts on timeout and THROWS (retryable)', async () => {
+    // A fetch that only rejects when the abort signal fires.
+    const fetchImpl = ((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      })) as unknown as typeof fetch;
+    await expect(
+      new WebhookDestination({ url: 'https://acme.io/hook', timeoutMs: 10 }, fetchImpl).deliver(ctx()),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/destinations/src/adapters/webhook.ts
+++ b/packages/destinations/src/adapters/webhook.ts
@@ -1,0 +1,133 @@
+import { createHmac } from 'node:crypto';
+import type {
+  DestinationContext,
+  DestinationResult,
+  SubmissionDestination,
+} from '../destination.port';
+
+/** The default header carrying the HMAC signature (overridable per destination). */
+export const DEFAULT_SIGNATURE_HEADER = 'X-Quill-Signature';
+/** The default per-request timeout. */
+export const DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
+/** The event name carried in the payload + the X-Quill-Event header. */
+export const WEBHOOK_EVENT = 'form.submission';
+
+export interface WebhookDestinationOptions {
+  /** The customer endpoint to POST each submission to. */
+  url: string;
+  /** Optional HMAC-SHA256 signing secret. When set, every request is signed. */
+  secret?: string;
+  /** Header the signature is sent in. Defaults to `X-Quill-Signature`. */
+  signatureHeader?: string;
+  /** Per-request timeout (ms). Defaults to 10s. A slow endpoint is retried by the outbox. */
+  timeoutMs?: number;
+}
+
+/** The stable JSON envelope POSTed to a webhook destination. */
+export interface WebhookPayload {
+  /** The idempotency key (also sent as `X-Quill-Delivery`) — de-dup on the receiver. */
+  id: string;
+  type: typeof WEBHOOK_EVENT;
+  phase: 'partial' | 'complete';
+  /** ISO-8601 timestamp of the submission phase. */
+  submittedAt: string;
+  form: { id: string; name: string };
+  submission: {
+    id: string;
+    sessionId: string;
+    score: number;
+    outcome: string | null;
+  };
+  data: Record<string, unknown>;
+  utm: Record<string, string>;
+}
+
+/**
+ * Outbound WEBHOOK destination — POSTs a stable JSON envelope of the submission
+ * to a customer-configured URL, optionally HMAC-SHA256 signed so the receiver can
+ * verify authenticity. No redirects are followed (a 3xx is treated as a failure,
+ * so an endpoint can't silently bounce a delivery to an attacker-controlled host)
+ * and the request is bounded by a timeout. A non-2xx response, a redirect, a
+ * timeout, or a network error THROWS so the durable outbox worker retries with
+ * backoff — a delivery is never silently dropped.
+ */
+export class WebhookDestination implements SubmissionDestination {
+  readonly type = 'webhook' as const;
+
+  constructor(
+    private readonly opts: WebhookDestinationOptions,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  /** Build the signed request body exactly as it is sent (exported shape for tests). */
+  buildPayload(ctx: DestinationContext): WebhookPayload {
+    return {
+      id: ctx.idempotencyKey,
+      type: WEBHOOK_EVENT,
+      phase: ctx.phase,
+      submittedAt: new Date(ctx.submittedAt).toISOString(),
+      form: { id: ctx.formId, name: ctx.formName },
+      submission: {
+        id: ctx.submissionId,
+        sessionId: ctx.sessionId,
+        score: ctx.score,
+        outcome: ctx.outcomeLabel,
+      },
+      data: ctx.data,
+      utm: ctx.utm,
+    };
+  }
+
+  async deliver(ctx: DestinationContext): Promise<DestinationResult> {
+    const body = JSON.stringify(this.buildPayload(ctx));
+    const timestamp = String(Math.floor(ctx.submittedAt / 1000));
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      'x-quill-event': WEBHOOK_EVENT,
+      'x-quill-delivery': ctx.idempotencyKey,
+      'x-quill-timestamp': timestamp,
+    };
+    if (this.opts.secret) {
+      const header = this.opts.signatureHeader || DEFAULT_SIGNATURE_HEADER;
+      headers[header.toLowerCase()] = signWebhookBody(body, this.opts.secret);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      this.opts.timeoutMs ?? DEFAULT_WEBHOOK_TIMEOUT_MS,
+    );
+    let res: Response;
+    try {
+      res = await this.fetchImpl(this.opts.url, {
+        method: 'POST',
+        headers,
+        body,
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // Timeout (abort) or network error — surface so the outbox retries.
+      throw err instanceof Error ? err : new Error(`webhook delivery failed: ${String(err)}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+    // No redirects: a 3xx (or the opaque redirect fetch surfaces as status 0)
+    // is a failure, never a followed hop.
+    if (res.status === 0 || (res.status >= 300 && res.status < 400)) {
+      throw new Error(`webhook delivery refused: endpoint attempted a redirect (HTTP ${res.status})`);
+    }
+    if (!res.ok) throw new Error(`webhook delivery failed: HTTP ${res.status}`);
+    return { delivered: true, driver: 'webhook' };
+  }
+}
+
+/**
+ * The HMAC-SHA256 signature of the raw request body, prefixed `sha256=` so the
+ * scheme is explicit (GitHub-style). Receivers recompute
+ * `HMAC-SHA256(secret, rawBody)` and compare in constant time. Exported for
+ * direct contract testing.
+ */
+export function signWebhookBody(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}

--- a/packages/destinations/src/config.spec.ts
+++ b/packages/destinations/src/config.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Validation of the additive `destinations` config section (@quill/types). These
+ * guard the contract the admin UI writes and the API re-validates.
+ */
+import { describe, it, expect } from 'vitest';
+import { formConfigSchema, formDestinationSchema } from '@quill/types';
+
+describe('formConfigSchema destinations (additive)', () => {
+  it('accepts a config with NO destinations (legacy configs unaffected)', () => {
+    const r = formConfigSchema.safeParse({ version: 1, steps: [] });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.destinations).toBeUndefined();
+  });
+
+  it('accepts a webhook destination and defaults enabled=false', () => {
+    const r = formDestinationSchema.safeParse({
+      type: 'webhook',
+      settings: { url: 'https://acme.io/hook', secret: 'shh' },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.enabled).toBe(false);
+  });
+
+  it('rejects a webhook destination with a non-URL', () => {
+    const r = formDestinationSchema.safeParse({
+      type: 'webhook',
+      enabled: true,
+      settings: { url: 'not-a-url' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a hubspot destination with mappings + score/date properties', () => {
+    const r = formDestinationSchema.safeParse({
+      type: 'hubspot',
+      enabled: true,
+      fieldMappings: { email_step: 'email', name_step: 'firstname' },
+      utmMappings: { utm_source: 'hs_analytics_source' },
+      scoreProperty: 'lead_score',
+      dateProperty: 'submitted_date',
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.type === 'hubspot') {
+      expect(r.data.fieldMappings.email_step).toBe('email');
+      expect(r.data.settings).toEqual({});
+    }
+  });
+
+  it('rejects an unknown destination type (discriminated union)', () => {
+    expect(formDestinationSchema.safeParse({ type: 'sheets', settings: {} }).success).toBe(false);
+  });
+
+  it('round-trips inside a full form config', () => {
+    const r = formConfigSchema.safeParse({
+      version: 1,
+      steps: [],
+      destinations: [
+        { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/h' } },
+        { type: 'hubspot', enabled: false, fieldMappings: { e: 'email' } },
+      ],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.destinations).toHaveLength(2);
+  });
+});

--- a/packages/destinations/src/config.spec.ts
+++ b/packages/destinations/src/config.spec.ts
@@ -30,6 +30,23 @@ describe('formConfigSchema destinations (additive)', () => {
     expect(r.success).toBe(false);
   });
 
+  it('rejects a plain-http webhook URL for a non-localhost host (https-only)', () => {
+    const r = formDestinationSchema.safeParse({
+      type: 'webhook',
+      enabled: true,
+      settings: { url: 'http://acme.io/hook' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts plain http for localhost (documented dev-testing exception)', () => {
+    for (const url of ['http://localhost:9099/hook', 'http://127.0.0.1:9099/hook']) {
+      expect(
+        formDestinationSchema.safeParse({ type: 'webhook', enabled: true, settings: { url } }).success,
+      ).toBe(true);
+    }
+  });
+
   it('accepts a hubspot destination with mappings + score/date properties', () => {
     const r = formDestinationSchema.safeParse({
       type: 'hubspot',

--- a/packages/destinations/src/destination.port.ts
+++ b/packages/destinations/src/destination.port.ts
@@ -1,0 +1,72 @@
+/**
+ * The SubmissionDestination port — the boundary every submission-sync caller
+ * depends on. Concrete integrations (log-only, webhook, HubSpot, …) are selected
+ * by configuration, never imported directly by application code. Adding a
+ * destination means adding an adapter behind this interface; callers never
+ * change. Mirrors the EmailProvider port in @quill/notifications.
+ *
+ * Reliability contract (identical to the email port): a destination NEVER rolls
+ * back or blocks a submission. `deliver` resolves for an outcome it can report;
+ * it THROWS only for a transient/retryable failure the durable outbox should
+ * retry. A permanent no-op (e.g. HubSpot with no email to key on) resolves with
+ * `delivered:false` so the outbox row is marked done, not retried forever.
+ */
+
+/** Which integration actually handled (or would handle) the delivery. */
+export type DestinationDriver = 'log-only' | 'webhook' | 'hubspot';
+
+/** The configurable destination kinds a form may declare. */
+export type DestinationType = 'webhook' | 'hubspot';
+
+/**
+ * The snapshot a destination receives for one submission. Built at ENQUEUE time
+ * and serialized into the outbox payload, so a later retry delivers exactly what
+ * was captured — independent of any subsequent edit to the form or its config.
+ */
+export interface DestinationContext {
+  /**
+   * Stable, event-specific de-duplication key
+   * (`submission:<id>:<phase>:<destinationType>`). A retried delivery reuses the
+   * same key; distinct events get distinct keys. Webhooks forward it as a header
+   * and HubSpot uses it to guard the note engagement.
+   */
+  idempotencyKey: string;
+  /** The persisted submission id (the domain anchor). */
+  submissionId: string;
+  formId: string;
+  formName: string;
+  /** Tenant context asserted by the authenticated backend, never by a browser. */
+  accountId: string;
+  sessionId: string;
+  /** Server-recomputed score (never the client's claim). */
+  score: number;
+  /** The resolved outcome bucket label, when the form scores to one. */
+  outcomeLabel: string | null;
+  /** `partial` = an intermediate save; `complete` = the final submit. */
+  phase: 'partial' | 'complete';
+  /** Epoch-ms the submission reached this phase. */
+  submittedAt: number;
+  /** The submission answers: fieldName -> value. */
+  data: Record<string, unknown>;
+  /** UTM values captured for the session (from `submission.data.utm`). */
+  utm: Record<string, string>;
+}
+
+export interface DestinationResult {
+  /** True when actually dispatched; false for log-only / a permanent no-op. */
+  delivered: boolean;
+  driver: DestinationDriver;
+  /** Optional human detail (a HubSpot contact id, a skipped-properties note…). */
+  detail?: string;
+}
+
+export interface SubmissionDestination {
+  /** The configured destination this instance speaks for (`log-only` when disabled). */
+  readonly type: DestinationType | 'log-only';
+  /**
+   * Deliver one submission to this destination. Resolves with `delivered:false`
+   * for a permanent no-op it can report (marked done, never retried); THROWS for
+   * a transient failure so the durable outbox worker retries with backoff.
+   */
+  deliver(ctx: DestinationContext): Promise<DestinationResult>;
+}

--- a/packages/destinations/src/factory.ts
+++ b/packages/destinations/src/factory.ts
@@ -1,0 +1,39 @@
+import type { DestinationType, SubmissionDestination } from './destination.port';
+import { LogOnlyDestination } from './adapters/log-only';
+import { WebhookDestination, type WebhookDestinationOptions } from './adapters/webhook';
+import { HubspotDestination, type HubspotDestinationOptions } from './adapters/hubspot';
+
+/**
+ * A fully-resolved destination spec: the form-config settings for the chosen
+ * `type`, with any server-side secret (the HubSpot token) already injected by the
+ * API layer. The factory owns ONLY selection + graceful degradation — it never
+ * reads env or the DB.
+ */
+export interface DestinationSpec {
+  type: DestinationType;
+  webhook?: WebhookDestinationOptions;
+  hubspot?: HubspotDestinationOptions;
+}
+
+/**
+ * Select the SubmissionDestination for a spec. Falls back to log-only whenever a
+ * chosen destination is missing its required settings (no webhook URL, no HubSpot
+ * token) — so a misconfigured destination degrades to a harmless log instead of
+ * crashing submission handling (mirrors createEmailProvider). `fetchImpl` is
+ * threaded through for tests.
+ */
+export function createDestination(
+  spec: DestinationSpec,
+  fetchImpl: typeof fetch = fetch,
+): SubmissionDestination {
+  switch (spec.type) {
+    case 'webhook':
+      if (spec.webhook?.url) return new WebhookDestination(spec.webhook, fetchImpl);
+      return new LogOnlyDestination('webhook destination missing URL');
+    case 'hubspot':
+      if (spec.hubspot?.token) return new HubspotDestination(spec.hubspot, fetchImpl);
+      return new LogOnlyDestination('hubspot destination missing token (HUBSPOT_PRIVATE_APP_TOKEN)');
+    default:
+      return new LogOnlyDestination(`unknown destination type: ${String(spec.type)}`);
+  }
+}

--- a/packages/destinations/src/index.ts
+++ b/packages/destinations/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @quill/destinations — pluggable submission destinations. Callers depend on the
+ * SubmissionDestination port; a destination is chosen by configuration (default
+ * log-only, so a bare fork runs). A destination NEVER crashes or blocks a
+ * submission — failures are surfaced for the durable outbox to retry.
+ */
+export * from './destination.port';
+export * from './factory';
+export { LogOnlyDestination } from './adapters/log-only';
+export {
+  WebhookDestination,
+  type WebhookDestinationOptions,
+  type WebhookPayload,
+  signWebhookBody,
+  DEFAULT_SIGNATURE_HEADER,
+  DEFAULT_WEBHOOK_TIMEOUT_MS,
+  WEBHOOK_EVENT,
+} from './adapters/webhook';
+export {
+  HubspotDestination,
+  type HubspotDestinationOptions,
+  extractRetryablePropertyNames,
+  buildSubmissionNoteBody,
+  toHubSpotDateMs,
+  HUBSPOT_API_BASE,
+} from './adapters/hubspot';

--- a/packages/destinations/tsconfig.json
+++ b/packages/destinations/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@quill/config/tsconfig/base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src", "types": ["node"] },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.spec.ts", "dist", "node_modules"]
+}

--- a/packages/destinations/vitest.config.ts
+++ b/packages/destinations/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({ test: { globals: true, include: ['src/**/*.spec.ts'] } });

--- a/packages/engine/src/form-config.spec.ts
+++ b/packages/engine/src/form-config.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import {
+  slugify,
+  uniqueKey,
+  defaultFlowGroup,
+  createEmptyStep,
+  createEmptyOutcome,
+  hasScoringSignal,
+  normalizeConfig,
+  interpolate,
+  resolveQuestion,
+} from './form-config';
+import type { FormConfig, FormStep } from './form-logic';
+
+const step = (p: Partial<FormStep> & Pick<FormStep, 'key' | 'type'>): FormStep => p;
+
+describe('slugify', () => {
+  it('lowercases, strips accents, and collapses non-alphanumerics', () => {
+    expect(slugify('¿Cuál es tu Rol?')).toBe('cual_es_tu_rol');
+    expect(slugify('  Hello  World  ')).toBe('hello_world');
+  });
+  it('falls back when nothing usable remains', () => {
+    expect(slugify('!!!', 'step')).toBe('step');
+    expect(slugify('')).toBe('item');
+  });
+});
+
+describe('uniqueKey', () => {
+  it('returns the base when free and suffixes on collision', () => {
+    const taken = new Set(['role', 'role_2']);
+    expect(uniqueKey('name', taken)).toBe('name');
+    expect(uniqueKey('role', taken)).toBe('role_3');
+  });
+});
+
+describe('defaultFlowGroup', () => {
+  it('marks lead-capture field types, qualification otherwise', () => {
+    expect(defaultFlowGroup('email')).toBe('lead_capture');
+    expect(defaultFlowGroup('phone')).toBe('lead_capture');
+    expect(defaultFlowGroup('name')).toBe('lead_capture');
+    expect(defaultFlowGroup('dropdown')).toBe('qualification');
+    expect(defaultFlowGroup('slider')).toBe('qualification');
+  });
+});
+
+describe('createEmptyStep', () => {
+  it('produces a valid step with a unique key and per-type defaults', () => {
+    const drop = createEmptyStep('dropdown', new Set(['dropdown_1']));
+    expect(drop.type).toBe('dropdown');
+    expect(drop.key).not.toBe('dropdown_1');
+    expect(drop.options).toHaveLength(1);
+    expect(drop.flowGroup).toBe('qualification');
+
+    const slider = createEmptyStep('slider');
+    expect(slider.min).toBe(0);
+    expect(slider.max).toBe(100);
+    expect(slider.default).toBe(50);
+
+    const msg = createEmptyStep('message');
+    expect(msg.required).toBe(false);
+    expect(msg.buttonText).toBeTruthy();
+
+    const email = createEmptyStep('email');
+    expect(email.flowGroup).toBe('lead_capture');
+  });
+});
+
+describe('createEmptyOutcome', () => {
+  it('mints a unique id', () => {
+    const o = createEmptyOutcome(new Set(['outcome_1']));
+    expect(o.id).toBeTruthy();
+    expect(o.label).toBe('');
+  });
+});
+
+describe('hasScoringSignal', () => {
+  it('detects points, ranges, and outcomes', () => {
+    expect(hasScoringSignal({ version: 1, steps: [] })).toBe(false);
+    expect(
+      hasScoringSignal({
+        version: 1,
+        steps: [step({ key: 'a', type: 'dropdown', options: [{ label: 'x', value: 'x', points: 3 }] })],
+      }),
+    ).toBe(true);
+    expect(
+      hasScoringSignal({ version: 1, steps: [], outcomes: [{ id: 'o', label: 'Hot', minScore: 5 }] }),
+    ).toBe(true);
+  });
+});
+
+describe('normalizeConfig', () => {
+  it('dedupes step keys and rewrites references to renamed keys', () => {
+    const config: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: 'dup', type: 'dropdown', options: [{ label: 'A', value: 'a', points: 1 }] }),
+        step({ key: 'dup', type: 'text' }), // collides → becomes dup_2
+        step({ key: 'q3', type: 'text', showWhen: { field: 'dup', values: ['a'] } }),
+      ],
+    };
+    const out = normalizeConfig(config);
+    expect(out.steps.map((s) => s.key)).toEqual(['dup', 'dup_2', 'q3']);
+    // The condition still points at the FIRST step (unchanged key).
+    expect(out.steps[2].showWhen).toEqual({ field: 'dup', values: ['a'] });
+  });
+
+  it('generates keys for blank ones from the question', () => {
+    const out = normalizeConfig({
+      version: 1,
+      steps: [step({ key: '', type: 'text', question: 'What is your budget?' })],
+    });
+    expect(out.steps[0].key).toBe('what_is_your_budget');
+  });
+
+  it('derives flowGroup and fills option values, and derives scoring', () => {
+    const out = normalizeConfig({
+      version: 1,
+      steps: [
+        step({ key: 'email', type: 'email' }),
+        step({
+          key: 'role',
+          type: 'dropdown',
+          options: [
+            { label: 'Founder', value: '', points: 10 },
+            { label: 'Founder', value: '', points: 0 }, // dup slug → founder_2
+          ],
+        }),
+      ],
+    });
+    expect(out.steps[0].flowGroup).toBe('lead_capture');
+    expect(out.steps[1].flowGroup).toBe('qualification');
+    expect(out.steps[1].options?.map((o) => o.value)).toEqual(['founder', 'founder_2']);
+    expect(out.scoring).toEqual({ enabled: true });
+  });
+
+  it('sorts outcomes by minScore ascending and keeps unique ids', () => {
+    const out = normalizeConfig({
+      version: 1,
+      steps: [],
+      outcomes: [
+        { id: 'hot', label: 'Hot', minScore: 20 },
+        { id: 'cold', label: 'Cold', minScore: 0 },
+      ],
+    });
+    expect(out.outcomes?.map((o) => o.minScore)).toEqual([0, 20]);
+  });
+
+  it('respects an explicit scoring flag and is idempotent', () => {
+    const config: FormConfig = {
+      version: 1,
+      scoring: { enabled: false },
+      steps: [step({ key: 'role', type: 'dropdown', options: [{ label: 'A', value: 'a', points: 5 }] })],
+    };
+    const once = normalizeConfig(config);
+    expect(once.scoring).toEqual({ enabled: false });
+    expect(normalizeConfig(once)).toEqual(once);
+  });
+});
+
+describe('interpolate', () => {
+  it('replaces [field] tokens with answers, joining arrays', () => {
+    expect(interpolate('Hi [name], budget [budget]?', { name: 'Ada', budget: 500 })).toBe(
+      'Hi Ada, budget 500?',
+    );
+    expect(interpolate('Picked [tools]', { tools: ['a', 'b'] })).toBe('Picked a, b');
+    expect(interpolate('Hi [missing]', {})).toBe('Hi ');
+  });
+});
+
+describe('resolveQuestion', () => {
+  const s = step({
+    key: 'detail',
+    type: 'text',
+    question: 'Tell us more',
+    questionField: 'role',
+    questionVariants: { founder: 'Tell us about [company]', '*': 'Tell us about your work' },
+  });
+  it('picks the variant matching the referenced answer, interpolated', () => {
+    expect(resolveQuestion(s, { role: 'founder', company: 'Acme' })).toBe('Tell us about Acme');
+  });
+  it('falls back to * then to the plain question', () => {
+    expect(resolveQuestion(s, { role: 'student' })).toBe('Tell us about your work');
+    expect(resolveQuestion({ ...s, questionVariants: { founder: 'x' } }, { role: 'student' })).toBe(
+      'Tell us more',
+    );
+  });
+});

--- a/packages/engine/src/form-config.spec.ts
+++ b/packages/engine/src/form-config.spec.ts
@@ -7,9 +7,9 @@ import {
   createEmptyOutcome,
   hasScoringSignal,
   normalizeConfig,
-  interpolate,
-  resolveQuestion,
 } from './form-config';
+// interpolate + resolveQuestion are unified in ./form-logic (shared by builder + runtime).
+import { interpolate, resolveQuestion } from './form-logic';
 import type { FormConfig, FormStep } from './form-logic';
 
 const step = (p: Partial<FormStep> & Pick<FormStep, 'key' | 'type'>): FormStep => p;

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -12,8 +12,6 @@ import type {
   FormFieldType,
   FormOption,
   FormOutcome,
-  Answers,
-  AnswerValue,
 } from './form-logic';
 
 /** Field kinds that capture the lead and therefore never score. */
@@ -196,26 +194,5 @@ export function normalizeConfig(config: FormConfig): FormConfig {
   return next;
 }
 
-/** Replace `[field]` tokens with the respondent's answer to that field. */
-export function interpolate(template: string, answers: Answers): string {
-  return template.replace(/\[([a-zA-Z0-9_]+)\]/g, (_, field: string) => {
-    const value: AnswerValue = answers[field];
-    if (value == null) return '';
-    return Array.isArray(value) ? value.join(', ') : String(value);
-  });
-}
-
-/**
- * The question to show for a step given the answers so far: a `questionVariants`
- * match on `questionField` (falling back to `*` then the plain `question`), with
- * `[field]` interpolation applied to the result.
- */
-export function resolveQuestion(step: FormStep, answers: Answers): string {
-  let text = step.question ?? '';
-  if (step.questionField && step.questionVariants) {
-    const raw = answers[step.questionField];
-    const key = raw == null ? '' : Array.isArray(raw) ? raw.join(',') : String(raw);
-    text = step.questionVariants[key] ?? step.questionVariants['*'] ?? text;
-  }
-  return interpolate(text, answers);
-}
+// `interpolate` and `resolveQuestion` are unified in ./form-logic (the core the
+// runtime and the builder preview both call) — re-exported via the package index.

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -1,0 +1,221 @@
+/**
+ * Pure config authoring helpers — the builder's counterpart to form-logic. No
+ * DB, no I/O, no framework. The admin editor and the API both lean on these so
+ * a saved config is always canonical: unique step keys, a stable derived flow
+ * group per step, sorted/id'd outcomes, and clean option values. Kept here (not
+ * in the UI) so it's fully unit-tested and identical on client and server.
+ */
+
+import type {
+  FormConfig,
+  FormStep,
+  FormFieldType,
+  FormOption,
+  FormOutcome,
+  Answers,
+  AnswerValue,
+} from './form-logic';
+
+/** Field kinds that capture the lead and therefore never score. */
+const LEAD_CAPTURE_TYPES: ReadonlySet<FormFieldType> = new Set<FormFieldType>([
+  'name',
+  'email',
+  'phone',
+]);
+
+/** slugify to a safe key/value token; falls back when nothing usable remains. */
+export function slugify(text: string, fallback = 'item'): string {
+  const slug = text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return slug || fallback;
+}
+
+/** Make `base` unique against `taken` by appending `_2`, `_3`, … (deterministic). */
+export function uniqueKey(base: string, taken: ReadonlySet<string>): string {
+  if (!taken.has(base)) return base;
+  let i = 2;
+  while (taken.has(`${base}_${i}`)) i += 1;
+  return `${base}_${i}`;
+}
+
+/** The default flow group for a step type when the author hasn't set one. */
+export function defaultFlowGroup(type: FormFieldType): FormStep['flowGroup'] {
+  return LEAD_CAPTURE_TYPES.has(type) ? 'lead_capture' : 'qualification';
+}
+
+let stepSeq = 0;
+/**
+ * A fresh, valid step of `type` with a unique key. Sensible per-type defaults
+ * mirror the pilot (choice steps start with one option; sliders get a 0–100
+ * range). `taken` guarantees the generated key doesn't collide.
+ */
+export function createEmptyStep(
+  type: FormFieldType,
+  taken: ReadonlySet<string> = new Set(),
+): FormStep {
+  stepSeq += 1;
+  const key = uniqueKey(`${type}_${stepSeq}`, taken);
+  const base: FormStep = {
+    key,
+    type,
+    question: '',
+    required: !(type === 'message'),
+    flowGroup: defaultFlowGroup(type),
+  };
+
+  if (type === 'dropdown' || type === 'multiple_choice') {
+    base.options = [{ label: 'Option 1', value: 'option_1', points: 0 }];
+  }
+  if (type === 'slider') {
+    base.min = 0;
+    base.max = 100;
+    base.step = 1;
+    base.default = 50;
+    base.sliderScoring = [];
+  }
+  if (type === 'message') {
+    base.buttonText = 'Continue';
+  }
+  return base;
+}
+
+/** A blank outcome bucket with a unique id. */
+export function createEmptyOutcome(taken: ReadonlySet<string> = new Set()): FormOutcome {
+  stepSeq += 1;
+  return { id: uniqueKey(`outcome_${stepSeq}`, taken), label: '', minScore: 0 };
+}
+
+/** Normalize a single step's options: fill values from labels, dedupe values. */
+function normalizeOptions(options: FormOption[] | undefined): FormOption[] | undefined {
+  if (!options || options.length === 0) return options;
+  const taken = new Set<string>();
+  return options.map((o, i) => {
+    const base = (o.value && o.value.trim()) || slugify(o.label ?? '', `option_${i + 1}`);
+    const value = uniqueKey(base, taken);
+    taken.add(value);
+    return {
+      label: o.label ?? value,
+      value,
+      ...(o.points != null ? { points: o.points } : {}),
+      ...(o.icon ? { icon: o.icon } : {}),
+    };
+  });
+}
+
+/** True when the config carries any scoring signal (points / ranges / outcomes). */
+export function hasScoringSignal(config: FormConfig): boolean {
+  if ((config.outcomes ?? []).length > 0) return true;
+  return config.steps.some(
+    (s) =>
+      (s.points ?? 0) !== 0 ||
+      (s.sliderScoring ?? []).length > 0 ||
+      (s.options ?? []).some((o) => (o.points ?? 0) !== 0),
+  );
+}
+
+/**
+ * Return a canonical, save-ready config:
+ *  - every step has a unique, non-empty `key` (collisions get `_2`, `_3`…),
+ *  - references (`showWhen`/`hideWhen`/`questionField`) are rewritten to follow
+ *    any key that had to change, so skip-logic never dangles,
+ *  - each step gets a derived `flowGroup` when absent (lead-capture fields
+ *    never score),
+ *  - options get filled/deduped values,
+ *  - outcomes are sorted by `minScore` ascending with unique ids,
+ *  - `scoring.enabled` is derived when the author left it unset but the form
+ *    clearly scores.
+ * Pure and idempotent: normalizing an already-canonical config is a no-op.
+ */
+export function normalizeConfig(config: FormConfig): FormConfig {
+  const taken = new Set<string>();
+  const assigned: string[] = [];
+  const preserved = new Set<string>();
+
+  const steps: FormStep[] = config.steps.map((step, i) => {
+    const desired =
+      (step.key && step.key.trim()) || slugify(step.question ?? '', `step_${i + 1}`);
+    const key = uniqueKey(desired, taken);
+    taken.add(key);
+    assigned.push(key);
+    if (step.key && step.key === key) preserved.add(step.key);
+    return { ...step, key };
+  });
+
+  // Build the rename map only for keys that actually changed and weren't kept
+  // by an earlier step (a reference to a duplicated key resolves to the first,
+  // preserved occurrence — never to the suffixed later one).
+  const rename = new Map<string, string>();
+  config.steps.forEach((step, i) => {
+    if (step.key && step.key !== assigned[i] && !preserved.has(step.key) && !rename.has(step.key)) {
+      rename.set(step.key, assigned[i]);
+    }
+  });
+
+  const remap = (field: string): string => rename.get(field) ?? field;
+
+  const normalized = steps.map((step) => {
+    const next: FormStep = {
+      ...step,
+      flowGroup: step.flowGroup ?? defaultFlowGroup(step.type),
+    };
+    if (step.options) next.options = normalizeOptions(step.options);
+    if (step.showWhen) next.showWhen = { ...step.showWhen, field: remap(step.showWhen.field) };
+    if (step.hideWhen) next.hideWhen = { ...step.hideWhen, field: remap(step.hideWhen.field) };
+    if (step.questionField) next.questionField = remap(step.questionField);
+    return next;
+  });
+
+  const outcomeIds = new Set<string>();
+  const outcomes = (config.outcomes ?? [])
+    .map((o, i) => {
+      const id = uniqueKey((o.id && o.id.trim()) || `outcome_${i + 1}`, outcomeIds);
+      outcomeIds.add(id);
+      return { ...o, id };
+    })
+    .sort((a, b) => (a.minScore ?? 0) - (b.minScore ?? 0));
+
+  const next: FormConfig = {
+    version: 1,
+    steps: normalized,
+    ...(config.cover != null ? { cover: config.cover } : {}),
+    ...(config.branding != null ? { branding: config.branding } : {}),
+    ...(outcomes.length ? { outcomes } : {}),
+  };
+
+  // Derive scoring only when the author never spoke to it.
+  if (config.scoring != null) {
+    next.scoring = config.scoring;
+  } else if (hasScoringSignal(next)) {
+    next.scoring = { enabled: true };
+  }
+
+  return next;
+}
+
+/** Replace `[field]` tokens with the respondent's answer to that field. */
+export function interpolate(template: string, answers: Answers): string {
+  return template.replace(/\[([a-zA-Z0-9_]+)\]/g, (_, field: string) => {
+    const value: AnswerValue = answers[field];
+    if (value == null) return '';
+    return Array.isArray(value) ? value.join(', ') : String(value);
+  });
+}
+
+/**
+ * The question to show for a step given the answers so far: a `questionVariants`
+ * match on `questionField` (falling back to `*` then the plain `question`), with
+ * `[field]` interpolation applied to the result.
+ */
+export function resolveQuestion(step: FormStep, answers: Answers): string {
+  let text = step.question ?? '';
+  if (step.questionField && step.questionVariants) {
+    const raw = answers[step.questionField];
+    const key = raw == null ? '' : Array.isArray(raw) ? raw.join(',') : String(raw);
+    text = step.questionVariants[key] ?? step.questionVariants['*'] ?? text;
+  }
+  return interpolate(text, answers);
+}

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -12,6 +12,8 @@ import {
   runtimeSteps,
   partialSubmitKey,
   nameFields,
+  isSafeHttpUrl,
+  isSafeImageUrl,
   type FormConfig,
   type FormStep,
 } from './form-logic';
@@ -249,5 +251,42 @@ describe('partialSubmitKey', () => {
   it('resolves the 1-based threshold step key or null', () => {
     expect(partialSubmitKey({ ...config, partialSubmitAfterStep: 4 })).toBe('email');
     expect(partialSubmitKey(config)).toBeNull();
+  });
+});
+
+describe('corporateEmailOnly validation parity (validateAnswer ⇄ validateAnswerCode)', () => {
+  // Both validators must agree on the SAME address — validateAnswer previously
+  // only checked PERSONAL_EMAIL_DOMAINS while validateAnswerCode used the fuller
+  // isPersonalEmail() (domain list + free-mail bases). Now both use isPersonalEmail().
+  const s = step({ key: 'e', type: 'email', corporateEmailOnly: true });
+  it.each([
+    ['user@msn.com', false], // free-mail base "msn"
+    ['user@hotmail.co.uk', false], // free-mail base "hotmail" on a cc-TLD
+    ['a@gmail.com', false], // exact personal domain
+    ['jane@acme.com', true], // corporate → accepted
+  ])('agrees on %s (accepted=%s)', (email, expectedOk) => {
+    expect(validateAnswer(s, email).ok).toBe(expectedOk);
+    expect(validateAnswerCode(s, email).ok).toBe(expectedOk);
+  });
+});
+
+describe('URL safety guards (XSS)', () => {
+  it('isSafeHttpUrl allows only http(s)', () => {
+    expect(isSafeHttpUrl('https://example.com/thanks')).toBe(true);
+    expect(isSafeHttpUrl('http://localhost:3000/x')).toBe(true);
+    expect(isSafeHttpUrl('  HTTPS://Example.com ')).toBe(true);
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeHttpUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeHttpUrl('/relative/path')).toBe(false);
+  });
+  it('isSafeImageUrl blocks script protocols but allows images/relative', () => {
+    expect(isSafeImageUrl('https://cdn.example.com/logo.png')).toBe(true);
+    expect(isSafeImageUrl('//cdn.example.com/logo.png')).toBe(true);
+    expect(isSafeImageUrl('/assets/logo.svg')).toBe(true);
+    expect(isSafeImageUrl('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+    expect(isSafeImageUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeImageUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeImageUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
   });
 });

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -2,8 +2,16 @@ import { describe, it, expect } from 'vitest';
 import {
   visibleSteps,
   validateAnswer,
+  validateAnswerCode,
   computeScore,
   resolveOutcome,
+  isPersonalEmail,
+  orderSteps,
+  interpolate,
+  resolveStepDisplay,
+  runtimeSteps,
+  partialSubmitKey,
+  nameFields,
   type FormConfig,
   type FormStep,
 } from './form-logic';
@@ -124,5 +132,122 @@ describe('resolveOutcome', () => {
   it('picks the highest bucket the score clears', () => {
     expect(resolveOutcome(config, 15)?.id).toBe('high');
     expect(resolveOutcome(config, 3)?.id).toBe('low');
+  });
+});
+
+describe('isPersonalEmail', () => {
+  it('flags free-mail domains and passes corporate ones', () => {
+    expect(isPersonalEmail('a@gmail.com')).toBe(true);
+    expect(isPersonalEmail('a@hotmail.co.uk')).toBe(true);
+    expect(isPersonalEmail('a@acme.io')).toBe(false);
+    expect(isPersonalEmail(null)).toBe(false);
+    expect(isPersonalEmail(123)).toBe(false);
+  });
+});
+
+describe('orderSteps', () => {
+  it('puts qualification before lead_capture, preserving order within a phase', () => {
+    const steps: FormStep[] = [
+      step({ key: 'email', type: 'email', flowGroup: 'lead_capture' }),
+      step({ key: 'q1', type: 'text', flowGroup: 'qualification' }),
+      step({ key: 'phone', type: 'phone', flowGroup: 'lead_capture' }),
+      step({ key: 'q2', type: 'text' }), // no group → qualification
+    ];
+    expect(orderSteps(steps).map((s) => s.key)).toEqual(['q1', 'q2', 'email', 'phone']);
+  });
+});
+
+describe('personal-email branch (showForPersonalEmailOnly)', () => {
+  const branchCfg: FormConfig = {
+    version: 1,
+    steps: [
+      step({ key: 'email', type: 'email', flowGroup: 'lead_capture' }),
+      step({ key: 'website', type: 'text', flowGroup: 'lead_capture', showForPersonalEmailOnly: true }),
+      step({ key: 'phone', type: 'phone', flowGroup: 'lead_capture' }),
+    ],
+  };
+  it('hides the branch for a corporate email and shows it for a personal one', () => {
+    expect(visibleSteps(branchCfg, { email: 'a@acme.io' }).map((s) => s.key)).toEqual(['email', 'phone']);
+    expect(visibleSteps(branchCfg, { email: 'a@gmail.com' }).map((s) => s.key)).toEqual([
+      'email',
+      'website',
+      'phone',
+    ]);
+  });
+});
+
+describe('interpolate + resolveStepDisplay', () => {
+  it('substitutes [key] tokens, removing unknown/empty tokens', () => {
+    expect(interpolate('Hi [firstname]!', { firstname: 'Ada' })).toBe('Hi Ada!');
+    expect(interpolate('Hi [firstname]!', {})).toBe('Hi !');
+  });
+  it('picks the dynamic question variant and slider unit label', () => {
+    const s = step({
+      key: 'volume',
+      type: 'slider',
+      question: 'How much?',
+      questionField: 'problem',
+      questionVariants: { leads: 'How many leads, [firstname]?' },
+      sliderLabelVariants: { leads: 'leads / mo' },
+    });
+    const resolved = resolveStepDisplay(s, { problem: 'leads', firstname: 'Sam' });
+    expect(resolved.question).toBe('How many leads, Sam?');
+    expect(resolved.sliderUnitLabel).toBe('leads / mo');
+  });
+});
+
+describe('runtimeSteps', () => {
+  it('orders two-phase, applies skip-logic, and resolves display', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: 'email', type: 'email', flowGroup: 'lead_capture' }),
+        step({
+          key: 'problem',
+          type: 'dropdown',
+          flowGroup: 'qualification',
+          question: 'What is the problem?',
+          options: [{ label: 'Leads', value: 'leads' }],
+        }),
+        step({
+          key: 'detail',
+          type: 'text',
+          flowGroup: 'qualification',
+          question: 'Tell us more about [problem].',
+          showWhen: { field: 'problem', values: ['leads'] },
+        }),
+      ],
+    };
+    const walked = runtimeSteps(cfg, { problem: 'leads' });
+    expect(walked.map((s) => s.key)).toEqual(['problem', 'detail', 'email']);
+    expect(walked[1].question).toBe('Tell us more about leads.');
+  });
+});
+
+describe('validateAnswerCode', () => {
+  it('returns stable codes for each failure', () => {
+    expect(validateAnswerCode(step({ key: 'x', type: 'text', required: true }), '')).toEqual({
+      ok: false,
+      code: 'required',
+    });
+    expect(validateAnswerCode(step({ key: 'e', type: 'email', required: true }), 'nope').code).toBe('email');
+    expect(
+      validateAnswerCode(step({ key: 'e', type: 'email', corporateEmailOnly: true }), 'a@gmail.com').code,
+    ).toBe('work_email');
+    expect(validateAnswerCode(step({ key: 'p', type: 'phone', phoneMinDigits: 8 }), '12').code).toBe('phone');
+    expect(validateAnswerCode(step({ key: 's', type: 'slider', min: 0, max: 5 }), 9).code).toBe('too_high');
+  });
+  it('checks both name sub-fields', () => {
+    const s = step({ key: 'name', type: 'name', required: true });
+    expect(validateAnswerCode(s, undefined, { firstname: 'Ada', lastname: '' }).ok).toBe(false);
+    expect(validateAnswerCode(s, undefined, { firstname: 'Ada', lastname: 'Lovelace' }).ok).toBe(true);
+    expect(nameFields(s)).toEqual(['firstname', 'lastname']);
+  });
+});
+
+describe('partialSubmitKey', () => {
+  it('resolves the 1-based threshold step key or null', () => {
+    expect(partialSubmitKey({ ...config, partialSubmitAfterStep: 4 })).toBe('email');
+    expect(partialSubmitKey(config)).toBeNull();
   });
 });

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -274,11 +274,10 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
     case 'email': {
       const email = String(value).trim().toLowerCase();
       if (!EMAIL_RE.test(email)) return { ok: false, error: 'Enter a valid email address.' };
-      if (step.corporateEmailOnly) {
-        const domain = email.split('@')[1] ?? '';
-        if (PERSONAL_EMAIL_DOMAINS.has(domain))
-          return { ok: false, error: 'Please use your work email address.' };
-      }
+      // Use the SAME personal-email test as validateAnswerCode (domain list +
+      // free-mail bases) so both validators agree on any given address.
+      if (step.corporateEmailOnly && isPersonalEmail(email))
+        return { ok: false, error: 'Please use your work email address.' };
       return { ok: true };
     }
     case 'phone': {
@@ -507,4 +506,32 @@ export function partialSubmitKey(config: FormConfig): string | null {
   const n = config.partialSubmitAfterStep;
   if (n == null || n < 1) return null;
   return config.steps[n - 1]?.key ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// URL safety (XSS). Shared by the zod config schema (server-side validation on
+// save) AND the public renderer (a runtime guard before navigating). Belt-and-
+// braces: a config could reach the renderer from an older/looser source, so the
+// sink is guarded too — never assign a non-http(s) URL to `window.location`.
+// ---------------------------------------------------------------------------
+
+/**
+ * True only for http(s) URLs — the allowlist for anything assigned to
+ * `window.location` (e.g. an outcome `redirectUrl`). Rejects `javascript:`,
+ * `data:`, `vbscript:`, etc., which `URL`/zod `.url()` would otherwise accept.
+ */
+export function isSafeHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
+}
+
+/**
+ * True for URLs safe to render into an `<img src>`: http(s), protocol-relative
+ * (`//host`), root/relative paths, and `data:image/…` URIs. Rejects script
+ * protocols (`javascript:`/`vbscript:`) and non-image `data:` payloads.
+ */
+export function isSafeImageUrl(url: string): boolean {
+  const s = url.trim().toLowerCase();
+  if (s.startsWith('javascript:') || s.startsWith('vbscript:')) return false;
+  if (s.startsWith('data:') && !s.startsWith('data:image/')) return false;
+  return true;
 }

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -75,6 +75,14 @@ export interface FormStep {
   corporateEmailOnly?: boolean;
   /** Phone validation: minimum digit count. */
   phoneMinDigits?: number;
+  /**
+   * Dynamic question variants: pick the question text from the answer to
+   * `questionField`. `questionVariants[value]` overrides `question` when the
+   * respondent's answer to that earlier field matches a key; a `*` key (or the
+   * plain `question`) is the fallback. Lets one step ask a tailored question.
+   */
+  questionField?: string | null;
+  questionVariants?: Record<string, string>;
 }
 
 export interface FormOutcome {
@@ -87,6 +95,8 @@ export interface FormOutcome {
 
 export interface FormCover {
   enabled?: boolean;
+  /** A sticky banner line shown above the form throughout the flow. */
+  bannerText?: string | null;
   eyebrow?: string | null;
   headline?: string | null;
   subheadline?: string | null;
@@ -94,9 +104,15 @@ export interface FormCover {
   trustBadge?: string | null;
 }
 
+/** Per-form branding — the single accent color drives the public surface. */
+export interface FormBranding {
+  primaryColor?: string | null;
+}
+
 export interface FormConfig {
   version: 1;
   cover?: FormCover | null;
+  branding?: FormBranding | null;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -75,6 +75,11 @@ export interface FormStep {
   corporateEmailOnly?: boolean;
   /** Phone validation: minimum digit count. */
   phoneMinDigits?: number;
+  // --- Builder + runtime extensions (all optional; back-compat) -------------
+  /** `name` step: the two fields collected on one slide (default firstname+lastname). */
+  fields?: string[];
+  /** `name` step: per-field placeholders keyed by field name. */
+  placeholders?: Record<string, string>;
   /**
    * Dynamic question variants: pick the question text from the answer to
    * `questionField`. `questionVariants[value]` overrides `question` when the
@@ -82,7 +87,26 @@ export interface FormStep {
    * plain `question`) is the fallback. Lets one step ask a tailored question.
    */
   questionField?: string | null;
+  /** Question text per value of `questionField` (falls back to `question`). */
   questionVariants?: Record<string, string>;
+  /** Slider unit label per value of `questionField` (falls back to `sliderUnitLabel`). */
+  sliderLabelVariants?: Record<string, string>;
+  /** Static unit label shown next to the slider value (e.g. "leads / mo"). */
+  sliderUnitLabel?: string | null;
+  /** `multiple_choice`: render as an icon grid instead of a radio list. */
+  showIcons?: boolean;
+  /**
+   * Branch insertion: show this step ONLY when the `email` answer is a personal/
+   * free-mail domain (the pilot's "ask for company/website when email is personal").
+   */
+  showForPersonalEmailOnly?: boolean;
+  /**
+   * Terminal step (disqualify path): completing it ends the flow — the submission
+   * is finalized and the outcome resolved, skipping any reveal/booking screen.
+   */
+  terminal?: boolean;
+  /** Show the processing/reveal interstitial after this step completes. */
+  triggersReveal?: boolean;
 }
 
 export interface FormOutcome {
@@ -93,32 +117,67 @@ export interface FormOutcome {
   redirectUrl?: string | null;
 }
 
+/** A client logo chip on the cover marquee (image `src`, or the `name` as text). */
+export interface FormClientLogo {
+  name: string;
+  src?: string | null;
+}
+
 export interface FormCover {
   enabled?: boolean;
-  /** A sticky banner line shown above the form throughout the flow. */
+  /** A sticky banner line (promo strip) shown above every screen throughout the flow. */
   bannerText?: string | null;
   eyebrow?: string | null;
+  /** Alias for eyebrow (pilot `badge`); eyebrow wins when both are set. */
+  badge?: string | null;
   headline?: string | null;
   subheadline?: string | null;
   ctaText?: string | null;
   trustBadge?: string | null;
+  /** Cover logo image URL (falls back to branding.logo, then the product mark). */
+  logo?: string | null;
+  /** Optional "trusted by" marquee shown on the cover. */
+  clientLogos?: FormClientLogo[];
 }
 
-/** Per-form branding — the single accent color drives the public surface. */
+/** Per-form branding — the accent color threads the banner/CTA/selected states. */
 export interface FormBranding {
   primaryColor?: string | null;
+  logo?: string | null;
+  clientLogos?: FormClientLogo[];
+}
+
+/** Optional processing/result-reveal interstitial (generic, templated copy). */
+export interface FormReveal {
+  enabled?: boolean;
+  headline?: string | null;
+  subtitle?: string | null;
 }
 
 export interface FormConfig {
   version: 1;
-  cover?: FormCover | null;
   branding?: FormBranding | null;
+  cover?: FormCover | null;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];
+  reveal?: FormReveal | null;
+  /**
+   * Persist a partial submission once the step at this 1-based position in
+   * `steps` is completed (typically just past the lead-capture email). Absent =
+   * no partial save.
+   */
+  partialSubmitAfterStep?: number;
 }
 
-export type AnswerValue = string | string[] | number | boolean | null | undefined;
+export type AnswerValue =
+  | string
+  | string[]
+  | number
+  | boolean
+  | Record<string, string>
+  | null
+  | undefined;
 export type Answers = Record<string, AnswerValue>;
 
 /** Normalize an answer to the set of string tokens it represents (for matching). */
@@ -136,14 +195,36 @@ function conditionHolds(cond: StepCondition, answers: Answers): boolean {
 
 /**
  * The steps to show given the answers so far, in config order. A step appears
- * when its `showWhen` holds (or is absent) AND its `hideWhen` does not hold.
+ * when its `showWhen` holds (or is absent) AND its `hideWhen` does not hold —
+ * and, for a personal-email-only branch step, only when the email is personal.
  */
 export function visibleSteps(config: FormConfig, answers: Answers): FormStep[] {
   return config.steps.filter((step) => {
     if (step.showWhen && !conditionHolds(step.showWhen, answers)) return false;
     if (step.hideWhen && conditionHolds(step.hideWhen, answers)) return false;
+    if (step.showForPersonalEmailOnly) {
+      const emailKey = findEmailKey(config);
+      if (!emailKey || !isPersonalEmail(answers[emailKey])) return false;
+    }
     return true;
   });
+}
+
+/** The first `email`-typed step's key (the branch pivot for personal-email logic). */
+function findEmailKey(config: FormConfig): string | null {
+  return config.steps.find((s) => s.type === 'email')?.key ?? null;
+}
+
+/**
+ * True when the answer looks like a personal/free-mail address. Accepts an
+ * answer value (or a raw string); non-strings and empties are never personal.
+ */
+export function isPersonalEmail(value: AnswerValue): boolean {
+  if (typeof value !== 'string') return false;
+  const domain = value.trim().toLowerCase().split('@')[1] ?? '';
+  if (!domain) return false;
+  const base = domain.split('.')[0] ?? '';
+  return PERSONAL_EMAIL_DOMAINS.has(domain) || FREE_EMAIL_BASES.has(base);
 }
 
 export type ValidationResult = { ok: true } | { ok: false; error: string };
@@ -160,6 +241,19 @@ const PERSONAL_EMAIL_DOMAINS = new Set([
   'aol.com',
   'proton.me',
   'protonmail.com',
+]);
+/** Domain "base" tokens (before the first dot) also treated as free-mail. */
+const FREE_EMAIL_BASES = new Set([
+  'gmail',
+  'hotmail',
+  'outlook',
+  'yahoo',
+  'icloud',
+  'live',
+  'aol',
+  'msn',
+  'proton',
+  'protonmail',
 ]);
 
 /** Validate one answer against its step. Pure; used on both client and server. */
@@ -257,4 +351,160 @@ export function resolveOutcome(config: FormConfig, score: number): FormOutcome |
     .filter((o) => (o.minScore ?? 0) <= score)
     .sort((a, b) => (b.minScore ?? 0) - (a.minScore ?? 0));
   return buckets[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Phase-1 runtime helpers (pure; unit-tested). The renderer walks these so the
+// public experience is fully engine-driven — client and server agree on flow,
+// score, and outcome. Existing signatures above are untouched; these are new.
+// ---------------------------------------------------------------------------
+
+/** Stable-code validation for localized inline errors (renderer maps code→copy). */
+export type ValidationCode =
+  | 'required'
+  | 'email'
+  | 'work_email'
+  | 'phone'
+  | 'number'
+  | 'too_low'
+  | 'too_high'
+  | 'option';
+
+export type ValidationCodeResult = { ok: true } | { ok: false; code: ValidationCode };
+
+/**
+ * Like `validateAnswer` but returns a stable machine code instead of English
+ * copy — the renderer resolves the code to a localized message. For a `name`
+ * step, pass the full answers object so both sub-fields are checked.
+ */
+export function validateAnswerCode(
+  step: FormStep,
+  value: AnswerValue,
+  answers: Answers = {},
+): ValidationCodeResult {
+  if (step.type === 'message') return { ok: true };
+
+  if (step.type === 'name') {
+    const fields = nameFields(step);
+    for (const f of fields) {
+      const v = answers[f];
+      const empty = v == null || String(v).trim() === '';
+      if (empty && step.required) return { ok: false, code: 'required' };
+    }
+    return { ok: true };
+  }
+
+  const empty =
+    value == null || value === '' || (Array.isArray(value) && value.length === 0);
+  if (empty) return step.required ? { ok: false, code: 'required' } : { ok: true };
+
+  switch (step.type) {
+    case 'email': {
+      const email = String(value).trim().toLowerCase();
+      if (!EMAIL_RE.test(email)) return { ok: false, code: 'email' };
+      if (step.corporateEmailOnly && isPersonalEmail(email))
+        return { ok: false, code: 'work_email' };
+      return { ok: true };
+    }
+    case 'phone': {
+      const digits = String(value).replace(/\D/g, '');
+      if (digits.length < (step.phoneMinDigits ?? 7)) return { ok: false, code: 'phone' };
+      return { ok: true };
+    }
+    case 'slider': {
+      const n = Number(value);
+      if (Number.isNaN(n)) return { ok: false, code: 'number' };
+      if (step.min != null && n < step.min) return { ok: false, code: 'too_low' };
+      if (step.max != null && n > step.max) return { ok: false, code: 'too_high' };
+      return { ok: true };
+    }
+    case 'dropdown':
+    case 'multiple_choice': {
+      const allowed = new Set((step.options ?? []).map((o) => o.value));
+      if (tokens(value).some((t) => !allowed.has(t))) return { ok: false, code: 'option' };
+      return { ok: true };
+    }
+    default:
+      return { ok: true };
+  }
+}
+
+/** The sub-fields a `name` step collects (default firstname + lastname). */
+export function nameFields(step: FormStep): string[] {
+  if (step.type === 'name') return step.fields ?? ['firstname', 'lastname'];
+  return [step.key];
+}
+
+/**
+ * Two-phase order: qualification steps first, then lead-capture — a stable
+ * partition that preserves each step's relative order within its phase. Steps
+ * with no `flowGroup` are treated as qualification.
+ */
+export function orderSteps(steps: FormStep[]): FormStep[] {
+  const qualification = steps.filter((s) => s.flowGroup !== 'lead_capture');
+  const leadCapture = steps.filter((s) => s.flowGroup === 'lead_capture');
+  return [...qualification, ...leadCapture];
+}
+
+/** Replace `[key]` tokens in copy with the corresponding answer (empty → left as-is). */
+export function interpolate(template: string, answers: Answers): string {
+  return template.replace(/\[([a-zA-Z0-9_]+)\]/g, (_m, field: string) => {
+    const value: AnswerValue = answers[field];
+    if (value == null) return '';
+    return Array.isArray(value) ? value.join(', ') : String(value);
+  });
+}
+
+/** The lookup token a `questionField` answer resolves to for variant selection. */
+function variantKey(raw: AnswerValue): string {
+  return raw == null ? '' : Array.isArray(raw) ? raw.join(',') : String(raw);
+}
+
+/**
+ * The question to show for a step given the answers so far: a `questionVariants`
+ * match on `questionField` (falling back to `*` then the plain `question`), with
+ * `[field]` interpolation applied to the result. Shared by the builder preview
+ * and the public renderer so both resolve dynamic questions identically.
+ */
+export function resolveQuestion(step: FormStep, answers: Answers): string {
+  let text = step.question ?? '';
+  if (step.questionField && step.questionVariants) {
+    const key = variantKey(answers[step.questionField]);
+    text = step.questionVariants[key] ?? step.questionVariants['*'] ?? text;
+  }
+  return interpolate(text, answers);
+}
+
+/**
+ * Resolve a step for display against the answers: pick the dynamic question
+ * variant (via `resolveQuestion`), interpolate `[key]` tokens in the question,
+ * and resolve the slider unit label variant. Returns a shallow copy — never
+ * mutates the config.
+ */
+export function resolveStepDisplay(step: FormStep, answers: Answers): FormStep {
+  const question = resolveQuestion(step, answers);
+  let sliderUnitLabel = step.sliderUnitLabel ?? null;
+  if (step.questionField && step.sliderLabelVariants) {
+    const key = variantKey(answers[step.questionField]);
+    if (step.sliderLabelVariants[key]) sliderUnitLabel = step.sliderLabelVariants[key];
+  }
+  return { ...step, question, sliderUnitLabel };
+}
+
+/**
+ * The ordered, visible, display-resolved steps the renderer walks — the single
+ * source of truth for the public flow. Composes `orderSteps` (two-phase) +
+ * `visibleSteps` (skip-logic + personal-email branch) + `resolveStepDisplay`
+ * (dynamic variants + interpolation).
+ */
+export function runtimeSteps(config: FormConfig, answers: Answers): FormStep[] {
+  const ordered: FormConfig = { ...config, steps: orderSteps(config.steps) };
+  return visibleSteps(ordered, answers).map((s) => resolveStepDisplay(s, answers));
+}
+
+/** The key of the step at `partialSubmitAfterStep` (1-based over `steps`), or null. */
+export function partialSubmitKey(config: FormConfig): string | null {
+  const n = config.partialSubmitAfterStep;
+  if (n == null || n < 1) return null;
+  return config.steps[n - 1]?.key ?? null;
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,6 +3,7 @@
  * Fully unit-tested; portable across SQLite and Postgres deployments.
  */
 export * from './form-logic';
+export * from './form-config';
 export * from './short-links';
 export * from './manage-token';
 export * from './pg-errors';

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -563,7 +563,7 @@ export const en: FormsMessages = {
       webhookDesc: 'POST each submission as JSON to a URL you control.',
       webhookUrl: 'Endpoint URL',
       webhookUrlPlaceholder: 'https://example.com/webhooks/forms',
-      webhookUrlInvalid: 'Enter a valid https URL.',
+      webhookUrlInvalid: 'Enter a valid https:// URL (plain http is allowed only for localhost).',
       webhookSecret: 'Signing secret (optional)',
       webhookSecretHelp:
         'When set, each request is signed with HMAC-SHA256 in the X-Quill-Signature header so you can verify it.',
@@ -852,7 +852,7 @@ export const es: FormsMessages = {
       webhookDesc: 'Envía cada respuesta como JSON (POST) a una URL que tú controlas.',
       webhookUrl: 'URL del endpoint',
       webhookUrlPlaceholder: 'https://ejemplo.com/webhooks/forms',
-      webhookUrlInvalid: 'Introduce una URL https válida.',
+      webhookUrlInvalid: 'Introduce una URL https:// válida (http solo se permite para localhost).',
       webhookSecret: 'Secreto de firma (opcional)',
       webhookSecretHelp:
         'Si se define, cada solicitud se firma con HMAC-SHA256 en la cabecera X-Quill-Signature para que puedas verificarla.',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -30,6 +30,171 @@ export interface FormsMessages {
       error: string;
       retry: string;
     };
+    /** The forms list (index) page. */
+    forms: {
+      title: string;
+      subtitle: string;
+      create: string;
+      createTitle: string;
+      nameLabel: string;
+      namePlaceholder: string;
+      cancel: string;
+      emptyTitle: string;
+      emptyBody: string;
+      updated: string;
+      duplicate: string;
+      delete: string;
+      deleteConfirm: string;
+      copy: string;
+      copied: string;
+      open: string;
+    };
+    /** The form editor (builder). */
+    editor: {
+      back: string;
+      save: string;
+      saving: string;
+      saved: string;
+      saveError: string;
+      previewBtn: string;
+      formNamePlaceholder: string;
+      tabs: { build: string; cover: string; outcomes: string; flow: string };
+      steps: {
+        title: string;
+        add: string;
+        addType: string;
+        empty: string;
+        select: string;
+        delete: string;
+        deleteConfirm: string;
+        dragHint: string;
+        stepN: string;
+        untitled: string;
+      };
+      types: {
+        text: string;
+        name: string;
+        email: string;
+        phone: string;
+        dropdown: string;
+        multiple_choice: string;
+        slider: string;
+        textarea: string;
+        message: string;
+      };
+      props: {
+        type: string;
+        question: string;
+        questionPlaceholder: string;
+        helper: string;
+        placeholder: string;
+        required: string;
+        buttonText: string;
+        buttonTextPlaceholder: string;
+        flowGroup: string;
+        qualification: string;
+        leadCapture: string;
+        flowGroupHint: string;
+        corporateEmailOnly: string;
+        corporateEmailHint: string;
+        phoneMinDigits: string;
+        sliderMin: string;
+        sliderMax: string;
+        sliderStep: string;
+        sliderDefault: string;
+      };
+      options: {
+        title: string;
+        add: string;
+        label: string;
+        value: string;
+        points: string;
+        icon: string;
+        remove: string;
+        empty: string;
+      };
+      sliderScoring: {
+        title: string;
+        hint: string;
+        add: string;
+        min: string;
+        max: string;
+        points: string;
+        remove: string;
+        empty: string;
+      };
+      logic: {
+        title: string;
+        showWhen: string;
+        hideWhen: string;
+        none: string;
+        field: string;
+        values: string;
+        valuesHint: string;
+        clear: string;
+        noPriorFields: string;
+      };
+      variants: {
+        title: string;
+        hint: string;
+        enable: string;
+        field: string;
+        add: string;
+        matchValue: string;
+        matchValuePlaceholder: string;
+        variantQuestion: string;
+        fallback: string;
+        remove: string;
+        interpolationHint: string;
+      };
+      cover: {
+        title: string;
+        subtitle: string;
+        enabled: string;
+        bannerText: string;
+        eyebrow: string;
+        headline: string;
+        subheadline: string;
+        ctaText: string;
+        trustBadge: string;
+        branding: string;
+        primaryColor: string;
+        primaryColorHint: string;
+      };
+      outcomes: {
+        title: string;
+        subtitle: string;
+        scoringEnabled: string;
+        scoringHint: string;
+        add: string;
+        label: string;
+        labelPlaceholder: string;
+        minScore: string;
+        redirectUrl: string;
+        redirectPlaceholder: string;
+        remove: string;
+        empty: string;
+      };
+      flow: {
+        title: string;
+        subtitle: string;
+        cover: string;
+        end: string;
+        conditional: string;
+        empty: string;
+      };
+      preview: {
+        title: string;
+        empty: string;
+        coverTitle: string;
+        step: string;
+        of: string;
+        device: string;
+        mobile: string;
+        desktop: string;
+        close: string;
+      };
+    };
   };
 }
 
@@ -56,6 +221,169 @@ export const en: FormsMessages = {
       error: 'Something went wrong signing in. Please try again.',
       retry: 'Try again',
     },
+    forms: {
+      title: 'Forms',
+      subtitle: 'Build a form, share the public link, collect submissions.',
+      create: 'Create form',
+      createTitle: 'Create a new form',
+      nameLabel: 'Form name',
+      namePlaceholder: 'e.g. Lead qualification quiz',
+      cancel: 'Cancel',
+      emptyTitle: 'No forms yet',
+      emptyBody: 'Create your first form to start collecting responses.',
+      updated: 'Updated {when}',
+      duplicate: 'Duplicate',
+      delete: 'Delete',
+      deleteConfirm: 'Delete this form and all its submissions?',
+      copy: 'Copy link',
+      copied: 'Copied',
+      open: 'Open',
+    },
+    editor: {
+      back: 'Back to forms',
+      save: 'Save',
+      saving: 'Saving…',
+      saved: 'Saved.',
+      saveError: 'Could not save — please try again.',
+      previewBtn: 'Preview',
+      formNamePlaceholder: 'Form name',
+      tabs: { build: 'Build', cover: 'Cover', outcomes: 'Outcomes', flow: 'Flow' },
+      steps: {
+        title: 'Steps',
+        add: 'Add step',
+        addType: 'Step type',
+        empty: 'No steps yet. Add your first step.',
+        select: 'Select a step to edit it.',
+        delete: 'Delete step',
+        deleteConfirm: 'Delete this step?',
+        dragHint: 'Drag to reorder',
+        stepN: 'Step {n}',
+        untitled: 'Untitled step',
+      },
+      types: {
+        text: 'Text',
+        name: 'Full name',
+        email: 'Email',
+        phone: 'Phone',
+        dropdown: 'Dropdown',
+        multiple_choice: 'Multiple choice',
+        slider: 'Slider',
+        textarea: 'Long text',
+        message: 'Message (no input)',
+      },
+      props: {
+        type: 'Type',
+        question: 'Question',
+        questionPlaceholder: 'What do you want to ask?',
+        helper: 'Helper text',
+        placeholder: 'Placeholder',
+        required: 'Required',
+        buttonText: 'Button text',
+        buttonTextPlaceholder: 'Continue',
+        flowGroup: 'Flow group',
+        qualification: 'Qualification',
+        leadCapture: 'Lead capture',
+        flowGroupHint: 'Lead-capture fields (name, email, phone) never contribute to the score.',
+        corporateEmailOnly: 'Require work email',
+        corporateEmailHint: 'Blocks Gmail, Hotmail, Yahoo and other personal domains.',
+        phoneMinDigits: 'Minimum digits',
+        sliderMin: 'Min',
+        sliderMax: 'Max',
+        sliderStep: 'Step',
+        sliderDefault: 'Default',
+      },
+      options: {
+        title: 'Options',
+        add: 'Add option',
+        label: 'Label',
+        value: 'Value',
+        points: 'Points',
+        icon: 'Icon',
+        remove: 'Remove option',
+        empty: 'No options yet.',
+      },
+      sliderScoring: {
+        title: 'Slider scoring',
+        hint: 'Award points when the value falls inside a range.',
+        add: 'Add range',
+        min: 'From',
+        max: 'To',
+        points: 'Points',
+        remove: 'Remove range',
+        empty: 'No scoring ranges — the slider does not score.',
+      },
+      logic: {
+        title: 'Conditional visibility',
+        showWhen: 'Show when',
+        hideWhen: 'Hide when',
+        none: 'Always show',
+        field: 'Field',
+        values: 'Matches any of',
+        valuesHint: 'Comma-separated values from that field’s options.',
+        clear: 'Clear',
+        noPriorFields: 'Add a step before this one to branch on its answer.',
+      },
+      variants: {
+        title: 'Dynamic question',
+        hint: 'Ask a different question depending on an earlier answer.',
+        enable: 'Vary the question by a field',
+        field: 'Based on field',
+        add: 'Add variant',
+        matchValue: 'When answer is',
+        matchValuePlaceholder: 'e.g. founder',
+        variantQuestion: 'Ask instead',
+        fallback: 'Fallback (any other answer)',
+        remove: 'Remove variant',
+        interpolationHint: 'Use [field] to insert an earlier answer into the question.',
+      },
+      cover: {
+        title: 'Cover screen',
+        subtitle: 'The intro screen shown before the first step.',
+        enabled: 'Show a cover screen',
+        bannerText: 'Banner text',
+        eyebrow: 'Eyebrow',
+        headline: 'Headline',
+        subheadline: 'Subheadline',
+        ctaText: 'Start button text',
+        trustBadge: 'Trust badge',
+        branding: 'Branding',
+        primaryColor: 'Primary color',
+        primaryColorHint: 'Drives the accent on the public form. Auto-adjusted for contrast.',
+      },
+      outcomes: {
+        title: 'Outcomes',
+        subtitle: 'Route respondents by their score. The highest bucket they clear wins.',
+        scoringEnabled: 'Enable scoring',
+        scoringHint: 'When off, every submission scores 0 and no outcome is resolved.',
+        add: 'Add outcome',
+        label: 'Label',
+        labelPlaceholder: 'e.g. Hot lead',
+        minScore: 'Minimum score',
+        redirectUrl: 'Redirect URL',
+        redirectPlaceholder: 'https://…',
+        remove: 'Remove outcome',
+        empty: 'No outcomes yet. Add buckets to route by score.',
+      },
+      flow: {
+        title: 'Flow overview',
+        subtitle: 'A read-only map of the form, including conditional branches.',
+        cover: 'Cover',
+        end: 'End',
+        conditional: 'Conditional',
+        empty: 'Add steps to see the flow.',
+      },
+      preview: {
+        title: 'Live preview',
+        empty: 'Select a step to preview it.',
+        coverTitle: 'Cover',
+        step: 'Step',
+        of: 'of',
+        device: 'Device preview',
+        mobile: 'Mobile',
+        desktop: 'Desktop',
+        close: 'Close',
+      },
+    },
   },
 };
 
@@ -81,6 +409,169 @@ export const es: FormsMessages = {
       workosSubtitle: 'Te redirigiremos para iniciar sesión de forma segura.',
       error: 'Algo salió mal al iniciar sesión. Inténtalo de nuevo.',
       retry: 'Reintentar',
+    },
+    forms: {
+      title: 'Formularios',
+      subtitle: 'Crea un formulario, comparte el enlace público y recibe respuestas.',
+      create: 'Crear formulario',
+      createTitle: 'Crear un formulario nuevo',
+      nameLabel: 'Nombre del formulario',
+      namePlaceholder: 'p. ej. Cuestionario de calificación de leads',
+      cancel: 'Cancelar',
+      emptyTitle: 'Aún no hay formularios',
+      emptyBody: 'Crea tu primer formulario para empezar a recibir respuestas.',
+      updated: 'Actualizado {when}',
+      duplicate: 'Duplicar',
+      delete: 'Eliminar',
+      deleteConfirm: '¿Eliminar este formulario y todas sus respuestas?',
+      copy: 'Copiar enlace',
+      copied: 'Copiado',
+      open: 'Abrir',
+    },
+    editor: {
+      back: 'Volver a formularios',
+      save: 'Guardar',
+      saving: 'Guardando…',
+      saved: 'Guardado.',
+      saveError: 'No se pudo guardar — inténtalo de nuevo.',
+      previewBtn: 'Vista previa',
+      formNamePlaceholder: 'Nombre del formulario',
+      tabs: { build: 'Construir', cover: 'Portada', outcomes: 'Resultados', flow: 'Flujo' },
+      steps: {
+        title: 'Pasos',
+        add: 'Añadir paso',
+        addType: 'Tipo de paso',
+        empty: 'Aún no hay pasos. Añade el primero.',
+        select: 'Selecciona un paso para editarlo.',
+        delete: 'Eliminar paso',
+        deleteConfirm: '¿Eliminar este paso?',
+        dragHint: 'Arrastra para reordenar',
+        stepN: 'Paso {n}',
+        untitled: 'Paso sin título',
+      },
+      types: {
+        text: 'Texto',
+        name: 'Nombre completo',
+        email: 'Correo',
+        phone: 'Teléfono',
+        dropdown: 'Desplegable',
+        multiple_choice: 'Opción múltiple',
+        slider: 'Deslizador',
+        textarea: 'Texto largo',
+        message: 'Mensaje (sin campo)',
+      },
+      props: {
+        type: 'Tipo',
+        question: 'Pregunta',
+        questionPlaceholder: '¿Qué quieres preguntar?',
+        helper: 'Texto de ayuda',
+        placeholder: 'Marcador de posición',
+        required: 'Obligatorio',
+        buttonText: 'Texto del botón',
+        buttonTextPlaceholder: 'Continuar',
+        flowGroup: 'Grupo de flujo',
+        qualification: 'Calificación',
+        leadCapture: 'Captura de lead',
+        flowGroupHint: 'Los campos de captura (nombre, correo, teléfono) nunca suman al puntaje.',
+        corporateEmailOnly: 'Exigir correo corporativo',
+        corporateEmailHint: 'Bloquea Gmail, Hotmail, Yahoo y otros dominios personales.',
+        phoneMinDigits: 'Dígitos mínimos',
+        sliderMin: 'Mín',
+        sliderMax: 'Máx',
+        sliderStep: 'Paso',
+        sliderDefault: 'Predeterminado',
+      },
+      options: {
+        title: 'Opciones',
+        add: 'Añadir opción',
+        label: 'Etiqueta',
+        value: 'Valor',
+        points: 'Puntos',
+        icon: 'Ícono',
+        remove: 'Quitar opción',
+        empty: 'Aún no hay opciones.',
+      },
+      sliderScoring: {
+        title: 'Puntaje del deslizador',
+        hint: 'Otorga puntos cuando el valor cae dentro de un rango.',
+        add: 'Añadir rango',
+        min: 'Desde',
+        max: 'Hasta',
+        points: 'Puntos',
+        remove: 'Quitar rango',
+        empty: 'Sin rangos de puntaje — el deslizador no suma.',
+      },
+      logic: {
+        title: 'Visibilidad condicional',
+        showWhen: 'Mostrar cuando',
+        hideWhen: 'Ocultar cuando',
+        none: 'Mostrar siempre',
+        field: 'Campo',
+        values: 'Coincide con',
+        valuesHint: 'Valores separados por comas de las opciones de ese campo.',
+        clear: 'Limpiar',
+        noPriorFields: 'Añade un paso antes de este para ramificar por su respuesta.',
+      },
+      variants: {
+        title: 'Pregunta dinámica',
+        hint: 'Haz una pregunta distinta según una respuesta anterior.',
+        enable: 'Variar la pregunta según un campo',
+        field: 'Según el campo',
+        add: 'Añadir variante',
+        matchValue: 'Cuando la respuesta sea',
+        matchValuePlaceholder: 'p. ej. fundador',
+        variantQuestion: 'Preguntar en su lugar',
+        fallback: 'Alternativa (cualquier otra respuesta)',
+        remove: 'Quitar variante',
+        interpolationHint: 'Usa [campo] para insertar una respuesta anterior en la pregunta.',
+      },
+      cover: {
+        title: 'Portada',
+        subtitle: 'La pantalla de introducción antes del primer paso.',
+        enabled: 'Mostrar una portada',
+        bannerText: 'Texto del banner',
+        eyebrow: 'Antetítulo',
+        headline: 'Titular',
+        subheadline: 'Subtítulo',
+        ctaText: 'Texto del botón de inicio',
+        trustBadge: 'Sello de confianza',
+        branding: 'Marca',
+        primaryColor: 'Color primario',
+        primaryColorHint: 'Define el acento del formulario público. Se ajusta para contraste.',
+      },
+      outcomes: {
+        title: 'Resultados',
+        subtitle: 'Enruta según el puntaje. Gana el rango más alto que alcancen.',
+        scoringEnabled: 'Activar puntaje',
+        scoringHint: 'Si está desactivado, todo suma 0 y no se resuelve ningún resultado.',
+        add: 'Añadir resultado',
+        label: 'Etiqueta',
+        labelPlaceholder: 'p. ej. Lead caliente',
+        minScore: 'Puntaje mínimo',
+        redirectUrl: 'URL de redirección',
+        redirectPlaceholder: 'https://…',
+        remove: 'Quitar resultado',
+        empty: 'Aún no hay resultados. Añade rangos para enrutar por puntaje.',
+      },
+      flow: {
+        title: 'Vista del flujo',
+        subtitle: 'Un mapa de solo lectura del formulario, incluidas las ramas condicionales.',
+        cover: 'Portada',
+        end: 'Fin',
+        conditional: 'Condicional',
+        empty: 'Añade pasos para ver el flujo.',
+      },
+      preview: {
+        title: 'Vista previa en vivo',
+        empty: 'Selecciona un paso para previsualizarlo.',
+        coverTitle: 'Portada',
+        step: 'Paso',
+        of: 'de',
+        device: 'Vista por dispositivo',
+        mobile: 'Móvil',
+        desktop: 'Escritorio',
+        close: 'Cerrar',
+      },
     },
   },
 };

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -200,6 +200,7 @@ export interface FormsMessages {
       edit: string;
       analytics: string;
       submissions: string;
+      integrations: string;
       backToForms: string;
     };
     /** The analytics dashboard (funnel + per-step drop-off). */
@@ -257,6 +258,46 @@ export interface FormsMessages {
       na: string;
       error: string;
       retry: string;
+    };
+    integrations: {
+      title: string;
+      subtitle: string;
+      back: string;
+      save: string;
+      saving: string;
+      saved: string;
+      saveError: string;
+      loadError: string;
+      enabled: string;
+      disabled: string;
+      // Webhook
+      webhookTitle: string;
+      webhookDesc: string;
+      webhookUrl: string;
+      webhookUrlPlaceholder: string;
+      webhookUrlInvalid: string;
+      webhookSecret: string;
+      webhookSecretHelp: string;
+      // HubSpot
+      hubspotTitle: string;
+      hubspotDesc: string;
+      hubspotDisabled: string;
+      hubspotLoading: string;
+      fieldMappings: string;
+      fieldMappingsHelp: string;
+      utmMappings: string;
+      utmMappingsHelp: string;
+      scoreProperty: string;
+      dateProperty: string;
+      createNote: string;
+      createNoteHelp: string;
+      selectProperty: string;
+      noProperty: string;
+      addMapping: string;
+      remove: string;
+      stepKey: string;
+      property: string;
+      emptyMappings: string;
     };
   };
 }
@@ -451,6 +492,7 @@ export const en: FormsMessages = {
       edit: 'Edit',
       analytics: 'Analytics',
       submissions: 'Submissions',
+      integrations: 'Integrations',
       backToForms: 'Back to forms',
     },
     analytics: {
@@ -505,6 +547,46 @@ export const en: FormsMessages = {
       na: '—',
       error: 'Couldn’t load submissions.',
       retry: 'Try again',
+    },
+    integrations: {
+      title: 'Integrations',
+      subtitle: 'Send each submission to your CRM or a webhook. Delivery is durable and retried.',
+      back: '← Back to forms',
+      save: 'Save integrations',
+      saving: 'Saving…',
+      saved: 'Integrations saved.',
+      saveError: 'Could not save integrations.',
+      loadError: 'Could not load integrations.',
+      enabled: 'Enabled',
+      disabled: 'Disabled',
+      webhookTitle: 'Webhook',
+      webhookDesc: 'POST each submission as JSON to a URL you control.',
+      webhookUrl: 'Endpoint URL',
+      webhookUrlPlaceholder: 'https://example.com/webhooks/forms',
+      webhookUrlInvalid: 'Enter a valid https URL.',
+      webhookSecret: 'Signing secret (optional)',
+      webhookSecretHelp:
+        'When set, each request is signed with HMAC-SHA256 in the X-Quill-Signature header so you can verify it.',
+      hubspotTitle: 'HubSpot',
+      hubspotDesc: 'Upsert the respondent as a contact and attach a note on completed submissions.',
+      hubspotDisabled:
+        'HubSpot is not configured on this server (HUBSPOT_PRIVATE_APP_TOKEN). Property lookup is unavailable, but you can still save a mapping to use once it is set.',
+      hubspotLoading: 'Loading HubSpot properties…',
+      fieldMappings: 'Field mappings',
+      fieldMappingsHelp: 'Map a form step key to a HubSpot contact property. Map one step to “email”.',
+      utmMappings: 'UTM mappings',
+      utmMappingsHelp: 'Map captured UTM values to HubSpot contact properties.',
+      scoreProperty: 'Score property',
+      dateProperty: 'Submitted-date property',
+      createNote: 'Create a note on completed submissions',
+      createNoteHelp: 'Attaches a note with the form name and score to the contact.',
+      selectProperty: 'Select a property…',
+      noProperty: '— none —',
+      addMapping: 'Add mapping',
+      remove: 'Remove',
+      stepKey: 'Form step key',
+      property: 'HubSpot property',
+      emptyMappings: 'No mappings yet.',
     },
   },
 };
@@ -699,6 +781,7 @@ export const es: FormsMessages = {
       edit: 'Editar',
       analytics: 'Analíticas',
       submissions: 'Respuestas',
+      integrations: 'Integraciones',
       backToForms: 'Volver a formularios',
     },
     analytics: {
@@ -753,6 +836,46 @@ export const es: FormsMessages = {
       na: '—',
       error: 'No se pudieron cargar las respuestas.',
       retry: 'Reintentar',
+    },
+    integrations: {
+      title: 'Integraciones',
+      subtitle: 'Envía cada respuesta a tu CRM o a un webhook. La entrega es duradera y con reintentos.',
+      back: '← Volver a formularios',
+      save: 'Guardar integraciones',
+      saving: 'Guardando…',
+      saved: 'Integraciones guardadas.',
+      saveError: 'No se pudieron guardar las integraciones.',
+      loadError: 'No se pudieron cargar las integraciones.',
+      enabled: 'Activado',
+      disabled: 'Desactivado',
+      webhookTitle: 'Webhook',
+      webhookDesc: 'Envía cada respuesta como JSON (POST) a una URL que tú controlas.',
+      webhookUrl: 'URL del endpoint',
+      webhookUrlPlaceholder: 'https://ejemplo.com/webhooks/forms',
+      webhookUrlInvalid: 'Introduce una URL https válida.',
+      webhookSecret: 'Secreto de firma (opcional)',
+      webhookSecretHelp:
+        'Si se define, cada solicitud se firma con HMAC-SHA256 en la cabecera X-Quill-Signature para que puedas verificarla.',
+      hubspotTitle: 'HubSpot',
+      hubspotDesc: 'Crea o actualiza el contacto y adjunta una nota en las respuestas completadas.',
+      hubspotDisabled:
+        'HubSpot no está configurado en este servidor (HUBSPOT_PRIVATE_APP_TOKEN). La búsqueda de propiedades no está disponible, pero puedes guardar un mapeo para usarlo cuando se configure.',
+      hubspotLoading: 'Cargando propiedades de HubSpot…',
+      fieldMappings: 'Mapeo de campos',
+      fieldMappingsHelp: 'Asigna la clave de un paso del formulario a una propiedad de contacto de HubSpot. Asigna un paso a “email”.',
+      utmMappings: 'Mapeo de UTM',
+      utmMappingsHelp: 'Asigna los valores UTM capturados a propiedades de contacto de HubSpot.',
+      scoreProperty: 'Propiedad de puntuación',
+      dateProperty: 'Propiedad de fecha de envío',
+      createNote: 'Crear una nota en respuestas completadas',
+      createNoteHelp: 'Adjunta al contacto una nota con el nombre del formulario y la puntuación.',
+      selectProperty: 'Selecciona una propiedad…',
+      noProperty: '— ninguna —',
+      addMapping: 'Añadir mapeo',
+      remove: 'Quitar',
+      stepKey: 'Clave del paso',
+      property: 'Propiedad de HubSpot',
+      emptyMappings: 'Aún no hay mapeos.',
     },
   },
 };

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -195,6 +195,69 @@ export interface FormsMessages {
         close: string;
       };
     };
+    /** Cross-page tabs shown on a form's analytics/submissions surfaces. */
+    nav: {
+      edit: string;
+      analytics: string;
+      submissions: string;
+      backToForms: string;
+    };
+    /** The analytics dashboard (funnel + per-step drop-off). */
+    analytics: {
+      title: string;
+      subtitle: string;
+      metricViews: string;
+      metricStarts: string;
+      metricSubmissions: string;
+      metricCompletionRate: string;
+      metricAvgTime: string;
+      metricPartials: string;
+      rangeLast7: string;
+      rangeLast30: string;
+      rangeLast90: string;
+      rangeAll: string;
+      rangeCustom: string;
+      rangeFrom: string;
+      rangeTo: string;
+      rangeApply: string;
+      dropoffTitle: string;
+      dropoffSubtitle: string;
+      colStep: string;
+      colViews: string;
+      colDropoff: string;
+      coverRow: string;
+      emptyTitle: string;
+      emptyBody: string;
+      error: string;
+      retry: string;
+      seconds: string; // short unit, e.g. "s"
+    };
+    /** The submissions table (responses + CSV export + delete). */
+    submissions: {
+      title: string;
+      subtitle: string;
+      statusAll: string;
+      statusCompleted: string;
+      statusPartial: string;
+      badgeCompleted: string;
+      badgePartial: string;
+      colSubmitted: string;
+      colStatus: string;
+      colScore: string;
+      export: string;
+      exporting: string;
+      delete: string;
+      deleteConfirm: string;
+      emptyTitle: string;
+      emptyBody: string;
+      prev: string;
+      next: string;
+      /** "{from}–{to} of {total}" */
+      showing: string;
+      na: string;
+      error: string;
+      retry: string;
+    };
   };
 }
 
@@ -384,6 +447,65 @@ export const en: FormsMessages = {
         close: 'Close',
       },
     },
+    nav: {
+      edit: 'Edit',
+      analytics: 'Analytics',
+      submissions: 'Submissions',
+      backToForms: 'Back to forms',
+    },
+    analytics: {
+      title: 'Analytics',
+      subtitle: 'Funnel performance and question-by-question drop-off.',
+      metricViews: 'Views',
+      metricStarts: 'Starts',
+      metricSubmissions: 'Submissions',
+      metricCompletionRate: 'Completion rate',
+      metricAvgTime: 'Avg. time to complete',
+      metricPartials: 'Partial submits',
+      rangeLast7: 'Last 7 days',
+      rangeLast30: 'Last 30 days',
+      rangeLast90: 'Last 90 days',
+      rangeAll: 'All time',
+      rangeCustom: 'Custom',
+      rangeFrom: 'From',
+      rangeTo: 'To',
+      rangeApply: 'Apply',
+      dropoffTitle: 'Question-by-question drop-off',
+      dropoffSubtitle: 'How many people reach each step, and how many leave.',
+      colStep: 'Step',
+      colViews: 'Views',
+      colDropoff: 'Drop-off',
+      coverRow: 'Cover / landing',
+      emptyTitle: 'No data yet',
+      emptyBody: 'Once people open and fill out this form, the funnel and drop-off will appear here.',
+      error: 'Couldn’t load analytics.',
+      retry: 'Try again',
+      seconds: 's',
+    },
+    submissions: {
+      title: 'Submissions',
+      subtitle: 'Every response to this form.',
+      statusAll: 'All',
+      statusCompleted: 'Completed',
+      statusPartial: 'Partial',
+      badgeCompleted: 'Completed',
+      badgePartial: 'Partial',
+      colSubmitted: 'Submitted',
+      colStatus: 'Status',
+      colScore: 'Score',
+      export: 'Download CSV',
+      exporting: 'Preparing…',
+      delete: 'Delete',
+      deleteConfirm: 'Delete this submission? This cannot be undone.',
+      emptyTitle: 'No submissions yet',
+      emptyBody: 'Responses will show up here as people complete the form.',
+      prev: 'Previous',
+      next: 'Next',
+      showing: '{from}–{to} of {total}',
+      na: '—',
+      error: 'Couldn’t load submissions.',
+      retry: 'Try again',
+    },
   },
 };
 
@@ -572,6 +694,65 @@ export const es: FormsMessages = {
         desktop: 'Escritorio',
         close: 'Cerrar',
       },
+    },
+    nav: {
+      edit: 'Editar',
+      analytics: 'Analíticas',
+      submissions: 'Respuestas',
+      backToForms: 'Volver a formularios',
+    },
+    analytics: {
+      title: 'Analíticas',
+      subtitle: 'Rendimiento del embudo y abandono pregunta por pregunta.',
+      metricViews: 'Vistas',
+      metricStarts: 'Inicios',
+      metricSubmissions: 'Respuestas',
+      metricCompletionRate: 'Tasa de finalización',
+      metricAvgTime: 'Tiempo promedio para completar',
+      metricPartials: 'Envíos parciales',
+      rangeLast7: 'Últimos 7 días',
+      rangeLast30: 'Últimos 30 días',
+      rangeLast90: 'Últimos 90 días',
+      rangeAll: 'Todo el tiempo',
+      rangeCustom: 'Personalizado',
+      rangeFrom: 'Desde',
+      rangeTo: 'Hasta',
+      rangeApply: 'Aplicar',
+      dropoffTitle: 'Abandono pregunta por pregunta',
+      dropoffSubtitle: 'Cuántas personas llegan a cada paso y cuántas se van.',
+      colStep: 'Paso',
+      colViews: 'Vistas',
+      colDropoff: 'Abandono',
+      coverRow: 'Portada / inicio',
+      emptyTitle: 'Aún no hay datos',
+      emptyBody: 'Cuando las personas abran y completen este formulario, verás aquí el embudo y el abandono.',
+      error: 'No se pudieron cargar las analíticas.',
+      retry: 'Reintentar',
+      seconds: 's',
+    },
+    submissions: {
+      title: 'Respuestas',
+      subtitle: 'Todas las respuestas a este formulario.',
+      statusAll: 'Todas',
+      statusCompleted: 'Completadas',
+      statusPartial: 'Parciales',
+      badgeCompleted: 'Completada',
+      badgePartial: 'Parcial',
+      colSubmitted: 'Enviada',
+      colStatus: 'Estado',
+      colScore: 'Puntaje',
+      export: 'Descargar CSV',
+      exporting: 'Preparando…',
+      delete: 'Eliminar',
+      deleteConfirm: '¿Eliminar esta respuesta? No se puede deshacer.',
+      emptyTitle: 'Aún no hay respuestas',
+      emptyBody: 'Las respuestas aparecerán aquí a medida que las personas completen el formulario.',
+      prev: 'Anterior',
+      next: 'Siguiente',
+      showing: '{from}–{to} de {total}',
+      na: '—',
+      error: 'No se pudieron cargar las respuestas.',
+      retry: 'Reintentar',
     },
   },
 };

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -16,6 +16,37 @@ export interface FormsMessages {
     /** SEO/OG meta description for a public form page. */
     seoForm: string;
   };
+  /** Public form-renderer chrome (all user content comes from the form config). */
+  renderer: {
+    start: string;
+    back: string;
+    next: string;
+    submit: string;
+    submitting: string;
+    thankYouTitle: string;
+    thankYouBody: string; // {name}
+    ctaQuestion: string;
+    ctaAction: string;
+    progressLabel: string; // {current} {total}
+    revealHeadline: string;
+    revealSubtitle: string;
+    noSteps: string;
+    dropdownPlaceholder: string;
+    dropdownEmpty: string;
+    trustedBy: string;
+    newTab: string;
+    errors: {
+      required: string;
+      email: string;
+      work_email: string;
+      phone: string;
+      number: string;
+      too_low: string;
+      too_high: string;
+      option: string;
+      submit: string;
+    };
+  };
   admin: {
     login: {
       title: string;
@@ -309,6 +340,36 @@ export const en: FormsMessages = {
     ctaAction: 'Get Dapta Forms — free',
     seoForm: 'Fill out {name} online.',
   },
+  renderer: {
+    start: 'Start',
+    back: 'Back',
+    next: 'Next',
+    submit: 'Submit',
+    submitting: 'Submitting…',
+    thankYouTitle: 'Thank you!',
+    thankYouBody: 'Your responses to “{name}” were recorded.',
+    ctaQuestion: 'Want your own form?',
+    ctaAction: 'Get Dapta Forms — free',
+    progressLabel: 'Step {current} of {total}',
+    revealHeadline: 'Reviewing your answers…',
+    revealSubtitle: 'One moment while we match you with the best next step.',
+    noSteps: 'This form has no steps yet.',
+    dropdownPlaceholder: 'Type to search…',
+    dropdownEmpty: 'No results found',
+    trustedBy: 'Trusted by',
+    newTab: '(opens in a new tab)',
+    errors: {
+      required: 'This field is required.',
+      email: 'Enter a valid email address.',
+      work_email: 'Please use your work email address.',
+      phone: 'Enter a valid phone number.',
+      number: 'Enter a number.',
+      too_low: 'Value is too low.',
+      too_high: 'Value is too high.',
+      option: 'Choose one of the available options.',
+      submit: 'Could not submit — please try again.',
+    },
+  },
   admin: {
     login: {
       title: 'Sign in',
@@ -597,6 +658,36 @@ export const es: FormsMessages = {
     ctaQuestion: '¿Quieres tu propio formulario?',
     ctaAction: 'Consigue Dapta Forms — gratis',
     seoForm: 'Completa {name} en línea.',
+  },
+  renderer: {
+    start: 'Comenzar',
+    back: 'Atrás',
+    next: 'Siguiente',
+    submit: 'Enviar',
+    submitting: 'Enviando…',
+    thankYouTitle: '¡Gracias!',
+    thankYouBody: 'Tus respuestas a «{name}» quedaron registradas.',
+    ctaQuestion: '¿Quieres tu propio formulario?',
+    ctaAction: 'Consigue Dapta Forms — gratis',
+    progressLabel: 'Paso {current} de {total}',
+    revealHeadline: 'Revisando tus respuestas…',
+    revealSubtitle: 'Un momento mientras encontramos el mejor siguiente paso para ti.',
+    noSteps: 'Este formulario aún no tiene pasos.',
+    dropdownPlaceholder: 'Escribe para buscar…',
+    dropdownEmpty: 'No se encontraron resultados',
+    trustedBy: 'Confían en nosotros',
+    newTab: '(se abre en una pestaña nueva)',
+    errors: {
+      required: 'Este campo es obligatorio.',
+      email: 'Introduce un correo válido.',
+      work_email: 'Usa tu correo corporativo.',
+      phone: 'Introduce un número de teléfono válido.',
+      number: 'Introduce un número.',
+      too_low: 'El valor es muy bajo.',
+      too_high: 'El valor es muy alto.',
+      option: 'Elige una de las opciones disponibles.',
+      submit: 'No se pudo enviar. Inténtalo de nuevo.',
+    },
   },
   admin: {
     login: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,6 +54,11 @@ const sliderScoringSchema = z.object({
   points: z.number().int(),
 });
 
+const clientLogoSchema = z.object({
+  name: z.string().min(1).max(80),
+  src: z.string().max(2048).nullable().optional(),
+});
+
 export const formStepSchema = z.object({
   key: z.string().min(1).max(64),
   type: z.enum(formFieldType),
@@ -74,10 +79,19 @@ export const formStepSchema = z.object({
   flowGroup: z.enum(['qualification', 'lead_capture']).optional(),
   corporateEmailOnly: z.boolean().optional(),
   phoneMinDigits: z.number().int().positive().optional(),
+  // --- Builder + runtime extensions (all optional; back-compat) -------------
   /** Dynamic question: pick the text from the answer to this earlier field. */
-  questionField: z.string().min(1).nullable().optional(),
+  questionField: z.string().min(1).max(64).nullable().optional(),
   /** value → question text (a `*` key is the fallback); `[field]` interpolated. */
   questionVariants: z.record(z.string(), z.string().max(500)).optional(),
+  fields: z.array(z.string().min(1).max(64)).max(4).optional(),
+  placeholders: z.record(z.string(), z.string().max(200)).optional(),
+  sliderLabelVariants: z.record(z.string(), z.string().max(80)).optional(),
+  sliderUnitLabel: z.string().max(80).nullable().optional(),
+  showIcons: z.boolean().optional(),
+  showForPersonalEmailOnly: z.boolean().optional(),
+  terminal: z.boolean().optional(),
+  triggersReveal: z.boolean().optional(),
 });
 export type FormStepInput = z.infer<typeof formStepSchema>;
 
@@ -86,15 +100,25 @@ export const formCoverSchema = z.object({
   /** A sticky banner line shown above the form throughout the flow. */
   bannerText: z.string().max(200).nullable().optional(),
   eyebrow: z.string().max(200).nullable().optional(),
+  badge: z.string().max(200).nullable().optional(),
   headline: z.string().max(300).nullable().optional(),
   subheadline: z.string().max(500).nullable().optional(),
   ctaText: z.string().max(80).nullable().optional(),
   trustBadge: z.string().max(200).nullable().optional(),
+  logo: z.string().max(2048).nullable().optional(),
+  clientLogos: z.array(clientLogoSchema).max(24).optional(),
 });
 
-/** Per-form branding — the single accent color drives the public surface. */
 export const formBrandingSchema = z.object({
   primaryColor: z.string().max(32).nullable().optional(),
+  logo: z.string().max(2048).nullable().optional(),
+  clientLogos: z.array(clientLogoSchema).max(24).optional(),
+});
+
+export const formRevealSchema = z.object({
+  enabled: z.boolean().optional(),
+  headline: z.string().max(300).nullable().optional(),
+  subtitle: z.string().max(500).nullable().optional(),
 });
 
 export const formOutcomeSchema = z.object({
@@ -172,8 +196,8 @@ export type FormDestination = z.infer<typeof formDestinationSchema>;
 /** The versioned config blob. `version` gates future migrations of the shape. */
 export const formConfigSchema = z.object({
   version: z.literal(1),
-  cover: formCoverSchema.nullable().optional(),
   branding: formBrandingSchema.nullable().optional(),
+  cover: formCoverSchema.nullable().optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),
@@ -182,6 +206,8 @@ export const formConfigSchema = z.object({
    * ADDITIVE — absent on every legacy config; the renderer never receives it.
    */
   destinations: z.array(formDestinationSchema).optional(),
+  reveal: formRevealSchema.nullable().optional(),
+  partialSubmitAfterStep: z.number().int().positive().optional(),
 });
 export type FormConfig = z.infer<typeof formConfigSchema>;
 
@@ -219,10 +245,22 @@ export type PublicForm = z.infer<typeof publicFormSchema>;
 
 // --- Submissions -------------------------------------------------------------
 
-/** One submission's answers: fieldName -> value. */
+/**
+ * One submission's answers: fieldName -> value. Most values are scalars (or a
+ * string[] for multi-select); the reserved `utm` key carries a flat string map
+ * of the URL's `utm_*` params (additive — captured from the public URL, never a
+ * new column: it rides inside the free-form answers JSON).
+ */
 export const submissionAnswersSchema = z.record(
   z.string(),
-  z.union([z.string(), z.number(), z.boolean(), z.array(z.string()), z.null()]),
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(z.string()),
+    z.record(z.string(), z.string()),
+    z.null(),
+  ]),
 );
 export type SubmissionAnswers = z.infer<typeof submissionAnswersSchema>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -122,7 +122,17 @@ export const webhookDestinationSchema = z.object({
   type: z.literal('webhook'),
   enabled: z.boolean().default(false),
   settings: z.object({
-    url: z.string().url(),
+    // https-only, with ONE exception: plain http for localhost/127.0.0.1 (local
+    // dev catcher). Mirrors the admin UI validation — keep the two in sync.
+    url: z
+      .string()
+      .url()
+      .refine(
+        // Already a valid URL per .url(); prefix checks avoid the URL global
+        // (not in this package's lib set).
+        (v) => v.startsWith('https://') || /^http:\/\/(localhost|127\.0\.0\.1)([:/?#]|$)/.test(v),
+        { message: 'Webhook URL must use https (plain http is allowed only for localhost).' },
+      ),
     /** HMAC-SHA256 signing secret (optional). */
     secret: z.string().max(500).nullable().optional(),
     /** Header the signature is sent in (defaults to `X-Quill-Signature`). */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,7 +5,13 @@
  * from the same schema (never trust the client; validate on both sides).
  */
 import { z } from 'zod';
-import { FORM_FIELD_TYPES } from '@quill/engine';
+import { FORM_FIELD_TYPES, isSafeHttpUrl, isSafeImageUrl } from '@quill/engine';
+
+/** A URL rendered into `<img src>` — reject script protocols (XSS defense-in-depth). */
+const safeImageUrl = z
+  .string()
+  .max(2048)
+  .refine(isSafeImageUrl, { message: 'Image URL protocol not allowed.' });
 
 // --- Identity enums (kept from the platform, portable across SQLite & PG) ----
 
@@ -56,7 +62,7 @@ const sliderScoringSchema = z.object({
 
 const clientLogoSchema = z.object({
   name: z.string().min(1).max(80),
-  src: z.string().max(2048).nullable().optional(),
+  src: safeImageUrl.nullable().optional(),
 });
 
 export const formStepSchema = z.object({
@@ -105,13 +111,13 @@ export const formCoverSchema = z.object({
   subheadline: z.string().max(500).nullable().optional(),
   ctaText: z.string().max(80).nullable().optional(),
   trustBadge: z.string().max(200).nullable().optional(),
-  logo: z.string().max(2048).nullable().optional(),
+  logo: safeImageUrl.nullable().optional(),
   clientLogos: z.array(clientLogoSchema).max(24).optional(),
 });
 
 export const formBrandingSchema = z.object({
   primaryColor: z.string().max(32).nullable().optional(),
-  logo: z.string().max(2048).nullable().optional(),
+  logo: safeImageUrl.nullable().optional(),
   clientLogos: z.array(clientLogoSchema).max(24).optional(),
 });
 
@@ -125,7 +131,15 @@ export const formOutcomeSchema = z.object({
   id: z.string().min(1).max(64),
   label: z.string().min(1).max(200),
   minScore: z.number().int().optional(),
-  redirectUrl: z.string().url().nullable().optional(),
+  // http(s) only: the renderer navigates here (`window.location`), so a
+  // `javascript:`/`data:` URL — which `.url()` alone would accept — is a stored
+  // XSS vector. Guarded again at the sink in the renderer (belt-and-braces).
+  redirectUrl: z
+    .string()
+    .url()
+    .refine(isSafeHttpUrl, { message: 'redirectUrl must use http(s).' })
+    .nullable()
+    .optional(),
 });
 
 // --- Submission destinations (pluggable CRM / webhook sync) ------------------

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -74,16 +74,27 @@ export const formStepSchema = z.object({
   flowGroup: z.enum(['qualification', 'lead_capture']).optional(),
   corporateEmailOnly: z.boolean().optional(),
   phoneMinDigits: z.number().int().positive().optional(),
+  /** Dynamic question: pick the text from the answer to this earlier field. */
+  questionField: z.string().min(1).nullable().optional(),
+  /** value → question text (a `*` key is the fallback); `[field]` interpolated. */
+  questionVariants: z.record(z.string(), z.string().max(500)).optional(),
 });
 export type FormStepInput = z.infer<typeof formStepSchema>;
 
 export const formCoverSchema = z.object({
   enabled: z.boolean().optional(),
+  /** A sticky banner line shown above the form throughout the flow. */
+  bannerText: z.string().max(200).nullable().optional(),
   eyebrow: z.string().max(200).nullable().optional(),
   headline: z.string().max(300).nullable().optional(),
   subheadline: z.string().max(500).nullable().optional(),
   ctaText: z.string().max(80).nullable().optional(),
   trustBadge: z.string().max(200).nullable().optional(),
+});
+
+/** Per-form branding — the single accent color drives the public surface. */
+export const formBrandingSchema = z.object({
+  primaryColor: z.string().max(32).nullable().optional(),
 });
 
 export const formOutcomeSchema = z.object({
@@ -97,6 +108,7 @@ export const formOutcomeSchema = z.object({
 export const formConfigSchema = z.object({
   version: z.literal(1),
   cover: formCoverSchema.nullable().optional(),
+  branding: formBrandingSchema.nullable().optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -104,6 +104,61 @@ export const formOutcomeSchema = z.object({
   redirectUrl: z.string().url().nullable().optional(),
 });
 
+// --- Submission destinations (pluggable CRM / webhook sync) ------------------
+
+/** The configurable destination kinds a form may deliver submissions to. */
+export const destinationType = ['webhook', 'hubspot'] as const;
+export type DestinationType = (typeof destinationType)[number];
+
+/** A property map: form stepKey / utmKey -> external property name. */
+const propertyMapSchema = z.record(z.string().min(1).max(200), z.string().min(1).max(200));
+
+/**
+ * Webhook destination — POST each submission as JSON to a URL, optionally HMAC
+ * signed. The secret is server-side config, never leaked to the public renderer
+ * (the API strips `destinations` before serving a public form).
+ */
+export const webhookDestinationSchema = z.object({
+  type: z.literal('webhook'),
+  enabled: z.boolean().default(false),
+  settings: z.object({
+    url: z.string().url(),
+    /** HMAC-SHA256 signing secret (optional). */
+    secret: z.string().max(500).nullable().optional(),
+    /** Header the signature is sent in (defaults to `X-Quill-Signature`). */
+    signatureHeader: z.string().max(128).nullable().optional(),
+    /** Per-request timeout in ms (defaults to 10s). */
+    timeoutMs: z.number().int().positive().max(60_000).optional(),
+  }),
+});
+export type WebhookDestination = z.infer<typeof webhookDestinationSchema>;
+
+/**
+ * HubSpot destination — upsert the respondent as a contact and (on complete)
+ * attach a Note. The private-app token is a server-side env secret
+ * (`HUBSPOT_PRIVATE_APP_TOKEN`), NOT stored in the form config.
+ */
+export const hubspotDestinationSchema = z.object({
+  type: z.literal('hubspot'),
+  enabled: z.boolean().default(false),
+  settings: z.object({ note: z.boolean().optional() }).default({}),
+  /** stepKey -> contact property (one property SHOULD be `email`). */
+  fieldMappings: propertyMapSchema.default({}),
+  /** utm_source/medium/campaign/term/content -> contact property. */
+  utmMappings: propertyMapSchema.default({}),
+  /** Contact property to receive the score (complete submissions). */
+  scoreProperty: z.string().max(200).nullable().optional(),
+  /** Contact date property to receive the submitted date. */
+  dateProperty: z.string().max(200).nullable().optional(),
+});
+export type HubspotDestination = z.infer<typeof hubspotDestinationSchema>;
+
+export const formDestinationSchema = z.discriminatedUnion('type', [
+  webhookDestinationSchema,
+  hubspotDestinationSchema,
+]);
+export type FormDestination = z.infer<typeof formDestinationSchema>;
+
 /** The versioned config blob. `version` gates future migrations of the shape. */
 export const formConfigSchema = z.object({
   version: z.literal(1),
@@ -112,6 +167,11 @@ export const formConfigSchema = z.object({
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),
+  /**
+   * Pluggable submission destinations (CRM/webhook sync via the durable outbox).
+   * ADDITIVE — absent on every legacy config; the renderer never receives it.
+   */
+  destinations: z.array(formDestinationSchema).optional(),
 });
 export type FormConfig = z.infer<typeof formConfigSchema>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -196,6 +196,69 @@ export const formEventSchema = z.object({
 });
 export type FormEventInput = z.infer<typeof formEventSchema>;
 
+// --- Analytics (funnel + per-step drop-off) ----------------------------------
+// ADDITIVE: new exports only. These describe the admin analytics dashboard
+// response (GET /v1/forms/:id/analytics) — a funnel summary plus a
+// question-by-question drop-off table (a cover row + one row per configured
+// step). Computed server-side from form_event + submission; works identically
+// on SQLite and Postgres.
+
+/** One row of the question-by-question drop-off table. */
+export const dropoffRowSchema = z.object({
+  /** -1 for the synthetic cover/landing row, otherwise the 0-based step index. */
+  stepIndex: z.number().int(),
+  /** The step's field key (null for the cover row). */
+  key: z.string().nullable(),
+  /** Human label for the row (the step question, or the cover title). */
+  question: z.string(),
+  /** True for the synthetic cover/landing row. */
+  isCover: z.boolean(),
+  /** Sessions that viewed this step (form views for the cover row). */
+  views: z.number().int(),
+  /** Sessions lost between this row and the next (never negative). */
+  dropoff: z.number().int(),
+  /** Drop-off as a percentage of this row's views (1 decimal). */
+  dropoffPercent: z.number(),
+});
+export type DropoffRow = z.infer<typeof dropoffRowSchema>;
+
+/** The funnel summary + drop-off table for a form over an optional date range. */
+export const analyticsResponseSchema = z.object({
+  /** Count of `view` events. */
+  views: z.number().int(),
+  /** Count of `start` events. */
+  starts: z.number().int(),
+  /** Count of completed submissions (completedAt set). */
+  submissions: z.number().int(),
+  /** submissions / starts as a percentage (1 decimal); 0 when starts=0. */
+  completionRate: z.number(),
+  /** Average seconds from startedAt→completedAt over completed submissions. */
+  avgTimeToComplete: z.number().int(),
+  /** Partial-only submissions (partialAt set, completedAt null). */
+  partialSubmits: z.number().int(),
+  /** Cover row + one row per configured step. */
+  dropoff: z.array(dropoffRowSchema),
+  /** Echoes the resolved range (epoch ms) so the client can render it. */
+  range: z.object({ from: z.number().nullable(), to: z.number().nullable() }),
+});
+export type AnalyticsResponse = z.infer<typeof analyticsResponseSchema>;
+
+// --- Submissions listing (paginated + filtered) ------------------------------
+// ADDITIVE: the admin submissions table response. `status` narrows to complete
+// or partial; `from`/`to` bound by startedAt; `limit`/`offset` paginate.
+
+export const submissionStatusFilter = ['all', 'completed', 'partial'] as const;
+export type SubmissionStatusFilter = (typeof submissionStatusFilter)[number];
+
+export const submissionsPageSchema = z.object({
+  items: z.array(submissionViewSchema),
+  /** Total rows matching the filter (before pagination). */
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+});
+export type SubmissionsPage = z.infer<typeof submissionsPageSchema>;
+
 // --- Member management (workspace roster) ------------------------------------
 
 export const memberInviteSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@quill/engine':
         specifier: workspace:*
         version: link:../../packages/engine
@@ -343,6 +352,28 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
@@ -3010,6 +3041,31 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.2.0
       prettier: 2.8.8
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@emnapi/runtime@1.11.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@quill/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@quill/destinations':
+        specifier: workspace:*
+        version: link:../../packages/destinations
       '@quill/engine':
         specifier: workspace:*
         version: link:../../packages/engine
@@ -201,6 +204,28 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.23.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.20.1)(lightningcss@1.32.0)
+
+  packages/destinations:
+    dependencies:
+      '@quill/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@quill/config':
+        specifier: workspace:*
+        version: link:../config
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.20.1
+      eslint:
+        specifier: ^9.17.0
+        version: 9.39.5(jiti@2.7.0)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3


### PR DESCRIPTION
First release to main. All four Phase-1 tracks merged and gated (PRs #1-#4: CI green, OptiBot fully triaged incl. 2 blockers fixed, DCO). Integrated MVP verification: PASS 11/11 against the mission MVP scope — 104/104 tests, security spot-checks (stored-XSS redirect guard, cross-account isolation, rate-limit), analytics reconciled to ground truth, webhook HMAC verified, i18n EN/ES, entitlements open/locked. Proof: projects/product/20260704_sidecar_products/forms/MVP-VERIFICATION.md (brain repo).