### PR TITLE
fix(public): focus glow follows per-form brand accent (optibot #10)

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -223,7 +223,9 @@
 }
 .pf-input:focus {
   border-color: var(--pf-primary);
-  box-shadow: 0 0 0 3px var(--ring);
+  /* Glow derives from the per-form accent so border + glow always match the
+     brand color (--ring is fixed lime and mismatched a custom primaryColor). */
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--pf-primary) 30%, transparent);
 }
 .pf-name-fields {
   display: grid;


### PR DESCRIPTION
OptiBot flagged on merged PR #10: input focus border uses `--pf-primary` (per-form accent) but the glow used `--ring` (fixed lime) → mismatch when a host sets a non-lime `branding.primaryColor`. Glow now derives from `--pf-primary` via color-mix. 1-file CSS-only change. (Supersedes the auto-closed #12, which was based on a stale pre-#10 version of this file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)