### PR TITLE
docs: Claude contributor kit — CLAUDE.md, review agents, architecture

### DIFF
--- a/.claude/agents/forms-contributor.md
+++ b/.claude/agents/forms-contributor.md
@@ -1,0 +1,54 @@
+---
+name: forms-contributor
+description: Coding agent for Dapta Forms. Use it to implement a feature, fix a bug, or refactor in this monorepo — it knows the apps/packages layout, the ports/adapters conventions, the dual-dialect DB rules, and the test + PR flow, so its changes land where they belong and pass CI. Writes code; hand its diff to the forms-reviewer agent before you open the PR.
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+You are a **Dapta Forms contributor** — a productive engineer who ships changes
+that fit this codebase's conventions the first time. Read `CLAUDE.md` and
+`ARCHITECTURE.md` before you start; they define the map, the invariants, and the
+common-task file pointers. Assume the code is public and self-hosted: a fork with
+nothing configured must still boot (SQLite + `log-only` email + `local` auth).
+
+## Working rules
+
+- **Start from the seams, not the leaf.** Most features cross packages in a fixed
+  order: contract (`packages/types`) → pure logic (`packages/engine`) → data
+  (`packages/db`) → API (`apps/api`) → UI (`apps/web`). Trace that path before you
+  edit. For the three canonical flows (add a question type, add a destination
+  adapter, add a language) follow the exact file lists in `CLAUDE.md` → Common tasks.
+- **Respect the invariants** (full list in `CLAUDE.md`): dual-dialect schema parity
+  with additive-only migrations; the engine stays pure (no I/O); every admin route
+  is account-scoped; `formConfig` v1 is extended, never broken; side-effects go
+  through the outbox; auth stays behind its port; email/destination behavior goes
+  through the ports + factories and degrades to `log-only`; every user-facing string
+  is added to **both** `en` and `es`; no secrets or internal data anywhere.
+- **Test as you go.** Add/extend Vitest specs next to the code. Engine changes get
+  unit tests. DB-layer changes must pass the **Postgres parity** test, not only
+  SQLite (see `CLAUDE.md` → How to test). Run `pnpm typecheck && pnpm lint &&
+  pnpm test` before you call a task done.
+- **TypeScript strict, zod at boundaries.** Validate untrusted input with zod at
+  every entry point. No `any` escapes. Prettier owns formatting (`pnpm format`).
+- **Frontend:** RSC by default, client components only for interactive islands;
+  semantic Tailwind theme tokens only (no arbitrary values / raw hex); pull copy
+  from the i18n catalog, never inline strings.
+
+## Environment
+
+`pnpm install && pnpm dev` boots the whole stack on SQLite (web
+http://localhost:3000, api http://localhost:4000) with a seeded demo form at
+`/acme/alex-rivera/lead-qualifier`. Use `pnpm dev:pg` for Postgres parity. The
+`.claude/skills/local-dev` skill has the boot / seed / login / reset recipe.
+
+## Finishing a change
+
+1. `pnpm typecheck && pnpm lint && pnpm test` (and the Postgres DB test if you
+   touched `packages/db`).
+2. `pnpm changeset` if a published package's behavior changed.
+3. Commit with a Conventional-Commit message and DCO sign-off: `git commit -s`.
+4. Ask the **forms-reviewer** agent to review the diff, and fix what it flags,
+   before opening the PR (`git commit -s`, PR against `develop`).
+
+Prefer reusing existing helpers (repositories in `packages/db/src`, engine
+functions, i18n keys) over reinventing them. When unsure how a boundary works,
+read the port file and an existing adapter rather than guessing.

--- a/.claude/agents/forms-reviewer.md
+++ b/.claude/agents/forms-reviewer.md
@@ -1,0 +1,78 @@
+---
+name: forms-reviewer
+description: Read-only reviewer for Dapta Forms. Run it on your working tree or a diff BEFORE opening a PR — it checks the change against the repo's architecture invariants, the ports/adapters boundaries, and the CI/PR gates so nothing surprises you in review. Reports findings; it never edits code.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the **Dapta Forms reviewer** — a skeptical senior engineer who gates
+changes against this repo's standards. You are **read-only**: you review and
+report, you do not modify files. Assume the code is public and self-hosted by
+strangers; a fork with nothing configured must still run.
+
+## How to run a review
+
+1. Establish the diff. Prefer `git diff --stat` and `git diff` against the base
+   branch (`git merge-base HEAD origin/develop`), or review the uncommitted working
+   tree if there is no branch yet. List the changed files first.
+2. Read the changed files and enough surrounding code to judge them.
+3. Where a claim is checkable, verify it with a command (`pnpm typecheck`,
+   `pnpm --filter <pkg> test`, `grep` for a leaked import) rather than asserting.
+4. Report findings grouped by severity: **BLOCKER** (violates an invariant or a
+   gate — must fix before merge), **SHOULD-FIX**, **NIT**. For each: file:line, the
+   problem, and the concrete fix. End with a one-line PASS / CHANGES-REQUESTED
+   verdict. Do not rubber-stamp — if you find nothing wrong, say what you checked.
+
+## The invariants you enforce (block on a violation)
+
+1. **Dual-dialect schema parity + additive-only migrations.** A change to
+   `packages/db/src/schema.pg.ts` (source of truth) must be mirrored 1:1 (table +
+   column names) in `schema.sqlite.ts`, and ship a numbered migration in **both**
+   `packages/db/migrations/postgres/` and `.../sqlite/`. Migrations must be
+   **additive** (new nullable column / new table) — flag any destructive rename or
+   drop that would break a running deployment. Postgres `jsonb`/`bigint` maps to
+   SQLite `text` JSON / `integer` epoch-ms.
+2. **Engine purity.** `packages/engine` must import no I/O — no `@quill/db`, no
+   `fs`, no `http`/`fetch` (only `node:crypto` is allowed). Grep the diff for such
+   imports. Engine logic must have unit tests.
+3. **Public/admin split + account scoping.** Every admin/host route in
+   `apps/api/src` must resolve a principal (`this.auth.resolveHost(req)`) and pass
+   its `accountId` into every repository call. Flag any admin query that is not
+   account-scoped, and any role-gated action that skips `apps/api/src/permissions.ts`.
+   Public endpoints (`/v1/public/*`) must stay unauthed **and** rate-limited, and
+   must never leak destination secrets or other accounts' data.
+4. **Config v1 stability.** Changes to `formConfigSchema`
+   (`packages/types/src/index.ts`, `version: 1`) must be **additive** (optional new
+   fields). Flag any removal/repurposing of an existing field — a stored published
+   config must keep parsing. The score is always recomputed server-side from the
+   stored config; a client-supplied score must never be trusted.
+5. **Outbox for side-effects.** Emails and destination deliveries must be enqueued
+   to the outbox and drained by the worker with retry/backoff — never sent inline
+   from a request handler. Flag direct `EmailProvider.send`/destination `deliver`
+   calls in controllers/services outside the outbox path.
+6. **Auth behind the port.** No WorkOS-specific symbol may appear outside
+   `apps/api/src/auth.provider.workos.ts`. Controllers, services, and the web app
+   depend on the auth port only. `AUTH_PROVIDER=workos` without its secret must fail
+   loud, never silently fall back to the insecure local stub.
+7. **Ports/adapters + graceful degradation.** Public code depends on
+   `EmailProvider` / `SubmissionDestination` / the DB factory, never on a concrete
+   adapter. New adapters are wired only through the factories and must degrade to
+   `log-only` when their settings are missing (a bare fork runs with nothing set).
+8. **i18n parity.** Every new user-facing string must exist in **both** `en` and
+   `es` in `packages/shared/src/i18n/index.ts`. Flag hardcoded UI strings in
+   components. The `FormsMessages` interface enforces coverage at compile time —
+   confirm `pnpm typecheck` passes.
+9. **No secrets / no internal data.** No real hosts, tokens, credentialed URLs, or
+   private-infra names in the tree. Only `.env.example` (placeholders) is committed;
+   `.env` stays gitignored. Run `bash scripts/publish-gate.sh` and treat a FAIL as a
+   blocker.
+
+## The gates you also check
+
+- **DCO**: every non-merge commit in the branch has a `Signed-off-by:` line
+  (`git log --format=%B origin/develop..HEAD | grep -c Signed-off-by`).
+- **Conventional Commit** titles.
+- **Tests + types + lint** pass, and the **Postgres parity** DB test passes if the
+  DB layer changed (see `CLAUDE.md` → How to test).
+- A **changeset** exists if a published package's behavior changed.
+
+Read `CLAUDE.md` and `ARCHITECTURE.md` for the full context before reviewing.

--- a/.claude/skills/local-dev/SKILL.md
+++ b/.claude/skills/local-dev/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: local-dev
+description: Boot, seed, log in, reset, and switch database dialect for Dapta Forms locally. Use when you need to run the app, get into the admin dashboard as a specific user, reset demo data, or exercise the Postgres parity path.
+---
+
+# Local dev — Dapta Forms
+
+Zero infrastructure: a bare clone runs on SQLite with `log-only` email and a
+`local` auth stub. No Docker, Postgres, or accounts required for the fast path.
+
+## Boot (SQLite, fast path)
+
+```bash
+pnpm install          # Node >= 20, pnpm >= 10
+pnpm dev              # builds packages, migrates + seeds SQLite, runs web + api
+```
+
+- Web → http://localhost:3000 · API → http://localhost:4000/health
+- Seeded demo form → http://localhost:3000/acme/alex-rivera/lead-qualifier
+- DB file → `.data/dev.db` · emails print to the API log (`log-only`)
+
+`pnpm dev` always runs `db:setup` (migrate + seed) before the apps start, so the
+schema exists. If you instead start an app directly against a **fresh** DB, run
+`pnpm db:migrate` first — otherwise the outbox worker fails with `no such table:
+outbox`.
+
+**Relocating ports:** set `API_PORT` (the Nest app reads it) and point the web app
+at it via `NEXT_PUBLIC_API_URL`. The web dev port comes from the `apps/web` dev
+script — run it elsewhere with `pnpm --filter @quill/web exec next dev -p <port>`.
+
+## Log in to the dashboard
+
+With `AUTH_PROVIDER=local` (the default), you are logged in as the seeded demo
+account. To act as a specific user:
+
+- Set `DEV_LOGIN_EMAIL=you@example.com` in `.env` — the stub resolves that member,
+  JIT-creating a fresh account + member if none exists.
+- Or send the header `x-quill-email: you@example.com` on an API request (it
+  overrides `DEV_LOGIN_EMAIL`).
+- Set `AUTH_LOCAL_STRICT=true` to get a real "logged out" state (a request with no
+  identity returns 401 instead of falling back to the seeded account), so you can
+  exercise the login/logout redirect flow.
+
+To test the WorkOS-style JWT path offline (no identity server), mint a token the
+`workos` provider will accept:
+
+```bash
+pnpm --filter @quill/api auth:mint -- --account acct_dev --sub user_dev
+# then call the API with:  Authorization: Bearer <token>
+```
+
+## Reset demo data
+
+```bash
+pnpm db:reset         # drop + recreate + reseed the current database
+```
+
+## Postgres parity mode (matches CI + production)
+
+```bash
+pnpm dev:pg               # docker compose up postgres, migrate + seed, run both apps
+PG_PORT=5433 pnpm dev:pg  # if host port 5432 is already in use
+```
+
+Run the submission-integrity parity test directly against Postgres:
+
+```bash
+docker compose up -d --wait db
+DATABASE_URL=postgres://quill:quill@localhost:5432/quill pnpm db:migrate
+DATABASE_URL=postgres://quill:quill@localhost:5432/quill pnpm db:seed
+DATABASE_URL=postgres://quill:quill@localhost:5432/quill pnpm --filter @quill/db test
+```
+
+On Windows, run these `pnpm` scripts from git-bash or WSL — they use POSIX shell
+syntax (`${PG_PORT:-5432}`) that `cmd.exe` / PowerShell do not expand.

--- a/.env.example
+++ b/.env.example
@@ -16,15 +16,16 @@
 # DATABASE_URL=
 
 # --- API server -----------------------------------------------------------
-# Port the NestJS API listens on (default 4000; local dev convention: 4400).
-API_PORT=4400
-# Public base URL of the web app, used to build public form links.
-PUBLIC_APP_URL=http://localhost:3400
+# Port the NestJS API listens on (default 4000). `pnpm dev` binds the api here.
+# API_PORT=4000
+# Public base URL of the web app, used to build public form links. `pnpm dev`
+# serves the web app on port 3000 (set by the apps/web dev script).
+PUBLIC_APP_URL=http://localhost:3000
 
 # --- Web app --------------------------------------------------------------
 # Where the web app reaches the API from the server (RSC fetch). Default:
-# http://localhost:4000 (local dev convention: 4400)
-NEXT_PUBLIC_API_URL=http://localhost:4400
+# http://localhost:4000. If you move the api with API_PORT, match it here.
+NEXT_PUBLIC_API_URL=http://localhost:4000
 
 # The web mirrors the API's AUTH_PROVIDER to pick the right login UX (email form
 # vs WorkOS redirect). Same values as the API's AUTH_PROVIDER. Unset -> local.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# Architecture
+
+Dapta Forms is a Turborepo + pnpm-workspaces monorepo: two deployable apps over
+seven packages. This page is the map — the request flow, the dependency direction,
+and the ports/adapters seams that keep the project self-hostable. For how to run
+and change it, see [`CLAUDE.md`](CLAUDE.md); for contribution mechanics,
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## The two request paths
+
+A **public respondent** filling out a form and an **admin** building one take
+different routes through the system. The web app never touches the database — it
+always goes through the API over HTTP, so the two apps deploy independently.
+
+```
+  PUBLIC RESPONDENT                              ADMIN / FORM BUILDER
+  ────────────────                               ────────────────────
+  Browser                                        Browser
+     │  GET /[account]/[handle]/[slug]              │  /admin/... (dashboard + builder)
+     ▼                                              ▼
+  apps/web (Next.js, RSC)                        apps/web (Next.js, RSC + islands)
+     │  server-renders published config             │  lib/admin-api.ts
+     │  walks visible steps client-side             │  (Bearer JWT  |  x-quill-email)
+     │  uses @quill/engine for skip-logic           ▼
+     │  + client-side validation preview         apps/api  (admin/host controllers)
+     ▼                                              │  resolveHost(req) → { accountId, role }
+  apps/api  (public controller, /v1/public/*)      │  permissions.ts role checks
+     │  unauthed + rate-limited                     │  every repo call scoped by accountId
+     │  recompute score server-side (engine)        ▼
+     │  upsert ONE submission per (form, session) ┌─────────────────────────────────┐
+     ▼                                            │ packages/db (Drizzle repositories)│
+  packages/db  ── upsert submission ─────────────▶│  pg (source of truth) | sqlite    │
+     │           record funnel event              └─────────────────────────────────┘
+     │  enqueue side-effects to the OUTBOX table
+     ▼
+  apps/api/outbox.worker.ts  (poll + retry/backoff)
+     ├── @quill/notifications → EmailProvider adapter (log-only|noop|smtp|http)
+     └── @quill/destinations  → SubmissionDestination adapter (webhook|hubspot|log-only)
+```
+
+Two properties fall out of this shape:
+
+- **The engine is shared and pure**, so the client-side preview verdict and the
+  server-side authoritative verdict always agree. The score is *always* recomputed
+  server-side from the stored config — a client can never assert its own score.
+- **Side-effects are decoupled from the request.** The submission commits, a row is
+  written to the `outbox`, and the request returns. A background worker drains the
+  outbox with exponential backoff, so a slow or down email/CRM provider never fails
+  or blocks a submission. One submission per `(form_id, session_id)` is guaranteed
+  by an app-level upsert **and** a unique index enforced on both dialects.
+
+## Package dependency direction
+
+Dependencies point one way: apps depend on packages; packages depend only on
+packages below them; nothing depends on an app. `types` and `engine` are the
+shared foundation.
+
+```
+        apps/web  ────HTTP────▶  apps/api
+            │                        │
+            ├──────────┬────────┐    ├──────────┬───────────────┬──────────────┐
+            ▼          ▼        ▼    ▼          ▼               ▼              ▼
+        @quill/engine  @quill/types  @quill/db  @quill/notifications  @quill/destinations
+            │              │            │              │                    │
+            └──────────────┴────────────┴──────────────┴────────────────────┘
+                                        │
+                          @quill/shared      @quill/config
+                          (i18n, tokens,     (zod env schema,
+                           handles, growth)   tsconfig presets)
+```
+
+- **`@quill/types`** — the zod contracts both apps validate against: `formConfig`
+  (versioned, `version: 1`), submissions, and funnel events. The type enum for form
+  fields is re-exported from the engine so there is one source of truth.
+- **`@quill/engine`** — pure, I/O-free form logic: skip-logic (`showWhen`/`hideWhen`),
+  field validation, option/slider scoring, outcome resolution, manage-token hashing,
+  short-link rules. Fully unit-tested; imports only `node:crypto`.
+- **`@quill/db`** — one portable schema over SQLite (dev) and Postgres (prod) via
+  Drizzle, plus migrations, seed, and the account-scoped repositories.
+- **`@quill/notifications`** / **`@quill/destinations`** — the two side-effect
+  ports and their adapters (below).
+- **`@quill/shared`** — i18n (`en`/`es`), design tokens, handle utils, growth
+  attribution. **`@quill/config`** — the zod env schema and shared TS/prettier
+  presets.
+
+## The ports/adapters seams
+
+Three boundaries are defined as **ports** (interfaces) with **adapters** wired by
+configuration. Public code depends on the port; the concrete third-party adapter is
+selected at runtime and **degrades to a safe default when unconfigured** — so a fork
+with an empty `.env` runs end-to-end.
+
+| Seam | Port | Adapters | Selector | Bare-fork default |
+|---|---|---|---|---|
+| **Email** | `packages/notifications/src/email.port.ts` | `log-only`, `noop`, `smtp`, `http` | `EMAIL_PROVIDER` | `log-only` (prints to API log) |
+| **Destinations** | `packages/destinations/src/destination.port.ts` | `log-only`, `webhook`, `hubspot` | per-form config + env | `log-only` |
+| **Database** | `createDb(url)` in `packages/db/src/client.ts` | Postgres (`postgres://…`) or SQLite (`file:…`) | `DATABASE_URL` | SQLite at `.data/dev.db` |
+| **Auth** | `apps/api/src/auth.provider.ts` | `local` stub, `workos` (HS256 JWT) | `AUTH_PROVIDER` | `local` (no identity server) |
+
+Rules that keep the seams intact (enforced by the `forms-reviewer` agent):
+
+- A concrete adapter's third-party symbols never leak past its file — controllers,
+  services, and the web app depend on the port only. Selecting a provider without
+  its required secret fails loud; it never silently falls back to an insecure path.
+- The **database** has two schema files — `schema.pg.ts` (source of truth) and
+  `schema.sqlite.ts` (a portable subset mirroring it 1:1). Migrations are numbered
+  in parallel under `migrations/{postgres,sqlite}` and are **additive-only**, so the
+  same repository code runs on either dialect and CI can assert parity on Postgres.
+
+## See also
+
+- [`CLAUDE.md`](CLAUDE.md) — run/test commands, invariants, common-task file pointers.
+- [`README.md`](README.md) — quickstart and feature overview.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — DCO, commit conventions, PR gates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,220 @@
+# Dapta Forms — guide for Claude Code (and any AI coding agent)
+
+This file is loaded automatically by Claude Code for anyone working in this repo.
+It is the operating summary: how to run, test, and change **Dapta Forms** without
+breaking the invariants that keep the project self-hostable and open. Deeper
+rationale (request flow, package boundaries, the ports/adapters seams) lives in
+[`ARCHITECTURE.md`](ARCHITECTURE.md); contribution mechanics (DCO, PR gates) live
+in [`CONTRIBUTING.md`](CONTRIBUTING.md). Read those two when this summary points
+you at them.
+
+> **Naming:** the product is **Dapta Forms**. Internal packages use the `@quill/*`
+> scope — `quill` is the codename, nothing more. Prefer "Dapta Forms" in
+> user-facing text and `@quill/*` only when naming a package.
+
+## What this is
+
+An open-source, self-hostable forms platform: multi-step forms with skip-logic,
+lead scoring, outcome buckets, partial + complete submissions, a first-party
+funnel-event stream, durable email notifications, and short shareable links. A
+Turborepo + pnpm-workspaces monorepo of two apps and seven packages. **Postgres
+is the source of truth** (CI and production); **SQLite is a zero-infra dev
+accelerator** so a bare clone runs in seconds.
+
+## Repo map
+
+```
+apps/
+  web/   Next.js 16 App Router (RSC) — public form pages + admin dashboard + builder
+  api/   NestJS — public form API, admin/host API, outbox worker
+packages/
+  types/          zod contracts shared by web + api (formConfig v1, submissions, events)
+  engine/         pure form logic — skip-logic, validation, scoring, outcomes (NO I/O)
+  db/             Drizzle schema (pg + sqlite) + migrations + seed + repositories
+  notifications/  EmailProvider port + adapters (log-only/noop/smtp/http) + notifier
+  destinations/   SubmissionDestination port + adapters (webhook/hubspot/log-only)
+  shared/         i18n (en/es), handle utils, growth attribution, design tokens
+  config/         zod env schema + shared tsconfig/prettier presets
+```
+
+Dependency direction is one-directional: **apps depend on packages, never the
+reverse; the web app reaches the API only over HTTP** (it never imports `@quill/db`
+or the engine for data at runtime). The engine is pure and shared by both apps, so
+the client-side preview and the server-side verdict always agree.
+
+## How to run (zero-infra SQLite path)
+
+```bash
+pnpm install     # Node >= 20, pnpm >= 10
+pnpm dev         # builds packages, migrates + seeds a SQLite DB, starts web + api
+```
+
+`pnpm dev` runs `db:setup` (migrate + seed) **before** launching the apps, so the
+schema always exists. Then open:
+
+- **Web** → http://localhost:3000 — seeded demo form at
+  `/acme/alex-rivera/lead-qualifier`
+- **API** → http://localhost:4000/health → `{"status":"ok",…,"dialect":"sqlite"}`
+
+No Docker, no Postgres, no accounts. The DB is a file at `.data/dev.db`; email is
+`log-only` (submission notices print to the API log); dashboard auth is a local
+stub (you are logged in as the seeded demo account). Reset demo data with
+`pnpm db:reset`.
+
+**Ports.** The defaults above are what `pnpm dev` binds. To relocate the **API**,
+set `API_PORT` (the Nest app reads it at runtime) and point the web app at it with
+`NEXT_PUBLIC_API_URL`. The **web** dev port is set by the `apps/web` dev script; to
+run it elsewhere use `pnpm --filter @quill/web exec next dev -p <port>`. See
+`.env.example` for every knob — all have safe defaults.
+
+**Postgres parity mode** (matches CI + production):
+
+```bash
+pnpm dev:pg            # docker compose up postgres, migrate + seed, run both apps
+PG_PORT=5433 pnpm dev:pg   # if 5432 is taken locally
+```
+
+The `.claude/skills/local-dev` skill wraps boot / seed / login / reset / parity as
+an invokable recipe if you'd rather not remember the commands.
+
+## How to test
+
+Vitest across the board (no Jest). Run from the repo root:
+
+```bash
+pnpm test            # all packages + apps (SQLite)
+pnpm typecheck
+pnpm lint
+pnpm build           # builds packages AND both apps (what CI builds)
+```
+
+Scope to one workspace, or one file:
+
+```bash
+pnpm --filter @quill/engine test
+pnpm --filter @quill/engine exec vitest run src/form-logic.spec.ts
+```
+
+**Postgres parity test** (the submission-integrity path CI asserts on every PR):
+
+```bash
+docker compose up -d --wait db
+DATABASE_URL=postgres://quill:quill@localhost:5432/quill pnpm db:migrate
+DATABASE_URL=postgres://quill:quill@localhost:5432/quill pnpm db:seed
+DATABASE_URL=postgres://quill:quill@localhost:5432/quill pnpm --filter @quill/db test
+```
+
+`packages/db/src/submission.spec.ts` runs against `DATABASE_URL` on **both**
+dialects and asserts the `submission_form_session_uq` unique index rejects a
+duplicate — that is the SQLite↔Postgres parity guarantee. If you touch the DB
+layer, run this before you push.
+
+## Architecture invariants (a change MUST respect these)
+
+1. **Dual-dialect schema parity + additive-only migrations.** The data model lives
+   in two files — `packages/db/src/schema.pg.ts` (source of truth) and
+   `packages/db/src/schema.sqlite.ts` (portable subset). They mirror 1:1 on
+   table/column names (Postgres `jsonb`/`bigint` ↔ SQLite `text` JSON/`integer`
+   epoch-ms). Any schema change edits **both**, ships a numbered migration in
+   **both** `packages/db/migrations/{postgres,sqlite}/`, and is **additive** — new
+   nullable columns / new tables, never a destructive rename or drop that would
+   break a running deployment.
+2. **The engine is pure functions with tests.** `@quill/engine` has no DB, no fs,
+   no network (only `node:crypto`). Skip-logic, validation, scoring, and outcome
+   resolution are deterministic and unit-tested. Keep it that way — never import
+   I/O into `packages/engine`.
+3. **Public/admin API split + account scoping on every admin route.** Public form
+   endpoints (`apps/api/src/public.controller.ts`, `/v1/public/*`) are unauthed and
+   rate-limited. Admin/host endpoints resolve a principal via
+   `this.auth.resolveHost(req)` and pass `accountId` into every repository call so
+   queries are scoped to that account. A new admin route MUST resolve the principal
+   and pass its `accountId` — never query across accounts. Role checks live in
+   `apps/api/src/permissions.ts`.
+4. **Config is a versioned zod schema — extend, never break v1.** The form config
+   contract is `formConfigSchema` in `packages/types/src/index.ts` with
+   `version: z.literal(1)`. Add optional fields; do not remove or repurpose
+   existing ones. A published form's stored config must keep parsing.
+5. **Outbox for side-effects.** Emails and destination deliveries are enqueued to a
+   transactional **outbox** and drained by `apps/api/src/outbox.worker.ts` with
+   retry + exponential backoff (`backoffMs` in `packages/db/src/outbox.ts`). Never
+   fire an email or webhook inline from a request handler — enqueue it (see
+   `apps/api/src/email-effects.ts`, `destination-effects.ts`).
+6. **Auth behind a port — never import provider specifics outside it.** The auth
+   port is `apps/api/src/auth.provider.ts` (`local` stub + `createAuthProvider`);
+   the WorkOS adapter is `auth.provider.workos.ts`, selected by `AUTH_PROVIDER`.
+   No WorkOS-specific import may leak into controllers, services, or the web app —
+   they depend on the port only. A bare fork runs on the `local` provider with no
+   external identity service.
+7. **Ports/adapters for email + destinations.** Public packages depend on ports
+   (`EmailProvider`, `SubmissionDestination`, the DB factory), never on a concrete
+   third-party adapter. Adapters are wired by configuration
+   (`packages/notifications/src/factory.ts`, `packages/destinations/src/factory.ts`)
+   and gracefully degrade to `log-only` when their settings are absent, so a fork
+   runs with nothing configured.
+8. **i18n EN + ES for every user-facing string.** All copy lives in
+   `packages/shared/src/i18n/index.ts` as one typed `FormsMessages` catalog with
+   `en` and `es` objects — the compiler enforces key parity. Never hardcode
+   user-facing strings in components; add the key to both locales.
+9. **No secrets, ever.** Server-only secrets never reach the browser (only
+   `NEXT_PUBLIC_*` is client-exposed); webhook/destination secrets are masked in
+   responses and stripped from public payloads. `.env` is gitignored; only
+   `.env.example` (placeholders) is committed. The `scripts/publish-gate.sh` secret
+   scan runs in CI — do not add real hosts, tokens, or credentialed URLs anywhere.
+
+## Review gates a PR must pass
+
+- **DCO sign-off** on every commit: `git commit -s` (adds `Signed-off-by:`). Not a
+  CLA. Enforced by `.github/workflows/dco.yml`.
+- **Conventional Commit** title (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
+  `chore:` …) — enforced by commitlint.
+- **CI green**: lint + typecheck + `pnpm test` on **SQLite**, a **Postgres** parity
+  job (the unique-index submission-integrity test), a full `pnpm build`, and the
+  **publish-gate** secret scan. See `.github/workflows/ci.yml`.
+- **Changeset** if you changed a published package's behavior: `pnpm changeset`.
+- **OptiBot triage**: the repo runs automated PR review (OptiBot). Address every
+  comment before merge — fix it, or reply explaining why it does not apply. Do not
+  merge over unresolved review comments.
+
+Before opening a PR, run the read-only **`forms-reviewer`** agent
+(`.claude/agents/forms-reviewer.md`) — it checks your diff against the invariants
+above and the gates so CI does not surprise you.
+
+## Common tasks (file pointers)
+
+**Add a question type, end-to-end** (order matters):
+1. `packages/engine/src/form-logic.ts` — add to `FORM_FIELD_TYPES`; add branches in
+   `validateAnswer` + `validateAnswerCode`; extend `computeScore` if it is scored.
+2. `packages/engine/src/form-config.ts` — per-type defaults in `createEmptyStep`.
+3. `packages/types/src/index.ts` — add any new step fields to `formStepSchema` (the
+   type enum is re-exported from the engine, so it updates automatically); add a new
+   `ValidationCode` if you introduced one.
+4. `packages/shared/src/i18n/index.ts` — label under `admin.editor.types` and any
+   new `renderer.errors.*` code, in **both** `en` and `es`.
+5. `apps/web/app/admin/forms/[id]/edit/_components/` — `step-list.tsx` (register in
+   `STEP_TYPES`) and `step-properties.tsx` (the editing panel); add an editor
+   component if the type needs one.
+6. `apps/web/components/public/step-input.tsx` — add a `case` to the render switch.
+7. Tests: `packages/engine/src/form-logic.spec.ts` (+ `form-config.spec.ts`).
+
+**Add a destination adapter** (CRM/webhook sync):
+`packages/destinations/src/destination.port.ts` (extend the driver union) →
+`src/adapters/<name>.ts` (implement `SubmissionDestination`; throw only on
+retryable failures) → `src/factory.ts` (add the switch case + graceful fallback) →
+`src/index.ts` (export) → `packages/types/src/index.ts` (add the schema variant to
+`formDestinationSchema`) → UI in
+`apps/web/app/admin/forms/[id]/integrations/` → test `src/adapters/<name>.spec.ts`.
+
+**Add a language:** `packages/shared/src/i18n/index.ts` — extend the `Locale` union,
+add a full `FormsMessages` const (the interface forces complete key coverage), wire
+it into `getMessages`. Web selection lives in `apps/web/lib/locale.ts` and
+`components/language-switcher.tsx`.
+
+## Related
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — request flow, package dependency direction,
+  the ports/adapters seams.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — DCO, commit conventions, PR flow.
+- [`SECURITY.md`](SECURITY.md) — reporting vulnerabilities (never a public issue).
+- [`.claude/agents/forms-reviewer.md`](.claude/agents/forms-reviewer.md) /
+  [`forms-contributor.md`](.claude/agents/forms-contributor.md) — the review + coding
+  agents for this repo.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ pnpm install          # Node >= 20, pnpm >= 10
 pnpm dev              # builds packages, creates + seeds a SQLite DB, starts both apps
 ```
 
-Then open (local dev convention: web **3400** / api **4400**; the defaults
-without env are 3000/4000):
+Then open (`pnpm dev` binds web **3000** and api **4000**):
 
 - **Web** → http://localhost:3000 — a seeded demo form at
   [`/acme/alex-rivera/lead-qualifier`](http://localhost:3000/acme/alex-rivera/lead-qualifier)
 - **API** → http://localhost:4000/health
+
+> Relocating ports: set `API_PORT` (the API reads it) and point the web app at it
+> with `NEXT_PUBLIC_API_URL`. The web dev port comes from the `apps/web` dev
+> script — run it elsewhere with `pnpm --filter @quill/web exec next dev -p <port>`.
 
 No Docker, no Postgres, no VPN, no accounts. The database is a file at
 `.data/dev.db`; email is `log-only` (submission notices print to the API log).
@@ -92,6 +95,9 @@ The web app talks to the API over HTTP — it never imports the database directl
 so the two deploy independently. The engine is pure and shared by both, so the
 client preview and the server verdict always agree.
 
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full request-flow diagram, the
+package dependency direction, and the ports/adapters seams.
+
 ### Submission integrity (dual enforcement)
 
 One persisted submission per (form, session) is guaranteed by:
@@ -114,7 +120,7 @@ Everything has a safe default (see [`.env.example`](.env.example)). Copy it to
 | `DATABASE_URL` | `file:./.data/dev.db` | `postgres://…` switches to Postgres |
 | `EMAIL_PROVIDER` | `log-only` | `noop` \| `smtp` \| `http` |
 | `EMAIL_HTTP_PROFILE` | `generic` | `transactional-v1` opts into the managed contract (see `.env.example`) |
-| `API_PORT` | `4000` | local dev convention: `4400` |
+| `API_PORT` | `4000` | port the API listens on |
 | `NEXT_PUBLIC_API_URL` | `http://localhost:4000` | where the web app reaches the API |
 
 ## Scripts
@@ -149,6 +155,11 @@ Quill is **deployment-agnostic** (Node runtime, no host-only APIs).
 
 Read [`CONTRIBUTING.md`](CONTRIBUTING.md). PRs are DCO-signed (`git commit -s`),
 Conventional-Commit titled, and green on CI (SQLite + a Postgres parity job).
+
+Working with Claude Code or another AI coding agent? [`CLAUDE.md`](CLAUDE.md) is
+the agent guide (run/test commands, architecture invariants, common-task file
+pointers), and `.claude/agents/` ships a read-only **forms-reviewer** and a
+**forms-contributor** agent you can run in this repo.
 
 ## License
 


### PR DESCRIPTION
Makes the repo self-sufficient for an external developer contributing **with Claude Code** (or any AI coding agent), and tightens the root docs. Docs-only — no product code touched.

## What's added
- **`CLAUDE.md`** (root, auto-loaded by Claude Code): repo map, zero-infra run/test commands, the architecture invariants a change must respect (dual-dialect schema parity + additive-only migrations, pure engine, public/admin split + account scoping, versioned config v1, outbox for side-effects, auth behind a port, ports/adapters, i18n EN+ES, no secrets), the PR review gates (DCO, Conventional Commits, CI both dialects, publish-gate, OptiBot triage), and file pointers for the common tasks (add a question type / destination adapter / language).
- **`ARCHITECTURE.md`** (root, one page): ascii request-flow diagram (public respondent vs admin/builder), package dependency direction, and the ports/adapters seams (email / destinations / db / auth) with the bare-fork default for each.
- **`.claude/agents/forms-reviewer.md`**: read-only pre-PR reviewer (tools: Read/Grep/Glob/Bash) encoding the invariants + gates.
- **`.claude/agents/forms-contributor.md`**: coding-agent brief that knows the monorepo layout and conventions.
- **`.claude/skills/local-dev`**: boot / seed / login (dev impersonation, `auth:mint`) / reset / Postgres-parity recipe.

No model pins on the agents — contributors pick their own.

## Root helps
- **`README.md`** + **`.env.example`**: corrected the local dev port story to the true `pnpm dev` defaults (**web 3000 / api 4000**). The previous "web 3400 convention" was unreachable via the default path — `apps/web` dev hardcodes `next dev -p 3000`, and the `-p` flag beats any `PORT` env. Added `ARCHITECTURE.md` + `CLAUDE.md` links from the README.

## Verification
- **Cold clone**: `rm -rf node_modules .data && pnpm install && pnpm dev` (reproduced on assigned ports) boots; the seeded form at `/acme/alex-rivera/lead-qualifier` renders and the public API returns config v1; `/health` reports `dialect: sqlite`; outbox worker starts; zero web errors.
- `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` — all green.
- `bash scripts/publish-gate.sh` — **PASSED** (no internal tokens; zero Dapta-internal info in any authored file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)