### PR TITLE
design: public form renderer — Calendars-family polish

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/loading.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/loading.tsx
@@ -1,20 +1,20 @@
 import { Skeleton } from '@/components/skeleton';
 
+/**
+ * Loading state for the public form — a skeleton that mirrors the cover screen
+ * region (logo, headline, sub, CTA), not a blocking spinner (R22). Centered and
+ * framed to match the rendered surface so there's no layout jump.
+ */
 export default function FormLoading() {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <div className="mb-8 flex flex-col gap-2">
-        <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-9 w-64" />
+    <main className="flex min-h-dvh flex-col items-center justify-center bg-background px-6 py-12">
+      <div className="flex w-full max-w-[460px] flex-col items-center gap-5 rounded-2xl border border-border bg-card p-11">
+        <Skeleton className="h-7 w-28 rounded-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-3/4" />
+        <Skeleton className="mt-1 h-4 w-56" />
         <Skeleton className="h-4 w-40" />
-      </div>
-      <div className="grid gap-8 md:grid-cols-[1fr_320px]">
-        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <Skeleton key={i} className="h-9 w-full" />
-          ))}
-        </div>
-        <Skeleton className="h-48 w-full" />
+        <Skeleton className="mt-4 h-[54px] w-full rounded-lg" />
       </div>
     </main>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1,63 +1,43 @@
 /* -----------------------------------------------------------------------------
- * Public form renderer — a self-contained, mobile-first "one question per screen"
- * surface (the pilot's King-Kong/Typeform feel). It is intentionally a single
- * LIGHT look regardless of the app theme: a public form is a branded landing
- * surface, not app chrome. The one instance-level value is the accent, threaded
- * through `--pf-primary` (set inline from `branding.primaryColor`, AA-clamped by
- * the engine's accent helper); everything else is a fixed local token so the
- * page reads as one system. All rules are scoped under `.pf`.
+ * Public form renderer — a mobile-first "one question per screen" surface (the
+ * pilot's King-Kong/Typeform feel), styled as a MEMBER OF THE DAPTA CALENDARS
+ * FAMILY: it consumes the same shadcn semantic token contract as the app and the
+ * public booking page (@quill/shared/tokens.css → globals), so it is dark-first,
+ * theme-aware (light via prefers-color-scheme / data-theme), and harmonic with
+ * Dapta everywhere. Depth = surface + 1px border (no heavy rest shadow), lime is
+ * the one accent (always black text on lime).
+ *
+ * The one instance-level value is the per-form accent, threaded through
+ * `--pf-primary` — it DEFAULTS to the theme `--primary` and is overridden inline
+ * from `branding.primaryColor` (AA-clamped by the engine's accent helper), the
+ * same pattern the booking page's BrandedShell uses. Everything else is a
+ * semantic token so the page reads as one system. All rules are scoped under `.pf`.
  * -------------------------------------------------------------------------- */
 
 .pf {
-  --pf-primary: #cbe84f;
-  --pf-primary-contrast: #1a1a1c;
-  --pf-bg: #f5f5f5;
-  --pf-surface: #ffffff;
-  --pf-text: #111114;
-  --pf-muted: #6b6b73;
-  --pf-border: #d9dade;
-  --pf-focus: #2563eb;
-  --pf-danger: #dc2626;
-  --pf-radius: 12px;
-  --pf-radius-sm: 8px;
+  /* Accent defaults to the theme primary; branding.primaryColor overrides inline. */
+  --pf-primary: var(--primary);
+  --pf-primary-contrast: var(--primary-foreground);
+
+  /* Radii derived from the token scale (8px control / 16px card). */
+  --pf-radius: calc(var(--radius) * 2); /* 16px — cards & prominent controls */
+  --pf-radius-sm: var(--radius); /* 8px — inputs */
   --pf-gap: 12px;
   --pf-ease: cubic-bezier(0.22, 1, 0.36, 1);
 
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
-  background: var(--pf-bg);
-  color: var(--pf-text);
+  background: var(--background);
+  color: var(--foreground);
   font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
   -webkit-font-smoothing: antialiased;
 }
 
-/* Themed scrollbars for any inner overflow region on this light surface
-   (Design Quality Bar §1 — never a native/dark track on a light surface). */
-.pf *::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-.pf *::-webkit-scrollbar-track {
-  background: transparent;
-}
-.pf *::-webkit-scrollbar-thumb {
-  background: var(--pf-border);
-  border-radius: 999px;
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
-.pf *::-webkit-scrollbar-thumb:hover {
-  background: var(--pf-muted);
-  background-clip: padding-box;
-}
-.pf * {
-  scrollbar-width: thin;
-  scrollbar-color: var(--pf-border) transparent;
-}
-
+/* Scrollbars are themed globally (globals.css, tokens); no native track appears.
+   Lime focus ring, everywhere on this surface. */
 .pf :focus-visible {
-  outline: 2px solid var(--pf-focus);
+  outline: 2px solid var(--pf-primary);
   outline-offset: 2px;
 }
 
@@ -69,44 +49,47 @@
   background: var(--pf-primary);
   color: var(--pf-primary-contrast);
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 600;
   text-align: center;
   padding: 12px 20px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   flex-shrink: 0;
 }
 
-/* ── Top bar (back · logo · spacer) ── */
+/* ── Top bar (back · logo · spacer) + progress ── */
 .pf__topbar {
-  background: var(--pf-surface);
-  border-bottom: 1px solid #eee;
-  padding: 14px 20px 18px;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  padding: 14px 20px 16px;
   flex-shrink: 0;
 }
 .pf__topbar-inner {
   display: grid;
-  grid-template-columns: 44px 1fr 44px;
+  grid-template-columns: 40px 1fr 40px;
   align-items: center;
   max-width: 480px;
-  margin: 0 auto 16px;
+  margin: 0 auto 14px;
 }
 .pf__back {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   background: none;
   border: none;
-  font-size: 22px;
+  font-size: 20px;
   line-height: 1;
-  color: var(--pf-text);
+  color: var(--muted-foreground);
   cursor: pointer;
   border-radius: var(--pf-radius-sm);
-  transition: background 0.12s var(--pf-ease);
+  transition: background 0.12s var(--pf-ease), color 0.12s var(--pf-ease);
 }
 .pf__back:hover {
-  background: var(--pf-bg);
+  background: var(--muted);
+  color: var(--foreground);
+}
+.pf__back:active {
+  transform: scale(0.94);
 }
 .pf__back--placeholder {
   visibility: hidden;
@@ -114,16 +97,18 @@
 }
 .pf__logo-img {
   display: block;
-  height: 32px;
+  height: 30px;
   width: auto;
-  max-width: 150px;
+  max-width: 160px;
   margin: 0 auto;
   object-fit: contain;
 }
 .pf__logo--fallback {
   text-align: center;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
 }
 .pf__logo-dot {
   color: var(--pf-primary);
@@ -134,12 +119,11 @@
   max-width: 480px;
   margin: 0 auto;
   width: 100%;
-  padding: 0 2px;
 }
 .pf-progress__track {
   height: 4px;
   width: 100%;
-  background: var(--pf-border);
+  background: var(--muted);
   border-radius: 999px;
   overflow: hidden;
 }
@@ -147,7 +131,7 @@
   height: 100%;
   background: var(--pf-primary);
   border-radius: 999px;
-  transition: width 0.3s var(--pf-ease);
+  transition: width 0.35s var(--pf-ease);
 }
 
 /* ── Body ── */
@@ -159,7 +143,7 @@
 }
 .pf__inner {
   width: 100%;
-  max-width: 600px;
+  max-width: 540px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -171,15 +155,15 @@
   flex: 1;
 }
 .pf-animate {
-  animation: pfSlideIn 0.32s var(--pf-ease);
+  animation: pfSlideIn 0.34s var(--pf-ease);
 }
 @keyframes pfSlideIn {
   from {
-    transform: translateX(28px);
+    transform: translateY(10px);
     opacity: 0;
   }
   to {
-    transform: translateX(0);
+    transform: translateY(0);
     opacity: 1;
   }
 }
@@ -192,46 +176,54 @@
 /* ── Question typography ── */
 .pf__question-wrap {
   width: 100%;
-  max-width: 540px;
+  max-width: 520px;
   margin: 0 auto;
-  padding: 0 8px;
 }
 .pf__question {
   text-align: center;
-  font-size: clamp(20px, 4.6vw, 27px);
-  font-weight: 800;
-  line-height: 1.3;
+  font-size: clamp(21px, 4.4vw, 28px);
+  font-weight: 700;
+  line-height: 1.28;
+  letter-spacing: -0.015em;
   margin: 0;
+  color: var(--foreground);
   text-wrap: balance;
 }
 .pf__helper {
   text-align: center;
-  font-size: 16px;
-  color: var(--pf-muted);
-  margin: 10px 0 0;
-  line-height: 1.45;
+  font-size: 15px;
+  color: var(--muted-foreground);
+  margin: 12px 0 0;
+  line-height: 1.5;
+  text-wrap: balance;
 }
 .pf__fields {
-  margin-top: 36px;
+  margin-top: 32px;
 }
 
 /* ── Inputs ── */
 .pf-input {
   width: 100%;
-  padding: 16px;
-  font-size: 17px;
+  padding: 14px 16px;
+  font-size: 16px;
   font-family: inherit;
-  color: var(--pf-text);
-  background: var(--pf-surface);
-  border: 1px solid var(--pf-border);
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--input);
   border-radius: var(--pf-radius-sm);
   outline: none;
   box-sizing: border-box;
   transition: border-color 0.12s var(--pf-ease), box-shadow 0.12s var(--pf-ease);
 }
+.pf-input::placeholder {
+  color: var(--muted-foreground);
+}
+.pf-input:hover {
+  border-color: var(--muted-foreground);
+}
 .pf-input:focus {
-  border-color: var(--pf-focus);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  border-color: var(--pf-primary);
+  box-shadow: 0 0 0 3px var(--ring);
 }
 .pf-name-fields {
   display: grid;
@@ -252,7 +244,7 @@
   margin: 0;
   font-size: 16px;
   line-height: 1.6;
-  color: var(--pf-muted);
+  color: var(--muted-foreground);
   text-align: center;
 }
 
@@ -265,56 +257,58 @@
 .pf-choice-list {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
   width: 100%;
   min-height: 56px;
-  padding: 16px 20px;
-  font-size: 16px;
+  padding: 14px 18px;
+  font-size: 15px;
   font-family: inherit;
   font-weight: 500;
   text-align: left;
-  color: var(--pf-text);
-  background: var(--pf-surface);
-  border: 2px solid transparent;
-  border-radius: var(--pf-radius);
+  color: var(--foreground);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--pf-radius-sm);
   cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-  transition: border-color 0.12s var(--pf-ease), transform 0.08s var(--pf-ease);
+  transition: border-color 0.12s var(--pf-ease), background 0.12s var(--pf-ease),
+    transform 0.08s var(--pf-ease);
 }
 .pf-choice-list:hover {
-  border-color: var(--pf-border);
+  border-color: var(--muted-foreground);
+  background: var(--muted);
 }
 .pf-choice-list:active {
-  transform: scale(0.995);
+  transform: scale(0.99);
 }
-.pf-choice-list--selected {
+.pf-choice-list--selected,
+.pf-choice-list--selected:hover {
   border-color: var(--pf-primary);
-  background: color-mix(in srgb, var(--pf-primary) 14%, var(--pf-surface));
+  background: color-mix(in srgb, var(--pf-primary) 14%, var(--card));
 }
 .pf-choice-list__radio {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  border: 2px solid var(--pf-border);
-  background: var(--pf-bg);
+  border: 2px solid var(--border);
+  background: var(--background);
   flex-shrink: 0;
   transition: background 0.12s, border-color 0.12s;
 }
 .pf-choice-list--selected .pf-choice-list__radio {
   background: var(--pf-primary);
   border-color: var(--pf-primary);
-  box-shadow: inset 0 0 0 3px var(--pf-surface);
+  box-shadow: inset 0 0 0 3px var(--card);
 }
 .pf-choice-list__icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
-  background: #f3f4f6;
+  background: var(--muted);
   flex-shrink: 0;
-  font-size: 20px;
+  font-size: 19px;
   line-height: 1;
 }
 .pf-choice-list__text {
@@ -338,35 +332,37 @@
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  min-height: 96px;
+  min-height: 100px;
   padding: 16px 8px;
-  background: var(--pf-surface);
-  border: 2px solid transparent;
-  border-radius: 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--pf-radius);
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-  transition: border-color 0.12s var(--pf-ease), transform 0.08s var(--pf-ease);
+  transition: border-color 0.12s var(--pf-ease), background 0.12s var(--pf-ease),
+    transform 0.08s var(--pf-ease);
   font-family: inherit;
 }
 .pf-choice-icon:hover {
-  border-color: var(--pf-border);
+  border-color: var(--muted-foreground);
+  background: var(--muted);
 }
 .pf-choice-icon:active {
   transform: scale(0.98);
 }
-.pf-choice-icon--selected {
+.pf-choice-icon--selected,
+.pf-choice-icon--selected:hover {
   border-color: var(--pf-primary);
-  background: color-mix(in srgb, var(--pf-primary) 12%, var(--pf-surface));
+  background: color-mix(in srgb, var(--pf-primary) 12%, var(--card));
 }
 .pf-choice-icon__circle {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
+  width: 46px;
+  height: 46px;
   border-radius: 50%;
-  background: #f3f4f6;
-  font-size: 24px;
+  background: var(--muted);
+  font-size: 23px;
   line-height: 1;
 }
 .pf-choice-icon__label {
@@ -374,6 +370,7 @@
   font-weight: 500;
   text-align: center;
   line-height: 1.25;
+  color: var(--foreground);
 }
 
 /* ── Searchable dropdown ── */
@@ -382,45 +379,46 @@
 }
 .pf-dropdown__list {
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + 6px);
   left: 0;
   right: 0;
   z-index: 50;
   margin: 0;
-  padding: 4px 0;
+  padding: 6px;
   list-style: none;
-  background: var(--pf-surface);
-  border: 1px solid var(--pf-border);
+  background: var(--popover);
+  border: 1px solid var(--border);
   border-radius: var(--pf-radius-sm);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
-  max-height: 240px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  max-height: 244px;
   overflow-y: auto;
 }
 .pf-dropdown__option {
   display: block;
   width: 100%;
-  padding: 12px 16px;
-  font-size: 16px;
+  padding: 11px 12px;
+  font-size: 15px;
   font-family: inherit;
   text-align: left;
-  color: var(--pf-text);
+  color: var(--popover-foreground);
   background: none;
   border: none;
+  border-radius: 6px;
   cursor: pointer;
   transition: background 0.1s;
 }
 .pf-dropdown__option:hover,
 .pf-dropdown__option:focus-visible {
-  background: var(--pf-bg);
+  background: var(--muted);
 }
 .pf-dropdown__option--selected {
-  background: color-mix(in srgb, var(--pf-primary) 18%, var(--pf-surface));
+  background: color-mix(in srgb, var(--pf-primary) 18%, var(--popover));
   font-weight: 600;
 }
 .pf-dropdown__empty {
-  padding: 12px 16px;
-  font-size: 15px;
-  color: var(--pf-muted);
+  padding: 12px;
+  font-size: 14px;
+  color: var(--muted-foreground);
   text-align: center;
 }
 
@@ -435,24 +433,24 @@
   gap: 10px;
   width: fit-content;
   margin: 0 auto 24px;
-  background: var(--pf-text);
+  background: var(--muted);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 16px 40px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  padding: 14px 36px;
   white-space: nowrap;
 }
 .pf-slider__pill-num {
-  font-size: 40px;
+  font-size: 38px;
   font-weight: 800;
   line-height: 1;
   color: var(--pf-primary);
   letter-spacing: -0.02em;
 }
 .pf-slider__pill-label {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   line-height: 1;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--muted-foreground);
 }
 .pf-slider__input {
   -webkit-appearance: none;
@@ -465,26 +463,26 @@
   display: block;
 }
 .pf-slider__input::-webkit-slider-runnable-track {
-  height: 12px;
+  height: 10px;
   border-radius: 999px;
   background: linear-gradient(
     to right,
     var(--pf-primary) 0%,
     var(--pf-primary) var(--pf-progress, 0%),
-    #e5e7eb var(--pf-progress, 0%),
-    #e5e7eb 100%
+    var(--muted) var(--pf-progress, 0%),
+    var(--muted) 100%
   );
 }
 .pf-slider__input::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
-  background: #fff;
-  border: 3px solid var(--pf-text);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
-  margin-top: -11px;
+  background: var(--card);
+  border: 3px solid var(--pf-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  margin-top: -10px;
   cursor: grab;
 }
 .pf-slider__input:active::-webkit-slider-thumb {
@@ -492,32 +490,32 @@
   cursor: grabbing;
 }
 .pf-slider__input::-moz-range-thumb {
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
-  background: #fff;
-  border: 3px solid var(--pf-text);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  background: var(--card);
+  border: 3px solid var(--pf-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
   cursor: grab;
 }
 .pf-slider__input::-moz-range-track {
-  height: 12px;
+  height: 10px;
   border-radius: 999px;
-  background: #e5e7eb;
+  background: var(--muted);
 }
 .pf-slider__input::-moz-range-progress {
-  height: 12px;
+  height: 10px;
   border-radius: 999px;
   background: var(--pf-primary);
 }
 .pf-slider__scale {
   display: flex;
   justify-content: space-between;
-  margin-top: 6px;
+  margin-top: 8px;
   padding: 0 2px;
   font-size: 12px;
   font-weight: 500;
-  color: #9ca3af;
+  color: var(--muted-foreground);
   user-select: none;
 }
 
@@ -525,7 +523,7 @@
 .pf__error {
   text-align: center;
   font-size: 14px;
-  color: var(--pf-danger);
+  color: var(--destructive);
   margin-top: 14px;
 }
 
@@ -533,17 +531,18 @@
 .pf__btn {
   display: block;
   width: 100%;
-  min-height: 56px;
+  min-height: 54px;
   padding: 0 24px;
-  font-size: 17px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 600;
   font-family: inherit;
   color: var(--pf-primary-contrast);
   background: var(--pf-primary);
   border: none;
-  border-radius: var(--pf-radius);
+  border-radius: var(--pf-radius-sm);
   cursor: pointer;
-  transition: opacity 0.12s, transform 0.08s var(--pf-ease);
+  transition: opacity 0.12s, transform 0.08s var(--pf-ease),
+    box-shadow 0.12s var(--pf-ease);
 }
 .pf__btn:hover {
   opacity: 0.92;
@@ -562,8 +561,8 @@
 /* ── Cover ── */
 .pf--cover .pf__cover-header {
   flex-shrink: 0;
-  background: var(--pf-surface);
-  border-bottom: 1px solid #eee;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -575,7 +574,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 24px;
+  padding: 32px 24px;
   text-align: center;
   gap: 8px;
 }
@@ -587,53 +586,61 @@
   align-items: center;
 }
 .pf__badge {
-  font-size: 14px;
+  display: inline-block;
+  font-size: 12px;
   font-weight: 600;
-  color: var(--pf-muted);
-  margin: 0 0 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pf-primary);
+  background: color-mix(in srgb, var(--pf-primary) 14%, transparent);
+  border-radius: 999px;
+  padding: 6px 14px;
+  margin: 0 0 18px;
 }
 .pf__title {
-  font-size: clamp(26px, 6vw, 36px);
+  font-size: clamp(28px, 6vw, 38px);
   font-weight: 800;
-  line-height: 1.25;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
   margin: 0;
+  color: var(--foreground);
   text-wrap: balance;
 }
 .pf__subheadline {
   font-size: clamp(15px, 3.6vw, 17px);
-  font-weight: 500;
-  line-height: 1.45;
-  color: var(--pf-muted);
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--muted-foreground);
   margin: 16px 0 0;
   text-wrap: balance;
 }
 .pf__trust {
   font-size: 13px;
-  color: var(--pf-muted);
-  margin: 18px 0 0;
+  color: var(--muted-foreground);
+  margin: 20px 0 0;
 }
 .pf__cover-footer {
   flex-shrink: 0;
   width: 100%;
-  max-width: 480px;
+  max-width: 460px;
   margin: 0 auto;
-  padding: 0 24px calc(40px + env(safe-area-inset-bottom));
+  padding: 0 24px calc(36px + env(safe-area-inset-bottom));
 }
 
 /* ── Client-logos marquee ── */
 .pf-logos {
   width: 100%;
-  max-width: 640px;
-  margin: 28px auto 0;
+  max-width: 620px;
+  margin: 32px auto 0;
 }
 .pf-logos__label {
-  margin: 0 0 12px;
+  margin: 0 0 14px;
   text-align: center;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(0, 0, 0, 0.5);
+  color: var(--muted-foreground);
 }
 .pf-logos__viewport {
   overflow: hidden;
@@ -658,18 +665,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.06);
-  border-radius: 12px;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 10px;
   padding: 8px 16px;
-  height: 48px;
+  height: 46px;
   min-width: 88px;
   flex-shrink: 0;
-  font-weight: 700;
+  font-weight: 600;
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--muted-foreground);
 }
 .pf-logos__img {
-  height: 26px;
+  height: 24px;
   max-width: 100px;
   object-fit: contain;
 }
@@ -698,10 +706,10 @@
   padding: 40px 24px;
 }
 .pf-reveal__spinner {
-  width: 56px;
-  height: 56px;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
-  border: 5px solid rgba(0, 0, 0, 0.1);
+  border: 4px solid var(--muted);
   border-top-color: var(--pf-primary);
   animation: pf-spin 0.9s linear infinite;
   margin-bottom: 28px;
@@ -715,12 +723,14 @@
   font-size: clamp(22px, 5vw, 28px);
   font-weight: 800;
   line-height: 1.2;
+  letter-spacing: -0.02em;
   margin: 0 0 12px;
+  color: var(--foreground);
   text-wrap: balance;
 }
 .pf-reveal__subtitle {
-  font-size: 16px;
-  color: var(--pf-muted);
+  font-size: 15px;
+  color: var(--muted-foreground);
   margin: 0 0 24px;
   line-height: 1.5;
   text-wrap: balance;
@@ -729,7 +739,7 @@
   width: 260px;
   max-width: 100%;
   height: 8px;
-  background: #e5e7eb;
+  background: var(--muted);
   border-radius: 999px;
   overflow: hidden;
 }
@@ -756,26 +766,29 @@
   padding: 40px 24px;
 }
 .pf-done__check {
-  width: 72px;
-  height: 72px;
+  width: 68px;
+  height: 68px;
   border-radius: 50%;
   background: var(--pf-primary);
   color: var(--pf-primary-contrast);
-  font-size: 34px;
+  font-size: 32px;
   font-weight: 800;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 24px;
+  box-shadow: 0 0 0 8px color-mix(in srgb, var(--pf-primary) 14%, transparent);
 }
 .pf-done__title {
   font-size: clamp(24px, 5vw, 30px);
   font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--foreground);
   margin: 0 0 10px;
 }
 .pf-done__body {
   font-size: 16px;
-  color: var(--pf-muted);
+  color: var(--muted-foreground);
   margin: 0 0 28px;
   line-height: 1.5;
   text-wrap: balance;
@@ -784,12 +797,13 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 14px 24px;
+  min-height: 48px;
+  padding: 0 24px;
   font-size: 16px;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--pf-primary-contrast);
   background: var(--pf-primary);
-  border-radius: var(--pf-radius);
+  border-radius: var(--pf-radius-sm);
   text-decoration: none;
   transition: opacity 0.12s, transform 0.08s var(--pf-ease);
 }
@@ -801,26 +815,85 @@
 }
 .pf-done__cta-question {
   font-size: 14px;
-  color: var(--pf-muted);
+  color: var(--muted-foreground);
   margin: 0 0 12px;
 }
 
-/* ── Desktop niceties ── */
+/* ── Desktop — a deliberate, centered, FRAMED card (not a lonely box on a void).
+   The interactive surface (topbar + body) reads as one bounded panel centered in
+   the viewport, echoing the booking page's card-on-canvas composition. Mobile
+   keeps the immersive full-bleed flow. ── */
 @media (min-width: 769px) {
-  /* Vertically center the single question on larger screens so the composition
-     stays balanced rather than top-heavy (Design Quality Bar §9). Mobile keeps
-     the natural top-aligned flow. */
   .pf__body {
-    padding: 44px 24px 36px;
+    padding: 40px 40px 36px;
     justify-content: center;
   }
   .pf__inner {
     flex: 0 1 auto;
   }
   .pf__fields {
-    margin-top: 40px;
+    margin-top: 36px;
+  }
+
+  /* Steps: join topbar + body into a single centered card. */
+  .pf:not(.pf--cover):not(.pf--reveal):not(.pf--done) {
+    justify-content: center;
+    padding: 40px 24px;
+  }
+  .pf:not(.pf--cover):not(.pf--reveal):not(.pf--done) .pf__topbar {
+    width: 100%;
+    max-width: 560px;
+    margin: 0 auto;
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: var(--pf-radius) var(--pf-radius) 0 0;
+    padding: 18px 24px 16px;
+  }
+  .pf:not(.pf--cover):not(.pf--reveal):not(.pf--done) .pf__body {
+    width: 100%;
+    max-width: 560px;
+    margin: 0 auto;
+    flex: 0 1 auto;
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 var(--pf-radius) var(--pf-radius);
+    background: var(--card);
+  }
+  /* Inputs on the card use the app canvas colour for depth contrast. */
+  .pf:not(.pf--cover) .pf-input {
+    background: var(--background);
+  }
+
+  /* Cover: logo + hero card + CTA as one vertically-centered group. */
+  .pf--cover {
+    justify-content: center;
+  }
+  .pf--cover .pf__cover-header {
+    background: transparent;
+    border-bottom: none;
+    padding-top: 32px;
+  }
+  .pf__cover-main {
+    flex: 0 1 auto;
+    padding: 24px;
+  }
+  .pf__cover-content {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--pf-radius);
+    padding: 44px 44px 40px;
+  }
+  .pf__cover-footer {
+    padding-bottom: 32px;
+  }
+
+  /* Centered outcome/interstitial cards. */
+  .pf--reveal,
+  .pf--done {
+    justify-content: center;
   }
 }
+
 @media (max-width: 480px) {
   .pf__banner {
     font-size: 12px;
@@ -831,8 +904,5 @@
   }
   .pf__fields {
     margin-top: 24px;
-  }
-  .pf-input {
-    font-size: 16px;
   }
 }


### PR DESCRIPTION
## What

Visual-quality pass on the **public form-filling experience** (the one-question-per-screen renderer) so it reads as a member of the **Dapta Calendars** public-page family and is harmonic with the Dapta app. Scope is the **public surface only** — no admin files touched.

## Why

The renderer was an intentionally-fixed **light** surface built on hard-coded raw-hex `--pf-*` values — diverging from the Calendars public booking page (dark-first, theme-aware, shadcn semantic tokens) and violating the tokens-only rule. This aligns it to the family and the token contract.

## Changes (files, all under `app/[accountCode]/**`)

- **`public-form.css`** — rebuilt to consume the shared **shadcn semantic tokens** (`--background/--card/--foreground/--muted-foreground/--border/--primary/--ring/--radius`): now **dark-first + theme-aware** (light via `prefers-color-scheme`/`data-theme`), lime as the one accent (always black text on lime), depth = surface + 1px border. Per-form accent still threads through `--pf-primary` (defaults to `--primary`, overridable from `branding.primaryColor`).
  - **Desktop composition**: topbar + body join into one **centered framed card**; the cover becomes logo + hero card + CTA as a centered group — deliberate, not a lonely box on a void. Mobile keeps the immersive full-bleed flow.
  - Radii from the token scale (8px controls / 16px cards); primary CTAs use the **8px control radius** to match the app's `bp-btn`; lime focus ring; themed inputs/choices/dropdown/slider/reveal/thank-you.
- **`loading.tsx`** — replaced the leftover **booking-slot** skeleton with a form-cover skeleton mirroring the rendered surface (R22, no layout jump).

## Verification

Walked the full public flow (cover → dropdown → slider → choice list → icon grid → inline validation → thank-you) in **headless Chrome** at **1520 / 768 / 360**, dark **and** light. 360 reflows the icon grid to 2 columns with no horizontal scroll (R27/R28); R22 press/hover + skeletons; R30 single primary CTA per screen. `pnpm lint typecheck test build` all green.

Screenshots in [`.design-out/`](.design-out/): `cover-1520-dark`, `cover-1520-light`, `step-dropdown`, `dropdown-open`, `step-slider`, `step-choices-list`, `step-choices-icons`, `step-validation-error`, `thankyou`, `cover-360-dark`, `step-choices-icons-360`.

## Notes

- The app hardcodes `data-theme="dark"` on `<html>` in the layout (admin-owned), so the live public page is dark by design (matches the reference); the CSS is nonetheless fully token-driven and adapts to light (verified by forcing `data-theme=light`).
- No new tokens required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)