### PR TITLE
fix(builder): stable dnd-kit ids — no hydration mismatch on drag handles

### DIFF
--- a/apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { HTMLAttributes, ReactNode } from 'react';
+import { useId, type HTMLAttributes, type ReactNode } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -40,6 +40,14 @@ export function SortableList({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
+  // dnd-kit derives its aria description / live-region element ids from the
+  // DndContext `id`. Left unset it falls back to a module-global counter that
+  // increments in a different order on the server than on the client, so the
+  // generated `DndDescribedBy-<n>` ids mismatch and React logs a hydration
+  // error. A stable, per-instance `useId()` makes those ids deterministic
+  // across SSR and client and removes the mismatch without touching drag.
+  const dndId = useId();
+
   function handleEnd(event: DragEndEvent) {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -49,7 +57,7 @@ export function SortableList({
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleEnd}>
+    <DndContext id={dndId} sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleEnd}>
       <SortableContext items={ids} strategy={verticalListSortingStrategy}>
         <div className={className}>{ids.map((id, index) => children(id, index))}</div>
       </SortableContext>


### PR DESCRIPTION
## Problem
The builder editor logged a React **hydration mismatch** (`DndDescribedBy-2` vs `DndDescribedBy-1`) on the option drag handles and the question spine. Functionality worked — this was a cosmetic/correctness cleanup.

## Root cause
The shared `SortableList` (`apps/web/app/admin/forms/[id]/edit/_components/sortable.tsx`) rendered `<DndContext>` with **no `id` prop**. dnd-kit then derives the `DndDescribedBy-<n>` aria-description element id from a **module-global counter** (`useUniqueId("DndDescribedBy", id)` → falls back to an incrementing counter). Two SortableList instances mount on the editor (options + question spine), and the counter increments in a different order on the server than on the client → the SSR and client markup disagree → hydration error.

The `DndLiveRegion-<n>` id also uses that counter but is **mounted-gated** (client-only portal, never SSR'd), so it never contributed to the mismatch.

## Fix
Pass a stable, per-instance React **`useId()`** as the `DndContext id`. dnd-kit uses it verbatim for the describedby id, so it's deterministic across SSR and hydration. Standard dnd-kit approach (option (a) in the brief). Drag/keyboard reorder untouched — no gating, no layout shift.

## Verification
- `pnpm lint typecheck test build` — all green; `publish-gate` green (internal-token scan clean).
- Booted api (4420) + web (3420) on SQLite, logged in local, opened a form's editor:
  - **chrome-devtools `list_console_messages` (error/warn, incl. preserved + fresh hard-reload SSR): zero hydration errors.**
  - Options drag-reorder works (keyboard pickup → live region "dropped over droppable area opt-1"; canvas + sidebar reflect new order).
  - Question-spine drag-reorder works (question 1 → position 2; live region announced the drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)