### PR TITLE
feat(onboarding): seed a polished demo form on new-account creation

### DIFF
--- a/apps/api/src/auth.provider.ts
+++ b/apps/api/src/auth.provider.ts
@@ -12,10 +12,16 @@
  * Machine identity is a separate, production-grade path (a hashed API key) and
  * lives on `AuthService`.
  */
-import { UnauthorizedException } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import type { Db, AccountRole } from '@quill/db';
-import { deriveUniqueHandle, getAccountByCode, insertAccountWithShortCode, sql } from '@quill/db';
+import {
+  deriveUniqueHandle,
+  getAccountByCode,
+  insertAccountWithShortCode,
+  seedDemoFormForAccount,
+  sql,
+} from '@quill/db';
 import type { ServerEnv } from '@quill/config/env';
 // The concrete `workos` adapter. The cycle (adapter imports the port/`header`
 // from here) is safe: each side references the other only inside function
@@ -45,6 +51,29 @@ export interface HostPrincipal extends ResolvedHost {
 export function header(req: ReqLike, name: string): string | undefined {
   const v = req.headers[name];
   return Array.isArray(v) ? v[0] : v;
+}
+
+/**
+ * Best-effort demo-form seed, shared by every AuthProvider that JIT-creates a
+ * new account+owner. Gated by `SEED_DEMO_FORM` (env, default ON) and idempotent
+ * in the DB layer (`seedDemoFormForAccount` only writes when the account has zero
+ * forms), so a repeat login never duplicates it. Seeding NEVER fails a login: a
+ * DB error here is logged and swallowed — the user still lands in their (empty)
+ * workspace rather than being locked out over a cosmetic sample.
+ */
+export async function maybeSeedDemoForm(
+  db: Db,
+  accountId: string,
+  enabled: boolean,
+  log: Logger,
+): Promise<void> {
+  if (!enabled) return;
+  try {
+    const form = await seedDemoFormForAccount(db, accountId);
+    if (form) log.log(`Seeded demo form ${form.id} for new account ${accountId}`);
+  } catch (err) {
+    log.warn(`Demo-form seed skipped for account ${accountId}: ${String(err)}`);
+  }
 }
 
 /** The port every host-auth backend implements. */
@@ -88,10 +117,14 @@ function legacyDevCodeFromEmail(email: string): string {
  */
 export class LocalAuthProvider implements AuthProvider {
   readonly name = 'local';
+  private readonly log = new Logger('LocalAuthProvider');
 
   constructor(
     private readonly db: Db,
-    private readonly env: Pick<ServerEnv, 'NODE_ENV' | 'DEV_LOGIN_EMAIL' | 'AUTH_LOCAL_STRICT'>,
+    private readonly env: Pick<
+      ServerEnv,
+      'NODE_ENV' | 'DEV_LOGIN_EMAIL' | 'AUTH_LOCAL_STRICT' | 'SEED_DEMO_FORM'
+    >,
   ) {}
 
   async resolveHost(req: ReqLike): Promise<ResolvedHost> {
@@ -161,6 +194,11 @@ export class LocalAuthProvider implements AuthProvider {
       sql`INSERT INTO member (id, account_id, email, display_name, handle, role, created_at)
           VALUES (${memberId}, ${account.id}, ${email}, ${email}, ${handle}, ${role}, ${Date.now()})`,
     );
+    // A fresh account (its first member is the owner) gets the polished demo form
+    // so the dashboard is never empty. Idempotent + best-effort (never blocks login).
+    if (role === 'owner') {
+      await maybeSeedDemoForm(this.db, account.id, this.env.SEED_DEMO_FORM, this.log);
+    }
     return { accountId: account.id, memberId };
   }
 }

--- a/apps/api/src/auth.provider.workos.ts
+++ b/apps/api/src/auth.provider.workos.ts
@@ -18,15 +18,21 @@
  * `createAuthProvider` still fails loud without it. No vendor host/secret name
  * appears here — issuer/audience/secret all arrive via env.
  */
-import { UnauthorizedException } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import type { Db, AccountRole } from '@quill/db';
 import { deriveUniqueHandle, insertAccountWithShortCode, sql } from '@quill/db';
 import type { ServerEnv } from '@quill/config/env';
-import { header, type AuthProvider, type ResolvedHost, type ReqLike } from './auth.provider';
+import {
+  header,
+  maybeSeedDemoForm,
+  type AuthProvider,
+  type ResolvedHost,
+  type ReqLike,
+} from './auth.provider';
 import { verifyJwtHs256, JwtError, type JwtClaims } from './jwt';
 
-type WorkOsEnv = Pick<ServerEnv, 'JWT_SECRET' | 'JWT_ISSUER' | 'JWT_AUDIENCE'>;
+type WorkOsEnv = Pick<ServerEnv, 'JWT_SECRET' | 'JWT_ISSUER' | 'JWT_AUDIENCE' | 'SEED_DEMO_FORM'>;
 
 function unauthenticated(message: string): UnauthorizedException {
   return new UnauthorizedException({ error: 'UNAUTHENTICATED', message });
@@ -39,6 +45,7 @@ function unauthenticated(message: string): UnauthorizedException {
 
 export class WorkOsAuthProvider implements AuthProvider {
   readonly name = 'workos';
+  private readonly log = new Logger('WorkOsAuthProvider');
   private readonly secret: string;
 
   constructor(
@@ -149,6 +156,11 @@ export class WorkOsAuthProvider implements AuthProvider {
       sql`SELECT id FROM member WHERE account_id = ${accountId} AND external_id = ${sub} LIMIT 1`,
     );
     if (!row) throw unauthenticated('Could not resolve member.');
+    // A fresh account (its first member is the owner) gets the polished demo form
+    // so the dashboard is never empty. Idempotent + best-effort (never blocks login).
+    if (role === 'owner') {
+      await maybeSeedDemoForm(this.db, accountId, this.env.SEED_DEMO_FORM, this.log);
+    }
     return row.id;
   }
 }

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -89,6 +89,14 @@ export const serverEnvSchema = z.object({
   ENTITLEMENTS_API_URL: z.string().url().optional(),
   ENTITLEMENTS_API_KEY: z.string().optional(),
 
+  // Onboarding: auto-seed a polished DEMO form into every brand-new account
+  // (JIT on first login) so a new user's admin is never empty and immediately
+  // shows a well-designed example. Idempotent — only ever runs when the account
+  // has zero forms, so a repeat login never duplicates it and the user can
+  // delete it like any normal form. Default ON; a fork can set it to false to
+  // ship empty workspaces.
+  SEED_DEMO_FORM: boolish.default('true'),
+
   // Auth — unset selects the local dev stub.
   AUTH_PROVIDER: z.enum(['local', 'workos']).default('local'),
 

--- a/packages/db/src/demo-form.spec.ts
+++ b/packages/db/src/demo-form.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Demo-form seed — the onboarding guarantee. Two things must hold:
+ *   1. the showcase config is a VALID v1 form config (it round-trips the shared
+ *      Zod schema the API re-validates against — the demo can never drift out of
+ *      contract), and
+ *   2. seeding is IDEMPOTENT — a brand-new account gets exactly one demo form,
+ *      and calling the seed again (a repeat login) never adds a duplicate nor
+ *      touches a form the user created or kept.
+ * Runs on SQLite locally; CI re-runs the same suite against Postgres for parity.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { formConfigSchema } from '@quill/types';
+import { normalizeConfig } from '@quill/engine';
+import { createDb, type Db } from './client';
+import { migrate } from './migrate';
+import { listForms, createForm } from './forms';
+import {
+  DEMO_FORM_CONFIG,
+  DEMO_FORM_NAME,
+  seedDemoFormForAccount,
+  accountHasForms,
+} from './demo-form';
+
+let db: Db;
+let accountId: string;
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+  accountId = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${'d' + accountId.slice(0, 5)}, ${'Demo Test'}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  // Keep a shared Postgres DB clean (memory SQLite just evaporates).
+  await db.run(
+    sql`DELETE FROM form WHERE account_id = ${accountId}`,
+  );
+  await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  await db.close();
+});
+
+describe('DEMO_FORM_CONFIG', () => {
+  it('is a valid v1 form config (passes the shared Zod schema)', () => {
+    const parsed = formConfigSchema.safeParse(DEMO_FORM_CONFIG);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('is canonical — normalizing it is a no-op (unique keys, derived flow groups)', () => {
+    const normalized = normalizeConfig(DEMO_FORM_CONFIG);
+    // Same set of step keys, all unique — the config is authored save-ready.
+    const keys = DEMO_FORM_CONFIG.steps.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(normalized.steps.map((s) => s.key)).toEqual(keys);
+  });
+
+  it('showcases the product range (cover, an icon choice, a slider, a lead email, outcomes)', () => {
+    expect(DEMO_FORM_CONFIG.cover?.enabled).toBe(true);
+    expect(DEMO_FORM_CONFIG.steps.some((s) => s.showIcons)).toBe(true);
+    expect(DEMO_FORM_CONFIG.steps.some((s) => s.type === 'slider')).toBe(true);
+    expect(DEMO_FORM_CONFIG.steps.some((s) => s.type === 'email')).toBe(true);
+    expect((DEMO_FORM_CONFIG.outcomes ?? []).length).toBeGreaterThan(0);
+  });
+});
+
+describe('seedDemoFormForAccount', () => {
+  it('seeds exactly one demo form for an empty account', async () => {
+    expect(await accountHasForms(db, accountId)).toBe(false);
+
+    const created = await seedDemoFormForAccount(db, accountId);
+    expect(created).not.toBeNull();
+    expect(created?.name).toBe(DEMO_FORM_NAME);
+
+    const forms = await listForms(db, accountId);
+    expect(forms).toHaveLength(1);
+    expect(forms[0]?.slug).toBe('customer-feedback');
+  });
+
+  it('is idempotent — a second call (repeat login) never duplicates the demo', async () => {
+    await seedDemoFormForAccount(db, accountId);
+    const second = await seedDemoFormForAccount(db, accountId);
+    expect(second).toBeNull();
+    expect(await listForms(db, accountId)).toHaveLength(1);
+  });
+
+  it('never seeds into an account that already has a form (no clobber)', async () => {
+    // The user built their own form first — seeding must not add the demo.
+    await createForm(db, accountId, { name: 'My real form', config: { version: 1, steps: [] } });
+    const seeded = await seedDemoFormForAccount(db, accountId);
+    expect(seeded).toBeNull();
+
+    const forms = await listForms(db, accountId);
+    expect(forms).toHaveLength(1);
+    expect(forms[0]?.name).toBe('My real form');
+  });
+
+  it('the seeded form persists a config that survives a save round-trip', async () => {
+    const created = await seedDemoFormForAccount(db, accountId);
+    // The stored config re-parses as a valid v1 config (JSON column round-trip).
+    const parsed = formConfigSchema.safeParse(created?.config);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/db/src/demo-form.ts
+++ b/packages/db/src/demo-form.ts
@@ -1,0 +1,210 @@
+/**
+ * The onboarding demo form — every brand-new account is auto-seeded with ONE
+ * polished, self-explanatory example so a new user's admin is never empty and
+ * immediately shows what a well-built Dapta form looks like. The auth providers
+ * call `seedDemoFormForAccount` right after they JIT-create a new account+owner
+ * (both the local OSS stub and the workos overlay), gated by the `SEED_DEMO_FORM`
+ * env flag (default ON — a fork can disable it).
+ *
+ * The demo is a normal form: the user can edit or delete it. Seeding is
+ * idempotent — it only ever runs when the account has ZERO forms, so a repeat
+ * login never produces a duplicate and a real form is never clobbered.
+ *
+ * The config is authored against the versioned v1 `formConfigSchema` (Zod) — the
+ * spec re-validates it so the showcase can never drift out of contract. Copy is
+ * in English (the OSS default); Spanish parity for every string the config
+ * carries is kept alongside in `DEMO_FORM_COPY_ES` for anyone localizing a fork.
+ */
+import { sql, type Db } from './client';
+import { createForm, type FormRow } from './forms';
+import type { FormConfig } from '@quill/types';
+
+/** The demo form's display name (slugifies to `customer-feedback`). */
+export const DEMO_FORM_NAME = 'Customer feedback';
+
+/**
+ * A flagship example that shows the product's range without overwhelming: a
+ * branded cover (eyebrow + headline + subheadline + CTA + trust line + accent),
+ * an icon single-choice, a second icon choice, an NPS slider, an open-text note,
+ * an optional email lead-capture, a processing reveal, and warm outcome buckets.
+ * Realistic use case: a customer-feedback survey — the clearest, most universal
+ * demo, and visually distinct from the CLI `pnpm db:seed` lead-qualifier sample.
+ */
+export const DEMO_FORM_CONFIG: FormConfig = {
+  version: 1,
+  branding: { primaryColor: '#6366f1' },
+  cover: {
+    enabled: true,
+    bannerText: 'Demo form — edit or delete it anytime from your dashboard',
+    eyebrow: 'We would love your feedback',
+    headline: 'How was your experience?',
+    subheadline:
+      'Three quick questions — under a minute. Your answers help us build a better product for you.',
+    ctaText: 'Share my feedback',
+    trustBadge: 'Anonymous unless you choose to leave your email',
+    clientLogos: [{ name: 'Northwind' }, { name: 'Acme Co' }, { name: 'Globex' }, { name: 'Initech' }],
+  },
+  steps: [
+    {
+      key: 'satisfaction',
+      type: 'multiple_choice',
+      question: 'Overall, how happy are you with us?',
+      helper: 'Pick the face that fits best.',
+      required: true,
+      showIcons: true,
+      flowGroup: 'qualification',
+      options: [
+        { label: 'Love it', value: 'love', icon: '\u{1F60D}', points: 10 },
+        { label: 'Pretty good', value: 'good', icon: '\u{1F642}', points: 7 },
+        { label: "It's okay", value: 'okay', icon: '\u{1F610}', points: 4 },
+        { label: 'Could be better', value: 'meh', icon: '\u{1F615}', points: 1 },
+      ],
+    },
+    {
+      key: 'favorite_area',
+      type: 'multiple_choice',
+      question: 'What do you value most about us?',
+      required: true,
+      showIcons: true,
+      flowGroup: 'qualification',
+      options: [
+        { label: 'Ease of use', value: 'ease', icon: '\u{1FA84}', points: 3 },
+        { label: 'Speed', value: 'speed', icon: '\u{26A1}', points: 3 },
+        { label: 'Support', value: 'support', icon: '\u{1F4AC}', points: 3 },
+        { label: 'Price', value: 'price', icon: '\u{1F4B0}', points: 3 },
+      ],
+    },
+    {
+      key: 'recommend',
+      type: 'slider',
+      question: 'How likely are you to recommend us to a friend or colleague?',
+      helper: '0 = not at all likely, 10 = absolutely.',
+      flowGroup: 'qualification',
+      min: 0,
+      max: 10,
+      step: 1,
+      default: 8,
+      sliderUnitLabel: '/ 10',
+      sliderScoring: [
+        { min: 0, max: 6, points: 0 },
+        { min: 7, max: 8, points: 3 },
+        { min: 9, max: 10, points: 6 },
+      ],
+    },
+    {
+      key: 'improvement',
+      type: 'textarea',
+      question: 'What is the one thing we could do better?',
+      placeholder: 'Optional — but we read every single note.',
+      required: false,
+      flowGroup: 'qualification',
+    },
+    {
+      key: 'email',
+      type: 'email',
+      question: 'Want us to follow up? Leave your email.',
+      helper: 'Optional. We only use it to reply to your feedback — no spam.',
+      placeholder: 'you@company.com',
+      required: false,
+      flowGroup: 'lead_capture',
+      triggersReveal: true,
+    },
+  ],
+  scoring: { enabled: true },
+  outcomes: [
+    { id: 'thanks', label: 'Thank you for sharing \u{1F64C}', minScore: 0 },
+    { id: 'delighted', label: 'You just made our day! \u{1F389}', minScore: 13 },
+  ],
+  reveal: {
+    enabled: true,
+    headline: 'Saving your feedback…',
+    subtitle: 'Hang tight — this only takes a second.',
+  },
+  partialSubmitAfterStep: 5,
+};
+
+/**
+ * Spanish parity for every user-facing string the demo config carries. Not wired
+ * into the single-language config (the v1 schema is mono-locale by design); kept
+ * here so a Spanish-first fork can swap the copy in one place. The renderer
+ * chrome (buttons, validation, thank-you body) is already localized separately
+ * via `@quill/shared`.
+ */
+export const DEMO_FORM_COPY_ES = {
+  name: 'Opiniones de clientes',
+  cover: {
+    bannerText: 'Formulario de demostración: puedes editarlo o eliminarlo cuando quieras',
+    eyebrow: 'Nos encantaría conocer tu opinión',
+    headline: '¿Cómo fue tu experiencia?',
+    subheadline:
+      'Tres preguntas rápidas, en menos de un minuto. Tus respuestas nos ayudan a construir un mejor producto para ti.',
+    ctaText: 'Compartir mi opinión',
+    trustBadge: 'Anónimo, salvo que decidas dejar tu correo',
+  },
+  steps: {
+    satisfaction: {
+      question: 'En general, ¿qué tan contento estás con nosotros?',
+      helper: 'Elige la cara que mejor te represente.',
+      options: {
+        love: 'Me encanta',
+        good: 'Bastante bien',
+        okay: 'Más o menos',
+        meh: 'Podría mejorar',
+      },
+    },
+    favorite_area: {
+      question: '¿Qué es lo que más valoras de nosotros?',
+      options: {
+        ease: 'Facilidad de uso',
+        speed: 'Rapidez',
+        support: 'Soporte',
+        price: 'Precio',
+      },
+    },
+    recommend: {
+      question: '¿Qué tan probable es que nos recomiendes a un amigo o colega?',
+      helper: '0 = nada probable, 10 = totalmente.',
+    },
+    improvement: {
+      question: '¿Cuál es la única cosa que podríamos hacer mejor?',
+      placeholder: 'Opcional, pero leemos cada nota.',
+    },
+    email: {
+      question: '¿Quieres que te contactemos? Déjanos tu correo.',
+      helper: 'Opcional. Solo lo usamos para responder tu opinión, sin spam.',
+    },
+  },
+  outcomes: {
+    thanks: 'Gracias por compartir \u{1F64C}',
+    delighted: '¡Nos alegraste el día! \u{1F389}',
+  },
+  reveal: {
+    headline: 'Guardando tu opinión…',
+    subtitle: 'Un momento, esto solo toma un segundo.',
+  },
+} as const;
+
+/** True when the account already owns at least one form. */
+export async function accountHasForms(db: Db, accountId: string): Promise<boolean> {
+  const row = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE account_id = ${accountId} LIMIT 1`,
+  );
+  return row != null;
+}
+
+/**
+ * Seed the polished demo form for `accountId` — but ONLY when the account has no
+ * forms yet, so this is safe to call on every login (idempotent) and never
+ * duplicates the demo nor overwrites a form the user created or kept. Reuses the
+ * standard `createForm` path so the slug/short-link/handle all resolve exactly
+ * like a hand-built form. Returns the created form, or `null` when it was
+ * skipped (the account already had forms).
+ */
+export async function seedDemoFormForAccount(db: Db, accountId: string): Promise<FormRow | null> {
+  if (await accountHasForms(db, accountId)) return null;
+  const result = await createForm(db, accountId, {
+    name: DEMO_FORM_NAME,
+    config: DEMO_FORM_CONFIG,
+  });
+  return result.ok ? result.value : null;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,7 @@ export * from './crud';
 export * from './forms';
 export * from './analytics';
 export * from './members';
+export * from './demo-form';
 export * from './short-links';
 export * from './outbox';
 export * from './notification-settings';


### PR DESCRIPTION
## What

Every **brand-new account** is now auto-seeded with **one polished DEMO form** on creation (JIT on first login), so a new user's admin is never empty and immediately shows a beautiful, self-explanatory example of what the product can do.

> Felipe: "toda cuenta debe venir con un form de demo y tiene que estar mucho mejor diseñado."

## The seed logic

- **New module `packages/db/src/demo-form.ts`** — exports `DEMO_FORM_CONFIG` (a valid v1 `formConfigSchema` blob) + `seedDemoFormForAccount(db, accountId)`.
- `seedDemoFormForAccount` **reuses the standard `createForm` path**, so the slug (`customer-feedback`), account short-link and member handle all resolve exactly like a hand-built form.
- **Idempotent by construction**: it only writes when the account has **zero forms**. A repeat login never duplicates it; a form the user created (or kept) is never clobbered. The demo is a **normal form** — the user can edit or delete it.
- **Wired into BOTH auth providers** (`auth.provider.ts` local OSS stub + `auth.provider.workos.ts` overlay), called right after a new account's **owner** member is inserted (the "new account" signal). Best-effort: a seed error is logged and swallowed via `maybeSeedDemoForm`, so it can **never block a login**.
- **Env flag `SEED_DEMO_FORM`** (default **ON**) lets a fork ship empty workspaces (`SEED_DEMO_FORM=false`).

## The demo form (the showcase)

A **"Customer feedback"** survey — the clearest universal use case, visually distinct from the CLI `pnpm db:seed` lead-qualifier sample:
- Branded cover (indigo accent) with eyebrow, headline, subheadline, CTA, trust line, banner strip + a "trusted by" marquee.
- Two **icon single-choice** steps (emoji faces / value pillars), an **NPS slider** (0–10 with an accent pill), an **open-text** note, an optional **email** lead-capture.
- A processing **reveal** interstitial → warm **outcome** thank-you ("You just made our day! 🎉" / "Thank you for sharing 🙌").
- Copy in **EN** with **ES parity** kept alongside in `DEMO_FORM_COPY_ES` for a Spanish-first fork.

## Verification (fresh SQLite DB, api :4413 + web :3413)

- Logged in as a brand-new email → admin lands with the demo form present (not empty); opened it in the editor (all 5 steps + options + points + live preview load); walked the full public flow cover → icons → slider → text → email → reveal → thank-you.
- **Logged in AGAIN as the same user → no duplicate** (still 1 form; the API log shows only 2 seed events total, none on re-login).
- **Second new account → its own demo form** (own short-code / form id).
- DB check: `2 accounts, 2 forms (exactly 1 each), 2 members`.
- `pnpm lint typecheck test build` all green; new unit test `demo-form.spec.ts` (7 cases: schema-valid config, canonical, showcases range, seeds once, idempotent, no-clobber, config round-trips).

Screenshots (admin list, editor, public cover, icon step, slider, thank-you) captured to `.design-out/` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)