### PR TITLE
fix(members): Add-member UI was never wired — adding a member now works

### DIFF
--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression: "members don't work — I can't add a new member."
+ *
+ * The add-member endpoint the dashboard's Settings page drives, exercised end to
+ * end through the real controller → AuthService → provider → db on in-memory
+ * SQLite. Before this fix the web UI never called it (dead client method, no
+ * button), so no test guarded the contract. These lock the intended flow:
+ *
+ *   1. an admin/owner adds a member by email + role → it persists as `invited`
+ *      with the granted role and shows up in the roster (what the "Add member"
+ *      button now triggers);
+ *   2. a plain member is refused (403) — management is admin/owner only;
+ *   3. a duplicate email is refused (409 EMAIL_TAKEN);
+ *   4. the invited member is ADOPTED on their first WorkOS login — external_id
+ *      bound, status flipped to active, granted role preserved (the JIT
+ *      invite→adoption model).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException, ConflictException } from '@nestjs/common';
+import {
+  createDb,
+  migrate,
+  seed,
+  insertAccountWithShortCode,
+  inviteMember,
+  sql,
+  type Db,
+} from '@quill/db';
+import { AdminCrudController } from './admin-crud.controller';
+import { AdminService } from './admin.service';
+import { AuthService } from './auth.service';
+import { LocalAuthProvider } from './auth.provider';
+import { WorkOsAuthProvider } from './auth.provider.workos';
+import { signJwtHs256 } from './jwt';
+import type { ReqLike } from './auth.provider';
+
+let db: Db;
+let controller: AdminCrudController;
+
+/** A request the local dev provider resolves to `email` (JIT-safe). */
+const asEmail = (email: string): ReqLike => ({ headers: { 'x-quill-email': email } });
+/** No identity → local provider falls back to the first seeded account+member (the owner). */
+const asOwner = (): ReqLike => ({ headers: {} });
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db); // account "acme" + owner alex@example.com
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: 'test',
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+  });
+  const auth = new AuthService(db, provider);
+  const admin = new AdminService(db);
+  // Submission/Analytics services are unused by the member routes under test.
+  controller = new AdminCrudController(db, auth, admin, {} as never, {} as never);
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('POST /v1/members (add a member)', () => {
+  it('an owner adds a member by email + role → invited, and it appears in the roster', async () => {
+    const before = await controller.members(asOwner());
+    expect(before).toHaveLength(1); // just the owner
+
+    const created = await controller.inviteMember(asOwner(), {
+      email: 'Newbie@Acme.test',
+      role: 'member',
+    });
+    expect(created.email).toBe('newbie@acme.test'); // normalized
+    expect(created.role).toBe('member');
+    expect(created.status).toBe('invited');
+    expect(created.handle).toBeTruthy(); // auto-handle so they're bookable on accept
+
+    const after = await controller.members(asOwner());
+    expect(after).toHaveLength(2);
+    expect(after.map((m) => m.email)).toContain('newbie@acme.test');
+  });
+
+  it('honors an admin role grant', async () => {
+    const created = await controller.inviteMember(asOwner(), {
+      email: 'boss@acme.test',
+      role: 'admin',
+    });
+    expect(created.role).toBe('admin');
+    expect(created.status).toBe('invited');
+  });
+
+  it('refuses a plain member (admin/owner only) with 403', async () => {
+    await controller.inviteMember(asOwner(), { email: 'plain@acme.test', role: 'member' });
+    // The invited member logs in later; here we just resolve them as the caller.
+    await expect(
+      controller.inviteMember(asEmail('plain@acme.test'), { email: 'x@acme.test' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(controller.members(asEmail('plain@acme.test'))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('refuses a duplicate email with 409 EMAIL_TAKEN', async () => {
+    await controller.inviteMember(asOwner(), { email: 'dup@acme.test' });
+    const err = await controller
+      .inviteMember(asOwner(), { email: 'DUP@acme.test' })
+      .then(() => null)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ConflictException);
+    expect((err as ConflictException).getResponse()).toMatchObject({ error: 'EMAIL_TAKEN' });
+  });
+});
+
+describe('invite → first-login adoption (WorkOS JIT model)', () => {
+  it('adopts the invited member on first login: binds external_id, activates, keeps the role', async () => {
+    const secret = 'test-shared-secret';
+    const externalId = 'org_adopt_1';
+    await insertAccountWithShortCode(db, { name: 'Adopt Co', externalId });
+    const account = (await db.get<{ id: string }>(
+      sql`SELECT id FROM account WHERE external_id = ${externalId} LIMIT 1`,
+    ))!;
+
+    // Invite (granted admin) — an `invited` row with no external_id yet.
+    const invited = await inviteMember(db, account.id, { email: 'invitee@adopt.test', role: 'admin' });
+    expect(invited.ok).toBe(true);
+    if (!invited.ok) return;
+    expect(invited.value.status).toBe('invited');
+
+    // Their first login: the identity service mints a token for the same email.
+    const provider = new WorkOsAuthProvider(db, {
+      JWT_SECRET: secret,
+      JWT_ISSUER: undefined,
+      JWT_AUDIENCE: undefined,
+    });
+    const nowSec = Math.floor(Date.now() / 1000);
+    const token = signJwtHs256(
+      {
+        sub: 'workos_user_42',
+        account_id: externalId,
+        email: 'invitee@adopt.test',
+        name: 'Invited Person',
+        iat: nowSec,
+        exp: nowSec + 3600,
+      },
+      secret,
+    );
+    const resolved = await provider.resolveHost({ headers: { authorization: `Bearer ${token}` } });
+
+    // Adopted the SAME row (not a fresh member), bound + activated, role kept.
+    expect(resolved.memberId).toBe(invited.value.id);
+    const row = (await db.get<{ external_id: string | null; status: string; role: string }>(
+      sql`SELECT external_id, status, role FROM member WHERE id = ${invited.value.id} LIMIT 1`,
+    ))!;
+    expect(row.external_id).toBe('workos_user_42');
+    expect(row.status).toBe('active');
+    expect(row.role).toBe('admin');
+  });
+});

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
+
+/** Machine-readable outcome of an invite so the client can localize the message. */
+export type InviteMemberState =
+  | { ok: true }
+  | { ok: false; code: 'INVALID' | 'TAKEN' | 'FAILED' }
+  | null;
+
+/**
+ * Invite a member by email with an account role. The API creates an `invited`
+ * member row that is adopted (bound + activated, keeping the granted role) the
+ * first time that email signs in — the JIT invite→adoption model. Admin/owner
+ * only; the API enforces this too, this is a defence-in-depth re-check.
+ *
+ * Returns a stable code (never a raw server string) so the Settings UI renders a
+ * localized message. Success revalidates the roster so the new member appears.
+ */
+export async function inviteMemberAction(
+  _prev: InviteMemberState,
+  formData: FormData,
+): Promise<InviteMemberState> {
+  const email = String(formData.get('email') ?? '').trim();
+  const roleRaw = String(formData.get('role') ?? 'member');
+  const role: 'admin' | 'member' = roleRaw === 'admin' ? 'admin' : 'member';
+
+  // Cheap client-side-mirrored guard: a blank/invalid email never hits the API.
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return { ok: false, code: 'INVALID' };
+  }
+
+  // Only admins/owners can manage the roster (the API is the real gate).
+  const me = await adminApi.me();
+  if (!isAdminRole(me.role)) return { ok: false, code: 'FAILED' };
+
+  try {
+    await adminApi.inviteMember({ email, role });
+    revalidatePath('/admin/settings');
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ApiError) {
+      if (e.code === 'EMAIL_TAKEN') return { ok: false, code: 'TAKEN' };
+      if (e.status === 400) return { ok: false, code: 'INVALID' };
+    }
+    return { ok: false, code: 'FAILED' };
+  }
+}

--- a/apps/web/app/admin/settings/invite-member.tsx
+++ b/apps/web/app/admin/settings/invite-member.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useActionState, useEffect, useRef, useState } from 'react';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/toast';
+import { inviteMemberAction, type InviteMemberState } from './actions';
+
+export interface InviteMemberLabels {
+  addMember: string;
+  inviteTitle: string;
+  inviteSubtitle: string;
+  inviteEmailLabel: string;
+  inviteEmailPlaceholder: string;
+  inviteRoleLabel: string;
+  roleAdmin: string;
+  roleMember: string;
+  inviteSubmit: string;
+  inviteCancel: string;
+  inviteSuccess: string;
+  inviteErrorTaken: string;
+  inviteErrorInvalid: string;
+  inviteErrorFailed: string;
+}
+
+/**
+ * Add-member entry point on the Settings page (admin/owner only). Follows the
+ * list/create pattern (Design Quality Bar): a primary trigger opens a dedicated
+ * dialog, never an inline form under the list. Submits to `inviteMemberAction`,
+ * which creates an `invited` member adopted on their first sign-in. On success
+ * the dialog closes, a toast confirms, and the revalidated roster shows the row.
+ */
+export function InviteMember({ labels }: { labels: InviteMemberLabels }) {
+  const [open, setOpen] = useState(false);
+  const [state, action, pending] = useActionState<InviteMemberState, FormData>(
+    inviteMemberAction,
+    null,
+  );
+  const toast = useToast();
+  const formRef = useRef<HTMLFormElement>(null);
+  // Each action result is a fresh object; handle each exactly once. Without this
+  // guard the effect re-fires on every render (the toast context value changes
+  // identity each render), stacking duplicate toasts.
+  const handledRef = useRef<InviteMemberState>(null);
+
+  // On a successful invite: close the dialog, confirm, and clear the form so a
+  // reopen starts clean. The server action already revalidated the roster.
+  useEffect(() => {
+    if (!state || state === handledRef.current) return;
+    handledRef.current = state;
+    if (state.ok) {
+      setOpen(false);
+      formRef.current?.reset();
+      toast.success(labels.inviteSuccess);
+    }
+  }, [state, toast, labels.inviteSuccess]);
+
+  const errorMessage =
+    state && !state.ok
+      ? state.code === 'TAKEN'
+        ? labels.inviteErrorTaken
+        : state.code === 'INVALID'
+          ? labels.inviteErrorInvalid
+          : labels.inviteErrorFailed
+      : null;
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {labels.addMember}
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title={labels.inviteTitle}
+        labelId="invite-member-title"
+      >
+        <p className="-mt-2 mb-4 text-sm text-muted-foreground">{labels.inviteSubtitle}</p>
+        <form ref={formRef} action={action} className="flex flex-col gap-4">
+          <label className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">{labels.inviteEmailLabel}</span>
+            <input
+              name="email"
+              type="email"
+              required
+              autoComplete="off"
+              placeholder={labels.inviteEmailPlaceholder}
+              aria-invalid={errorMessage ? true : undefined}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </label>
+          <label className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">{labels.inviteRoleLabel}</span>
+            <select
+              name="role"
+              defaultValue="member"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="member">{labels.roleMember}</option>
+              <option value="admin">{labels.roleAdmin}</option>
+            </select>
+          </label>
+          {errorMessage ? (
+            <p role="alert" className="text-sm text-destructive">
+              {errorMessage}
+            </p>
+          ) : null}
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+              {labels.inviteCancel}
+            </Button>
+            <Button type="submit" disabled={pending} className="min-w-[120px]">
+              {labels.inviteSubmit}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -4,6 +4,7 @@ import { getMessages } from '@quill/shared';
 import { adminApi, isAdminRole, type AccountMember, type AccountRole, type MemberStatus } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { PageHeader } from '@/components/ui/page-header';
+import { InviteMember } from './invite-member';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,8 +60,30 @@ export default async function SettingsPage() {
 
       {isAdminRole(me.role) ? (
         <section className="rounded-md border border-border bg-card p-6">
-          <h2 className="text-lg font-semibold tracking-tight">{s.membersHeading}</h2>
-          <p className="mt-0.5 text-sm text-muted-foreground">{s.membersSubtitle}</p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight">{s.membersHeading}</h2>
+              <p className="mt-0.5 text-sm text-muted-foreground">{s.membersSubtitle}</p>
+            </div>
+            <InviteMember
+              labels={{
+                addMember: s.addMember,
+                inviteTitle: s.inviteTitle,
+                inviteSubtitle: s.inviteSubtitle,
+                inviteEmailLabel: s.inviteEmailLabel,
+                inviteEmailPlaceholder: s.inviteEmailPlaceholder,
+                inviteRoleLabel: s.inviteRoleLabel,
+                roleAdmin: s.roleAdmin,
+                roleMember: s.roleMember,
+                inviteSubmit: s.inviteSubmit,
+                inviteCancel: s.inviteCancel,
+                inviteSuccess: s.inviteSuccess,
+                inviteErrorTaken: s.inviteErrorTaken,
+                inviteErrorInvalid: s.inviteErrorInvalid,
+                inviteErrorFailed: s.inviteErrorFailed,
+              }}
+            />
+          </div>
           {members.length === 0 ? (
             <p className="mt-5 text-sm text-muted-foreground">{s.membersEmpty}</p>
           ) : (

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -136,6 +136,18 @@ export interface FormsMessages {
       statusDisabled: string;
       membersEmpty: string;
       you: string;
+      addMember: string;
+      inviteTitle: string;
+      inviteSubtitle: string;
+      inviteEmailLabel: string;
+      inviteEmailPlaceholder: string;
+      inviteRoleLabel: string;
+      inviteSubmit: string;
+      inviteCancel: string;
+      inviteSuccess: string;
+      inviteErrorTaken: string;
+      inviteErrorInvalid: string;
+      inviteErrorFailed: string;
     };
     login: {
       title: string;
@@ -544,6 +556,18 @@ export const en: FormsMessages = {
       statusDisabled: 'Disabled',
       membersEmpty: 'No members yet.',
       you: 'You',
+      addMember: 'Add member',
+      inviteTitle: 'Add a member',
+      inviteSubtitle: 'They join as invited and get full access the first time they sign in.',
+      inviteEmailLabel: 'Email',
+      inviteEmailPlaceholder: 'name@company.com',
+      inviteRoleLabel: 'Role',
+      inviteSubmit: 'Add member',
+      inviteCancel: 'Cancel',
+      inviteSuccess: 'Member added.',
+      inviteErrorTaken: 'A member with that email already exists.',
+      inviteErrorInvalid: 'Enter a valid email address.',
+      inviteErrorFailed: 'Could not add the member. Please try again.',
     },
     login: {
       title: 'Sign in',
@@ -948,6 +972,18 @@ export const es: FormsMessages = {
       statusDisabled: 'Desactivado',
       membersEmpty: 'Aún no hay miembros.',
       you: 'Tú',
+      addMember: 'Añadir miembro',
+      inviteTitle: 'Añadir un miembro',
+      inviteSubtitle: 'Se une como invitado y obtiene acceso completo la primera vez que inicia sesión.',
+      inviteEmailLabel: 'Correo',
+      inviteEmailPlaceholder: 'nombre@empresa.com',
+      inviteRoleLabel: 'Rol',
+      inviteSubmit: 'Añadir miembro',
+      inviteCancel: 'Cancelar',
+      inviteSuccess: 'Miembro añadido.',
+      inviteErrorTaken: 'Ya existe un miembro con ese correo.',
+      inviteErrorInvalid: 'Introduce un correo válido.',
+      inviteErrorFailed: 'No se pudo añadir el miembro. Inténtalo de nuevo.',
     },
     login: {
       title: 'Iniciar sesión',


### PR DESCRIPTION
## Root cause

The reported bug — **\"members don't work — I can't add a new member\"** — is a **missing UI wiring**, not an API bug.

The backend add-member path is **complete and correct**:
- `POST /v1/members` (`AdminCrudController.inviteMember`) validates `memberInviteSchema`, checks admin/owner, and calls `inviteMember()` which inserts an `invited` member row with the granted role + an auto-derived handle.
- `GET /v1/members` lists them.
- `WorkOsAuthProvider` **adopts** the pending invite on the invitee's first login — binds their `external_id`, flips status to `active`, and keeps the granted role (the intended JIT invite→adoption model).
- The web client even exposes `adminApi.inviteMember()`.

But the **Settings page rendered the roster read-only**: no button, no form, and `inviteMember` / `updateMember` / `removeMember` were **dead code called from nowhere**. There was literally no way to add a member from the app.

Verified by reproduction: `POST /v1/members` via curl works perfectly (creates + persists + lists an `invited` member); the UI had no affordance to trigger it.

## The fix (web-only — the API is untouched)

- **`InviteMember`** client component: an **\"Add member\"** button (admin/owner only, matching the existing gate) opens a dialog with **email + role (member/admin)**, following the same list/create dialog pattern used for forms.
- **`inviteMemberAction`** server action: validates, re-checks admin, calls `adminApi.inviteMember`, `revalidatePath('/admin/settings')`, and returns a **stable code** (`INVALID` / `TAKEN` / `FAILED`) the UI localizes.
- Wired into the Members section header; on success the dialog closes, a toast confirms, and the revalidated roster shows the new **invited** member. (A ref-guard in the success effect ensures exactly one toast per submission.)
- **i18n:** EN + ES strings for the dialog, roles, and errors.

## Regression test

`apps/api/src/members.controller.spec.ts` drives the **real controller → AuthService → provider → db** (in-memory SQLite) end to end — the exact server path the new button triggers. It locks:
1. an owner/admin adds a member → persists as `invited` with the granted role and appears in the roster;
2. a plain member is refused (**403**);
3. a duplicate email is refused (**409 `EMAIL_TAKEN`**);
4. the invited member is **adopted on first WorkOS login** (external_id bound, activated, role preserved).

This surface had **zero tests** before — which is why it shipped half-wired.

## Before / after evidence

**Before:** Settings → Members showed only the read-only roster (owner row), no way to add anyone.

**After (verified live on api :4412 / web :3412, fresh SQLite, logged in as the seeded owner):**
- Added `jordan@example.com` as **Admin** and `taylor@example.com` as **Member** through the dialog; both appear in the roster as **Invited**.
- Persistence confirmed via `GET /v1/members`:
  ```json
  [
    {"email":"alex@example.com","role":"owner","status":"active"},
    {"email":"jordan@example.com","role":"admin","status":"invited"},
    {"email":"taylor@example.com","role":"member","status":"invited"}
  ]
  ```
- Also added via `curl -X POST /v1/members` directly — works.

## Gates

`pnpm typecheck lint test build` all green (API tests: 43 passing incl. the 5 new members specs). `publish-gate` PASSED (no internal tokens). No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)