### PR TITLE
feat(email): Dapta-mail submission notifications (Dapta-deployed only; form@notifications-dapta.ai)

### DIFF
--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -45,8 +45,9 @@ export class EmailEffects {
     try {
       // The account-side notice goes to the owner inbox; a fork with no member
       // email just carries no recipient and the notifier no-ops on empty `to`.
-      const owner = await this.db.get<{ email: string | null }>(
-        sql`SELECT email FROM member
+      // The owner's `locale` selects the EN/ES copy (absent = English default).
+      const owner = await this.db.get<{ email: string | null; locale: string | null }>(
+        sql`SELECT email, locale FROM member
             WHERE account_id = ${accountId} AND role = 'owner' AND status = 'active'
             ORDER BY created_at ASC LIMIT 1`,
       );
@@ -54,7 +55,12 @@ export class EmailEffects {
       // Snapshot the toggle: absent row = enabled (fork-friendly default).
       const settings = await getNotificationSettings(this.db, accountId);
       if (settings.get('submission_received')?.enabled === false) return;
-      const payload: SubmissionNotification = { ...n, accountId, to };
+      const payload: SubmissionNotification = {
+        ...n,
+        accountId,
+        to,
+        locale: n.locale ?? owner?.locale ?? null,
+      };
       await enqueueOutbox(this.db, {
         kind: 'email',
         action: 'submission_received',

--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -50,6 +50,7 @@ beforeEach(async () => {
     NODE_ENV: 'test',
     DEV_LOGIN_EMAIL: undefined,
     AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
   });
   const auth = new AuthService(db, provider);
   const admin = new AdminService(db);
@@ -131,6 +132,7 @@ describe('invite → first-login adoption (WorkOS JIT model)', () => {
       JWT_SECRET: secret,
       JWT_ISSUER: undefined,
       JWT_AUDIENCE: undefined,
+      SEED_DEMO_FORM: false,
     });
     const nowSec = Math.floor(Date.now() / 1000);
     const token = signJwtHs256(

--- a/packages/notifications/src/adapters/http.spec.ts
+++ b/packages/notifications/src/adapters/http.spec.ts
@@ -1,0 +1,148 @@
+import { createHash, createHmac } from 'node:crypto';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  HttpEmailProvider,
+  TRANSACTIONAL_EMAIL_PATH,
+  signTransactionalRequest,
+  interpretTransactionalResponse,
+} from './http';
+
+const ENDPOINT = `https://email.internal.example.com${TRANSACTIONAL_EMAIL_PATH}`;
+const CLIENT_ID = 'forms';
+const SECRET = 'a'.repeat(48); // >= 32 chars, like a real signing secret
+
+/** A fetch stub that records the single request and returns a canned 2xx JSON. */
+function stubFetch(status = 200, body: unknown = { status: 'accepted', messageId: 'msg-1' }) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  });
+  return { impl: impl as unknown as typeof fetch, calls };
+}
+
+describe('signTransactionalRequest', () => {
+  it('signs the canonical v1 payload with the logical path (not the request URL)', () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const ts = '1700000000';
+    const idem = 'submission:s1:received';
+    const bodyHash = createHash('sha256').update(body).digest('hex');
+    const canonical = ['v1', 'POST', TRANSACTIONAL_EMAIL_PATH, ts, idem, bodyHash].join('\n');
+    const expected = createHmac('sha256', SECRET).update(canonical).digest('hex');
+    expect(signTransactionalRequest(body, ts, idem, SECRET)).toBe(expected);
+    expect(signTransactionalRequest(body, ts, idem, SECRET)).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('HttpEmailProvider — transactional-v1', () => {
+  it('POSTs a correctly-signed transactional payload the server can verify', async () => {
+    const { impl, calls } = stubFetch();
+    const provider = new HttpEmailProvider(
+      {
+        endpoint: ENDPOINT,
+        profile: 'transactional-v1',
+        clientId: CLIENT_ID,
+        signingSecret: SECRET,
+        fromEmail: 'form@notifications-dapta.ai',
+        fromName: 'Dapta Forms',
+      },
+      impl,
+    );
+
+    const result = await provider.send({
+      accountId: 'acc-1',
+      to: 'owner@acme.io',
+      subject: 'New submission — Lead Qualifier',
+      text: 'You have a new submission.',
+      html: '<p>You have a new submission.</p>',
+      idempotencyKey: 'submission:s1:received',
+    });
+
+    expect(result).toEqual({ delivered: true, messageId: 'msg-1', driver: 'http' });
+    expect(calls).toHaveLength(1);
+    const { init } = calls[0]!;
+    const headers = init.headers as Record<string, string>;
+
+    // Auth headers present, signature is a 64-hex HMAC.
+    expect(headers['x-dapta-client-id']).toBe(CLIENT_ID);
+    expect(headers['x-dapta-timestamp']).toMatch(/^\d+$/);
+    expect(headers['x-dapta-signature']).toMatch(/^[a-f0-9]{64}$/);
+    // No legacy bearer when the HMAC pair is configured.
+    expect(headers.authorization).toBeUndefined();
+
+    // Body carries ONLY the managed fields — never from/fromName/headers.
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toMatchObject({
+      mode: 'html',
+      to: ['owner@acme.io'],
+      subject: 'New submission — Lead Qualifier',
+      category: 'lifecycle',
+      idempotencyKey: 'submission:s1:received',
+      businessContext: { accountId: 'acc-1' },
+    });
+    expect(sent.from).toBeUndefined();
+    expect(sent.fromName).toBeUndefined();
+    expect(sent.headers).toBeUndefined();
+
+    // The server rebuilds the SAME signature from the raw body + headers — prove it verifies.
+    const recomputed = signTransactionalRequest(
+      init.body as string,
+      headers['x-dapta-timestamp']!,
+      sent.idempotencyKey,
+      SECRET,
+    );
+    expect(headers['x-dapta-signature']).toBe(recomputed);
+  });
+
+  it('requires a tenant account context on the signed wire', async () => {
+    const { impl } = stubFetch();
+    const provider = new HttpEmailProvider(
+      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'form@notifications-dapta.ai' },
+      impl,
+    );
+    expect(provider.requiresAccountContext).toBe(true);
+    await expect(provider.send({ to: 'x@y.com', subject: 's' })).rejects.toThrow(/account context/i);
+  });
+
+  it('throws on a non-2xx so the outbox retries (never a silent drop)', async () => {
+    const { impl } = stubFetch(500, {});
+    const provider = new HttpEmailProvider(
+      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'form@notifications-dapta.ai' },
+      impl,
+    );
+    await expect(
+      provider.send({ accountId: 'acc-1', to: 'x@y.com', subject: 's', idempotencyKey: 'k' }),
+    ).rejects.toThrow(/HTTP 500/);
+  });
+});
+
+describe('interpretTransactionalResponse', () => {
+  it('accepts accepted/delivered (incl. idempotent duplicates)', () => {
+    expect(interpretTransactionalResponse(200, { status: 'accepted', messageId: 'm' })).toEqual({
+      delivered: true,
+      messageId: 'm',
+      driver: 'http',
+    });
+    expect(interpretTransactionalResponse(200, { status: 'delivered', id: 'd', duplicate: true })).toEqual({
+      delivered: true,
+      messageId: 'd',
+      driver: 'http',
+    });
+  });
+
+  it('throws for non-2xx regardless of body', () => {
+    expect(() => interpretTransactionalResponse(422, { status: 'accepted' })).toThrow(/HTTP 422/);
+  });
+
+  it('throws for blocked_by_policy and for a malformed 2xx', () => {
+    expect(() => interpretTransactionalResponse(200, { status: 'blocked_by_policy', blockedReason: 'x' })).toThrow(
+      /blocked by policy/i,
+    );
+    expect(() => interpretTransactionalResponse(200, {})).toThrow(/malformed/i);
+    expect(() => interpretTransactionalResponse(200, { status: 'weird' })).toThrow(/unexpected status/i);
+  });
+});

--- a/packages/notifications/src/factory.spec.ts
+++ b/packages/notifications/src/factory.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEmailProvider } from './factory';
+import { HttpEmailProvider } from './adapters/http';
+import { LogOnlyEmailProvider } from './adapters/log-only';
+
+/**
+ * The env-gate rule (KEY): a bare fork (nothing set) stays log-only; the Dapta
+ * deployment (EMAIL_PROVIDER=http + endpoint + transactional-v1 credentials)
+ * gets the real signed provider. Missing pieces degrade to log-only — a
+ * submission never blocks on mail config.
+ */
+describe('createEmailProvider — env gating', () => {
+  it('defaults to log-only for a bare fork (provider unset → log-only)', () => {
+    expect(createEmailProvider({ provider: 'log-only', fromEmail: 'forms@example.com' })).toBeInstanceOf(
+      LogOnlyEmailProvider,
+    );
+  });
+
+  it('falls back to log-only when http is selected but no endpoint is set', () => {
+    expect(createEmailProvider({ provider: 'http', fromEmail: 'forms@example.com', http: {} })).toBeInstanceOf(
+      LogOnlyEmailProvider,
+    );
+  });
+
+  it('falls back to log-only when transactional-v1 has an endpoint but no credentials', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = createEmailProvider({
+      provider: 'http',
+      fromEmail: 'form@notifications-dapta.ai',
+      http: { endpoint: 'https://email.example.com/api/internal/email/send', profile: 'transactional-v1' },
+    });
+    expect(provider).toBeInstanceOf(LogOnlyEmailProvider);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('builds the signed HTTP provider when endpoint + clientId + secret are all set', () => {
+    const provider = createEmailProvider({
+      provider: 'http',
+      fromEmail: 'form@notifications-dapta.ai',
+      fromName: 'Dapta Forms',
+      http: {
+        endpoint: 'https://email.example.com/api/internal/email/send',
+        profile: 'transactional-v1',
+        clientId: 'forms',
+        signingSecret: 'x'.repeat(48),
+      },
+    });
+    expect(provider).toBeInstanceOf(HttpEmailProvider);
+    expect(provider.requiresAccountContext).toBe(true);
+  });
+});

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -6,6 +6,15 @@
 export * from './email.port';
 export * from './factory';
 export * from './submission-notifier';
+export {
+  normalizeLocale,
+  renderSubmissionReceived,
+  renderSubmissionConfirmed,
+  type NotificationLocale,
+  type ReceivedCopyVars,
+  type ConfirmedCopyVars,
+  type RenderedCopy,
+} from './templates';
 export { LogOnlyEmailProvider } from './adapters/log-only';
 export { NoopEmailProvider } from './adapters/noop';
 export { SmtpEmailProvider, type SmtpOptions } from './adapters/smtp';

--- a/packages/notifications/src/submission-notifier.spec.ts
+++ b/packages/notifications/src/submission-notifier.spec.ts
@@ -34,6 +34,26 @@ describe('SubmissionNotifier', () => {
     expect(m.text).toContain('Outcome: Qualified');
   });
 
+  it('renders the received notice in Spanish when locale=es', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-es',
+      formName: 'Calificador',
+      to: ['owner@example.com'],
+      respondentEmail: 'lead@acme.io',
+      score: 9,
+      locale: 'es-CO',
+    });
+    const m = provider.sent[0]!;
+    expect(m.subject).toBe('Nueva respuesta — Calificador');
+    expect(m.text).toContain('Puntuación: 9');
+    expect(m.text).toContain('De: lead@acme.io');
+    // Idempotency key is language-independent.
+    expect(m.idempotencyKey).toBe('submission:sub-es:received');
+  });
+
   it('confirms to the respondent when their email was captured', async () => {
     const provider = new CaptureProvider();
     const notifier = new SubmissionNotifier(provider);

--- a/packages/notifications/src/submission-notifier.ts
+++ b/packages/notifications/src/submission-notifier.ts
@@ -1,5 +1,11 @@
 import type { EmailProvider, EmailResult } from './email.port';
 import { escapeHtml } from './util';
+import {
+  normalizeLocale,
+  renderSubmissionConfirmed,
+  renderSubmissionReceived,
+  type NotificationLocale,
+} from './templates';
 
 /** Render plaintext lines to a safe HTML body — every line HTML-escaped (E8). */
 function htmlBody(lines: string[]): string {
@@ -20,30 +26,33 @@ export interface SubmissionNotification {
   outcomeLabel?: string | null;
   /** A public link back to the form (book-again style). */
   formLink?: string | null;
+  /**
+   * Language for the rendered copy. Accepts a bare `en`/`es` or any locale-ish
+   * value (e.g. `es-CO`, an Accept-Language fragment) — normalized to one of the
+   * two supported languages. Unset defaults to English (the bare-fork default).
+   */
+  locale?: NotificationLocale | string | null;
 }
 
 /**
  * Renders and sends submission emails through the EmailProvider port — plain
  * text + escaped HTML, no attachments. The app only ever calls these methods;
- * the transport is whatever adapter is wired (log-only by default).
+ * the transport is whatever adapter is wired (log-only by default). Copy is
+ * bilingual (EN/ES) via the templates module; the caller supplies `locale`.
  */
 export class SubmissionNotifier {
   constructor(private readonly email: EmailProvider) {}
 
   /** Internal notice to the account: a new submission landed. */
   sendSubmissionReceived(n: SubmissionNotification): Promise<EmailResult> {
-    const lines = [
-      `New submission for "${n.formName}".`,
-      n.respondentEmail ? `From: ${n.respondentEmail}` : '',
-      n.score != null ? `Score: ${n.score}` : '',
-      n.outcomeLabel ? `Outcome: ${n.outcomeLabel}` : '',
-    ];
+    const { subject, lines } = renderSubmissionReceived(normalizeLocale(n.locale), n);
+    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.to,
-      subject: `New submission — ${n.formName}`,
-      text: lines.filter(Boolean).join('\n'),
-      html: htmlBody(lines),
+      subject,
+      text: body.join('\n'),
+      html: htmlBody(body),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:received`,
     });
@@ -51,16 +60,14 @@ export class SubmissionNotifier {
 
   /** Confirmation to the respondent that their answers were recorded. */
   sendSubmissionConfirmed(n: SubmissionNotification): Promise<EmailResult> {
-    const lines = [
-      `Thanks — we received your responses to "${n.formName}".`,
-      n.formLink ? `View or edit: ${n.formLink}` : '',
-    ];
+    const { subject, lines } = renderSubmissionConfirmed(normalizeLocale(n.locale), n);
+    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.respondentEmail ? [n.respondentEmail] : n.to,
-      subject: `We got your responses — ${n.formName}`,
-      text: lines.filter(Boolean).join('\n'),
-      html: htmlBody(lines),
+      subject,
+      text: body.join('\n'),
+      html: htmlBody(body),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:confirmed`,
     });

--- a/packages/notifications/src/templates.spec.ts
+++ b/packages/notifications/src/templates.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLocale, renderSubmissionReceived, renderSubmissionConfirmed } from './templates';
+
+describe('normalizeLocale', () => {
+  it('maps Spanish-ish values to es and everything else to en', () => {
+    expect(normalizeLocale('es')).toBe('es');
+    expect(normalizeLocale('es-CO')).toBe('es');
+    expect(normalizeLocale('ES_es')).toBe('es');
+    expect(normalizeLocale('en')).toBe('en');
+    expect(normalizeLocale('en-US')).toBe('en');
+    expect(normalizeLocale('fr')).toBe('en');
+    expect(normalizeLocale(undefined)).toBe('en');
+    expect(normalizeLocale(null)).toBe('en');
+    expect(normalizeLocale('')).toBe('en');
+  });
+});
+
+describe('renderSubmissionReceived', () => {
+  it('renders the English owner notice with interpolated fields', () => {
+    const { subject, lines } = renderSubmissionReceived('en', {
+      formName: 'Lead Qualifier',
+      respondentEmail: 'lead@acme.io',
+      score: 15,
+      outcomeLabel: 'Qualified',
+    });
+    expect(subject).toBe('New submission — Lead Qualifier');
+    const text = lines.filter(Boolean).join('\n');
+    expect(text).toContain('Lead Qualifier');
+    expect(text).toContain('From: lead@acme.io');
+    expect(text).toContain('Score: 15');
+    expect(text).toContain('Outcome: Qualified');
+  });
+
+  it('renders the Spanish owner notice', () => {
+    const { subject, lines } = renderSubmissionReceived('es', {
+      formName: 'Calificador de Leads',
+      respondentEmail: 'lead@acme.io',
+      score: 15,
+      outcomeLabel: 'Calificado',
+    });
+    expect(subject).toBe('Nueva respuesta — Calificador de Leads');
+    const text = lines.filter(Boolean).join('\n');
+    expect(text).toContain('Recibiste una nueva respuesta');
+    expect(text).toContain('De: lead@acme.io');
+    expect(text).toContain('Puntuación: 15');
+    expect(text).toContain('Resultado: Calificado');
+  });
+
+  it('drops absent optional fields (only the headline line remains)', () => {
+    const { lines } = renderSubmissionReceived('en', { formName: 'Survey' });
+    expect(lines.filter(Boolean)).toHaveLength(1);
+  });
+});
+
+describe('renderSubmissionConfirmed', () => {
+  it('renders EN and ES respondent confirmations with the form link', () => {
+    const en = renderSubmissionConfirmed('en', { formName: 'Survey', formLink: 'https://forms.example.com/x' });
+    expect(en.subject).toBe('We got your responses — Survey');
+    expect(en.lines.join('\n')).toContain('View or edit: https://forms.example.com/x');
+
+    const es = renderSubmissionConfirmed('es', { formName: 'Encuesta', formLink: 'https://forms.example.com/x' });
+    expect(es.subject).toBe('Recibimos tus respuestas — Encuesta');
+    expect(es.lines.join('\n')).toContain('Ver o editar: https://forms.example.com/x');
+  });
+});

--- a/packages/notifications/src/templates.ts
+++ b/packages/notifications/src/templates.ts
@@ -1,0 +1,108 @@
+/**
+ * Submission-email COPY, in English and Spanish. Kept in the notifications
+ * package (not the UI i18n catalog in @quill/shared) so this boundary package
+ * stays framework-free and self-contained — a fork can read exactly what an
+ * email says without pulling the whole web message catalog.
+ *
+ * The transport is chosen by config (log-only by default); this module only
+ * decides WHAT the two submission emails say. Every dynamic value is left raw
+ * here — the notifier HTML-escapes each line before it reaches an HTML body
+ * (see submission-notifier.ts / util.escapeHtml), so subjects (plain text) and
+ * text bodies read naturally while the HTML path stays XSS-safe (E8).
+ */
+
+/** The two supported notification languages. Mirrors @quill/shared `Locale`. */
+export type NotificationLocale = 'en' | 'es';
+
+/**
+ * Normalize any locale-ish value (a member.locale like `es`, `es-CO`, `en-US`,
+ * or an Accept-Language fragment) to one of the two supported languages.
+ * Anything that is not clearly Spanish falls back to English — the safe default
+ * for a bare fork with no locale set anywhere.
+ */
+export function normalizeLocale(value?: string | null): NotificationLocale {
+  return typeof value === 'string' && value.trim().toLowerCase().startsWith('es') ? 'es' : 'en';
+}
+
+/** Everything the "new submission" (owner) copy can interpolate. */
+export interface ReceivedCopyVars {
+  formName: string;
+  respondentEmail?: string | null;
+  score?: number | null;
+  outcomeLabel?: string | null;
+  /** A link back to the submissions view (owner) — optional. */
+  formLink?: string | null;
+}
+
+/** Everything the "we got your responses" (respondent) copy can interpolate. */
+export interface ConfirmedCopyVars {
+  formName: string;
+  /** A public link back to the form (view/edit) — optional. */
+  formLink?: string | null;
+}
+
+/** A rendered email: a plain subject + the body lines (blank entries dropped). */
+export interface RenderedCopy {
+  subject: string;
+  lines: string[];
+}
+
+/**
+ * The internal notice to the account owner: "a new submission landed on your
+ * form." This is the primary Forms notification — the equivalent of the
+ * host-notification email a Calendly/Bookings flow emits when someone books.
+ */
+export function renderSubmissionReceived(
+  locale: NotificationLocale,
+  v: ReceivedCopyVars,
+): RenderedCopy {
+  if (locale === 'es') {
+    return {
+      subject: `Nueva respuesta — ${v.formName}`,
+      lines: [
+        `Recibiste una nueva respuesta en "${v.formName}".`,
+        v.respondentEmail ? `De: ${v.respondentEmail}` : '',
+        v.score != null ? `Puntuación: ${v.score}` : '',
+        v.outcomeLabel ? `Resultado: ${v.outcomeLabel}` : '',
+        v.formLink ? `Ver las respuestas: ${v.formLink}` : '',
+      ],
+    };
+  }
+  return {
+    subject: `New submission — ${v.formName}`,
+    lines: [
+      `You have a new submission on "${v.formName}".`,
+      v.respondentEmail ? `From: ${v.respondentEmail}` : '',
+      v.score != null ? `Score: ${v.score}` : '',
+      v.outcomeLabel ? `Outcome: ${v.outcomeLabel}` : '',
+      v.formLink ? `View submissions: ${v.formLink}` : '',
+    ],
+  };
+}
+
+/**
+ * The confirmation to the respondent that their answers were recorded. Fully
+ * rendered here for both languages; whether it is actually enqueued is a caller
+ * decision (the owner notice is the default Forms behavior).
+ */
+export function renderSubmissionConfirmed(
+  locale: NotificationLocale,
+  v: ConfirmedCopyVars,
+): RenderedCopy {
+  if (locale === 'es') {
+    return {
+      subject: `Recibimos tus respuestas — ${v.formName}`,
+      lines: [
+        `Gracias — registramos tus respuestas de "${v.formName}".`,
+        v.formLink ? `Ver o editar: ${v.formLink}` : '',
+      ],
+    };
+  }
+  return {
+    subject: `We got your responses — ${v.formName}`,
+    lines: [
+      `Thanks — we've recorded your responses to "${v.formName}".`,
+      v.formLink ? `View or edit: ${v.formLink}` : '',
+    ],
+  };
+}


### PR DESCRIPTION
## What

Wires Dapta Forms' submission notifications to the shared **dapta-email** service, mirroring how Dapta Calendars did it — so the **Dapta-deployed** version of Forms (`forms.dapta.ai`) sends real submission-notification emails, while an **OSS fork stays log-only** with nothing configured.

The `transactional-v1` HTTP adapter + HMAC contract already existed in `@quill/notifications` (ported from Calendars). This PR makes the **content** correct and **bilingual**, resolves the recipient's language, and adds the missing test coverage.

## Changes (core, OSS-safe)

- **EN/ES templates** (`packages/notifications/src/templates.ts`): the owner "new submission" notice and the respondent confirmation, in English and Spanish. `normalizeLocale()` maps any `es*` value to Spanish; everything else defaults to English (bare-fork default).
- `SubmissionNotifier` renders through the bilingual templates (was hardcoded English).
- `EmailEffects` resolves the account **owner's `member.locale`** when enqueuing, so the owner gets the notice in their language.
- **Tests** (all green): HMAC request signing + a mock endpoint verifying the signature server-side; `interpretTransactionalResponse` cases; factory **env-gating** (unset / partial creds → log-only, full creds → signed http); EN/ES template rendering; Spanish owner-notice end-to-end.

## Env-gating (the KEY rule)

- **OSS fork** (nothing set) → `EMAIL_PROVIDER=log-only` default → logs "would send", no network, submissions never block.
- **Dapta deploy** → `EMAIL_PROVIDER=http` + `EMAIL_HTTP_PROFILE=transactional-v1` + endpoint + `EMAIL_HTTP_CLIENT_ID=forms` + `EMAIL_HTTP_SIGNING_SECRET` (from Secrets Manager) → real signed sends.
- The **sender** (`form@notifications-dapta.ai`) is owned by the dapta-email service registry (client `forms`), **not** baked into this public core. The transactional wire deliberately sends no `from`/`fromName`.

## Verification

- `pnpm lint typecheck test build` — all green; `publish-gate` PASSED (no Dapta config in the public core).
- Runtime check: (1) log-only logs the correct email on a submission; (2) a live mock endpoint server-side-verified the HMAC and accepted the payload, with the ES subject applied.

## Not in this PR (gated, handed to PM/Felipe)

- DEV dapta-email registry `forms` sender fix (applied to `dapta-dev` Secrets Manager — sender corrected to `form@`).
- PROD dapta-email registry `forms` client + flux2 `forms-api` email env — **prepared, not applied** (flux2 PM hold). See `EMAIL-INTEGRATION-PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)