### PR TITLE
fix(public): focus ring follows per-form brand accent (optibot #10 follow-up)

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -16,7 +16,9 @@
   --pf-text: #111114;
   --pf-muted: #6b6b73;
   --pf-border: #d9dade;
-  --pf-focus: #2563eb;
+  /* Focus follows the per-form accent so border + glow always match the brand
+     color (falls back to the lime default when no branding.primaryColor is set). */
+  --pf-focus: var(--pf-primary);
   --pf-danger: #dc2626;
   --pf-radius: 12px;
   --pf-radius-sm: 8px;
@@ -231,7 +233,7 @@
 }
 .pf-input:focus {
   border-color: var(--pf-focus);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--pf-focus) 30%, transparent);
 }
 .pf-name-fields {
   display: grid;


### PR DESCRIPTION
OptiBot flagged on the merged public-renderer PR #10: the input focus glow was hardcoded blue (`rgba(37,99,235,...)`) while the border used `--pf-focus`, and neither followed `branding.primaryColor` — a non-lime brand color mismatched. Now `--pf-focus: var(--pf-primary)` and the glow is `color-mix` of it, so border+glow always match the brand accent (lime default when unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)