### PR TITLE
feat(members): remove member + change role from the roster

### DIFF
--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -17,6 +17,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ForbiddenException, ConflictException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
 import {
   createDb,
   migrate,
@@ -109,6 +110,88 @@ describe('POST /v1/members (add a member)', () => {
       .catch((e) => e);
     expect(err).toBeInstanceOf(ConflictException);
     expect((err as ConflictException).getResponse()).toMatchObject({ error: 'EMAIL_TAKEN' });
+  });
+});
+
+/** Find a roster member's id by email (owner-scoped read). */
+async function memberIdByEmail(email: string): Promise<string> {
+  const roster = await controller.members(asOwner());
+  const found = roster.find((m) => m.email === email.toLowerCase());
+  if (!found) throw new Error(`member ${email} not in roster`);
+  return found.id;
+}
+
+describe('PATCH /v1/members/:id (change role)', () => {
+  it('an owner promotes a member to admin, then demotes back to member', async () => {
+    await controller.inviteMember(asOwner(), { email: 'm@acme.test', role: 'member' });
+    const id = await memberIdByEmail('m@acme.test');
+
+    const up = await controller.updateMember(asOwner(), id, { role: 'admin' });
+    expect(up.role).toBe('admin');
+    const down = await controller.updateMember(asOwner(), id, { role: 'member' });
+    expect(down.role).toBe('member');
+  });
+
+  it('refuses a plain member (admin/owner only) with 403', async () => {
+    await controller.inviteMember(asOwner(), { email: 'plain@acme.test', role: 'member' });
+    const target = await controller.inviteMember(asOwner(), { email: 'victim@acme.test' });
+    await expect(
+      controller.updateMember(asEmail('plain@acme.test'), target.id, { role: 'admin' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses an admin trying to manage an owner with 403 (only an owner can)', async () => {
+    await controller.inviteMember(asOwner(), { email: 'boss@acme.test', role: 'admin' });
+    const ownerId = await memberIdByEmail('alex@example.com');
+    await expect(
+      controller.updateMember(asEmail('boss@acme.test'), ownerId, { role: 'member' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses changing your own membership with 403', async () => {
+    const ownerId = await memberIdByEmail('alex@example.com');
+    await expect(
+      controller.updateMember(asOwner(), ownerId, { role: 'member' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});
+
+describe('DELETE /v1/members/:id (remove member)', () => {
+  it('an owner removes a member → gone from the roster', async () => {
+    await controller.inviteMember(asOwner(), { email: 'r@acme.test', role: 'member' });
+    const id = await memberIdByEmail('r@acme.test');
+
+    const res = await controller.removeMember(asOwner(), id);
+    expect(res).toEqual({ ok: true });
+    const roster = await controller.members(asOwner());
+    expect(roster.map((m) => m.email)).not.toContain('r@acme.test');
+  });
+
+  it('is idempotent for an unknown member (200 ok)', async () => {
+    expect(await controller.removeMember(asOwner(), randomUUID())).toEqual({ ok: true });
+  });
+
+  it('refuses a plain member (admin/owner only) with 403', async () => {
+    await controller.inviteMember(asOwner(), { email: 'plain@acme.test', role: 'member' });
+    const target = await controller.inviteMember(asOwner(), { email: 'victim@acme.test' });
+    await expect(
+      controller.removeMember(asEmail('plain@acme.test'), target.id),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses an admin removing an owner with 403', async () => {
+    await controller.inviteMember(asOwner(), { email: 'boss@acme.test', role: 'admin' });
+    const ownerId = await memberIdByEmail('alex@example.com');
+    await expect(
+      controller.removeMember(asEmail('boss@acme.test'), ownerId),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses removing yourself with 403', async () => {
+    const ownerId = await memberIdByEmail('alex@example.com');
+    await expect(controller.removeMember(asOwner(), ownerId)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
   });
 });
 

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -47,3 +47,63 @@ export async function inviteMemberAction(
     return { ok: false, code: 'FAILED' };
   }
 }
+
+/**
+ * Machine-readable outcome of a roster management op (change-role / remove) so the
+ * client localizes the message. `LAST_OWNER` = the guarded 409 (would leave the
+ * workspace ownerless); `FORBIDDEN` = the guarded 403 (non-admin, or an admin
+ * touching an owner); `FAILED` = anything else.
+ */
+export type ManageMemberState =
+  | { ok: true }
+  | { ok: false; code: 'LAST_OWNER' | 'FORBIDDEN' | 'FAILED' };
+
+/** Map an API failure to a stable, localizable code (never a raw server string). */
+function manageError(e: unknown): ManageMemberState {
+  if (e instanceof ApiError) {
+    if (e.code === 'LAST_OWNER') return { ok: false, code: 'LAST_OWNER' };
+    if (e.status === 403 || e.code === 'FORBIDDEN') return { ok: false, code: 'FORBIDDEN' };
+  }
+  return { ok: false, code: 'FAILED' };
+}
+
+/**
+ * Change a member's account role (Member ⇄ Admin). The API is the real gate:
+ * admin/owner only, an admin cannot touch an owner, no self-service, and the
+ * last active owner cannot be demoted (LAST_OWNER). This mirrored admin check is
+ * defence-in-depth. Success revalidates the roster so the new role renders.
+ */
+export async function updateMemberRoleAction(
+  id: string,
+  role: 'admin' | 'member',
+): Promise<ManageMemberState> {
+  if (role !== 'admin' && role !== 'member') return { ok: false, code: 'FAILED' };
+  const me = await adminApi.me();
+  if (!isAdminRole(me.role)) return { ok: false, code: 'FORBIDDEN' };
+  try {
+    await adminApi.updateMember(id, { role });
+    revalidatePath('/admin/settings');
+    return { ok: true };
+  } catch (e) {
+    return manageError(e);
+  }
+}
+
+/**
+ * Remove a member from the workspace. Admin/owner only; an admin cannot remove an
+ * owner; you cannot remove yourself; the last active owner cannot be removed
+ * (LAST_OWNER). Forms are account-owned, so removing a member never deletes
+ * forms or submissions — only the roster row. Success revalidates the roster.
+ */
+export async function removeMemberAction(id: string): Promise<ManageMemberState> {
+  const me = await adminApi.me();
+  if (!isAdminRole(me.role)) return { ok: false, code: 'FORBIDDEN' };
+  if (id === me.memberId) return { ok: false, code: 'FORBIDDEN' };
+  try {
+    await adminApi.removeMember(id);
+    revalidatePath('/admin/settings');
+    return { ok: true };
+  } catch (e) {
+    return manageError(e);
+  }
+}

--- a/apps/web/app/admin/settings/member-row-actions.tsx
+++ b/apps/web/app/admin/settings/member-row-actions.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useRef, useState, useTransition } from 'react';
+import { useToast } from '@/components/toast';
+import type { AccountRole } from '@/lib/admin-api';
+import {
+  removeMemberAction,
+  updateMemberRoleAction,
+  type ManageMemberState,
+} from './actions';
+
+export interface MemberRowActionsLabels {
+  membersMenu: string;
+  makeAdmin: string;
+  makeMember: string;
+  removeMember: string;
+  removeConfirm: string;
+  roleChangeSuccess: string;
+  removeSuccess: string;
+  manageErrorLastOwner: string;
+  manageErrorForbidden: string;
+  manageErrorFailed: string;
+}
+
+/**
+ * Per-row management controls for a roster member — a single kebab menu
+ * (WAI-ARIA menu-button) that mirrors the forms row-actions pattern. Holds the
+ * role change (Member ⇄ Admin; an owner target, only reachable when the caller
+ * is an owner, can be demoted to either) and Remove (native confirm). The API is
+ * the real gate; the page only renders this when the caller may manage the row
+ * (never for yourself, never an owner unless you are an owner). Escape /
+ * outside-click dismiss; focus the first item on open. Tokens only; R22 press +
+ * pending feedback; every outcome surfaces a localized toast.
+ */
+export function MemberRowActions({
+  memberId,
+  role,
+  labels,
+}: {
+  memberId: string;
+  role: AccountRole;
+  labels: MemberRowActionsLabels;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, start] = useTransition();
+  const toast = useToast();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (open) menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+  }, [open]);
+
+  /** Turn a failure code into its localized toast; success carries its own message. */
+  const handle = (result: ManageMemberState, successMessage: string) => {
+    if (result.ok) {
+      toast.success(successMessage);
+      return;
+    }
+    const message =
+      result.code === 'LAST_OWNER'
+        ? labels.manageErrorLastOwner
+        : result.code === 'FORBIDDEN'
+          ? labels.manageErrorForbidden
+          : labels.manageErrorFailed;
+    toast.error(message);
+  };
+
+  const changeRole = (next: 'admin' | 'member') => {
+    setOpen(false);
+    start(async () => handle(await updateMemberRoleAction(memberId, next), labels.roleChangeSuccess));
+  };
+
+  const remove = () => {
+    if (!confirm(labels.removeConfirm)) return;
+    setOpen(false);
+    start(async () => handle(await removeMemberAction(memberId), labels.removeSuccess));
+  };
+
+  const itemClass =
+    'flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:outline-none disabled:opacity-50';
+
+  return (
+    <div ref={wrapRef} className="relative shrink-0">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={labels.membersMenu}
+        title={labels.membersMenu}
+        disabled={pending}
+        onClick={() => setOpen((o) => !o)}
+        className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.98] disabled:opacity-50"
+      >
+        <i aria-hidden className="pi pi-ellipsis-v" style={{ fontSize: 15 }} />
+      </button>
+
+      {open ? (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label={labels.membersMenu}
+          className="absolute right-0 z-50 mt-2 w-52 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
+        >
+          {role !== 'admin' ? (
+            <button
+              type="button"
+              role="menuitem"
+              tabIndex={-1}
+              disabled={pending}
+              onClick={() => changeRole('admin')}
+              className={itemClass}
+            >
+              <i aria-hidden className="pi pi-shield text-muted-foreground" style={{ fontSize: 13 }} />
+              {labels.makeAdmin}
+            </button>
+          ) : null}
+          {role !== 'member' ? (
+            <button
+              type="button"
+              role="menuitem"
+              tabIndex={-1}
+              disabled={pending}
+              onClick={() => changeRole('member')}
+              className={itemClass}
+            >
+              <i aria-hidden className="pi pi-user text-muted-foreground" style={{ fontSize: 13 }} />
+              {labels.makeMember}
+            </button>
+          ) : null}
+
+          <div className="my-1 border-t border-border" role="separator" />
+
+          <button
+            type="button"
+            role="menuitem"
+            tabIndex={-1}
+            disabled={pending}
+            onClick={remove}
+            className="flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:opacity-50"
+          >
+            <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+            {labels.removeMember}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -5,6 +5,7 @@ import { adminApi, isAdminRole, type AccountMember, type AccountRole, type Membe
 import { getLocale } from '@/lib/locale';
 import { PageHeader } from '@/components/ui/page-header';
 import { InviteMember } from './invite-member';
+import { MemberRowActions } from './member-row-actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -90,6 +91,11 @@ export default async function SettingsPage() {
             <ul className="mt-5 flex flex-col gap-2">
               {members.map((mem) => {
                 const isYou = mem.id === me.memberId;
+                // The API is the real gate (assertAdmin + assertCanManageTarget +
+                // assertNotSelf). Mirror it here so the controls only render when
+                // they'd succeed: never yourself, and an admin may not manage an
+                // owner (only an owner can). The whole section is already admin-only.
+                const canManage = !isYou && (me.role === 'owner' || mem.role !== 'owner');
                 const initial = (mem.displayName?.trim()?.charAt(0) || mem.email?.charAt(0) || '?').toUpperCase();
                 return (
                   <li
@@ -116,6 +122,26 @@ export default async function SettingsPage() {
                       {roleLabel[mem.role]}
                     </span>
                     <span className="shrink-0 text-xs text-muted-foreground">{statusLabel[mem.status]}</span>
+                    {canManage ? (
+                      <MemberRowActions
+                        memberId={mem.id}
+                        role={mem.role}
+                        labels={{
+                          membersMenu: s.membersMenu,
+                          makeAdmin: s.makeAdmin,
+                          makeMember: s.makeMember,
+                          removeMember: s.removeMember,
+                          removeConfirm: s.removeConfirm,
+                          roleChangeSuccess: s.roleChangeSuccess,
+                          removeSuccess: s.removeSuccess,
+                          manageErrorLastOwner: s.manageErrorLastOwner,
+                          manageErrorForbidden: s.manageErrorForbidden,
+                          manageErrorFailed: s.manageErrorFailed,
+                        }}
+                      />
+                    ) : (
+                      <span aria-hidden className="h-9 w-9 shrink-0" />
+                    )}
                   </li>
                 );
               })}

--- a/packages/db/src/members.spec.ts
+++ b/packages/db/src/members.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Account-roster management guards, on the data layer (SQLite locally, Postgres
+ * in the CI parity job). These lock the invariants the Settings roster controls
+ * depend on: role changes and removals work, and the workspace can never lose its
+ * last active owner (LAST_OWNER) — whether by demotion, disabling, or removal.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createDb, sql, type Db } from './client';
+import { migrate } from './migrate';
+import {
+  changeMemberRole,
+  getAccountMember,
+  listMembers,
+  removeMember,
+  setMemberStatus,
+  type AccountRole,
+  type MemberStatus,
+} from './members';
+
+let db: Db;
+let accountId: string;
+
+/** Insert a member row directly (bypasses invite, which cannot mint owners). */
+async function addMember(
+  email: string,
+  role: AccountRole,
+  status: MemberStatus = 'active',
+): Promise<string> {
+  const id = randomUUID();
+  const handle = email.split('@')[0];
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, created_at)
+        VALUES (${id}, ${accountId}, ${email}, ${email.split('@')[0]}, ${handle}, ${role}, ${status}, ${Date.now()})`,
+  );
+  return id;
+}
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  accountId = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${'acme'}, ${'Acme'}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('changeMemberRole', () => {
+  it('promotes a member to admin and demotes an admin to member', async () => {
+    await addMember('owner@acme.test', 'owner');
+    const memberId = await addMember('mem@acme.test', 'member');
+
+    const up = await changeMemberRole(db, accountId, memberId, 'admin');
+    expect(up.ok).toBe(true);
+    if (up.ok) expect(up.value.role).toBe('admin');
+
+    const down = await changeMemberRole(db, accountId, memberId, 'member');
+    expect(down.ok).toBe(true);
+    if (down.ok) expect(down.value.role).toBe('member');
+  });
+
+  it('refuses to demote the last active owner (LAST_OWNER)', async () => {
+    const ownerId = await addMember('solo-owner@acme.test', 'owner');
+    const res = await changeMemberRole(db, accountId, ownerId, 'member');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('LAST_OWNER');
+    // Unchanged.
+    expect((await getAccountMember(db, accountId, ownerId))!.role).toBe('owner');
+  });
+
+  it('allows demoting an owner while another active owner remains', async () => {
+    await addMember('owner-a@acme.test', 'owner');
+    const ownerB = await addMember('owner-b@acme.test', 'owner');
+    const res = await changeMemberRole(db, accountId, ownerB, 'member');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value.role).toBe('member');
+  });
+});
+
+describe('setMemberStatus', () => {
+  it('refuses to disable the last active owner (LAST_OWNER)', async () => {
+    const ownerId = await addMember('solo-owner@acme.test', 'owner');
+    const res = await setMemberStatus(db, accountId, ownerId, 'disabled');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('LAST_OWNER');
+  });
+});
+
+describe('removeMember', () => {
+  it('removes a member from the roster', async () => {
+    await addMember('owner@acme.test', 'owner');
+    const memberId = await addMember('mem@acme.test', 'member');
+
+    const res = await removeMember(db, accountId, memberId);
+    expect(res.ok).toBe(true);
+    expect(await getAccountMember(db, accountId, memberId)).toBeNull();
+    expect((await listMembers(db, accountId)).map((m) => m.email)).not.toContain('mem@acme.test');
+  });
+
+  it('refuses to remove the last active owner (LAST_OWNER)', async () => {
+    const ownerId = await addMember('solo-owner@acme.test', 'owner');
+    const res = await removeMember(db, accountId, ownerId);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('LAST_OWNER');
+    expect(await getAccountMember(db, accountId, ownerId)).not.toBeNull();
+  });
+
+  it('allows removing an owner while another active owner remains', async () => {
+    await addMember('owner-a@acme.test', 'owner');
+    const ownerB = await addMember('owner-b@acme.test', 'owner');
+    const res = await removeMember(db, accountId, ownerB);
+    expect(res.ok).toBe(true);
+    expect(await getAccountMember(db, accountId, ownerB)).toBeNull();
+  });
+
+  it('is idempotent for an already-removed member', async () => {
+    const res = await removeMember(db, accountId, randomUUID());
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -148,6 +148,16 @@ export interface FormsMessages {
       inviteErrorTaken: string;
       inviteErrorInvalid: string;
       inviteErrorFailed: string;
+      membersMenu: string;
+      makeAdmin: string;
+      makeMember: string;
+      removeMember: string;
+      removeConfirm: string;
+      roleChangeSuccess: string;
+      removeSuccess: string;
+      manageErrorLastOwner: string;
+      manageErrorForbidden: string;
+      manageErrorFailed: string;
     };
     login: {
       title: string;
@@ -568,6 +578,16 @@ export const en: FormsMessages = {
       inviteErrorTaken: 'A member with that email already exists.',
       inviteErrorInvalid: 'Enter a valid email address.',
       inviteErrorFailed: 'Could not add the member. Please try again.',
+      membersMenu: 'Member actions',
+      makeAdmin: 'Change to Admin',
+      makeMember: 'Change to Member',
+      removeMember: 'Remove member',
+      removeConfirm: 'Remove this member? They will lose access to this workspace.',
+      roleChangeSuccess: 'Role updated.',
+      removeSuccess: 'Member removed.',
+      manageErrorLastOwner: 'A workspace must keep at least one owner.',
+      manageErrorForbidden: 'You do not have permission to do that.',
+      manageErrorFailed: 'Something went wrong. Please try again.',
     },
     login: {
       title: 'Sign in',
@@ -984,6 +1004,16 @@ export const es: FormsMessages = {
       inviteErrorTaken: 'Ya existe un miembro con ese correo.',
       inviteErrorInvalid: 'Introduce un correo válido.',
       inviteErrorFailed: 'No se pudo añadir el miembro. Inténtalo de nuevo.',
+      membersMenu: 'Acciones de miembro',
+      makeAdmin: 'Cambiar a Administrador',
+      makeMember: 'Cambiar a Miembro',
+      removeMember: 'Quitar miembro',
+      removeConfirm: '¿Quitar a este miembro? Perderá el acceso a este espacio de trabajo.',
+      roleChangeSuccess: 'Rol actualizado.',
+      removeSuccess: 'Miembro eliminado.',
+      manageErrorLastOwner: 'Un espacio de trabajo debe conservar al menos un propietario.',
+      manageErrorForbidden: 'No tienes permiso para hacer eso.',
+      manageErrorFailed: 'Algo salió mal. Inténtalo de nuevo.',
     },
     login: {
       title: 'Iniciar sesión',


### PR DESCRIPTION
## What

The Settings members roster (`/admin/settings`) was **add-only** — E2E on prod (form.dapta.ai) confirmed you can invite a member but there is no control to change a role or remove one. A team-management panel you can't manage is incomplete. This adds **remove** + **change role**, wired to the existing backend.

## Backend additions: none

The endpoints, guards, and client methods already shipped and were verified live — this was dead UI, not a missing API:
- `PATCH /v1/members/:id` (role/status) and `DELETE /v1/members/:id` in `admin-crud.controller.ts`
- Permission guards (`assertAdmin` / `assertCanManageTarget` / `assertNotSelf`) in `permissions.ts`
- db-level last-owner guard in `packages/db/src/members.ts` (`changeMemberRole` / `setMemberStatus` / `removeMember`)
- `adminApi.updateMember` / `adminApi.removeMember` in `lib/admin-api.ts`

All the frontend needed was to call them.

## Changes

- **`member-row-actions.tsx`** (new): per-row kebab menu mirroring the forms row-actions pattern — **Change to Admin / Change to Member** and **Remove member** (native confirm). Tokens-only, R22 pending state, a localized toast per outcome.
- **`actions.ts`**: `updateMemberRoleAction` / `removeMemberAction` server actions with stable, localizable codes (`LAST_OWNER` / `FORBIDDEN` / `FAILED`); revalidate the roster on success (defence-in-depth admin re-check).
- **`page.tsx`**: controls render only when the caller may manage the row — never yourself, and an admin may not manage an owner (only an owner can). Mirrors the API gate.
- **i18n**: EN/ES for every new label, error, and the confirm copy.

## Guard behavior

- Cannot remove or demote the **last active owner** (409 `LAST_OWNER`, db-level).
- Cannot change your own membership / remove yourself (403; also hidden in the UI).
- Non-admin cannot manage (403); an admin cannot manage an owner (403).

## Verification

- `pnpm lint typecheck test build` all green; `publish-gate` PASSED.
- New tests: `packages/db/src/members.spec.ts` (8) — change-role, disable, remove + last-owner guard on all three, idempotent remove; `members.controller.spec.ts` extended 5→14 — change-role/remove success, non-admin 403, admin-manages-owner 403, self 403.
- Runtime: booted api (4417) + web (3417) on fresh SQLite, logged in as a JIT owner, invited members, then via the **UI**: promoted a member Member→Admin ("Role updated." toast), removed a member via confirm ("Member removed." toast), and confirmed the sole owner (YOU) row exposes no controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)