### PR TITLE
fix: verification polish — cross-account 404, sign-out i18n, webhook secret masking, boot docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@
 # Unset  -> SQLite at ./.data/dev.db (the default, zero-infra clone-and-run)
 # file:… -> SQLite file
 # A PostgreSQL connection URL selects Postgres in production. Keep credentials in `.env`.
+# NOTE: the schema must be migrated before the API boots. `pnpm dev` / `pnpm dev:pg`
+# do this for you (they run db:setup first). If you start an app directly against a
+# fresh DB, run `pnpm db:migrate` first — otherwise the outbox worker fails with
+# "no such table: outbox".
 # DATABASE_URL=file:./.data/dev.db
 # DATABASE_URL=
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Everything has a safe default (see [`.env.example`](.env.example)). Copy it to
 | `pnpm typecheck` / `pnpm lint` | type-check / lint the workspace |
 | `pnpm db:migrate` / `pnpm db:seed` / `pnpm db:reset` | database lifecycle |
 
+> **Always start with `pnpm dev`** (or `pnpm dev:pg`) — it runs `db:setup`
+> (migrate + seed) **before** launching the apps, so the schema always exists.
+> If you instead run an app directly against a **fresh** database — two
+> terminals, e.g. `pnpm db:migrate` then `pnpm --filter @quill/api dev` and
+> `pnpm --filter @quill/web dev` — **run `pnpm db:migrate` first**. The bare app
+> start does *not* migrate; booting the API against an unmigrated DB makes the
+> outbox worker fail on every poll with `no such table: outbox`.
+
 ## Deploy
 
 Quill is **deployment-agnostic** (Node runtime, no host-only APIs).

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -31,7 +31,12 @@ import {
   updateForm,
   type CrudResult,
 } from '@quill/db';
-import { formInputSchema, memberInviteSchema, memberPatchSchema } from '@quill/types';
+import {
+  formInputSchema,
+  maskConfigSecrets,
+  memberInviteSchema,
+  memberPatchSchema,
+} from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
 import { SubmissionService } from './submission.service';
@@ -55,6 +60,16 @@ function unwrapCrud<T>(r: CrudResult<T>): T {
   if (r.ok) return r.value;
   if (r.reason === 'NOT_FOUND') throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
   throw new ConflictException({ error: r.reason, message: r.message ?? 'Conflict.' });
+}
+
+/**
+ * Mask webhook signing secrets in a form's config before it leaves the server to
+ * the admin client. Every form-returning endpoint runs this so the plaintext
+ * secret is never exposed in a READ; the integrations UI round-trips the sentinel
+ * and the write layer restores the stored secret (see mergeWebhookSecrets).
+ */
+function maskForm<T extends { config: unknown }>(form: T): T {
+  return { ...form, config: maskConfigSecrets(form.config) };
 }
 
 /** Host-authed CRUD for forms + submissions + members, and identity/vanity. */
@@ -102,7 +117,7 @@ export class AdminCrudController {
     const p = await this.auth.resolveHost(req);
     const f = await getFormById(this.db, p.accountId, id);
     if (!f) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    return f;
+    return maskForm(f);
   }
 
   @Post('forms')
@@ -110,21 +125,21 @@ export class AdminCrudController {
   async createForm(@Req() req: ReqLike, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
     const input = parse(formInputSchema, body);
-    return unwrapCrud(await createForm(this.db, p.accountId, input));
+    return maskForm(unwrapCrud(await createForm(this.db, p.accountId, input)));
   }
 
   @Put('forms/:id')
   async updateForm(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
     const input = parse(formInputSchema.partial(), body);
-    return unwrapCrud(await updateForm(this.db, p.accountId, id, input));
+    return maskForm(unwrapCrud(await updateForm(this.db, p.accountId, id, input)));
   }
 
   @Post('forms/:id/duplicate')
   @HttpCode(201)
   async duplicateForm(@Req() req: ReqLike, @Param('id') id: string) {
     const p = await this.auth.resolveHost(req);
-    return unwrapCrud(await duplicateForm(this.db, p.accountId, id));
+    return maskForm(unwrapCrud(await duplicateForm(this.db, p.accountId, id)));
   }
 
   @Delete('forms/:id')

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -114,11 +114,19 @@ export class AnalyticsController {
     res.end();
   }
 
-  /** Delete a submission (account-scoped, idempotent → always 204). */
+  /**
+   * Delete a submission (account-scoped). Same-account delete — including a
+   * repeat on an already-deleted row — is idempotent → 204. A cross-account id
+   * is never touched and returns 404 (mirrors GET; no data leak, no misleading
+   * 204 "success").
+   */
   @Delete('submissions/:id')
   @HttpCode(204)
   async deleteSubmission(@Req() req: ReqLike, @Param('id') id: string): Promise<void> {
     const p = await this.auth.resolveHost(req);
-    await this.analytics.deleteSubmission(p.accountId, id); // idempotent: absent/out-of-account → no-op
+    const result = await this.analytics.deleteSubmission(p.accountId, id);
+    if (result === 'forbidden')
+      throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    // 'deleted' | 'absent' → idempotent 204.
   }
 }

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -157,14 +157,39 @@ describe('submissions query', () => {
 });
 
 describe('delete submission (account-scoped, idempotent)', () => {
-  it('deletes an owned submission and is a no-op on repeat / wrong account', async () => {
+  it('classifies deleted / absent / forbidden and never touches a cross-account row', async () => {
     const one = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
-    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe(true);
-    // Idempotent second call.
-    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe(false);
-    // Wrong account never touches the row.
+    // Owned → deleted.
+    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe('deleted');
+    // Same-account repeat on an already-gone row → absent (idempotent 204).
+    expect(await deleteSubmissionForAccount(db, accountId, one.id)).toBe('absent');
+    // A cross-account id → forbidden (HTTP 404), and the row is left intact.
     const other = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
-    expect(await deleteSubmissionForAccount(db, 'wrong-account', other.id)).toBe(false);
+    expect(await deleteSubmissionForAccount(db, 'wrong-account', other.id)).toBe('forbidden');
+    expect((await querySubmissions(db, formId, { status: 'completed' })).total).toBe(2);
+    // A never-existed id → absent (not a leak-y 404).
+    expect(await deleteSubmissionForAccount(db, accountId, 'no-such-id')).toBe('absent');
+  });
+});
+
+describe('delete submission (controller HTTP semantics)', () => {
+  function ctrlFor(actAccount: string) {
+    const auth = {
+      resolveHost: async () => ({ accountId: actAccount, memberId: 'm', role: 'owner' as const }),
+    } as unknown as AuthService;
+    return new AnalyticsController(db, auth, svc);
+  }
+
+  it('204s an owned delete + idempotent repeat, but 404s a cross-account id', async () => {
+    const one = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
+    // Owner: deletes (no throw) and repeat is a no-op (no throw).
+    await expect(ctrlFor(accountId).deleteSubmission({} as never, one.id)).resolves.toBeUndefined();
+    await expect(ctrlFor(accountId).deleteSubmission({} as never, one.id)).resolves.toBeUndefined();
+    // Attacker: a real (other-account) submission → 404, row untouched.
+    const other = (await querySubmissions(db, formId, { status: 'completed', limit: 1 })).items[0]!;
+    await expect(ctrlFor('attacker-account').deleteSubmission({} as never, other.id)).rejects.toMatchObject({
+      status: 404,
+    });
     expect((await querySubmissions(db, formId, { status: 'completed' })).total).toBe(2);
   });
 });

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -9,6 +9,7 @@ import {
   deleteSubmissionForAccount,
   getFormById,
   type DateRange,
+  type DeleteSubmissionResult,
   type SubmissionQuery,
 } from '@quill/db';
 import type {
@@ -122,8 +123,12 @@ export class AnalyticsService {
     return allSubmissionsForExport(this.db, formId, q);
   }
 
-  /** Delete a submission if it belongs to the account. Idempotent. */
-  deleteSubmission(accountId: string, submissionId: string): Promise<boolean> {
+  /**
+   * Delete a submission if it belongs to the account. Returns a discriminated
+   * result so the controller can 204 an idempotent same-account delete but 404 a
+   * cross-account id (which is never mutated).
+   */
+  deleteSubmission(accountId: string, submissionId: string): Promise<DeleteSubmissionResult> {
     return deleteSubmissionForAccount(this.db, accountId, submissionId);
   }
 }

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -13,7 +13,7 @@ import {
 import { z, ZodError } from 'zod';
 import type { Db } from '@quill/db';
 import { updateFormDestinations } from '@quill/db';
-import { formDestinationSchema } from '@quill/types';
+import { formDestinationSchema, maskConfigSecrets } from '@quill/types';
 import type { ServerEnv } from '@quill/config/env';
 import { AuthService, type ReqLike } from './auth.service';
 import { DB, ENV } from './tokens';
@@ -132,6 +132,7 @@ export class FormDestinationsController {
     }
     const out = await updateFormDestinations(this.db, p.accountId, id, destinations);
     if (!out.ok) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    return out.value;
+    // Never echo the stored webhook secret back to the client (mask on READ).
+    return { ...out.value, config: maskConfigSecrets(out.value.config) };
   }
 }

--- a/apps/api/src/webhook-secret-masking.spec.ts
+++ b/apps/api/src/webhook-secret-masking.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * The admin READ surface must never echo a stored webhook signing secret in
+ * plaintext. Drives the real AdminCrudController.getForm over in-memory SQLite
+ * and asserts the returned config carries the mask sentinel, not the ciphertext.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import {
+  createDb,
+  migrate,
+  updateFormDestinations,
+  sql,
+  type Db,
+} from '@quill/db';
+import { WEBHOOK_SECRET_MASK } from '@quill/types';
+import { AdminCrudController } from './admin-crud.controller';
+import type { AuthService } from './auth.service';
+import type { AdminService } from './admin.service';
+import type { SubmissionService } from './submission.service';
+import type { AnalyticsService } from './analytics.service';
+
+let db: Db;
+let accountId: string;
+let formId: string;
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  accountId = randomUUID();
+  formId = randomUUID();
+  const now = Date.now();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at) VALUES (${accountId}, ${'t' + accountId.slice(0, 5)}, ${'Test'}, ${now})`,
+  );
+  await db.run(
+    sql`INSERT INTO form (id, account_id, name, slug, config, created_at, updated_at)
+        VALUES (${formId}, ${accountId}, ${'F'}, ${'f'}, ${'{"version":1,"steps":[]}'}, ${now}, ${now})`,
+  );
+  await updateFormDestinations(db, accountId, formId, [
+    { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook', secret: 's3cr3t' } },
+  ]);
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+function controller() {
+  const auth = {
+    resolveHost: async () => ({ accountId, memberId: 'm', role: 'owner' as const }),
+  } as unknown as AuthService;
+  return new AdminCrudController(
+    db,
+    auth,
+    {} as AdminService,
+    {} as SubmissionService,
+    {} as AnalyticsService,
+  );
+}
+
+describe('GET /v1/forms/:id — webhook secret masking', () => {
+  it('returns the mask sentinel, never the stored ciphertext', async () => {
+    const form = (await controller().getForm({} as never, formId)) as {
+      config: { destinations: Array<{ settings: { secret: unknown } }> };
+    };
+    const secret = form.config.destinations[0]!.settings.secret;
+    expect(secret).toBe(WEBHOOK_SECRET_MASK);
+    expect(secret).not.toBe('s3cr3t');
+  });
+});

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useTransition } from 'react';
 import type { FormsMessages } from '@quill/shared';
-import type { FormDestination } from '@quill/types';
+import { WEBHOOK_SECRET_MASK, type FormDestination } from '@quill/types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
@@ -22,7 +22,10 @@ interface Pair {
 interface WebhookState {
   enabled: boolean;
   url: string;
+  /** What the user has typed. Empty + `hasSecret` = "keep the stored secret". */
   secret: string;
+  /** A signing secret is already stored server-side (returned masked on READ). */
+  hasSecret: boolean;
 }
 interface HubspotState {
   enabled: boolean;
@@ -36,9 +39,12 @@ interface HubspotState {
 function initialWebhook(destinations: FormDestination[]): WebhookState {
   const w = destinations.find((d) => d.type === 'webhook');
   if (w && w.type === 'webhook') {
-    return { enabled: w.enabled, url: w.settings.url ?? '', secret: w.settings.secret ?? '' };
+    // The API masks a stored secret to WEBHOOK_SECRET_MASK on READ — surface it
+    // as "set" (empty input, placeholder) rather than leaking the ciphertext.
+    const hasSecret = w.settings.secret === WEBHOOK_SECRET_MASK;
+    return { enabled: w.enabled, url: w.settings.url ?? '', secret: '', hasSecret };
   }
-  return { enabled: false, url: '', secret: '' };
+  return { enabled: false, url: '', secret: '', hasSecret: false };
 }
 
 function initialHubspot(destinations: FormDestination[]): HubspotState {
@@ -95,12 +101,17 @@ export function IntegrationsEditor({
     const out: FormDestination[] = [];
     if (webhook.enabled || webhook.url.trim()) {
       if (!isHttpsOrLocalhostUrl(webhook.url.trim())) return { error: m.webhookUrlInvalid };
+      // Secret write semantics: a typed value overwrites; an empty field keeps
+      // the stored secret (send the sentinel the server merges back) when one is
+      // set, or stays cleared/null when none exists.
+      const typed = webhook.secret.trim();
+      const secret = typed ? typed : webhook.hasSecret ? WEBHOOK_SECRET_MASK : null;
       out.push({
         type: 'webhook',
         enabled: webhook.enabled,
         settings: {
           url: webhook.url.trim(),
-          secret: webhook.secret.trim() || null,
+          secret,
         },
       });
     }
@@ -293,6 +304,7 @@ function WebhookCard({
           type="text"
           value={state.secret}
           autoComplete="off"
+          placeholder={state.hasSecret ? m.webhookSecretSetPlaceholder : undefined}
           onChange={(e) => onChange({ ...state, secret: e.target.value })}
         />
       </Field>

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,13 +1,17 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 import { ToastProvider } from '@/components/toast';
 
 // Customer-facing name (build-time inlined); the codename never surfaces in the UI.
 const productName = process.env.NEXT_PUBLIC_PRODUCT_NAME || 'Forms';
 
 export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const chrome = getMessages(await getLocale()).admin.chrome;
+
   // The real auth gate: identity is whatever `/v1/me` resolves. A 401 → /login.
   let me: Awaited<ReturnType<typeof adminApi.me>>;
   try {
@@ -29,7 +33,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
             <span>{me.displayName ?? me.email ?? me.handle}</span>
             <a href="/api/auth/logout" className="hover:text-foreground">
-              Sign out
+              {chrome.signOut}
             </a>
           </div>
         </header>

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@quill/engine": "workspace:*",
+    "@quill/types": "workspace:*",
     "better-sqlite3": "^11.7.0",
     "drizzle-orm": "^0.38.2",
     "postgres": "^3.4.5"

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -180,23 +180,39 @@ export async function allSubmissionsForExport(
 // --- Account-scoped submission delete ----------------------------------------
 
 /**
- * Delete a submission, but ONLY if it belongs to a form the account owns.
- * Idempotent: returns false when the row is absent or out-of-account (both
- * indistinguishable to the caller — no cross-account existence leak). The
- * account scope is enforced in SQL via the form join, so a forged id can't
- * touch another tenant's data.
+ * Outcome of an account-scoped submission delete:
+ *  - `deleted`   — the row belonged to the account and was removed.
+ *  - `absent`    — no such submission anywhere (already-deleted or never
+ *                  existed) → the caller treats this as an idempotent success.
+ *  - `forbidden` — the row exists but belongs to ANOTHER account → the caller
+ *                  surfaces a 404 (mirrors GET, and never mutates the row).
+ */
+export type DeleteSubmissionResult = 'deleted' | 'absent' | 'forbidden';
+
+/**
+ * Delete a submission, but ONLY if it belongs to a form the account owns. The
+ * account scope is enforced in SQL via the form join, so a forged id can never
+ * touch another tenant's data. Cross-account and same-account-already-deleted
+ * are distinguished (a second existence probe) so the HTTP layer can idempotent-
+ * 204 a genuine already-gone row while 404-ing a cross-account id.
  */
 export async function deleteSubmissionForAccount(
   db: Db,
   accountId: string,
   submissionId: string,
-): Promise<boolean> {
+): Promise<DeleteSubmissionResult> {
   const owned = await db.get<{ id: string }>(
     sql`SELECT s.id FROM submission s
         JOIN form f ON f.id = s.form_id
         WHERE s.id = ${submissionId} AND f.account_id = ${accountId} LIMIT 1`,
   );
-  if (!owned) return false;
-  await db.run(sql`DELETE FROM submission WHERE id = ${submissionId}`);
-  return true;
+  if (owned) {
+    await db.run(sql`DELETE FROM submission WHERE id = ${submissionId}`);
+    return 'deleted';
+  }
+  // Not owned: does it exist under a different account, or is it simply gone?
+  const exists = await db.get<{ id: string }>(
+    sql`SELECT id FROM submission WHERE id = ${submissionId} LIMIT 1`,
+  );
+  return exists ? 'forbidden' : 'absent';
 }

--- a/packages/db/src/forms-destinations.spec.ts
+++ b/packages/db/src/forms-destinations.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Webhook signing-secret masking + merge, on the data layer (SQLite locally,
+ * Postgres in the CI parity job via DATABASE_URL). Proves the security-critical
+ * contract behind the integrations screen: a stored secret is never re-read in
+ * plaintext (masked on READ), and a save that round-trips the mask keeps the
+ * stored secret rather than overwriting it with the sentinel.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import {
+  WEBHOOK_SECRET_MASK,
+  maskConfigSecrets,
+  maskDestinationSecrets,
+  mergeWebhookSecrets,
+} from '@quill/types';
+import { createDb, type Db } from './client';
+import { migrate } from './migrate';
+import { getFormById, updateFormDestinations } from './forms';
+
+let db: Db;
+let accountId: string;
+let formId: string;
+
+interface WebhookLike {
+  type: string;
+  enabled: boolean;
+  settings: { url?: string; secret: unknown };
+}
+
+const webhook = (secret: unknown, url = 'https://acme.io/hook'): WebhookLike => ({
+  type: 'webhook',
+  enabled: true,
+  settings: { url, secret },
+});
+
+const firstSecret = (destinations: unknown[]): unknown =>
+  (destinations[0] as WebhookLike).settings.secret;
+
+/** Read the raw stored secret straight from the row (bypasses masking). */
+async function storedSecret(): Promise<unknown> {
+  const row = await db.get<{ config: unknown }>(sql`SELECT config FROM form WHERE id = ${formId}`);
+  const raw = row!.config;
+  const config = (typeof raw === 'string' ? JSON.parse(raw) : raw) as {
+    destinations?: WebhookLike[];
+  };
+  return config.destinations?.[0]?.settings?.secret;
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+  accountId = randomUUID();
+  formId = randomUUID();
+  const now = Date.now();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at) VALUES (${accountId}, ${'t' + accountId.slice(0, 5)}, ${'Test'}, ${now})`,
+  );
+  await db.run(
+    sql`INSERT INTO form (id, account_id, name, slug, config, created_at, updated_at)
+        VALUES (${formId}, ${accountId}, ${'F'}, ${'f'}, ${'{"version":1,"steps":[]}'}, ${now}, ${now})`,
+  );
+});
+
+afterEach(async () => {
+  await db.run(sql`DELETE FROM form WHERE id = ${formId}`);
+  await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  await db.close();
+});
+
+describe('mask helpers (pure)', () => {
+  it('masks a non-empty webhook secret and leaves an unset one alone', () => {
+    const masked = maskDestinationSecrets([webhook('shh'), webhook(undefined)]) as WebhookLike[];
+    expect(masked[0]!.settings.secret).toBe(WEBHOOK_SECRET_MASK);
+    expect(masked[1]!.settings.secret).toBeUndefined();
+  });
+
+  it('maskConfigSecrets masks nested destinations without touching other keys', () => {
+    const masked = maskConfigSecrets({ version: 1, steps: [], destinations: [webhook('shh')] }) as {
+      version: number;
+      destinations: WebhookLike[];
+    };
+    expect(masked.version).toBe(1);
+    expect(masked.destinations[0]!.settings.secret).toBe(WEBHOOK_SECRET_MASK);
+  });
+
+  it('merge keeps the stored secret when the sentinel comes back, overwrites otherwise', () => {
+    const stored = [webhook('real')];
+    expect(firstSecret(mergeWebhookSecrets([webhook(WEBHOOK_SECRET_MASK)], stored))).toBe('real');
+    expect(firstSecret(mergeWebhookSecrets([webhook('rotated')], stored))).toBe('rotated');
+    expect(firstSecret(mergeWebhookSecrets([webhook(null)], stored))).toBeNull();
+  });
+});
+
+describe('updateFormDestinations — secret merge round-trip', () => {
+  it('preserves the stored secret on a mask round-trip and rotates/clears on real input', async () => {
+    // 1. Set a real secret.
+    await updateFormDestinations(db, accountId, formId, [webhook('s3cr3t')]);
+    expect(await storedSecret()).toBe('s3cr3t');
+
+    // 2. READ masks it — the plaintext never leaves the DB layer's masked view.
+    const read = await getFormById(db, accountId, formId);
+    const maskedRead = maskConfigSecrets(read!.config) as { destinations: WebhookLike[] };
+    expect(maskedRead.destinations[0]!.settings.secret).toBe(WEBHOOK_SECRET_MASK);
+
+    // 3. Save an unrelated change (toggle enabled) WITHOUT retyping the secret
+    //    (UI submits the sentinel) → the stored secret is preserved.
+    await updateFormDestinations(db, accountId, formId, [
+      { type: 'webhook', enabled: false, settings: { url: 'https://acme.io/hook', secret: WEBHOOK_SECRET_MASK } },
+    ]);
+    expect(await storedSecret()).toBe('s3cr3t');
+
+    // 4. Retype a new secret → it rotates.
+    await updateFormDestinations(db, accountId, formId, [webhook('rotated')]);
+    expect(await storedSecret()).toBe('rotated');
+
+    // 5. Explicitly clear it.
+    await updateFormDestinations(db, accountId, formId, [webhook(null)]);
+    expect(await storedSecret()).toBeNull();
+  });
+});

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -6,6 +6,7 @@
  * so the identical code runs on SQLite (clone-and-run) and Postgres (prod).
  */
 import { randomUUID } from 'node:crypto';
+import { mergeWebhookSecrets } from '@quill/types';
 import { sql, type Db } from './client';
 import { canonicalPublicCode } from './short-links';
 import type { CrudResult } from './crud';
@@ -221,7 +222,27 @@ export async function updateForm(
     if (clash) return { ok: false, reason: 'SLUG_TAKEN', message: 'That slug is already in use.' };
     sets.push(sql`slug = ${slug}`);
   }
-  if (patch.config !== undefined) sets.push(sql`config = ${jsonParam(patch.config)}`);
+  if (patch.config !== undefined) {
+    // Preserve masked webhook secrets: a full-config write that round-trips the
+    // READ-masked config (WEBHOOK_SECRET_MASK) must not clobber the stored
+    // secret with the sentinel. Real secrets pass through unchanged.
+    let nextConfig = patch.config;
+    if (
+      nextConfig &&
+      typeof nextConfig === 'object' &&
+      Array.isArray((nextConfig as Record<string, unknown>).destinations)
+    ) {
+      const cfg = nextConfig as Record<string, unknown>;
+      nextConfig = {
+        ...cfg,
+        destinations: mergeWebhookSecrets(
+          cfg.destinations as unknown[],
+          (existing.config as Record<string, unknown> | null)?.destinations,
+        ),
+      };
+    }
+    sets.push(sql`config = ${jsonParam(nextConfig)}`);
+  }
   if (sets.length > 0) {
     sets.push(sql`updated_at = ${Date.now()}`);
     await db.run(
@@ -250,7 +271,13 @@ export async function updateFormDestinations(
 ): Promise<CrudResult<FormRow>> {
   const existing = await getFormById(db, accountId, id);
   if (!existing) return { ok: false, reason: 'NOT_FOUND' };
-  const config = { ...(existing.config as Record<string, unknown>), destinations };
+  // Preserve masked webhook secrets: when the integrations UI leaves the secret
+  // field untouched it submits WEBHOOK_SECRET_MASK; keep the stored secret.
+  const merged = mergeWebhookSecrets(
+    destinations,
+    (existing.config as Record<string, unknown> | null)?.destinations,
+  );
+  const config = { ...(existing.config as Record<string, unknown>), destinations: merged };
   await db.run(
     sql`UPDATE form SET config = ${jsonParam(config)}, updated_at = ${Date.now()}
         WHERE account_id = ${accountId} AND id = ${id}`,

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -48,6 +48,10 @@ export interface FormsMessages {
     };
   };
   admin: {
+    /** App shell chrome shared across every admin page (header/nav). */
+    chrome: {
+      signOut: string;
+    };
     login: {
       title: string;
       subtitle: string;
@@ -309,6 +313,7 @@ export interface FormsMessages {
       webhookUrlInvalid: string;
       webhookSecret: string;
       webhookSecretHelp: string;
+      webhookSecretSetPlaceholder: string;
       // HubSpot
       hubspotTitle: string;
       hubspotDesc: string;
@@ -371,6 +376,9 @@ export const en: FormsMessages = {
     },
   },
   admin: {
+    chrome: {
+      signOut: 'Sign out',
+    },
     login: {
       title: 'Sign in',
       subtitle:
@@ -628,6 +636,7 @@ export const en: FormsMessages = {
       webhookSecret: 'Signing secret (optional)',
       webhookSecretHelp:
         'When set, each request is signed with HMAC-SHA256 in the X-Quill-Signature header so you can verify it.',
+      webhookSecretSetPlaceholder: 'A secret is set — leave blank to keep it, or type a new one.',
       hubspotTitle: 'HubSpot',
       hubspotDesc: 'Upsert the respondent as a contact and attach a note on completed submissions.',
       hubspotDisabled:
@@ -690,6 +699,9 @@ export const es: FormsMessages = {
     },
   },
   admin: {
+    chrome: {
+      signOut: 'Cerrar sesión',
+    },
     login: {
       title: 'Iniciar sesión',
       subtitle:
@@ -947,6 +959,7 @@ export const es: FormsMessages = {
       webhookSecret: 'Secreto de firma (opcional)',
       webhookSecretHelp:
         'Si se define, cada solicitud se firma con HMAC-SHA256 en la cabecera X-Quill-Signature para que puedas verificarla.',
+      webhookSecretSetPlaceholder: 'Hay un secreto guardado — déjalo en blanco para conservarlo o escribe uno nuevo.',
       hubspotTitle: 'HubSpot',
       hubspotDesc: 'Crea o actualiza el contacto y adjunta una nota en las respuestas completadas.',
       hubspotDisabled:

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -207,6 +207,68 @@ export const formDestinationSchema = z.discriminatedUnion('type', [
 ]);
 export type FormDestination = z.infer<typeof formDestinationSchema>;
 
+/**
+ * Sentinel returned in place of a stored webhook signing secret on every ADMIN
+ * READ (GET /v1/forms/:id and the create/update/duplicate/destinations
+ * responses) so the plaintext secret never leaves the server. It doubles as the
+ * "unchanged" marker on WRITE: when the integrations UI submits this value back
+ * (the operator left the field untouched), the server keeps the stored secret —
+ * see `mergeWebhookSecrets`. Distinctive so a real secret can never collide.
+ */
+export const WEBHOOK_SECRET_MASK = '__DAPTA_FORMS_SECRET_KEEP__';
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Return a copy of a destinations array with every non-empty webhook signing
+ * secret replaced by `WEBHOOK_SECRET_MASK` (so a READ never exposes plaintext).
+ * Destinations with no secret are returned untouched. Defensive against loosely
+ * typed stored JSON — non-webhook / malformed entries pass through unchanged.
+ */
+export function maskDestinationSecrets(destinations: unknown): unknown {
+  if (!Array.isArray(destinations)) return destinations;
+  return destinations.map((d) => {
+    if (!isRecord(d) || d.type !== 'webhook' || !isRecord(d.settings)) return d;
+    const secret = d.settings.secret;
+    if (typeof secret === 'string' && secret.length > 0) {
+      return { ...d, settings: { ...d.settings, secret: WEBHOOK_SECRET_MASK } };
+    }
+    return d;
+  });
+}
+
+/** Return a copy of a form config with its destinations' webhook secrets masked. */
+export function maskConfigSecrets(config: unknown): unknown {
+  if (!isRecord(config) || !('destinations' in config)) return config;
+  return { ...config, destinations: maskDestinationSecrets(config.destinations) };
+}
+
+/**
+ * Merge an incoming destinations array against the currently-stored one: any
+ * webhook whose incoming secret is `WEBHOOK_SECRET_MASK` keeps the stored secret
+ * (the UI left the field untouched). A real string overwrites it; an empty
+ * string / null clears it. Incoming webhooks are matched to stored webhooks by
+ * position among webhook-type entries (the UI manages a single webhook).
+ */
+export function mergeWebhookSecrets(incoming: unknown[], existing: unknown): unknown[] {
+  const storedWebhooks = (Array.isArray(existing) ? existing : []).filter(
+    (d): d is Record<string, unknown> => isRecord(d) && d.type === 'webhook',
+  );
+  let wi = 0;
+  return incoming.map((d) => {
+    if (!isRecord(d) || d.type !== 'webhook') return d;
+    const prev = storedWebhooks[wi++];
+    const settings = isRecord(d.settings) ? d.settings : {};
+    if (settings.secret === WEBHOOK_SECRET_MASK) {
+      const prevSecret = isRecord(prev?.settings) ? prev!.settings.secret : undefined;
+      return { ...d, settings: { ...settings, secret: prevSecret ?? null } };
+    }
+    return d;
+  });
+}
+
 /** The versioned config blob. `version` gates future migrations of the shape. */
 export const formConfigSchema = z.object({
   version: z.literal(1),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@quill/engine':
         specifier: workspace:*
         version: link:../engine
+      '@quill/types':
+        specifier: workspace:*
+        version: link:../types
       better-sqlite3:
         specifier: ^11.7.0
         version: 11.10.0


### PR DESCRIPTION
Fast-follow polish closing the 4 LOW gaps from the MVP integration verification (`projects/product/20260704_sidecar_products/forms/MVP-VERIFICATION.md` § Failures & gaps).

## Fixes

1. **Cross-account DELETE → 404 (was misleading 204 no-op).** `deleteSubmissionForAccount` returns a discriminated `deleted | absent | forbidden`; the controller 204s a same-account idempotent delete but 404s a cross-account id (mirrors GET, row never mutated).
2. **`Sign out` localized** (EN `Sign out` / ES `Cerrar sesión`) via a new `admin.chrome` catalog group wired through `getMessages(getLocale())`. It was the only hardcoded English string in the admin chrome.
3. **Webhook secret masking.** Every admin READ (GET `/v1/forms/:id` + create/update/duplicate/destinations responses) returns the `WEBHOOK_SECRET_MASK` sentinel, never plaintext. Writes merge: the sentinel round-tripped from the UI keeps the stored secret; a real value overwrites; empty/null clears (`mergeWebhookSecrets` in `updateForm` + `updateFormDestinations`). The integrations UI shows "secret set — blank to keep". Public config strip untouched (its test stays green).
4. **Boot docs.** README + `.env.example` make `pnpm dev` (runs `db:setup`) THE path and tell anyone running an app directly against a fresh DB to `pnpm db:migrate` first — else the outbox worker fails with `no such table: outbox`.

## Verification
- `pnpm lint / typecheck / test / build` all green (api 30 tests, db 8 tests, +2 new spec files).
- Runtime drive (fresh SQLite, migrate-first, API on 4405, two users via `x-quill-email`, webhook catcher):
  - GET form → secret returned as mask sentinel (not plaintext).
  - Unchanged-secret save (sentinel) → 200; webhook still delivered with a **valid HMAC** on the next submission → the stored secret was preserved.
  - Cross-account DELETE → **404** (victim row intact); owner DELETE → **204**; idempotent repeat → **204**; nonexistent → **204**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)