### PR TITLE
release: members invite fix + per-account demo form + dapta-mail email code

### DIFF
--- a/apps/api/src/auth.provider.ts
+++ b/apps/api/src/auth.provider.ts
@@ -12,10 +12,16 @@
  * Machine identity is a separate, production-grade path (a hashed API key) and
  * lives on `AuthService`.
  */
-import { UnauthorizedException } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import type { Db, AccountRole } from '@quill/db';
-import { deriveUniqueHandle, getAccountByCode, insertAccountWithShortCode, sql } from '@quill/db';
+import {
+  deriveUniqueHandle,
+  getAccountByCode,
+  insertAccountWithShortCode,
+  seedDemoFormForAccount,
+  sql,
+} from '@quill/db';
 import type { ServerEnv } from '@quill/config/env';
 // The concrete `workos` adapter. The cycle (adapter imports the port/`header`
 // from here) is safe: each side references the other only inside function
@@ -45,6 +51,29 @@ export interface HostPrincipal extends ResolvedHost {
 export function header(req: ReqLike, name: string): string | undefined {
   const v = req.headers[name];
   return Array.isArray(v) ? v[0] : v;
+}
+
+/**
+ * Best-effort demo-form seed, shared by every AuthProvider that JIT-creates a
+ * new account+owner. Gated by `SEED_DEMO_FORM` (env, default ON) and idempotent
+ * in the DB layer (`seedDemoFormForAccount` only writes when the account has zero
+ * forms), so a repeat login never duplicates it. Seeding NEVER fails a login: a
+ * DB error here is logged and swallowed — the user still lands in their (empty)
+ * workspace rather than being locked out over a cosmetic sample.
+ */
+export async function maybeSeedDemoForm(
+  db: Db,
+  accountId: string,
+  enabled: boolean,
+  log: Logger,
+): Promise<void> {
+  if (!enabled) return;
+  try {
+    const form = await seedDemoFormForAccount(db, accountId);
+    if (form) log.log(`Seeded demo form ${form.id} for new account ${accountId}`);
+  } catch (err) {
+    log.warn(`Demo-form seed skipped for account ${accountId}: ${String(err)}`);
+  }
 }
 
 /** The port every host-auth backend implements. */
@@ -88,10 +117,14 @@ function legacyDevCodeFromEmail(email: string): string {
  */
 export class LocalAuthProvider implements AuthProvider {
   readonly name = 'local';
+  private readonly log = new Logger('LocalAuthProvider');
 
   constructor(
     private readonly db: Db,
-    private readonly env: Pick<ServerEnv, 'NODE_ENV' | 'DEV_LOGIN_EMAIL' | 'AUTH_LOCAL_STRICT'>,
+    private readonly env: Pick<
+      ServerEnv,
+      'NODE_ENV' | 'DEV_LOGIN_EMAIL' | 'AUTH_LOCAL_STRICT' | 'SEED_DEMO_FORM'
+    >,
   ) {}
 
   async resolveHost(req: ReqLike): Promise<ResolvedHost> {
@@ -161,6 +194,11 @@ export class LocalAuthProvider implements AuthProvider {
       sql`INSERT INTO member (id, account_id, email, display_name, handle, role, created_at)
           VALUES (${memberId}, ${account.id}, ${email}, ${email}, ${handle}, ${role}, ${Date.now()})`,
     );
+    // A fresh account (its first member is the owner) gets the polished demo form
+    // so the dashboard is never empty. Idempotent + best-effort (never blocks login).
+    if (role === 'owner') {
+      await maybeSeedDemoForm(this.db, account.id, this.env.SEED_DEMO_FORM, this.log);
+    }
     return { accountId: account.id, memberId };
   }
 }

--- a/apps/api/src/auth.provider.workos.ts
+++ b/apps/api/src/auth.provider.workos.ts
@@ -18,15 +18,21 @@
  * `createAuthProvider` still fails loud without it. No vendor host/secret name
  * appears here — issuer/audience/secret all arrive via env.
  */
-import { UnauthorizedException } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import type { Db, AccountRole } from '@quill/db';
 import { deriveUniqueHandle, insertAccountWithShortCode, sql } from '@quill/db';
 import type { ServerEnv } from '@quill/config/env';
-import { header, type AuthProvider, type ResolvedHost, type ReqLike } from './auth.provider';
+import {
+  header,
+  maybeSeedDemoForm,
+  type AuthProvider,
+  type ResolvedHost,
+  type ReqLike,
+} from './auth.provider';
 import { verifyJwtHs256, JwtError, type JwtClaims } from './jwt';
 
-type WorkOsEnv = Pick<ServerEnv, 'JWT_SECRET' | 'JWT_ISSUER' | 'JWT_AUDIENCE'>;
+type WorkOsEnv = Pick<ServerEnv, 'JWT_SECRET' | 'JWT_ISSUER' | 'JWT_AUDIENCE' | 'SEED_DEMO_FORM'>;
 
 function unauthenticated(message: string): UnauthorizedException {
   return new UnauthorizedException({ error: 'UNAUTHENTICATED', message });
@@ -39,6 +45,7 @@ function unauthenticated(message: string): UnauthorizedException {
 
 export class WorkOsAuthProvider implements AuthProvider {
   readonly name = 'workos';
+  private readonly log = new Logger('WorkOsAuthProvider');
   private readonly secret: string;
 
   constructor(
@@ -149,6 +156,11 @@ export class WorkOsAuthProvider implements AuthProvider {
       sql`SELECT id FROM member WHERE account_id = ${accountId} AND external_id = ${sub} LIMIT 1`,
     );
     if (!row) throw unauthenticated('Could not resolve member.');
+    // A fresh account (its first member is the owner) gets the polished demo form
+    // so the dashboard is never empty. Idempotent + best-effort (never blocks login).
+    if (role === 'owner') {
+      await maybeSeedDemoForm(this.db, accountId, this.env.SEED_DEMO_FORM, this.log);
+    }
     return row.id;
   }
 }

--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -45,8 +45,9 @@ export class EmailEffects {
     try {
       // The account-side notice goes to the owner inbox; a fork with no member
       // email just carries no recipient and the notifier no-ops on empty `to`.
-      const owner = await this.db.get<{ email: string | null }>(
-        sql`SELECT email FROM member
+      // The owner's `locale` selects the EN/ES copy (absent = English default).
+      const owner = await this.db.get<{ email: string | null; locale: string | null }>(
+        sql`SELECT email, locale FROM member
             WHERE account_id = ${accountId} AND role = 'owner' AND status = 'active'
             ORDER BY created_at ASC LIMIT 1`,
       );
@@ -54,7 +55,12 @@ export class EmailEffects {
       // Snapshot the toggle: absent row = enabled (fork-friendly default).
       const settings = await getNotificationSettings(this.db, accountId);
       if (settings.get('submission_received')?.enabled === false) return;
-      const payload: SubmissionNotification = { ...n, accountId, to };
+      const payload: SubmissionNotification = {
+        ...n,
+        accountId,
+        to,
+        locale: n.locale ?? owner?.locale ?? null,
+      };
       await enqueueOutbox(this.db, {
         kind: 'email',
         action: 'submission_received',

--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression: "members don't work — I can't add a new member."
+ *
+ * The add-member endpoint the dashboard's Settings page drives, exercised end to
+ * end through the real controller → AuthService → provider → db on in-memory
+ * SQLite. Before this fix the web UI never called it (dead client method, no
+ * button), so no test guarded the contract. These lock the intended flow:
+ *
+ *   1. an admin/owner adds a member by email + role → it persists as `invited`
+ *      with the granted role and shows up in the roster (what the "Add member"
+ *      button now triggers);
+ *   2. a plain member is refused (403) — management is admin/owner only;
+ *   3. a duplicate email is refused (409 EMAIL_TAKEN);
+ *   4. the invited member is ADOPTED on their first WorkOS login — external_id
+ *      bound, status flipped to active, granted role preserved (the JIT
+ *      invite→adoption model).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException, ConflictException } from '@nestjs/common';
+import {
+  createDb,
+  migrate,
+  seed,
+  insertAccountWithShortCode,
+  inviteMember,
+  sql,
+  type Db,
+} from '@quill/db';
+import { AdminCrudController } from './admin-crud.controller';
+import { AdminService } from './admin.service';
+import { AuthService } from './auth.service';
+import { LocalAuthProvider } from './auth.provider';
+import { WorkOsAuthProvider } from './auth.provider.workos';
+import { signJwtHs256 } from './jwt';
+import type { ReqLike } from './auth.provider';
+
+let db: Db;
+let controller: AdminCrudController;
+
+/** A request the local dev provider resolves to `email` (JIT-safe). */
+const asEmail = (email: string): ReqLike => ({ headers: { 'x-quill-email': email } });
+/** No identity → local provider falls back to the first seeded account+member (the owner). */
+const asOwner = (): ReqLike => ({ headers: {} });
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db); // account "acme" + owner alex@example.com
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: 'test',
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+  });
+  const auth = new AuthService(db, provider);
+  const admin = new AdminService(db);
+  // Submission/Analytics services are unused by the member routes under test.
+  controller = new AdminCrudController(db, auth, admin, {} as never, {} as never);
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('POST /v1/members (add a member)', () => {
+  it('an owner adds a member by email + role → invited, and it appears in the roster', async () => {
+    const before = await controller.members(asOwner());
+    expect(before).toHaveLength(1); // just the owner
+
+    const created = await controller.inviteMember(asOwner(), {
+      email: 'Newbie@Acme.test',
+      role: 'member',
+    });
+    expect(created.email).toBe('newbie@acme.test'); // normalized
+    expect(created.role).toBe('member');
+    expect(created.status).toBe('invited');
+    expect(created.handle).toBeTruthy(); // auto-handle so they're bookable on accept
+
+    const after = await controller.members(asOwner());
+    expect(after).toHaveLength(2);
+    expect(after.map((m) => m.email)).toContain('newbie@acme.test');
+  });
+
+  it('honors an admin role grant', async () => {
+    const created = await controller.inviteMember(asOwner(), {
+      email: 'boss@acme.test',
+      role: 'admin',
+    });
+    expect(created.role).toBe('admin');
+    expect(created.status).toBe('invited');
+  });
+
+  it('refuses a plain member (admin/owner only) with 403', async () => {
+    await controller.inviteMember(asOwner(), { email: 'plain@acme.test', role: 'member' });
+    // The invited member logs in later; here we just resolve them as the caller.
+    await expect(
+      controller.inviteMember(asEmail('plain@acme.test'), { email: 'x@acme.test' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(controller.members(asEmail('plain@acme.test'))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('refuses a duplicate email with 409 EMAIL_TAKEN', async () => {
+    await controller.inviteMember(asOwner(), { email: 'dup@acme.test' });
+    const err = await controller
+      .inviteMember(asOwner(), { email: 'DUP@acme.test' })
+      .then(() => null)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ConflictException);
+    expect((err as ConflictException).getResponse()).toMatchObject({ error: 'EMAIL_TAKEN' });
+  });
+});
+
+describe('invite → first-login adoption (WorkOS JIT model)', () => {
+  it('adopts the invited member on first login: binds external_id, activates, keeps the role', async () => {
+    const secret = 'test-shared-secret';
+    const externalId = 'org_adopt_1';
+    await insertAccountWithShortCode(db, { name: 'Adopt Co', externalId });
+    const account = (await db.get<{ id: string }>(
+      sql`SELECT id FROM account WHERE external_id = ${externalId} LIMIT 1`,
+    ))!;
+
+    // Invite (granted admin) — an `invited` row with no external_id yet.
+    const invited = await inviteMember(db, account.id, { email: 'invitee@adopt.test', role: 'admin' });
+    expect(invited.ok).toBe(true);
+    if (!invited.ok) return;
+    expect(invited.value.status).toBe('invited');
+
+    // Their first login: the identity service mints a token for the same email.
+    const provider = new WorkOsAuthProvider(db, {
+      JWT_SECRET: secret,
+      JWT_ISSUER: undefined,
+      JWT_AUDIENCE: undefined,
+    });
+    const nowSec = Math.floor(Date.now() / 1000);
+    const token = signJwtHs256(
+      {
+        sub: 'workos_user_42',
+        account_id: externalId,
+        email: 'invitee@adopt.test',
+        name: 'Invited Person',
+        iat: nowSec,
+        exp: nowSec + 3600,
+      },
+      secret,
+    );
+    const resolved = await provider.resolveHost({ headers: { authorization: `Bearer ${token}` } });
+
+    // Adopted the SAME row (not a fresh member), bound + activated, role kept.
+    expect(resolved.memberId).toBe(invited.value.id);
+    const row = (await db.get<{ external_id: string | null; status: string; role: string }>(
+      sql`SELECT external_id, status, role FROM member WHERE id = ${invited.value.id} LIMIT 1`,
+    ))!;
+    expect(row.external_id).toBe('workos_user_42');
+    expect(row.status).toBe('active');
+    expect(row.role).toBe('admin');
+  });
+});

--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -50,6 +50,7 @@ beforeEach(async () => {
     NODE_ENV: 'test',
     DEV_LOGIN_EMAIL: undefined,
     AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
   });
   const auth = new AuthService(db, provider);
   const admin = new AdminService(db);
@@ -131,6 +132,7 @@ describe('invite → first-login adoption (WorkOS JIT model)', () => {
       JWT_SECRET: secret,
       JWT_ISSUER: undefined,
       JWT_AUDIENCE: undefined,
+      SEED_DEMO_FORM: false,
     });
     const nowSec = Math.floor(Date.now() / 1000);
     const token = signJwtHs256(

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
+
+/** Machine-readable outcome of an invite so the client can localize the message. */
+export type InviteMemberState =
+  | { ok: true }
+  | { ok: false; code: 'INVALID' | 'TAKEN' | 'FAILED' }
+  | null;
+
+/**
+ * Invite a member by email with an account role. The API creates an `invited`
+ * member row that is adopted (bound + activated, keeping the granted role) the
+ * first time that email signs in — the JIT invite→adoption model. Admin/owner
+ * only; the API enforces this too, this is a defence-in-depth re-check.
+ *
+ * Returns a stable code (never a raw server string) so the Settings UI renders a
+ * localized message. Success revalidates the roster so the new member appears.
+ */
+export async function inviteMemberAction(
+  _prev: InviteMemberState,
+  formData: FormData,
+): Promise<InviteMemberState> {
+  const email = String(formData.get('email') ?? '').trim();
+  const roleRaw = String(formData.get('role') ?? 'member');
+  const role: 'admin' | 'member' = roleRaw === 'admin' ? 'admin' : 'member';
+
+  // Cheap client-side-mirrored guard: a blank/invalid email never hits the API.
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return { ok: false, code: 'INVALID' };
+  }
+
+  // Only admins/owners can manage the roster (the API is the real gate).
+  const me = await adminApi.me();
+  if (!isAdminRole(me.role)) return { ok: false, code: 'FAILED' };
+
+  try {
+    await adminApi.inviteMember({ email, role });
+    revalidatePath('/admin/settings');
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ApiError) {
+      if (e.code === 'EMAIL_TAKEN') return { ok: false, code: 'TAKEN' };
+      if (e.status === 400) return { ok: false, code: 'INVALID' };
+    }
+    return { ok: false, code: 'FAILED' };
+  }
+}

--- a/apps/web/app/admin/settings/invite-member.tsx
+++ b/apps/web/app/admin/settings/invite-member.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useActionState, useEffect, useRef, useState } from 'react';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/toast';
+import { inviteMemberAction, type InviteMemberState } from './actions';
+
+export interface InviteMemberLabels {
+  addMember: string;
+  inviteTitle: string;
+  inviteSubtitle: string;
+  inviteEmailLabel: string;
+  inviteEmailPlaceholder: string;
+  inviteRoleLabel: string;
+  roleAdmin: string;
+  roleMember: string;
+  inviteSubmit: string;
+  inviteCancel: string;
+  inviteSuccess: string;
+  inviteErrorTaken: string;
+  inviteErrorInvalid: string;
+  inviteErrorFailed: string;
+}
+
+/**
+ * Add-member entry point on the Settings page (admin/owner only). Follows the
+ * list/create pattern (Design Quality Bar): a primary trigger opens a dedicated
+ * dialog, never an inline form under the list. Submits to `inviteMemberAction`,
+ * which creates an `invited` member adopted on their first sign-in. On success
+ * the dialog closes, a toast confirms, and the revalidated roster shows the row.
+ */
+export function InviteMember({ labels }: { labels: InviteMemberLabels }) {
+  const [open, setOpen] = useState(false);
+  const [state, action, pending] = useActionState<InviteMemberState, FormData>(
+    inviteMemberAction,
+    null,
+  );
+  const toast = useToast();
+  const formRef = useRef<HTMLFormElement>(null);
+  // Each action result is a fresh object; handle each exactly once. Without this
+  // guard the effect re-fires on every render (the toast context value changes
+  // identity each render), stacking duplicate toasts.
+  const handledRef = useRef<InviteMemberState>(null);
+
+  // On a successful invite: close the dialog, confirm, and clear the form so a
+  // reopen starts clean. The server action already revalidated the roster.
+  useEffect(() => {
+    if (!state || state === handledRef.current) return;
+    handledRef.current = state;
+    if (state.ok) {
+      setOpen(false);
+      formRef.current?.reset();
+      toast.success(labels.inviteSuccess);
+    }
+  }, [state, toast, labels.inviteSuccess]);
+
+  const errorMessage =
+    state && !state.ok
+      ? state.code === 'TAKEN'
+        ? labels.inviteErrorTaken
+        : state.code === 'INVALID'
+          ? labels.inviteErrorInvalid
+          : labels.inviteErrorFailed
+      : null;
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {labels.addMember}
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title={labels.inviteTitle}
+        labelId="invite-member-title"
+      >
+        <p className="-mt-2 mb-4 text-sm text-muted-foreground">{labels.inviteSubtitle}</p>
+        <form ref={formRef} action={action} className="flex flex-col gap-4">
+          <label className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">{labels.inviteEmailLabel}</span>
+            <input
+              name="email"
+              type="email"
+              required
+              autoComplete="off"
+              placeholder={labels.inviteEmailPlaceholder}
+              aria-invalid={errorMessage ? true : undefined}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </label>
+          <label className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">{labels.inviteRoleLabel}</span>
+            <select
+              name="role"
+              defaultValue="member"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="member">{labels.roleMember}</option>
+              <option value="admin">{labels.roleAdmin}</option>
+            </select>
+          </label>
+          {errorMessage ? (
+            <p role="alert" className="text-sm text-destructive">
+              {errorMessage}
+            </p>
+          ) : null}
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+              {labels.inviteCancel}
+            </Button>
+            <Button type="submit" disabled={pending} className="min-w-[120px]">
+              {labels.inviteSubmit}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -4,6 +4,7 @@ import { getMessages } from '@quill/shared';
 import { adminApi, isAdminRole, type AccountMember, type AccountRole, type MemberStatus } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { PageHeader } from '@/components/ui/page-header';
+import { InviteMember } from './invite-member';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,8 +60,30 @@ export default async function SettingsPage() {
 
       {isAdminRole(me.role) ? (
         <section className="rounded-md border border-border bg-card p-6">
-          <h2 className="text-lg font-semibold tracking-tight">{s.membersHeading}</h2>
-          <p className="mt-0.5 text-sm text-muted-foreground">{s.membersSubtitle}</p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight">{s.membersHeading}</h2>
+              <p className="mt-0.5 text-sm text-muted-foreground">{s.membersSubtitle}</p>
+            </div>
+            <InviteMember
+              labels={{
+                addMember: s.addMember,
+                inviteTitle: s.inviteTitle,
+                inviteSubtitle: s.inviteSubtitle,
+                inviteEmailLabel: s.inviteEmailLabel,
+                inviteEmailPlaceholder: s.inviteEmailPlaceholder,
+                inviteRoleLabel: s.inviteRoleLabel,
+                roleAdmin: s.roleAdmin,
+                roleMember: s.roleMember,
+                inviteSubmit: s.inviteSubmit,
+                inviteCancel: s.inviteCancel,
+                inviteSuccess: s.inviteSuccess,
+                inviteErrorTaken: s.inviteErrorTaken,
+                inviteErrorInvalid: s.inviteErrorInvalid,
+                inviteErrorFailed: s.inviteErrorFailed,
+              }}
+            />
+          </div>
           {members.length === 0 ? (
             <p className="mt-5 text-sm text-muted-foreground">{s.membersEmpty}</p>
           ) : (

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -89,6 +89,14 @@ export const serverEnvSchema = z.object({
   ENTITLEMENTS_API_URL: z.string().url().optional(),
   ENTITLEMENTS_API_KEY: z.string().optional(),
 
+  // Onboarding: auto-seed a polished DEMO form into every brand-new account
+  // (JIT on first login) so a new user's admin is never empty and immediately
+  // shows a well-designed example. Idempotent — only ever runs when the account
+  // has zero forms, so a repeat login never duplicates it and the user can
+  // delete it like any normal form. Default ON; a fork can set it to false to
+  // ship empty workspaces.
+  SEED_DEMO_FORM: boolish.default('true'),
+
   // Auth — unset selects the local dev stub.
   AUTH_PROVIDER: z.enum(['local', 'workos']).default('local'),
 

--- a/packages/db/src/demo-form.spec.ts
+++ b/packages/db/src/demo-form.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Demo-form seed — the onboarding guarantee. Two things must hold:
+ *   1. the showcase config is a VALID v1 form config (it round-trips the shared
+ *      Zod schema the API re-validates against — the demo can never drift out of
+ *      contract), and
+ *   2. seeding is IDEMPOTENT — a brand-new account gets exactly one demo form,
+ *      and calling the seed again (a repeat login) never adds a duplicate nor
+ *      touches a form the user created or kept.
+ * Runs on SQLite locally; CI re-runs the same suite against Postgres for parity.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { formConfigSchema } from '@quill/types';
+import { normalizeConfig } from '@quill/engine';
+import { createDb, type Db } from './client';
+import { migrate } from './migrate';
+import { listForms, createForm } from './forms';
+import {
+  DEMO_FORM_CONFIG,
+  DEMO_FORM_NAME,
+  seedDemoFormForAccount,
+  accountHasForms,
+} from './demo-form';
+
+let db: Db;
+let accountId: string;
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+  accountId = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${'d' + accountId.slice(0, 5)}, ${'Demo Test'}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  // Keep a shared Postgres DB clean (memory SQLite just evaporates).
+  await db.run(
+    sql`DELETE FROM form WHERE account_id = ${accountId}`,
+  );
+  await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  await db.close();
+});
+
+describe('DEMO_FORM_CONFIG', () => {
+  it('is a valid v1 form config (passes the shared Zod schema)', () => {
+    const parsed = formConfigSchema.safeParse(DEMO_FORM_CONFIG);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('is canonical — normalizing it is a no-op (unique keys, derived flow groups)', () => {
+    const normalized = normalizeConfig(DEMO_FORM_CONFIG);
+    // Same set of step keys, all unique — the config is authored save-ready.
+    const keys = DEMO_FORM_CONFIG.steps.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(normalized.steps.map((s) => s.key)).toEqual(keys);
+  });
+
+  it('showcases the product range (cover, an icon choice, a slider, a lead email, outcomes)', () => {
+    expect(DEMO_FORM_CONFIG.cover?.enabled).toBe(true);
+    expect(DEMO_FORM_CONFIG.steps.some((s) => s.showIcons)).toBe(true);
+    expect(DEMO_FORM_CONFIG.steps.some((s) => s.type === 'slider')).toBe(true);
+    expect(DEMO_FORM_CONFIG.steps.some((s) => s.type === 'email')).toBe(true);
+    expect((DEMO_FORM_CONFIG.outcomes ?? []).length).toBeGreaterThan(0);
+  });
+});
+
+describe('seedDemoFormForAccount', () => {
+  it('seeds exactly one demo form for an empty account', async () => {
+    expect(await accountHasForms(db, accountId)).toBe(false);
+
+    const created = await seedDemoFormForAccount(db, accountId);
+    expect(created).not.toBeNull();
+    expect(created?.name).toBe(DEMO_FORM_NAME);
+
+    const forms = await listForms(db, accountId);
+    expect(forms).toHaveLength(1);
+    expect(forms[0]?.slug).toBe('customer-feedback');
+  });
+
+  it('is idempotent — a second call (repeat login) never duplicates the demo', async () => {
+    await seedDemoFormForAccount(db, accountId);
+    const second = await seedDemoFormForAccount(db, accountId);
+    expect(second).toBeNull();
+    expect(await listForms(db, accountId)).toHaveLength(1);
+  });
+
+  it('never seeds into an account that already has a form (no clobber)', async () => {
+    // The user built their own form first — seeding must not add the demo.
+    await createForm(db, accountId, { name: 'My real form', config: { version: 1, steps: [] } });
+    const seeded = await seedDemoFormForAccount(db, accountId);
+    expect(seeded).toBeNull();
+
+    const forms = await listForms(db, accountId);
+    expect(forms).toHaveLength(1);
+    expect(forms[0]?.name).toBe('My real form');
+  });
+
+  it('the seeded form persists a config that survives a save round-trip', async () => {
+    const created = await seedDemoFormForAccount(db, accountId);
+    // The stored config re-parses as a valid v1 config (JSON column round-trip).
+    const parsed = formConfigSchema.safeParse(created?.config);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/db/src/demo-form.ts
+++ b/packages/db/src/demo-form.ts
@@ -1,0 +1,210 @@
+/**
+ * The onboarding demo form — every brand-new account is auto-seeded with ONE
+ * polished, self-explanatory example so a new user's admin is never empty and
+ * immediately shows what a well-built Dapta form looks like. The auth providers
+ * call `seedDemoFormForAccount` right after they JIT-create a new account+owner
+ * (both the local OSS stub and the workos overlay), gated by the `SEED_DEMO_FORM`
+ * env flag (default ON — a fork can disable it).
+ *
+ * The demo is a normal form: the user can edit or delete it. Seeding is
+ * idempotent — it only ever runs when the account has ZERO forms, so a repeat
+ * login never produces a duplicate and a real form is never clobbered.
+ *
+ * The config is authored against the versioned v1 `formConfigSchema` (Zod) — the
+ * spec re-validates it so the showcase can never drift out of contract. Copy is
+ * in English (the OSS default); Spanish parity for every string the config
+ * carries is kept alongside in `DEMO_FORM_COPY_ES` for anyone localizing a fork.
+ */
+import { sql, type Db } from './client';
+import { createForm, type FormRow } from './forms';
+import type { FormConfig } from '@quill/types';
+
+/** The demo form's display name (slugifies to `customer-feedback`). */
+export const DEMO_FORM_NAME = 'Customer feedback';
+
+/**
+ * A flagship example that shows the product's range without overwhelming: a
+ * branded cover (eyebrow + headline + subheadline + CTA + trust line + accent),
+ * an icon single-choice, a second icon choice, an NPS slider, an open-text note,
+ * an optional email lead-capture, a processing reveal, and warm outcome buckets.
+ * Realistic use case: a customer-feedback survey — the clearest, most universal
+ * demo, and visually distinct from the CLI `pnpm db:seed` lead-qualifier sample.
+ */
+export const DEMO_FORM_CONFIG: FormConfig = {
+  version: 1,
+  branding: { primaryColor: '#6366f1' },
+  cover: {
+    enabled: true,
+    bannerText: 'Demo form — edit or delete it anytime from your dashboard',
+    eyebrow: 'We would love your feedback',
+    headline: 'How was your experience?',
+    subheadline:
+      'Three quick questions — under a minute. Your answers help us build a better product for you.',
+    ctaText: 'Share my feedback',
+    trustBadge: 'Anonymous unless you choose to leave your email',
+    clientLogos: [{ name: 'Northwind' }, { name: 'Acme Co' }, { name: 'Globex' }, { name: 'Initech' }],
+  },
+  steps: [
+    {
+      key: 'satisfaction',
+      type: 'multiple_choice',
+      question: 'Overall, how happy are you with us?',
+      helper: 'Pick the face that fits best.',
+      required: true,
+      showIcons: true,
+      flowGroup: 'qualification',
+      options: [
+        { label: 'Love it', value: 'love', icon: '\u{1F60D}', points: 10 },
+        { label: 'Pretty good', value: 'good', icon: '\u{1F642}', points: 7 },
+        { label: "It's okay", value: 'okay', icon: '\u{1F610}', points: 4 },
+        { label: 'Could be better', value: 'meh', icon: '\u{1F615}', points: 1 },
+      ],
+    },
+    {
+      key: 'favorite_area',
+      type: 'multiple_choice',
+      question: 'What do you value most about us?',
+      required: true,
+      showIcons: true,
+      flowGroup: 'qualification',
+      options: [
+        { label: 'Ease of use', value: 'ease', icon: '\u{1FA84}', points: 3 },
+        { label: 'Speed', value: 'speed', icon: '\u{26A1}', points: 3 },
+        { label: 'Support', value: 'support', icon: '\u{1F4AC}', points: 3 },
+        { label: 'Price', value: 'price', icon: '\u{1F4B0}', points: 3 },
+      ],
+    },
+    {
+      key: 'recommend',
+      type: 'slider',
+      question: 'How likely are you to recommend us to a friend or colleague?',
+      helper: '0 = not at all likely, 10 = absolutely.',
+      flowGroup: 'qualification',
+      min: 0,
+      max: 10,
+      step: 1,
+      default: 8,
+      sliderUnitLabel: '/ 10',
+      sliderScoring: [
+        { min: 0, max: 6, points: 0 },
+        { min: 7, max: 8, points: 3 },
+        { min: 9, max: 10, points: 6 },
+      ],
+    },
+    {
+      key: 'improvement',
+      type: 'textarea',
+      question: 'What is the one thing we could do better?',
+      placeholder: 'Optional — but we read every single note.',
+      required: false,
+      flowGroup: 'qualification',
+    },
+    {
+      key: 'email',
+      type: 'email',
+      question: 'Want us to follow up? Leave your email.',
+      helper: 'Optional. We only use it to reply to your feedback — no spam.',
+      placeholder: 'you@company.com',
+      required: false,
+      flowGroup: 'lead_capture',
+      triggersReveal: true,
+    },
+  ],
+  scoring: { enabled: true },
+  outcomes: [
+    { id: 'thanks', label: 'Thank you for sharing \u{1F64C}', minScore: 0 },
+    { id: 'delighted', label: 'You just made our day! \u{1F389}', minScore: 13 },
+  ],
+  reveal: {
+    enabled: true,
+    headline: 'Saving your feedback…',
+    subtitle: 'Hang tight — this only takes a second.',
+  },
+  partialSubmitAfterStep: 5,
+};
+
+/**
+ * Spanish parity for every user-facing string the demo config carries. Not wired
+ * into the single-language config (the v1 schema is mono-locale by design); kept
+ * here so a Spanish-first fork can swap the copy in one place. The renderer
+ * chrome (buttons, validation, thank-you body) is already localized separately
+ * via `@quill/shared`.
+ */
+export const DEMO_FORM_COPY_ES = {
+  name: 'Opiniones de clientes',
+  cover: {
+    bannerText: 'Formulario de demostración: puedes editarlo o eliminarlo cuando quieras',
+    eyebrow: 'Nos encantaría conocer tu opinión',
+    headline: '¿Cómo fue tu experiencia?',
+    subheadline:
+      'Tres preguntas rápidas, en menos de un minuto. Tus respuestas nos ayudan a construir un mejor producto para ti.',
+    ctaText: 'Compartir mi opinión',
+    trustBadge: 'Anónimo, salvo que decidas dejar tu correo',
+  },
+  steps: {
+    satisfaction: {
+      question: 'En general, ¿qué tan contento estás con nosotros?',
+      helper: 'Elige la cara que mejor te represente.',
+      options: {
+        love: 'Me encanta',
+        good: 'Bastante bien',
+        okay: 'Más o menos',
+        meh: 'Podría mejorar',
+      },
+    },
+    favorite_area: {
+      question: '¿Qué es lo que más valoras de nosotros?',
+      options: {
+        ease: 'Facilidad de uso',
+        speed: 'Rapidez',
+        support: 'Soporte',
+        price: 'Precio',
+      },
+    },
+    recommend: {
+      question: '¿Qué tan probable es que nos recomiendes a un amigo o colega?',
+      helper: '0 = nada probable, 10 = totalmente.',
+    },
+    improvement: {
+      question: '¿Cuál es la única cosa que podríamos hacer mejor?',
+      placeholder: 'Opcional, pero leemos cada nota.',
+    },
+    email: {
+      question: '¿Quieres que te contactemos? Déjanos tu correo.',
+      helper: 'Opcional. Solo lo usamos para responder tu opinión, sin spam.',
+    },
+  },
+  outcomes: {
+    thanks: 'Gracias por compartir \u{1F64C}',
+    delighted: '¡Nos alegraste el día! \u{1F389}',
+  },
+  reveal: {
+    headline: 'Guardando tu opinión…',
+    subtitle: 'Un momento, esto solo toma un segundo.',
+  },
+} as const;
+
+/** True when the account already owns at least one form. */
+export async function accountHasForms(db: Db, accountId: string): Promise<boolean> {
+  const row = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE account_id = ${accountId} LIMIT 1`,
+  );
+  return row != null;
+}
+
+/**
+ * Seed the polished demo form for `accountId` — but ONLY when the account has no
+ * forms yet, so this is safe to call on every login (idempotent) and never
+ * duplicates the demo nor overwrites a form the user created or kept. Reuses the
+ * standard `createForm` path so the slug/short-link/handle all resolve exactly
+ * like a hand-built form. Returns the created form, or `null` when it was
+ * skipped (the account already had forms).
+ */
+export async function seedDemoFormForAccount(db: Db, accountId: string): Promise<FormRow | null> {
+  if (await accountHasForms(db, accountId)) return null;
+  const result = await createForm(db, accountId, {
+    name: DEMO_FORM_NAME,
+    config: DEMO_FORM_CONFIG,
+  });
+  return result.ok ? result.value : null;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,7 @@ export * from './crud';
 export * from './forms';
 export * from './analytics';
 export * from './members';
+export * from './demo-form';
 export * from './short-links';
 export * from './outbox';
 export * from './notification-settings';

--- a/packages/notifications/src/adapters/http.spec.ts
+++ b/packages/notifications/src/adapters/http.spec.ts
@@ -1,0 +1,148 @@
+import { createHash, createHmac } from 'node:crypto';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  HttpEmailProvider,
+  TRANSACTIONAL_EMAIL_PATH,
+  signTransactionalRequest,
+  interpretTransactionalResponse,
+} from './http';
+
+const ENDPOINT = `https://email.internal.example.com${TRANSACTIONAL_EMAIL_PATH}`;
+const CLIENT_ID = 'forms';
+const SECRET = 'a'.repeat(48); // >= 32 chars, like a real signing secret
+
+/** A fetch stub that records the single request and returns a canned 2xx JSON. */
+function stubFetch(status = 200, body: unknown = { status: 'accepted', messageId: 'msg-1' }) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  });
+  return { impl: impl as unknown as typeof fetch, calls };
+}
+
+describe('signTransactionalRequest', () => {
+  it('signs the canonical v1 payload with the logical path (not the request URL)', () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const ts = '1700000000';
+    const idem = 'submission:s1:received';
+    const bodyHash = createHash('sha256').update(body).digest('hex');
+    const canonical = ['v1', 'POST', TRANSACTIONAL_EMAIL_PATH, ts, idem, bodyHash].join('\n');
+    const expected = createHmac('sha256', SECRET).update(canonical).digest('hex');
+    expect(signTransactionalRequest(body, ts, idem, SECRET)).toBe(expected);
+    expect(signTransactionalRequest(body, ts, idem, SECRET)).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('HttpEmailProvider — transactional-v1', () => {
+  it('POSTs a correctly-signed transactional payload the server can verify', async () => {
+    const { impl, calls } = stubFetch();
+    const provider = new HttpEmailProvider(
+      {
+        endpoint: ENDPOINT,
+        profile: 'transactional-v1',
+        clientId: CLIENT_ID,
+        signingSecret: SECRET,
+        fromEmail: 'form@notifications-dapta.ai',
+        fromName: 'Dapta Forms',
+      },
+      impl,
+    );
+
+    const result = await provider.send({
+      accountId: 'acc-1',
+      to: 'owner@acme.io',
+      subject: 'New submission — Lead Qualifier',
+      text: 'You have a new submission.',
+      html: '<p>You have a new submission.</p>',
+      idempotencyKey: 'submission:s1:received',
+    });
+
+    expect(result).toEqual({ delivered: true, messageId: 'msg-1', driver: 'http' });
+    expect(calls).toHaveLength(1);
+    const { init } = calls[0]!;
+    const headers = init.headers as Record<string, string>;
+
+    // Auth headers present, signature is a 64-hex HMAC.
+    expect(headers['x-dapta-client-id']).toBe(CLIENT_ID);
+    expect(headers['x-dapta-timestamp']).toMatch(/^\d+$/);
+    expect(headers['x-dapta-signature']).toMatch(/^[a-f0-9]{64}$/);
+    // No legacy bearer when the HMAC pair is configured.
+    expect(headers.authorization).toBeUndefined();
+
+    // Body carries ONLY the managed fields — never from/fromName/headers.
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toMatchObject({
+      mode: 'html',
+      to: ['owner@acme.io'],
+      subject: 'New submission — Lead Qualifier',
+      category: 'lifecycle',
+      idempotencyKey: 'submission:s1:received',
+      businessContext: { accountId: 'acc-1' },
+    });
+    expect(sent.from).toBeUndefined();
+    expect(sent.fromName).toBeUndefined();
+    expect(sent.headers).toBeUndefined();
+
+    // The server rebuilds the SAME signature from the raw body + headers — prove it verifies.
+    const recomputed = signTransactionalRequest(
+      init.body as string,
+      headers['x-dapta-timestamp']!,
+      sent.idempotencyKey,
+      SECRET,
+    );
+    expect(headers['x-dapta-signature']).toBe(recomputed);
+  });
+
+  it('requires a tenant account context on the signed wire', async () => {
+    const { impl } = stubFetch();
+    const provider = new HttpEmailProvider(
+      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'form@notifications-dapta.ai' },
+      impl,
+    );
+    expect(provider.requiresAccountContext).toBe(true);
+    await expect(provider.send({ to: 'x@y.com', subject: 's' })).rejects.toThrow(/account context/i);
+  });
+
+  it('throws on a non-2xx so the outbox retries (never a silent drop)', async () => {
+    const { impl } = stubFetch(500, {});
+    const provider = new HttpEmailProvider(
+      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'form@notifications-dapta.ai' },
+      impl,
+    );
+    await expect(
+      provider.send({ accountId: 'acc-1', to: 'x@y.com', subject: 's', idempotencyKey: 'k' }),
+    ).rejects.toThrow(/HTTP 500/);
+  });
+});
+
+describe('interpretTransactionalResponse', () => {
+  it('accepts accepted/delivered (incl. idempotent duplicates)', () => {
+    expect(interpretTransactionalResponse(200, { status: 'accepted', messageId: 'm' })).toEqual({
+      delivered: true,
+      messageId: 'm',
+      driver: 'http',
+    });
+    expect(interpretTransactionalResponse(200, { status: 'delivered', id: 'd', duplicate: true })).toEqual({
+      delivered: true,
+      messageId: 'd',
+      driver: 'http',
+    });
+  });
+
+  it('throws for non-2xx regardless of body', () => {
+    expect(() => interpretTransactionalResponse(422, { status: 'accepted' })).toThrow(/HTTP 422/);
+  });
+
+  it('throws for blocked_by_policy and for a malformed 2xx', () => {
+    expect(() => interpretTransactionalResponse(200, { status: 'blocked_by_policy', blockedReason: 'x' })).toThrow(
+      /blocked by policy/i,
+    );
+    expect(() => interpretTransactionalResponse(200, {})).toThrow(/malformed/i);
+    expect(() => interpretTransactionalResponse(200, { status: 'weird' })).toThrow(/unexpected status/i);
+  });
+});

--- a/packages/notifications/src/factory.spec.ts
+++ b/packages/notifications/src/factory.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEmailProvider } from './factory';
+import { HttpEmailProvider } from './adapters/http';
+import { LogOnlyEmailProvider } from './adapters/log-only';
+
+/**
+ * The env-gate rule (KEY): a bare fork (nothing set) stays log-only; the Dapta
+ * deployment (EMAIL_PROVIDER=http + endpoint + transactional-v1 credentials)
+ * gets the real signed provider. Missing pieces degrade to log-only — a
+ * submission never blocks on mail config.
+ */
+describe('createEmailProvider — env gating', () => {
+  it('defaults to log-only for a bare fork (provider unset → log-only)', () => {
+    expect(createEmailProvider({ provider: 'log-only', fromEmail: 'forms@example.com' })).toBeInstanceOf(
+      LogOnlyEmailProvider,
+    );
+  });
+
+  it('falls back to log-only when http is selected but no endpoint is set', () => {
+    expect(createEmailProvider({ provider: 'http', fromEmail: 'forms@example.com', http: {} })).toBeInstanceOf(
+      LogOnlyEmailProvider,
+    );
+  });
+
+  it('falls back to log-only when transactional-v1 has an endpoint but no credentials', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = createEmailProvider({
+      provider: 'http',
+      fromEmail: 'form@notifications-dapta.ai',
+      http: { endpoint: 'https://email.example.com/api/internal/email/send', profile: 'transactional-v1' },
+    });
+    expect(provider).toBeInstanceOf(LogOnlyEmailProvider);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('builds the signed HTTP provider when endpoint + clientId + secret are all set', () => {
+    const provider = createEmailProvider({
+      provider: 'http',
+      fromEmail: 'form@notifications-dapta.ai',
+      fromName: 'Dapta Forms',
+      http: {
+        endpoint: 'https://email.example.com/api/internal/email/send',
+        profile: 'transactional-v1',
+        clientId: 'forms',
+        signingSecret: 'x'.repeat(48),
+      },
+    });
+    expect(provider).toBeInstanceOf(HttpEmailProvider);
+    expect(provider.requiresAccountContext).toBe(true);
+  });
+});

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -6,6 +6,15 @@
 export * from './email.port';
 export * from './factory';
 export * from './submission-notifier';
+export {
+  normalizeLocale,
+  renderSubmissionReceived,
+  renderSubmissionConfirmed,
+  type NotificationLocale,
+  type ReceivedCopyVars,
+  type ConfirmedCopyVars,
+  type RenderedCopy,
+} from './templates';
 export { LogOnlyEmailProvider } from './adapters/log-only';
 export { NoopEmailProvider } from './adapters/noop';
 export { SmtpEmailProvider, type SmtpOptions } from './adapters/smtp';

--- a/packages/notifications/src/submission-notifier.spec.ts
+++ b/packages/notifications/src/submission-notifier.spec.ts
@@ -34,6 +34,26 @@ describe('SubmissionNotifier', () => {
     expect(m.text).toContain('Outcome: Qualified');
   });
 
+  it('renders the received notice in Spanish when locale=es', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-es',
+      formName: 'Calificador',
+      to: ['owner@example.com'],
+      respondentEmail: 'lead@acme.io',
+      score: 9,
+      locale: 'es-CO',
+    });
+    const m = provider.sent[0]!;
+    expect(m.subject).toBe('Nueva respuesta — Calificador');
+    expect(m.text).toContain('Puntuación: 9');
+    expect(m.text).toContain('De: lead@acme.io');
+    // Idempotency key is language-independent.
+    expect(m.idempotencyKey).toBe('submission:sub-es:received');
+  });
+
   it('confirms to the respondent when their email was captured', async () => {
     const provider = new CaptureProvider();
     const notifier = new SubmissionNotifier(provider);

--- a/packages/notifications/src/submission-notifier.ts
+++ b/packages/notifications/src/submission-notifier.ts
@@ -1,5 +1,11 @@
 import type { EmailProvider, EmailResult } from './email.port';
 import { escapeHtml } from './util';
+import {
+  normalizeLocale,
+  renderSubmissionConfirmed,
+  renderSubmissionReceived,
+  type NotificationLocale,
+} from './templates';
 
 /** Render plaintext lines to a safe HTML body — every line HTML-escaped (E8). */
 function htmlBody(lines: string[]): string {
@@ -20,30 +26,33 @@ export interface SubmissionNotification {
   outcomeLabel?: string | null;
   /** A public link back to the form (book-again style). */
   formLink?: string | null;
+  /**
+   * Language for the rendered copy. Accepts a bare `en`/`es` or any locale-ish
+   * value (e.g. `es-CO`, an Accept-Language fragment) — normalized to one of the
+   * two supported languages. Unset defaults to English (the bare-fork default).
+   */
+  locale?: NotificationLocale | string | null;
 }
 
 /**
  * Renders and sends submission emails through the EmailProvider port — plain
  * text + escaped HTML, no attachments. The app only ever calls these methods;
- * the transport is whatever adapter is wired (log-only by default).
+ * the transport is whatever adapter is wired (log-only by default). Copy is
+ * bilingual (EN/ES) via the templates module; the caller supplies `locale`.
  */
 export class SubmissionNotifier {
   constructor(private readonly email: EmailProvider) {}
 
   /** Internal notice to the account: a new submission landed. */
   sendSubmissionReceived(n: SubmissionNotification): Promise<EmailResult> {
-    const lines = [
-      `New submission for "${n.formName}".`,
-      n.respondentEmail ? `From: ${n.respondentEmail}` : '',
-      n.score != null ? `Score: ${n.score}` : '',
-      n.outcomeLabel ? `Outcome: ${n.outcomeLabel}` : '',
-    ];
+    const { subject, lines } = renderSubmissionReceived(normalizeLocale(n.locale), n);
+    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.to,
-      subject: `New submission — ${n.formName}`,
-      text: lines.filter(Boolean).join('\n'),
-      html: htmlBody(lines),
+      subject,
+      text: body.join('\n'),
+      html: htmlBody(body),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:received`,
     });
@@ -51,16 +60,14 @@ export class SubmissionNotifier {
 
   /** Confirmation to the respondent that their answers were recorded. */
   sendSubmissionConfirmed(n: SubmissionNotification): Promise<EmailResult> {
-    const lines = [
-      `Thanks — we received your responses to "${n.formName}".`,
-      n.formLink ? `View or edit: ${n.formLink}` : '',
-    ];
+    const { subject, lines } = renderSubmissionConfirmed(normalizeLocale(n.locale), n);
+    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.respondentEmail ? [n.respondentEmail] : n.to,
-      subject: `We got your responses — ${n.formName}`,
-      text: lines.filter(Boolean).join('\n'),
-      html: htmlBody(lines),
+      subject,
+      text: body.join('\n'),
+      html: htmlBody(body),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:confirmed`,
     });

--- a/packages/notifications/src/templates.spec.ts
+++ b/packages/notifications/src/templates.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLocale, renderSubmissionReceived, renderSubmissionConfirmed } from './templates';
+
+describe('normalizeLocale', () => {
+  it('maps Spanish-ish values to es and everything else to en', () => {
+    expect(normalizeLocale('es')).toBe('es');
+    expect(normalizeLocale('es-CO')).toBe('es');
+    expect(normalizeLocale('ES_es')).toBe('es');
+    expect(normalizeLocale('en')).toBe('en');
+    expect(normalizeLocale('en-US')).toBe('en');
+    expect(normalizeLocale('fr')).toBe('en');
+    expect(normalizeLocale(undefined)).toBe('en');
+    expect(normalizeLocale(null)).toBe('en');
+    expect(normalizeLocale('')).toBe('en');
+  });
+});
+
+describe('renderSubmissionReceived', () => {
+  it('renders the English owner notice with interpolated fields', () => {
+    const { subject, lines } = renderSubmissionReceived('en', {
+      formName: 'Lead Qualifier',
+      respondentEmail: 'lead@acme.io',
+      score: 15,
+      outcomeLabel: 'Qualified',
+    });
+    expect(subject).toBe('New submission — Lead Qualifier');
+    const text = lines.filter(Boolean).join('\n');
+    expect(text).toContain('Lead Qualifier');
+    expect(text).toContain('From: lead@acme.io');
+    expect(text).toContain('Score: 15');
+    expect(text).toContain('Outcome: Qualified');
+  });
+
+  it('renders the Spanish owner notice', () => {
+    const { subject, lines } = renderSubmissionReceived('es', {
+      formName: 'Calificador de Leads',
+      respondentEmail: 'lead@acme.io',
+      score: 15,
+      outcomeLabel: 'Calificado',
+    });
+    expect(subject).toBe('Nueva respuesta — Calificador de Leads');
+    const text = lines.filter(Boolean).join('\n');
+    expect(text).toContain('Recibiste una nueva respuesta');
+    expect(text).toContain('De: lead@acme.io');
+    expect(text).toContain('Puntuación: 15');
+    expect(text).toContain('Resultado: Calificado');
+  });
+
+  it('drops absent optional fields (only the headline line remains)', () => {
+    const { lines } = renderSubmissionReceived('en', { formName: 'Survey' });
+    expect(lines.filter(Boolean)).toHaveLength(1);
+  });
+});
+
+describe('renderSubmissionConfirmed', () => {
+  it('renders EN and ES respondent confirmations with the form link', () => {
+    const en = renderSubmissionConfirmed('en', { formName: 'Survey', formLink: 'https://forms.example.com/x' });
+    expect(en.subject).toBe('We got your responses — Survey');
+    expect(en.lines.join('\n')).toContain('View or edit: https://forms.example.com/x');
+
+    const es = renderSubmissionConfirmed('es', { formName: 'Encuesta', formLink: 'https://forms.example.com/x' });
+    expect(es.subject).toBe('Recibimos tus respuestas — Encuesta');
+    expect(es.lines.join('\n')).toContain('Ver o editar: https://forms.example.com/x');
+  });
+});

--- a/packages/notifications/src/templates.ts
+++ b/packages/notifications/src/templates.ts
@@ -1,0 +1,108 @@
+/**
+ * Submission-email COPY, in English and Spanish. Kept in the notifications
+ * package (not the UI i18n catalog in @quill/shared) so this boundary package
+ * stays framework-free and self-contained — a fork can read exactly what an
+ * email says without pulling the whole web message catalog.
+ *
+ * The transport is chosen by config (log-only by default); this module only
+ * decides WHAT the two submission emails say. Every dynamic value is left raw
+ * here — the notifier HTML-escapes each line before it reaches an HTML body
+ * (see submission-notifier.ts / util.escapeHtml), so subjects (plain text) and
+ * text bodies read naturally while the HTML path stays XSS-safe (E8).
+ */
+
+/** The two supported notification languages. Mirrors @quill/shared `Locale`. */
+export type NotificationLocale = 'en' | 'es';
+
+/**
+ * Normalize any locale-ish value (a member.locale like `es`, `es-CO`, `en-US`,
+ * or an Accept-Language fragment) to one of the two supported languages.
+ * Anything that is not clearly Spanish falls back to English — the safe default
+ * for a bare fork with no locale set anywhere.
+ */
+export function normalizeLocale(value?: string | null): NotificationLocale {
+  return typeof value === 'string' && value.trim().toLowerCase().startsWith('es') ? 'es' : 'en';
+}
+
+/** Everything the "new submission" (owner) copy can interpolate. */
+export interface ReceivedCopyVars {
+  formName: string;
+  respondentEmail?: string | null;
+  score?: number | null;
+  outcomeLabel?: string | null;
+  /** A link back to the submissions view (owner) — optional. */
+  formLink?: string | null;
+}
+
+/** Everything the "we got your responses" (respondent) copy can interpolate. */
+export interface ConfirmedCopyVars {
+  formName: string;
+  /** A public link back to the form (view/edit) — optional. */
+  formLink?: string | null;
+}
+
+/** A rendered email: a plain subject + the body lines (blank entries dropped). */
+export interface RenderedCopy {
+  subject: string;
+  lines: string[];
+}
+
+/**
+ * The internal notice to the account owner: "a new submission landed on your
+ * form." This is the primary Forms notification — the equivalent of the
+ * host-notification email a Calendly/Bookings flow emits when someone books.
+ */
+export function renderSubmissionReceived(
+  locale: NotificationLocale,
+  v: ReceivedCopyVars,
+): RenderedCopy {
+  if (locale === 'es') {
+    return {
+      subject: `Nueva respuesta — ${v.formName}`,
+      lines: [
+        `Recibiste una nueva respuesta en "${v.formName}".`,
+        v.respondentEmail ? `De: ${v.respondentEmail}` : '',
+        v.score != null ? `Puntuación: ${v.score}` : '',
+        v.outcomeLabel ? `Resultado: ${v.outcomeLabel}` : '',
+        v.formLink ? `Ver las respuestas: ${v.formLink}` : '',
+      ],
+    };
+  }
+  return {
+    subject: `New submission — ${v.formName}`,
+    lines: [
+      `You have a new submission on "${v.formName}".`,
+      v.respondentEmail ? `From: ${v.respondentEmail}` : '',
+      v.score != null ? `Score: ${v.score}` : '',
+      v.outcomeLabel ? `Outcome: ${v.outcomeLabel}` : '',
+      v.formLink ? `View submissions: ${v.formLink}` : '',
+    ],
+  };
+}
+
+/**
+ * The confirmation to the respondent that their answers were recorded. Fully
+ * rendered here for both languages; whether it is actually enqueued is a caller
+ * decision (the owner notice is the default Forms behavior).
+ */
+export function renderSubmissionConfirmed(
+  locale: NotificationLocale,
+  v: ConfirmedCopyVars,
+): RenderedCopy {
+  if (locale === 'es') {
+    return {
+      subject: `Recibimos tus respuestas — ${v.formName}`,
+      lines: [
+        `Gracias — registramos tus respuestas de "${v.formName}".`,
+        v.formLink ? `Ver o editar: ${v.formLink}` : '',
+      ],
+    };
+  }
+  return {
+    subject: `We got your responses — ${v.formName}`,
+    lines: [
+      `Thanks — we've recorded your responses to "${v.formName}".`,
+      v.formLink ? `View or edit: ${v.formLink}` : '',
+    ],
+  };
+}

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -136,6 +136,18 @@ export interface FormsMessages {
       statusDisabled: string;
       membersEmpty: string;
       you: string;
+      addMember: string;
+      inviteTitle: string;
+      inviteSubtitle: string;
+      inviteEmailLabel: string;
+      inviteEmailPlaceholder: string;
+      inviteRoleLabel: string;
+      inviteSubmit: string;
+      inviteCancel: string;
+      inviteSuccess: string;
+      inviteErrorTaken: string;
+      inviteErrorInvalid: string;
+      inviteErrorFailed: string;
     };
     login: {
       title: string;
@@ -544,6 +556,18 @@ export const en: FormsMessages = {
       statusDisabled: 'Disabled',
       membersEmpty: 'No members yet.',
       you: 'You',
+      addMember: 'Add member',
+      inviteTitle: 'Add a member',
+      inviteSubtitle: 'They join as invited and get full access the first time they sign in.',
+      inviteEmailLabel: 'Email',
+      inviteEmailPlaceholder: 'name@company.com',
+      inviteRoleLabel: 'Role',
+      inviteSubmit: 'Add member',
+      inviteCancel: 'Cancel',
+      inviteSuccess: 'Member added.',
+      inviteErrorTaken: 'A member with that email already exists.',
+      inviteErrorInvalid: 'Enter a valid email address.',
+      inviteErrorFailed: 'Could not add the member. Please try again.',
     },
     login: {
       title: 'Sign in',
@@ -948,6 +972,18 @@ export const es: FormsMessages = {
       statusDisabled: 'Desactivado',
       membersEmpty: 'Aún no hay miembros.',
       you: 'Tú',
+      addMember: 'Añadir miembro',
+      inviteTitle: 'Añadir un miembro',
+      inviteSubtitle: 'Se une como invitado y obtiene acceso completo la primera vez que inicia sesión.',
+      inviteEmailLabel: 'Correo',
+      inviteEmailPlaceholder: 'nombre@empresa.com',
+      inviteRoleLabel: 'Rol',
+      inviteSubmit: 'Añadir miembro',
+      inviteCancel: 'Cancelar',
+      inviteSuccess: 'Miembro añadido.',
+      inviteErrorTaken: 'Ya existe un miembro con ese correo.',
+      inviteErrorInvalid: 'Introduce un correo válido.',
+      inviteErrorFailed: 'No se pudo añadir el miembro. Inténtalo de nuevo.',
     },
     login: {
       title: 'Iniciar sesión',


### PR DESCRIPTION
Overnight release #3. Adds since f2b2008:
- **#16 members:** the add-member UI was never wired — new Invite Member dialog (email+role, admin-gated) + WorkOS invite-adoption. Fixes Felipe's 'can't add a member'.
- **#15 demo form:** every new account auto-seeded with a polished demo form (idempotent, SEED_DEMO_FORM env, deletable).
- **#17 email:** dapta-mail submission notifications (EN/ES), env-gated Dapta-only — stays log-only in prod until the gated email config lands (safe/dormant now).
- #13 focus-accent polish.

All gated (CI green, OptiBot triaged). Builder redesign lands in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)