### PR TITLE
fix(webhook): rename X-Quill-* headers → X-Forms-* (codename no longer leaks to customers)

### DIFF
--- a/apps/api/src/destination-effects.spec.ts
+++ b/apps/api/src/destination-effects.spec.ts
@@ -200,7 +200,7 @@ describe('destination enqueue on submission', () => {
     const got = received!;
     expect(got.url).toBe('https://acme.io/hook');
     // The signature validates against the exact body delivered.
-    expect(got.headers['x-quill-signature']).toBe(signWebhookBody(got.body, 'shh'));
+    expect(got.headers['x-forms-signature']).toBe(signWebhookBody(got.body, 'shh'));
     const payload = JSON.parse(got.body);
     expect(payload.submission.id).toBe((out as { id: string }).id);
     expect(payload.submission.score).toBe(18);

--- a/packages/destinations/src/adapters/webhook.spec.ts
+++ b/packages/destinations/src/adapters/webhook.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createHmac } from 'node:crypto';
-import { WebhookDestination, signWebhookBody } from './webhook';
+import { WebhookDestination, signWebhookBody, DEFAULT_SIGNATURE_HEADER } from './webhook';
 import type { DestinationContext } from '../destination.port';
 
 /** A resolver that maps every host to a public IP — keeps tests off real DNS. */
@@ -51,8 +51,8 @@ describe('WebhookDestination', () => {
 
     const { init } = calls[0]!;
     const headers = init.headers as Record<string, string>;
-    expect(headers['x-quill-delivery']).toBe(c.idempotencyKey);
-    expect(headers['x-quill-event']).toBe('form.submission');
+    expect(headers['x-forms-delivery']).toBe(c.idempotencyKey);
+    expect(headers['x-forms-event']).toBe('form.submission');
     // The signature validates against the exact body sent.
     const body = init.body as string;
     expect(headers['x-sig']).toBe(signWebhookBody(body, 'shh'));
@@ -73,7 +73,21 @@ describe('WebhookDestination', () => {
       { url: 'https://acme.io/hook', resolveDns: publicResolver },
       fetchImpl,
     ).deliver(ctx());
-    expect(headers['x-quill-signature']).toBeUndefined();
+    expect(headers['x-forms-signature']).toBeUndefined();
+  });
+
+  it('defaults the signature header to X-Forms-Signature', async () => {
+    expect(DEFAULT_SIGNATURE_HEADER).toBe('X-Forms-Signature');
+    let headers: Record<string, string> = {};
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      headers = init.headers as Record<string, string>;
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    await new WebhookDestination(
+      { url: 'https://acme.io/hook', secret: 'shh', resolveDns: publicResolver },
+      fetchImpl,
+    ).deliver(ctx());
+    expect(headers['x-forms-signature']).toBeDefined();
   });
 
   it('THROWS on a non-2xx response so the outbox retries', async () => {

--- a/packages/destinations/src/adapters/webhook.ts
+++ b/packages/destinations/src/adapters/webhook.ts
@@ -7,10 +7,10 @@ import type {
 import { assertPublicWebhookUrl, type DnsResolver } from '../ssrf-guard';
 
 /** The default header carrying the HMAC signature (overridable per destination). */
-export const DEFAULT_SIGNATURE_HEADER = 'X-Quill-Signature';
+export const DEFAULT_SIGNATURE_HEADER = 'X-Forms-Signature';
 /** The default per-request timeout. */
 export const DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
-/** The event name carried in the payload + the X-Quill-Event header. */
+/** The event name carried in the payload + the X-Forms-Event header. */
 export const WEBHOOK_EVENT = 'form.submission';
 
 export interface WebhookDestinationOptions {
@@ -18,7 +18,7 @@ export interface WebhookDestinationOptions {
   url: string;
   /** Optional HMAC-SHA256 signing secret. When set, every request is signed. */
   secret?: string;
-  /** Header the signature is sent in. Defaults to `X-Quill-Signature`. */
+  /** Header the signature is sent in. Defaults to `X-Forms-Signature`. */
   signatureHeader?: string;
   /** Per-request timeout (ms). Defaults to 10s. A slow endpoint is retried by the outbox. */
   timeoutMs?: number;
@@ -33,7 +33,7 @@ export interface WebhookDestinationOptions {
 
 /** The stable JSON envelope POSTed to a webhook destination. */
 export interface WebhookPayload {
-  /** The idempotency key (also sent as `X-Quill-Delivery`) — de-dup on the receiver. */
+  /** The idempotency key (also sent as `X-Forms-Delivery`) — de-dup on the receiver. */
   id: string;
   type: typeof WEBHOOK_EVENT;
   phase: 'partial' | 'complete';
@@ -99,9 +99,9 @@ export class WebhookDestination implements SubmissionDestination {
     const timestamp = String(Math.floor(ctx.submittedAt / 1000));
     const headers: Record<string, string> = {
       'content-type': 'application/json',
-      'x-quill-event': WEBHOOK_EVENT,
-      'x-quill-delivery': ctx.idempotencyKey,
-      'x-quill-timestamp': timestamp,
+      'x-forms-event': WEBHOOK_EVENT,
+      'x-forms-delivery': ctx.idempotencyKey,
+      'x-forms-timestamp': timestamp,
     };
     if (this.opts.secret) {
       const header = this.opts.signatureHeader || DEFAULT_SIGNATURE_HEADER;

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -826,7 +826,7 @@ export const en: FormsMessages = {
       webhookUrlInvalid: 'Enter a valid https:// URL (plain http is allowed only for localhost).',
       webhookSecret: 'Signing secret (optional)',
       webhookSecretHelp:
-        'When set, each request is signed with HMAC-SHA256 in the X-Quill-Signature header so you can verify it.',
+        'When set, each request is signed with HMAC-SHA256 in the X-Forms-Signature header so you can verify it.',
       webhookSecretSetPlaceholder: 'A secret is set — leave blank to keep it, or type a new one.',
       hubspotTitle: 'HubSpot',
       hubspotDesc: 'Upsert the respondent as a contact and attach a note on completed submissions.',
@@ -1242,7 +1242,7 @@ export const es: FormsMessages = {
       webhookUrlInvalid: 'Introduce una URL https:// válida (http solo se permite para localhost).',
       webhookSecret: 'Secreto de firma (opcional)',
       webhookSecretHelp:
-        'Si se define, cada solicitud se firma con HMAC-SHA256 en la cabecera X-Quill-Signature para que puedas verificarla.',
+        'Si se define, cada solicitud se firma con HMAC-SHA256 en la cabecera X-Forms-Signature para que puedas verificarla.',
       webhookSecretSetPlaceholder: 'Hay un secreto guardado — déjalo en blanco para conservarlo o escribe uno nuevo.',
       hubspotTitle: 'HubSpot',
       hubspotDesc: 'Crea o actualiza el contacto y adjunta una nota en las respuestas completadas.',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -194,7 +194,7 @@ export const webhookDestinationSchema = z.object({
       ),
     /** HMAC-SHA256 signing secret (optional). */
     secret: z.string().max(500).nullable().optional(),
-    /** Header the signature is sent in (defaults to `X-Quill-Signature`). */
+    /** Header the signature is sent in (defaults to `X-Forms-Signature`). */
     signatureHeader: z.string().max(128).nullable().optional(),
     /** Per-request timeout in ms (defaults to 10s). */
     timeoutMs: z.number().int().positive().max(60_000).optional(),


### PR DESCRIPTION
## What

The webhook integration leaked the internal codename **Quill** into the customer-facing webhook HTTP contract and help text. The code comments explicitly say Quill must never surface to users, yet the adapter sent `X-Quill-Signature` / `X-Quill-Event` / `X-Quill-Delivery` / `X-Quill-Timestamp` headers and the EN+ES integrations help text instructed customers to verify the `X-Quill-Signature` header.

Renamed the webhook header prefix to the product-neutral, OSS-fork-safe **`X-Forms-*`**.

## Changes

- `packages/destinations/src/adapters/webhook.ts` — `DEFAULT_SIGNATURE_HEADER = 'X-Forms-Signature'`; emitted headers `x-forms-event` / `x-forms-delivery` / `x-forms-timestamp`; doc comments updated.
- `packages/types/src/index.ts` — comment default `X-Forms-Signature`.
- `packages/shared/src/i18n/index.ts` — EN + ES help text `X-Forms-Signature`.
- `packages/destinations/src/adapters/webhook.spec.ts` — assertions renamed; added a test asserting `DEFAULT_SIGNATURE_HEADER === 'X-Forms-Signature'`.
- `apps/api/src/destination-effects.spec.ts` — signature-header assertion renamed.

## Not touched (intentional — not customer-facing)

- Local-dev impersonation headers `x-quill-email` / `x-quill-account` / `x-quill-member`.
- Internal cookie / localStorage keys `quill_oauth_state` / `quill-form-*`.

## Verification

- `pnpm lint typecheck test build` all green (webhook spec now 13 tests, all pass).
- `publish-gate` PASSED (internal-token scan clean; only missing local gitleaks/trufflehog tooling skipped via `PUBLISH_GATE_LOCAL=1`).
- Sweep confirms no remaining `X-Quill-Signature|Event|Delivery|Timestamp` in webhook code or i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)