### PR TITLE
fix: builder bug-fix round — reliable autosave, scoring, logic operators, reveal, URL prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,25 @@ subset for convenience and **never limits the schema**.
 > On Windows, run the `pnpm` scripts from **git-bash or WSL** — they use POSIX
 > shell syntax (`${PG_PORT:-5432}`) that `cmd.exe`/PowerShell don't expand.
 
-## What's new (July 2026)
+## What's new
 
-The latest UX round reworked the builder and integration surfaces — a
-**Connect** tab in the editor (integrations, webhooks, tracking pixels,
-per-form email templates), an `@` picker to recall previous answers into
-question text, a draggable partial-submit point in the question list,
-first-class actions on the forms list, branded dialogs, and a WYSIWYG fix so
-the public form always renders questions in the authored order. The full
-changelog with screenshots lives in
-[`docs/feedback-v3/`](docs/feedback-v3/README.md).
+**Jul 20 — builder bug-fix round** (from hands-on QA). Made editor autosave
+reliable across every tab and fixed the root blocker that kept the Results
+panel from saving; made scoring usable (per-option points with negatives,
+correct max, no leading-zero inputs); added conditional-visibility operators
+for numeric fields (equal/greater/less/between) with a contradiction guard;
+turned the reveal screen into a draggable marker that defaults to the end
+(no more mid-form reveal) with per-outcome messages; and added hidden fields
+with real `?param=value` URL prefill, a per-form phone default country, and
+`@` recall in descriptions. Full changelog:
+[`docs/feedback-v4/`](docs/feedback-v4/README.md).
+
+**Jul (earlier) — builder & integration UX.** A **Connect** tab in the editor
+(integrations, webhooks, tracking pixels, per-form email templates), an `@`
+picker to recall previous answers into question text, a draggable
+partial-submit point, first-class actions on the forms list, branded dialogs,
+and a WYSIWYG fix so the public form renders questions in the authored order.
+Changelog with screenshots: [`docs/feedback-v3/`](docs/feedback-v3/README.md).
 
 | | |
 |---|---|

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -18,6 +18,8 @@ import {
   resolveOutcome,
   computeScore,
   partialSubmitKey,
+  revealAfterKey,
+  interpolate,
   nameFields,
   isMultiSelect,
   isSafeHttpUrl,
@@ -129,6 +131,10 @@ export function FormRenderer({
   );
   const step = steps[index];
   const thresholdKey = useMemo(() => partialSubmitKey(engineConfig), [engineConfig]);
+  // WHERE the reveal plays (revealAfterStep → triggersReveal → default-last);
+  // null when the reveal is disabled. Position is authoritative, so a form no
+  // longer replays a reveal mid-form just because a step carries triggersReveal.
+  const revealKey = useMemo(() => revealAfterKey(engineConfig), [engineConfig]);
 
   // Accent branding (only override the local default when a color is configured).
   const primary = config.branding?.primaryColor ?? null;
@@ -277,9 +283,12 @@ export function FormRenderer({
           return;
         }
 
-        // Optional processing/reveal interstitial after this step.
-        const reveal = config.reveal && config.reveal.enabled !== false;
-        if (reveal && completed.triggersReveal) {
+        // Optional processing/reveal interstitial after this step. Position is
+        // resolved by the engine (revealAfterKey): the marker's revealAfterStep
+        // wins, else a legacy triggersReveal step, else the last step. When the
+        // reveal step is the last VISIBLE step it becomes the pre-result
+        // interstitial (submitAfterReveal); otherwise it plays then continues.
+        if (revealKey && completed.key === revealKey) {
           submitAfterReveal.current = isLast;
           if (!isLast) setIndex(completedIdx + 1);
           setPhase('reveal');
@@ -298,7 +307,7 @@ export function FormRenderer({
         advancing.current = false;
       }
     },
-    [engineConfig, index, thresholdKey, accountCode, slug, sessionId, config.reveal, finalize, track],
+    [engineConfig, index, thresholdKey, revealKey, accountCode, slug, sessionId, finalize, track],
   );
 
   function submitCurrent() {
@@ -404,7 +413,11 @@ export function FormRenderer({
             ✓
           </div>
           <h1 className="pf-done__title">{outcome?.label ?? m.thankYouTitle}</h1>
-          <p className="pf-done__body">{t(m.thankYouBody, { name })}</p>
+          <p className="pf-done__body">
+            {outcome?.message
+              ? interpolate(outcome.message, answersRef.current)
+              : t(m.thankYouBody, { name })}
+          </p>
           {cta ? (
             <>
               <p className="pf-done__cta-question">{m.ctaQuestion}</p>

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -66,6 +66,41 @@ function captureUtm(): Record<string, string> {
   return utm;
 }
 
+/** A query value can never be longer than this once seeded (defense-in-depth). */
+const PREFILL_MAX_LEN = 512;
+
+/**
+ * URL-parameter prefill (V4-13): read the query string and seed the answer for
+ * each param whose key matches a DECLARED field — a step's own key, or a `name`
+ * step's subfields (`nameFields`). Security-scoped by design:
+ *  - only keys that correspond to a declared step field are ever read (an
+ *    arbitrary `?anything=` is ignored — never trust the URL to name new fields);
+ *  - `utm_*` is captured separately (`captureUtm`) and skipped here;
+ *  - values are treated as PLAIN answer strings, capped in length, never eval'd
+ *    or interpreted as markup — and the engine re-validates every answer on
+ *    submit, so a bad value can only be rejected, never trusted.
+ * A prefilled HIDDEN step carries its answer into the submission though it is
+ * never shown; a prefilled VISIBLE step simply renders pre-filled.
+ */
+function capturePrefill(steps: FormStep[]): Answers {
+  if (typeof window === 'undefined') return {};
+  const declared = new Set<string>();
+  for (const step of steps) {
+    if (step.type === 'message') continue; // message steps capture no answer
+    for (const key of nameFields(step)) declared.add(key);
+  }
+  if (declared.size === 0) return {};
+  const params = new URLSearchParams(window.location.search);
+  const seed: Answers = {};
+  for (const [key, value] of params.entries()) {
+    if (key.toLowerCase().startsWith('utm_')) continue;
+    if (!declared.has(key)) continue;
+    if (typeof value !== 'string' || value === '') continue;
+    seed[key] = value.slice(0, PREFILL_MAX_LEN);
+  }
+  return seed;
+}
+
 /**
  * Per-phase page shell. The promo banner (`cover.bannerText`) renders ONCE here
  * as the first child of `.pf`, so it is a full-width strip pinned to the top of
@@ -152,9 +187,13 @@ export function FormRenderer({
     [accountCode, slug, sessionId],
   );
 
-  // Capture UTM once, and fire a single `view` per session per load.
+  // Capture UTM + declared-field URL prefill once on mount (client-only, so a
+  // seeded visible step never causes an SSR/hydration mismatch). Hidden steps
+  // ride their seeded answer into the submission; visible steps render filled.
   useEffect(() => {
     utmRef.current = captureUtm();
+    const seed = capturePrefill(engineConfig.steps);
+    if (Object.keys(seed).length > 0) setAnswers((a) => ({ ...seed, ...a }));
   }, []);
   useEffect(() => {
     if (!sessionId || viewTracked.current) return;

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -69,6 +69,25 @@ export interface BuilderMessages {
     /** One-line pointer left in the Design tab (the select moved to the spine). */
     designNote: string;
   };
+  /** The reveal-screen marker in the question spine (V4-04 — mirrors `partial`). */
+  revealPoint: {
+    /** Marker-row label ("Reveal screen"). */
+    label: string;
+    /** aria-label of the marker's remove (×) button. */
+    remove: string;
+    /** aria-label of the marker's drag grip. */
+    move: string;
+    /** aria-label of the info toggle on the marker row. */
+    info: string;
+    /** Popover: what the reveal marker does. */
+    tipPlays: string;
+    /** Popover line when the marker sits after the LAST question. */
+    tipEnd: string;
+    /** Popover line when the marker sits mid-form. */
+    tipMid: string;
+    /** Popover: where the reveal copy/duration is edited. */
+    tipEdit: string;
+  };
   canvas: {
     /** "Question {n}" */
     questionN: string;
@@ -284,6 +303,16 @@ const en: BuilderMessages = {
     tipAfterLast: 'After the last question it never fires — the final submit already captures everything.',
     designNote: 'Configured in the question list on the Build tab — look for the “Partial submit point” card.',
   },
+  revealPoint: {
+    label: 'Reveal screen',
+    remove: 'Remove reveal screen',
+    move: 'Move reveal screen',
+    info: 'About the reveal screen',
+    tipPlays: 'Plays a short processing screen for respondents at this point in the form.',
+    tipEnd: 'At the end it plays right before the result — never mid-form.',
+    tipMid: 'Here it plays after this question, then the form continues.',
+    tipEdit: 'Edit its headline, subtitle and duration in Design.',
+  },
   canvas: {
     questionN: 'Question {n}',
     titlePlaceholder: 'Type your question…',
@@ -492,6 +521,16 @@ const es: BuilderMessages = {
     tipAfterLast: 'Después de la última pregunta nunca se activa — el envío final ya lo captura todo.',
     designNote:
       'Se configura en la lista de preguntas, en la pestaña Construir — busca la tarjeta «Punto de envío parcial».',
+  },
+  revealPoint: {
+    label: 'Pantalla de revelación',
+    remove: 'Quitar la pantalla de revelación',
+    move: 'Mover la pantalla de revelación',
+    info: 'Acerca de la pantalla de revelación',
+    tipPlays: 'Muestra una breve pantalla de procesamiento en este punto del formulario.',
+    tipEnd: 'Al final se muestra justo antes del resultado — nunca a mitad del formulario.',
+    tipMid: 'Aquí se muestra después de esta pregunta y luego el formulario continúa.',
+    tipEdit: 'Edita su titular, subtítulo y duración en Diseño.',
   },
   canvas: {
     questionN: 'Pregunta {n}',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -97,6 +97,8 @@ export interface BuilderMessages {
     noRules: string;
     scoring: string;
     scoringHint: string;
+    /** Shown near the toggle when scoring is on but no points are assigned yet. */
+    scoringZeroHint: string;
     contactHint: string;
     delete: string;
     deleteConfirm: string;
@@ -176,6 +178,14 @@ export interface BuilderMessages {
     /** "If {value} → {target}" */
     jumpEdge: string;
     empty: string;
+    /** Caption under the Start node. */
+    startHint: string;
+    /** Caption on the default ("no rule matched") path so the flow is traceable. */
+    otherwiseHint: string;
+    /** Pill on a question that only shows when a show/hide condition holds. */
+    conditional: string;
+    /** Small kicker above a scored outcome node. */
+    outcomeKicker: string;
   };
   results: {
     pointsTitle: string;
@@ -200,7 +210,14 @@ export interface BuilderMessages {
   empty: {
     title: string;
     subtitle: string;
+    /** Legacy inline "or start from scratch" affordance (kept for compatibility). */
     scratch: string;
+    /** Title of the blank-canvas option presented first. */
+    scratchTitle: string;
+    /** One-line description under the blank-canvas option. */
+    scratchDesc: string;
+    /** Section-divider label above the template cards. */
+    templatesLabel: string;
     templates: Record<TemplateId, { name: string; desc: string; meta: string }>;
   };
 }
@@ -290,7 +307,9 @@ const en: BuilderMessages = {
     addRule: 'Add rule',
     noRules: 'No rules — everyone sees this question.',
     scoring: 'Scoring',
-    scoringHint: 'Points from the selected option add to the total score. Set ranges in Results.',
+    scoringHint:
+      'Scoring applies to the whole form, not just this question. Points from the selected option add to the total; set ranges in Results.',
+    scoringZeroHint: 'Assign points to your answers to enable ranges.',
     contactHint: 'Contact field — doesn’t affect the score.',
     delete: 'Delete question',
     deleteConfirm: 'Delete this question?',
@@ -370,6 +389,10 @@ const en: BuilderMessages = {
     skipEdge: 'If {value} → skip to end',
     jumpEdge: 'If {value} → {target}',
     empty: 'Add questions to see how answers route through your form.',
+    startHint: 'Respondents start here',
+    otherwiseHint: 'if no rule matches, continue in order',
+    conditional: 'Conditional',
+    outcomeKicker: 'Ending',
   },
   results: {
     pointsTitle: 'Points',
@@ -391,8 +414,11 @@ const en: BuilderMessages = {
   },
   empty: {
     title: 'Let’s build your form',
-    subtitle: 'Start from a template and edit every question live — or begin with a blank canvas.',
+    subtitle: 'Begin with a blank canvas, or pick a ready-made template to edit live.',
     scratch: 'or start from scratch — add your first question',
+    scratchTitle: 'Start from scratch',
+    scratchDesc: 'Begin with a blank canvas and add your own questions.',
+    templatesLabel: 'Or choose a template',
     templates: {
       lead: {
         name: 'Lead qualifier',
@@ -490,7 +516,9 @@ const es: BuilderMessages = {
     addRule: 'Añadir regla',
     noRules: 'Sin reglas — todos ven esta pregunta.',
     scoring: 'Puntaje',
-    scoringHint: 'Los puntos de la opción elegida suman al total. Define los rangos en Resultados.',
+    scoringHint:
+      'El puntaje se aplica a todo el formulario, no solo a esta pregunta. Los puntos de la opción elegida suman al total; define los rangos en Resultados.',
+    scoringZeroHint: 'Asigna puntos a tus respuestas para habilitar los rangos.',
     contactHint: 'Campo de contacto — no afecta el puntaje.',
     delete: 'Eliminar pregunta',
     deleteConfirm: '¿Eliminar esta pregunta?',
@@ -570,6 +598,10 @@ const es: BuilderMessages = {
     skipEdge: 'Si {value} → ir al final',
     jumpEdge: 'Si {value} → {target}',
     empty: 'Añade preguntas para ver cómo las respuestas recorren tu formulario.',
+    startHint: 'Aquí empiezan las personas',
+    otherwiseHint: 'si ninguna regla coincide, continúa en orden',
+    conditional: 'Condicional',
+    outcomeKicker: 'Final',
   },
   results: {
     pointsTitle: 'Puntos',
@@ -591,8 +623,11 @@ const es: BuilderMessages = {
   },
   empty: {
     title: 'Construyamos tu formulario',
-    subtitle: 'Empieza desde una plantilla y edita cada pregunta en vivo — o comienza con un lienzo en blanco.',
+    subtitle: 'Comienza con un lienzo en blanco, o elige una plantilla lista para editar en vivo.',
     scratch: 'o empieza desde cero — añade tu primera pregunta',
+    scratchTitle: 'Empezar desde cero',
+    scratchDesc: 'Comienza con un lienzo en blanco y añade tus propias preguntas.',
+    templatesLabel: 'O elige una plantilla',
     templates: {
       lead: {
         name: 'Calificador de leads',

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -121,10 +121,10 @@ export function CanvasQuestion({
           {tb(m.canvas.questionN, { n: index + 1 })}
         </p>
 
-        {/* Inline editable title — with the @ recall-information picker (the
-            engine interpolates `[key]` tokens in `question` from EARLIER
-            answers; the description/helper renders raw, so only the title gets
-            the picker). */}
+        {/* Inline editable title — with the @ recall-information picker. The
+            engine interpolates `[key]` tokens in BOTH `question` and the
+            description/`helper` from EARLIER answers (resolveStepDisplay), so
+            both fields get the picker. */}
         <TokenTextarea
           value={step.question ?? ''}
           onChange={(v) => onUpdate({ question: v })}
@@ -139,14 +139,23 @@ export function CanvasQuestion({
           className="canvas-title text-2xl font-semibold tracking-tight text-foreground sm:text-[28px]"
         />
 
-        {/* Inline editable description */}
-        <AutoTextarea
-          value={step.helper ?? ''}
-          onChange={(v) => onUpdate({ helper: v || null })}
-          placeholder={m.canvas.descriptionPlaceholder}
-          ariaLabel={m.canvas.descriptionPlaceholder}
-          className="mt-1.5 text-[15px] leading-relaxed text-muted-foreground"
-        />
+        {/* Inline editable description — same @ picker as the title (tokens =
+            fields captured before this step). No hint here so the single
+            discoverability chip stays under the title. */}
+        <div className="mt-1.5">
+          <TokenTextarea
+            value={step.helper ?? ''}
+            onChange={(v) => onUpdate({ helper: v || null })}
+            placeholder={m.canvas.descriptionPlaceholder}
+            ariaLabel={m.canvas.descriptionPlaceholder}
+            autoGrow
+            tokens={tokenOptionsBefore(config.steps, index)}
+            allKeys={allTokenKeys(config.steps)}
+            m={m.tokens}
+            testId="canvas-description-input"
+            className="text-[15px] leading-relaxed text-muted-foreground"
+          />
+        </div>
 
         {/* Body: the real rendered input */}
         <div className="mt-6">

--- a/apps/web/app/admin/forms/[id]/edit/_components/empty-state.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/empty-state.tsx
@@ -5,10 +5,16 @@ import { TEMPLATE_ORDER, TEMPLATE_ICON } from './templates';
 import type { TemplateId } from './builder-messages';
 
 /**
- * The guided empty state (new form / zero questions): four template cards +
- * "start from scratch". Replaces the old type-dropdown cold start — the user
- * begins from a decision, not a schema word. Picking a template loads a ready
- * config; scratch opens the type gallery.
+ * The guided empty state (new form / zero questions). The flow reads
+ * start-from-scratch-or-pick-a-template: a blank-canvas option comes first as a
+ * clear primary choice, then four ready-made template cards. Picking a template
+ * loads a ready config (the form keeps the name the user already gave it —
+ * applyTemplate only swaps `config`); scratch opens the type gallery.
+ *
+ * Only the emphasized (recommended) template carries the lime accent; every
+ * other card stays neutral/grey. Cards are real <button>s (implicit role=button)
+ * with an explicit pointer cursor + hover affordance (Tailwind v4 drops the
+ * default button pointer cursor).
  */
 export function EmptyState({
   onPickTemplate,
@@ -24,22 +30,55 @@ export function EmptyState({
       <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">{m.empty.title}</h1>
       <p className="mt-3 max-w-xl text-sm text-muted-foreground sm:text-base">{m.empty.subtitle}</p>
 
-      <div className="mt-10 grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {/* Start from scratch — the clear first option. */}
+      <button
+        type="button"
+        onClick={onScratch}
+        data-testid="empty-scratch"
+        className="group mt-10 flex w-full max-w-xl cursor-pointer items-center gap-4 rounded-2xl border border-border bg-card p-5 text-left transition-colors hover:border-primary/60 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-muted text-muted-foreground transition-colors group-hover:text-foreground">
+          <i aria-hidden className="pi pi-plus" style={{ fontSize: 18 }} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-base font-semibold text-foreground">{m.empty.scratchTitle}</span>
+          <span className="mt-0.5 block text-sm text-muted-foreground">{m.empty.scratchDesc}</span>
+        </span>
+        <i
+          aria-hidden
+          className="pi pi-arrow-right shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+          style={{ fontSize: 13 }}
+        />
+      </button>
+
+      {/* Or choose a template. */}
+      <div className="mt-10 flex w-full items-center gap-3">
+        <span className="h-px flex-1 bg-border" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {m.empty.templatesLabel}
+        </span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      <div className="mt-6 grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {TEMPLATE_ORDER.map((id) => {
           const t = m.empty.templates[id];
-          const first = id === 'lead';
+          // Only the recommended template is emphasized (lime); the rest stay grey.
+          const emphasized = id === 'lead';
+          const metaParts = t.meta.split(' · ');
           return (
             <button
               key={id}
               type="button"
               onClick={() => onPickTemplate(id)}
-              className="group flex flex-col rounded-2xl border border-border bg-card p-5 text-left transition-colors hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-testid={`empty-template-${id}`}
+              className="group flex cursor-pointer flex-col rounded-2xl border border-border bg-card p-5 text-left transition-colors hover:border-primary/60 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <span
                 className={
                   'inline-flex h-11 w-11 items-center justify-center rounded-xl transition-colors ' +
-                  (first
-                    ? 'bg-primary text-primary-foreground'
+                  (emphasized
+                    ? 'bg-primary/15 text-primary'
                     : 'bg-muted text-muted-foreground group-hover:text-foreground')
                 }
               >
@@ -48,22 +87,14 @@ export function EmptyState({
               <span className="mt-4 text-base font-semibold text-foreground">{t.name}</span>
               <span className="mt-1.5 flex-1 text-sm leading-relaxed text-muted-foreground">{t.desc}</span>
               <span className="mt-4 text-xs text-muted-foreground">
-                <span className="font-semibold text-primary">{t.meta.split(' · ')[0]}</span>
-                {t.meta.includes(' · ') ? ` · ${t.meta.split(' · ').slice(1).join(' · ')}` : ''}
+                {/* Neutral on every card — lime is reserved for the emphasized icon only. */}
+                <span className="font-semibold text-foreground">{metaParts[0]}</span>
+                {metaParts.length > 1 ? ` · ${metaParts.slice(1).join(' · ')}` : ''}
               </span>
             </button>
           );
         })}
       </div>
-
-      <button
-        type="button"
-        onClick={onScratch}
-        className="mt-8 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md px-2 py-1"
-      >
-        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} />
-        {m.empty.scratch}
-      </button>
     </div>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Children, isValidElement, type ReactNode } from 'react';
+import { Children, isValidElement, useEffect, useRef, useState, type ReactNode } from 'react';
 import { cn } from '@/lib/cn';
 import { Select, type SelectOption } from '@/components/ui/select';
 
@@ -56,9 +56,73 @@ export function TextArea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement
   return <textarea {...rest} rows={rows} className={cn(controlBase, 'resize-y', className)} />;
 }
 
-export function NumberField(props: React.InputHTMLAttributes<HTMLInputElement>) {
-  const { className, ...rest } = props;
-  return <input type="number" {...rest} className={cn(controlBase, className)} />;
+/** The display string for a numeric prop; nullish/empty → empty (never a
+ *  forced "0" that would pin a leading zero when the author starts typing). */
+function numberToDisplay(value: React.InputHTMLAttributes<HTMLInputElement>['value']): string {
+  if (value == null || value === '') return '';
+  return String(value);
+}
+
+/** Drop a leading-zero run for display: "01"→"1", "-007"→"-7". Leaves "0",
+ *  "0.5", "-", "" and any non-leading-zero string untouched. */
+function stripLeadingZeros(s: string): string {
+  const m = /^(-?)0+(\d.*)$/.exec(s);
+  return m ? `${m[1]}${m[2]}` : s;
+}
+
+/**
+ * A number input that owns its display string. `<input type="number">` won't
+ * rewrite "01"→"1" on its own (both coerce to 1), so a field seeded at 0 keeps
+ * a stale "0" in front of whatever the author types next. We mirror the
+ * controlled numeric prop into local text, strip the leading-zero run as you
+ * type, and — while focused — leave in-progress tokens ("", "-", "1.") alone so
+ * typing (including a negative) is never yanked back to the prop's value.
+ *
+ * The onChange CONTRACT is unchanged: the raw change event is forwarded, so
+ * every call site's `Number(e.target.value) || 0` still reads the same value.
+ * Clearing shows empty (not "0"); the display settles to the committed value on
+ * blur and re-syncs when the prop changes externally (e.g. switching questions).
+ */
+export function NumberField({
+  className,
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+  ...rest
+}: React.InputHTMLAttributes<HTMLInputElement>) {
+  const [display, setDisplay] = useState<string>(() => numberToDisplay(value));
+  const focused = useRef(false);
+
+  useEffect(() => {
+    // Mirror the controlled prop when the user isn't actively editing — this is
+    // how an external change (question switch, upstream reset/clamp) reaches the
+    // field. While focused we never overwrite the in-progress string.
+    if (focused.current) return;
+    setDisplay(numberToDisplay(value));
+  }, [value]);
+
+  return (
+    <input
+      {...rest}
+      type="number"
+      value={display}
+      onFocus={(e) => {
+        focused.current = true;
+        onFocus?.(e);
+      }}
+      onChange={(e) => {
+        setDisplay(stripLeadingZeros(e.target.value));
+        onChange?.(e);
+      }}
+      onBlur={(e) => {
+        focused.current = false;
+        setDisplay(numberToDisplay(value));
+        onBlur?.(e);
+      }}
+      className={cn(controlBase, className)}
+    />
+  );
 }
 
 /** Flatten an `<option>`'s children (strings, numbers, `{expr}` fragments) into

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-conditions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-conditions.tsx
@@ -1,18 +1,30 @@
 'use client';
 
 import { useState } from 'react';
-import type { FormStep, StepCondition } from '@quill/engine';
+import {
+  conditionsContradict,
+  operatorsForFieldType,
+  type ConditionOp,
+  type FormStep,
+  type StepCondition,
+} from '@quill/engine';
 import { cn } from '@/lib/cn';
 import { SelectField, TextField } from './fields';
 import { hasOptions } from './question-types';
 import type { EditorMessages } from './messages';
 
+type LogicMessages = EditorMessages['logic'];
+
 /**
  * Declarative visibility editor for a question's `showWhen` / `hideWhen`
- * conditions ({field, values[]}): pick an EARLIER question's field, then the
- * answer values that trigger the rule. Choice/dropdown sources offer their
- * options as toggle chips; free-text sources fall back to a comma-separated
- * values input. Honored by the engine's `visibleSteps` on client and server.
+ * conditions: pick an EARLIER question's field, then how its answer is compared.
+ * The operators offered follow the referenced field's TYPE (engine
+ * `operatorsForFieldType`): choice/dropdown/text sources keep "matches any of"
+ * (`in`) — option chips or a comma-separated values input; number/slider sources
+ * get a comparison dropdown (equal / greater / less / between) with numeric
+ * operand inputs. A contradiction guard (V4-08) warns when the show + hide rules
+ * on a step cancel out so it could never appear. Honored by the engine's
+ * `visibleSteps` on client and server.
  */
 export function LogicConditions({
   step,
@@ -25,7 +37,7 @@ export function LogicConditions({
   index: number;
   steps: FormStep[];
   onUpdate: (patch: Partial<FormStep>) => void;
-  m: EditorMessages['logic'];
+  m: LogicMessages;
 }) {
   const prior = steps.slice(0, index);
 
@@ -33,10 +45,16 @@ export function LogicConditions({
     return <p className="text-xs text-muted-foreground">{m.noPriorFields}</p>;
   }
 
+  // V4-08 guard: show + hide targeting the same field with an overlapping
+  // condition can never be visible (hide wins). Pure engine helper; we warn
+  // prominently and keep the offending rules visible so either can be fixed.
+  const contradiction = conditionsContradict(step.showWhen, step.hideWhen);
+
   return (
     <div className="flex flex-col gap-2.5">
       <p className="text-xs text-muted-foreground">{m.hint}</p>
       <ConditionEditor
+        testid="logic-show"
         label={m.showWhen}
         noneLabel={m.none}
         cond={step.showWhen ?? null}
@@ -45,6 +63,7 @@ export function LogicConditions({
         m={m}
       />
       <ConditionEditor
+        testid="logic-hide"
         label={m.hideWhen}
         noneLabel={m.hideNone}
         cond={step.hideWhen ?? null}
@@ -52,12 +71,38 @@ export function LogicConditions({
         onChange={(hideWhen) => onUpdate({ hideWhen: hideWhen ?? undefined })}
         m={m}
       />
+      {contradiction ? (
+        <p
+          role="alert"
+          data-testid="logic-contradiction"
+          className="rounded-md border border-destructive/50 bg-destructive/10 px-2.5 py-2 text-xs font-medium text-destructive"
+        >
+          {m.contradiction}
+        </p>
+      ) : null}
     </div>
   );
 }
 
-/** One condition row: field select (none = rule off) + value picker. */
+/** The localized label for one operator (the numeric ops + `in` fallback). */
+function opLabel(op: ConditionOp, m: LogicMessages): string {
+  switch (op) {
+    case 'eq':
+      return m.opEq;
+    case 'gt':
+      return m.opGt;
+    case 'lt':
+      return m.opLt;
+    case 'between':
+      return m.opBetween;
+    default:
+      return m.values; // 'in' — "matches any of"
+  }
+}
+
+/** One condition row: field select (none = rule off) + operator/value picker. */
 function ConditionEditor({
+  testid,
   label,
   noneLabel,
   cond,
@@ -65,15 +110,21 @@ function ConditionEditor({
   onChange,
   m,
 }: {
+  testid: string;
   label: string;
   noneLabel: string;
   cond: StepCondition | null;
   prior: FormStep[];
   onChange: (next: StepCondition | null) => void;
-  m: EditorMessages['logic'];
+  m: LogicMessages;
 }) {
   const NONE = '';
   const source = cond ? prior.find((s) => s.key === cond.field) : undefined;
+  const ops: ConditionOp[] = source ? operatorsForFieldType(source.type) : ['in'];
+  // Numeric sources (slider) expose the comparison operators; everything else
+  // keeps the single `in` ("matches any of") behavior with no operator UI.
+  const numeric = ops[0] !== 'in';
+  const op: ConditionOp = cond?.op ?? ops[0] ?? 'in';
   const sourceOptions = source && hasOptions(source.type) ? (source.options ?? []) : null;
 
   function pickField(key: string) {
@@ -83,17 +134,25 @@ function ConditionEditor({
     }
     const next = prior.find((s) => s.key === key);
     if (!next) return;
-    // Keep the values when re-picking the same field; otherwise seed a sensible
-    // default (the first option) so the rule matches something immediately.
+    // Keep the operands when re-picking the same field.
     if (cond && cond.field === key) return;
+    const nextOps = operatorsForFieldType(next.type);
+    if (nextOps[0] !== 'in') {
+      // Numeric source: seed the first comparison op (operand typed next).
+      onChange({ field: key, values: [], op: nextOps[0] });
+      return;
+    }
+    // Choice source: seed the first option so the rule matches something
+    // immediately. Free-text sources start with an empty list.
     const first = hasOptions(next.type) ? next.options?.[0]?.value : undefined;
     onChange({ field: key, values: first ? [first] : [] });
   }
 
   function toggleValue(value: string) {
     if (!cond) return;
-    const has = cond.values.includes(value);
-    onChange({ ...cond, values: has ? cond.values.filter((v) => v !== value) : [...cond.values, value] });
+    const values = cond.values ?? [];
+    const has = values.includes(value);
+    onChange({ ...cond, values: has ? values.filter((v) => v !== value) : [...values, value] });
   }
 
   return (
@@ -125,10 +184,56 @@ function ConditionEditor({
       </SelectField>
 
       {cond ? (
-        sourceOptions ? (
+        numeric ? (
+          <div className="flex flex-col gap-2">
+            <div data-testid={`${testid}-op`}>
+              <SelectField
+                aria-label={`${label} — ${m.operator}`}
+                value={op}
+                onChange={(e) => onChange({ ...cond, op: e.target.value as ConditionOp })}
+                className="h-8 py-1 text-xs"
+              >
+                {ops.map((o) => (
+                  <option key={o} value={o}>
+                    {opLabel(o, m)}
+                  </option>
+                ))}
+              </SelectField>
+            </div>
+            {op === 'between' ? (
+              <div className="flex items-end gap-2">
+                <NumberOperand
+                  key={`${cond.field}-min`}
+                  initial={cond.min}
+                  label={m.betweenMin}
+                  ariaLabel={`${label} — ${m.betweenMin}`}
+                  testid={`${testid}-min`}
+                  onCommit={(n) => onChange({ ...cond, min: n })}
+                />
+                <NumberOperand
+                  key={`${cond.field}-max`}
+                  initial={cond.max}
+                  label={m.betweenMax}
+                  ariaLabel={`${label} — ${m.betweenMax}`}
+                  testid={`${testid}-max`}
+                  onCommit={(n) => onChange({ ...cond, max: n })}
+                />
+              </div>
+            ) : (
+              <NumberOperand
+                key={`${cond.field}-value`}
+                initial={cond.value}
+                label={m.value}
+                ariaLabel={`${label} — ${m.value}`}
+                testid={`${testid}-value`}
+                onCommit={(n) => onChange({ ...cond, value: n })}
+              />
+            )}
+          </div>
+        ) : sourceOptions ? (
           <div className="flex flex-wrap gap-1.5" role="group" aria-label={m.values}>
             {sourceOptions.map((o) => {
-              const selected = cond.values.includes(o.value);
+              const selected = (cond.values ?? []).includes(o.value);
               return (
                 <button
                   key={o.value}
@@ -150,7 +255,7 @@ function ConditionEditor({
         ) : (
           <FreeValuesInput
             key={cond.field}
-            initial={cond.values}
+            initial={cond.values ?? []}
             label={m.values}
             hint={m.valuesHint}
             onCommit={(values) => onChange({ ...cond, values })}
@@ -158,6 +263,52 @@ function ConditionEditor({
         )
       ) : null}
     </div>
+  );
+}
+
+const numberControl =
+  'h-8 w-full rounded-md border border-input bg-background px-3 py-1 text-xs transition-colors ' +
+  'placeholder:text-muted-foreground hover:border-muted-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+/**
+ * A numeric operand input (eq/gt/lt value, or one side of a `between`) with
+ * LOCAL text state — the visible text stays exactly as typed while a parsed,
+ * finite number (or `undefined` for empty/partial input) commits upward. Keyed
+ * by the source field so switching fields reseeds it.
+ */
+function NumberOperand({
+  initial,
+  label,
+  ariaLabel,
+  testid,
+  onCommit,
+}: {
+  initial: number | undefined;
+  label: string;
+  ariaLabel: string;
+  testid: string;
+  onCommit: (n: number | undefined) => void;
+}) {
+  const [text, setText] = useState(initial == null ? '' : String(initial));
+  return (
+    <label className="flex flex-1 flex-col gap-1">
+      <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+      <input
+        type="number"
+        inputMode="decimal"
+        aria-label={ariaLabel}
+        data-testid={testid}
+        value={text}
+        onChange={(e) => {
+          const raw = e.target.value;
+          setText(raw);
+          const n = raw.trim() === '' ? undefined : Number(raw);
+          onCommit(n != null && Number.isFinite(n) ? n : undefined);
+        }}
+        className={numberControl}
+      />
+    </label>
   );
 }
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
@@ -1,19 +1,35 @@
 'use client';
 
-import type { FormConfig, FormStep } from '@quill/engine';
+import type { FormConfig, FormOutcome, FormStep } from '@quill/engine';
 import { cn } from '@/lib/cn';
 import { iconForStep } from './question-types';
 import { optionLabel } from './logic-util';
-import type { BuilderMessages } from './builder-messages';
+import type { BuilderMessages, GalleryItemId } from './builder-messages';
 import { tb } from './builder-messages';
 
 /**
- * The Logic Map — a truthful node graph of how answers route through the form:
- * Start → each question, with purple branch edges for forward `goto` jumps
- * ("If X → jump to Q / skip to end") and show/hide conditions, plus lime
- * end/result nodes derived from the scored outcomes. Read-to-understand; the
- * rules themselves are authored inline in Build.
+ * The Logic Map — a truthful, READ-ONLY node graph of how answers route through
+ * the form:  Start → each question, with purple branch edges for forward `goto`
+ * jumps ("If X → skip to end" / "If X → Q3") and show/hide conditions, then the
+ * lime end/result nodes derived from the scored outcomes. It is a map to read,
+ * not an editor — the rules themselves are authored inline in Build.
+ *
+ * Legibility (V4-17): distinct card styling per node role (Start capsule /
+ * question card / lime ending), a numbered step badge + type icon + kind label,
+ * indented & labelled branch edges with a traceable "Otherwise" path, and a
+ * calm animated flow on the connectors (disabled under prefers-reduced-motion,
+ * both here and by the app-wide reduce rule in globals.css).
  */
+
+/* Scoped connector animation. The thin dashed spine segments drift downward to
+   suggest flow toward the ending; kept slow + low-contrast so it reads as calm.
+   Guarded for reduced motion (belt-and-suspenders with the global reduce rule). */
+const MAP_STYLES = `
+@keyframes lm-flow { to { background-position: 0 8px; } }
+.lm-flow { animation: lm-flow 2s linear infinite; }
+@media (prefers-reduced-motion: reduce) { .lm-flow { animation: none; } }
+`;
+
 export function LogicMap({ config, m }: { config: FormConfig; m: BuilderMessages }) {
   const steps = config.steps;
   if (steps.length === 0) {
@@ -25,83 +41,151 @@ export function LogicMap({ config, m }: { config: FormConfig; m: BuilderMessages
   const outcomes = config.outcomes ?? [];
 
   return (
-    <div className="relative">
+    <div className="relative" data-testid="logic-map">
+      <style dangerouslySetInnerHTML={{ __html: MAP_STYLES }} />
+
       {/* Legend */}
-      <div className="pointer-events-none sticky top-0 z-10 mb-2 flex items-center justify-end gap-4 text-xs text-muted-foreground">
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block h-3 w-3 rounded border-2 border-secondary" /> {m.map.branchLegend}
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block h-3 w-3 rounded border-2 border-primary" /> {m.map.endLegend}
-        </span>
+      <div className="pointer-events-none sticky top-0 z-10 mb-3 flex items-center justify-end gap-3 text-xs text-muted-foreground">
+        <LegendSwatch className="bg-secondary" label={m.map.branchLegend} />
+        <LegendSwatch className="bg-primary" label={m.map.endLegend} />
       </div>
 
-      <div className="mx-auto flex max-w-[460px] flex-col items-stretch pb-12">
-        <MapNode tone="start">
-          <span className="mx-auto text-sm font-semibold">{m.map.start}</span>
-        </MapNode>
+      <div className="mx-auto flex max-w-[520px] flex-col items-stretch pb-12">
+        {/* Start — a capsule, visually distinct from the rectangular question cards */}
+        <div className="flex flex-col items-center" data-testid="logic-start">
+          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-muted px-4 py-2 shadow-sm">
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
+              <i aria-hidden className="pi pi-play" style={{ fontSize: 10 }} />
+            </span>
+            <span className="text-sm font-semibold text-foreground">{m.map.start}</span>
+          </span>
+          <span className="mt-1.5 text-[11px] text-muted-foreground">{m.map.startHint}</span>
+        </div>
 
         {steps.map((step, i) => {
           const branches = step.goto ?? [];
           const hasCond = !!(step.showWhen || step.hideWhen);
           const isLast = i === steps.length - 1;
+          const hasLogic = branches.length > 0 || hasCond;
           return (
-            <div key={step.key}>
-              <Down />
-              <MapNode tone={branches.length || hasCond ? 'branch' : 'default'}>
-                <div className="flex items-center gap-2.5">
-                  <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-[11px] font-bold text-muted-foreground">
+            <div key={step.key} data-testid="logic-step" data-step-key={step.key}>
+              <Connector />
+
+              {/* Question node card */}
+              <div
+                data-testid="logic-node"
+                className={cn(
+                  'relative w-full overflow-hidden rounded-xl border bg-card px-3.5 py-3 shadow-sm',
+                  hasLogic ? 'border-secondary/45' : 'border-border',
+                )}
+              >
+                {hasLogic ? (
+                  <span aria-hidden className="absolute inset-y-0 left-0 w-1 bg-secondary/70" />
+                ) : null}
+                <div className="flex items-center gap-3">
+                  <span
+                    aria-hidden
+                    className={cn(
+                      'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold tabular-nums',
+                      hasLogic ? 'bg-secondary/15 text-secondary' : 'bg-muted text-muted-foreground',
+                    )}
+                  >
                     {i + 1}
                   </span>
-                  <i aria-hidden className={`pi ${iconForStep(step)} shrink-0 text-muted-foreground`} style={{ fontSize: 13 }} />
-                  <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-                    {titleOf(step, i)}
-                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <i
+                        aria-hidden
+                        className={`pi ${iconForStep(step)} shrink-0 text-muted-foreground`}
+                        style={{ fontSize: 13 }}
+                      />
+                      <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+                        {titleOf(step, i)}
+                      </span>
+                    </div>
+                    <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                      {kindLabel(step, m)}
+                    </span>
+                  </div>
+                  {branches.length ? (
+                    <LogicPill>
+                      {branches.length === 1 ? m.badges.ruleOne : tb(m.map.branches, { n: branches.length })}
+                    </LogicPill>
+                  ) : hasCond ? (
+                    <LogicPill>{m.map.conditional}</LogicPill>
+                  ) : null}
                 </div>
-                {branches.length ? (
-                  <p className="mt-1 pl-8 text-xs font-medium text-secondary">
-                    {branches.length === 1 ? m.badges.ruleOne : tb(m.map.branches, { n: branches.length })}
-                  </p>
-                ) : null}
-              </MapNode>
+              </div>
 
-              {/* Branch edges */}
-              {branches.map((rule, ri) => {
-                const value = rule.values.map((v) => optionLabel(step, v)).join(', ');
-                if (rule.target == null) {
-                  return (
-                    <BranchEdge key={ri} label={tb(m.map.skipEdge, { value })}>
-                      <MapNode tone="result" compact>
-                        <div className="flex items-center gap-2">
-                          <i aria-hidden className="pi pi-comment text-primary" style={{ fontSize: 12 }} />
-                          <span className="text-sm font-semibold text-foreground">{m.map.thankYou}</span>
+              {/* Branch edges — indented, labelled, traceable */}
+              {branches.length ? (
+                <div className="mt-2 flex flex-col gap-2">
+                  {branches.map((rule, ri) => {
+                    const value = rule.values.map((v) => optionLabel(step, v)).join(', ');
+                    if (rule.target == null) {
+                      return (
+                        <BranchEdge key={ri} label={tb(m.map.skipEdge, { value })}>
+                          <div
+                            data-testid="logic-end"
+                            className="rounded-lg border border-primary/50 bg-primary/[0.07] px-3 py-2"
+                          >
+                            <div className="flex items-center gap-2">
+                              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/20">
+                                <i aria-hidden className="pi pi-flag-fill text-primary" style={{ fontSize: 9 }} />
+                              </span>
+                              <span className="text-sm font-semibold text-foreground">{m.map.thankYou}</span>
+                              <span className="ml-auto rounded bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                                {m.map.end}
+                              </span>
+                            </div>
+                          </div>
+                        </BranchEdge>
+                      );
+                    }
+                    const ti = stepByKey.get(rule.target);
+                    const targetStep = ti != null ? steps[ti] : undefined;
+                    const targetLabel = ti != null && targetStep ? titleOf(targetStep, ti) : rule.target;
+                    return (
+                      <BranchEdge key={ri} label={tb(m.map.jumpEdge, { value, target: targetLabel })}>
+                        <div
+                          data-testid="logic-jump"
+                          className="rounded-lg border border-dashed border-border bg-card px-3 py-2"
+                        >
+                          <div className="flex items-center gap-2">
+                            {targetStep ? (
+                              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted">
+                                <i
+                                  aria-hidden
+                                  className={`pi ${iconForStep(targetStep)} text-secondary`}
+                                  style={{ fontSize: 10 }}
+                                />
+                              </span>
+                            ) : null}
+                            {ti != null ? (
+                              <span className="inline-flex h-4 shrink-0 items-center rounded bg-muted px-1 text-[10px] font-bold tabular-nums text-muted-foreground">
+                                {ti + 1}
+                              </span>
+                            ) : null}
+                            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                              {targetLabel}
+                            </span>
+                            <i aria-hidden className="pi pi-arrow-up-right text-secondary" style={{ fontSize: 11 }} />
+                          </div>
                         </div>
-                        <p className="mt-0.5 text-xs text-muted-foreground">{m.map.end}</p>
-                      </MapNode>
-                    </BranchEdge>
-                  );
-                }
-                const ti = stepByKey.get(rule.target);
-                const targetStep = ti != null ? steps[ti] : undefined;
-                const targetLabel = ti != null && targetStep ? titleOf(targetStep, ti) : rule.target;
-                return (
-                  <BranchEdge key={ri} label={tb(m.map.jumpEdge, { value, target: targetLabel })}>
-                    <MapNode tone="ghost" compact>
-                      <div className="flex items-center gap-2">
-                        <i aria-hidden className="pi pi-bolt text-secondary" style={{ fontSize: 12 }} />
-                        <span className="truncate text-sm font-medium text-foreground">{targetLabel}</span>
-                      </div>
-                    </MapNode>
-                  </BranchEdge>
-                );
-              })}
+                      </BranchEdge>
+                    );
+                  })}
 
-              {/* "Otherwise" label when this node branches but isn't the last */}
-              {branches.length && !isLast ? (
-                <div className="flex justify-center">
-                  <span className="mt-2 inline-block rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                    {m.map.otherwise}
-                  </span>
+                  {/* The default path: if no rule matched, the flow continues in order */}
+                  {!isLast ? (
+                    <div className="flex justify-center pt-0.5" data-testid="logic-otherwise">
+                      <span className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-border bg-muted/60 px-2.5 py-0.5 text-[11px] text-muted-foreground">
+                        <i aria-hidden className="pi pi-arrow-down shrink-0" style={{ fontSize: 9 }} />
+                        <span className="font-semibold text-foreground/80">{m.map.otherwise}</span>
+                        <span className="truncate text-muted-foreground/80">· {m.map.otherwiseHint}</span>
+                      </span>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </div>
@@ -111,22 +195,8 @@ export function LogicMap({ config, m }: { config: FormConfig; m: BuilderMessages
         {/* Terminal result nodes from scored outcomes */}
         {outcomes.map((o) => (
           <div key={o.id}>
-            <Down />
-            <MapNode tone="result">
-              <div className="flex items-center gap-2.5">
-                <i
-                  aria-hidden
-                  className={`pi ${o.redirectUrl ? 'pi-external-link' : 'pi-flag'} text-primary`}
-                  style={{ fontSize: 13 }}
-                />
-                <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{o.label}</span>
-              </div>
-              {o.redirectUrl ? (
-                <p className="mt-0.5 truncate pl-6 text-xs text-muted-foreground">
-                  {tb(m.map.redirect, { url: o.redirectUrl.replace(/^https?:\/\//, '') })}
-                </p>
-              ) : null}
-            </MapNode>
+            <Connector />
+            <OutcomeNode outcome={o} m={m} />
           </div>
         ))}
       </div>
@@ -134,42 +204,122 @@ export function LogicMap({ config, m }: { config: FormConfig; m: BuilderMessages
   );
 }
 
-function Down() {
+/** Map a step to its gallery id so the node can show a localized kind label
+ *  ("Single choice", "Email", …) reusing the existing gallery catalog. */
+function galleryIdForStep(step: FormStep): GalleryItemId {
+  switch (step.type) {
+    case 'name':
+      return 'name';
+    case 'email':
+      return 'email';
+    case 'phone':
+      return 'phone';
+    case 'dropdown':
+      return 'dropdown';
+    case 'multiple_choice':
+      return step.selectionMode === 'multiple' ? 'multiple' : 'single';
+    case 'slider':
+      return 'slider';
+    case 'textarea':
+      return 'long';
+    case 'message':
+      return 'message';
+    case 'text':
+    default:
+      return 'short';
+  }
+}
+
+/** The human, localized kind label for a step (falls back to empty). */
+function kindLabel(step: FormStep, m: BuilderMessages): string {
+  return m.gallery.items[galleryIdForStep(step)]?.title ?? '';
+}
+
+/** A terminal (lime) node for a scored outcome bucket. */
+function OutcomeNode({ outcome, m }: { outcome: FormOutcome; m: BuilderMessages }) {
+  const redirects = !!outcome.redirectUrl;
   return (
-    <div aria-hidden className="flex justify-center py-1.5 text-muted-foreground/60">
-      <i className="pi pi-arrow-down" style={{ fontSize: 12 }} />
+    <div
+      data-testid="logic-outcome"
+      className="relative w-full overflow-hidden rounded-xl border border-primary/50 bg-primary/[0.06] px-3.5 py-3 shadow-sm"
+    >
+      <span aria-hidden className="absolute inset-y-0 left-0 w-1 bg-primary/70" />
+      <div className="flex items-center gap-3">
+        <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/20">
+          <i
+            aria-hidden
+            className={`pi ${redirects ? 'pi-external-link' : 'pi-flag-fill'} text-primary`}
+            style={{ fontSize: 13 }}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <span className="block text-[10px] font-semibold uppercase tracking-wide text-primary">
+            {m.map.outcomeKicker}
+          </span>
+          <span className="block truncate text-sm font-semibold text-foreground">{outcome.label}</span>
+          {redirects ? (
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {tb(m.map.redirect, { url: (outcome.redirectUrl ?? '').replace(/^https?:\/\//, '') })}
+            </span>
+          ) : null}
+        </div>
+      </div>
     </div>
   );
 }
 
-function MapNode({
-  children,
-  tone = 'default',
-  compact,
-}: {
-  children: React.ReactNode;
-  tone?: 'default' | 'start' | 'branch' | 'result' | 'ghost';
-  compact?: boolean;
-}) {
-  const toneClass = {
-    default: 'border-border bg-card',
-    start: 'border-border bg-muted',
-    branch: 'border-secondary bg-secondary/[0.06]',
-    result: 'border-primary bg-primary/[0.06]',
-    ghost: 'border-dashed border-border bg-card',
-  }[tone];
+/** A legend row: a filled colour swatch + its label. */
+function LegendSwatch({ className, label }: { className: string; label: string }) {
   return (
-    <div className={cn('w-full rounded-xl border px-4', compact ? 'py-2.5' : 'py-3', toneClass)}>{children}</div>
+    <span className="flex items-center gap-1.5">
+      <span aria-hidden className={cn('inline-block h-3 w-3 rounded-sm', className)} />
+      {label}
+    </span>
   );
 }
 
-/** A branch callout: a purple labelled edge to an offset target node. */
+/** The small purple pill on a question that carries logic. */
+function LogicPill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-secondary/40 bg-secondary/10 px-1.5 py-0.5 text-[11px] font-semibold text-secondary">
+      <i aria-hidden className="pi pi-directions" style={{ fontSize: 9 }} />
+      {children}
+    </span>
+  );
+}
+
+/** The vertical connector between spine nodes: a calm downward-flowing dashed
+ *  line capped with a chevron. Purely decorative. */
+function Connector() {
+  return (
+    <div aria-hidden className="flex flex-col items-center py-1">
+      <span
+        className="lm-flow h-5 w-0.5"
+        style={{
+          backgroundImage:
+            'repeating-linear-gradient(to bottom, var(--muted-foreground) 0, var(--muted-foreground) 3px, transparent 3px, transparent 8px)',
+          backgroundSize: '2px 8px',
+          opacity: 0.5,
+        }}
+      />
+      <i className="pi pi-angle-down -mt-1 text-muted-foreground/70" style={{ fontSize: 12 }} />
+    </div>
+  );
+}
+
+/** A branch callout: a purple labelled edge elbowing off the node to an offset
+ *  destination (a lime ending, or a jump-to-question chip). */
 function BranchEdge({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="ml-6 mt-2 flex items-stretch gap-2">
-      <span aria-hidden className="mt-4 h-px w-6 shrink-0 self-start bg-secondary/60" />
+    <div className="ml-5 flex items-stretch gap-2" data-testid="logic-branch">
+      {/* Elbow: a short vertical stub up to the node, then across to the label. */}
+      <span
+        aria-hidden
+        className="relative mt-3 h-px w-6 shrink-0 self-start bg-secondary/50 before:absolute before:-top-3 before:left-0 before:h-3 before:w-px before:bg-secondary/50"
+      />
       <div className="min-w-0 flex-1">
-        <span className="mb-1 inline-block rounded-md border border-secondary/40 bg-secondary/10 px-2 py-0.5 text-[11px] font-semibold text-secondary">
+        <span className="mb-1 inline-flex items-center gap-1 rounded-md border border-secondary/40 bg-secondary/10 px-2 py-0.5 text-[11px] font-semibold text-secondary">
+          <i aria-hidden className="pi pi-bolt" style={{ fontSize: 9 }} />
           {label}
         </span>
         {children}

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -81,9 +81,11 @@ export function OptionsEditor({
                         onChange={(e) => update(index, { value: e.target.value })}
                       />
                     </label>
-                    <label className="flex w-16 shrink-0 flex-col gap-1">
+                    <label className="flex w-20 shrink-0 flex-col gap-1">
                       <span className="text-[11px] font-medium text-muted-foreground">{m.points}</span>
                       <NumberField
+                        aria-label={m.points}
+                        data-testid={`option-points-${index}`}
                         value={o.points ?? 0}
                         onChange={(e) => update(index, { points: Number(e.target.value) || 0 })}
                       />
@@ -104,6 +106,9 @@ export function OptionsEditor({
           }}
         </SortableList>
       )}
+      <p className="text-[11px] leading-relaxed text-muted-foreground" data-testid="option-points-hint">
+        {m.pointsHint}
+      </p>
       <div>
         <Button variant="outline" size="sm" onClick={add}>
           <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -10,6 +10,7 @@ import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Field, NumberField, SelectField, InlineField, TextField } from './fields';
 import { OptionsEditor } from './options-editor';
 import { SliderScoringEditor } from './slider-scoring-editor';
+import { maxScoreForSteps } from './scoring-util';
 import { LogicRules } from './logic-rules';
 import { LogicConditions } from './logic-conditions';
 import { QuestionVariants } from './question-variants';
@@ -61,6 +62,9 @@ export function QuestionSettings({
   onOpenConnect: () => void;
 }) {
   const contact = isContactType(step.type);
+  // Form-wide "highest possible" total (same math as Results). Drives the
+  // "assign points" nudge when scoring is on but nothing scores yet.
+  const scoringMax = maxScoreForSteps(steps);
   const { confirm: confirmDialog, dialog } = useConfirmDialog();
 
   function changeType(itemId: string) {
@@ -220,7 +224,9 @@ export function QuestionSettings({
           {em.logic.title}
         </p>
         <LogicConditions step={step} index={index} steps={steps} onUpdate={onUpdate} m={em.logic} />
-        {step.type !== 'email' ? (
+        {/* Personal-email branch needs an earlier email answer — impossible on
+            the first question, so hide it there. */}
+        {step.type !== 'email' && index > 0 ? (
           <InlineField label={em.logic.personalEmailOnly} hint={em.logic.personalEmailHint}>
             <Switch
               checked={!!step.showForPersonalEmailOnly}
@@ -275,7 +281,18 @@ export function QuestionSettings({
               />
             </InlineField>
             <p className="mt-1 text-xs text-muted-foreground">{bm.settings.scoringHint}</p>
-            {step.type === 'slider' && scoringEnabled ? (
+            {scoringEnabled && scoringMax === 0 ? (
+              <p
+                data-testid="scoring-zero-hint"
+                className="mt-1.5 flex items-start gap-1.5 text-xs text-muted-foreground"
+              >
+                <i aria-hidden className="pi pi-info-circle mt-0.5 text-secondary" style={{ fontSize: 11 }} />
+                {bm.settings.scoringZeroHint}
+              </p>
+            ) : null}
+            {/* Slider ranges show for every slider (parity with the always-on
+                option Points column) so scoring isn't mysteriously hidden. */}
+            {step.type === 'slider' ? (
               <div className="mt-3">
                 <SliderScoringEditor
                   ranges={step.sliderScoring ?? []}
@@ -378,6 +395,9 @@ function NameFieldsEditor({
           </label>
         </div>
       ))}
+      <p className="text-[10px] leading-relaxed text-muted-foreground" data-testid="name-fieldkey-hint">
+        {m.fieldKeyHint}
+      </p>
     </div>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { useMemo } from 'react';
 import type { FormStep } from '@quill/engine';
 import { defaultFlowGroup } from '@quill/engine';
-import { getMessages } from '@quill/shared';
+import { COUNTRIES, countryName, getMessages } from '@quill/shared';
 import { clientLocale } from '@/lib/client-locale';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { Select, type SelectOption } from '@/components/ui/select';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Field, NumberField, SelectField, InlineField, TextField } from './fields';
 import { OptionsEditor } from './options-editor';
@@ -75,6 +77,18 @@ export function QuestionSettings({
   // "assign points" nudge when scoring is on but nothing scores yet.
   const scoringMax = maxScoreForSteps(steps);
   const { confirm: confirmDialog, dialog } = useConfirmDialog();
+
+  // Country options for the phone step's default-country picker: an "automatic"
+  // (locale-based) row first, then every country sorted by localized name.
+  const countryOptions = useMemo<SelectOption[]>(
+    () => [
+      { value: '', label: em.props.phoneDefaultCountryAuto },
+      ...[...COUNTRIES]
+        .sort((a, b) => countryName(a.code, locale).localeCompare(countryName(b.code, locale), locale))
+        .map((c) => ({ value: c.code, label: `${c.flag} ${countryName(c.code, locale)} (${c.dial})` })),
+    ],
+    [locale, em.props.phoneDefaultCountryAuto],
+  );
 
   function changeType(itemId: string) {
     const item = ALL_ITEMS.find((it) => it.id === itemId);
@@ -183,12 +197,22 @@ export function QuestionSettings({
       ) : null}
 
       {step.type === 'phone' ? (
-        <section className="border-t border-border pt-4">
+        <section className="flex flex-col gap-3 border-t border-border pt-4">
           <Field label={em.props.phoneMinDigits}>
             <NumberField
               value={step.phoneMinDigits ?? 7}
               min={1}
               onChange={(e) => onUpdate({ phoneMinDigits: Number(e.target.value) || undefined })}
+            />
+          </Field>
+          <Field label={em.props.phoneDefaultCountry}>
+            <Select
+              ariaLabel={em.props.phoneDefaultCountry}
+              value={step.phoneDefaultCountry ?? ''}
+              options={countryOptions}
+              searchable
+              locale={locale}
+              onChange={(v) => onUpdate({ phoneDefaultCountry: v || undefined })}
             />
           </Field>
         </section>
@@ -267,6 +291,18 @@ export function QuestionSettings({
             aria-label={em.behavior.terminal}
           />
         </InlineField>
+        {/* Hidden question — never shown; its answer is seeded from a matching
+            URL parameter and carried into the submission. Meaningless for a
+            message step (it collects no answer), so hide it there. */}
+        {step.type !== 'message' ? (
+          <InlineField label={em.behavior.hidden} hint={em.behavior.hiddenHint}>
+            <Switch
+              checked={!!step.hidden}
+              onCheckedChange={(v) => onUpdate({ hidden: v || undefined })}
+              aria-label={em.behavior.hidden}
+            />
+          </InlineField>
+        ) : null}
         {/* The reveal POSITION lives in config.revealAfterStep (the draggable
             spine marker is the primary control); this toggle is a convenience to
             pin the reveal after THIS question. Clearing reverts to the default

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -46,6 +46,9 @@ export function QuestionSettings({
   formId,
   locale,
   onOpenConnect,
+  onOpenDesign,
+  revealAfterStep,
+  onRevealAfterStepChange,
 }: {
   step: FormStep;
   index: number;
@@ -60,6 +63,12 @@ export function QuestionSettings({
   locale: string;
   /** Switch the editor to the Connect tab (HubSpot destination setup). */
   onOpenConnect: () => void;
+  /** Switch the editor to the Design tab (reveal-screen copy/duration — V4-12). */
+  onOpenDesign: () => void;
+  /** Current 1-based `config.revealAfterStep` (the reveal marker's position). */
+  revealAfterStep?: number;
+  /** Pin the reveal after THIS step (1-based) or clear it (`undefined`) — V4-04. */
+  onRevealAfterStepChange: (afterStep: number | undefined) => void;
 }) {
   const contact = isContactType(step.type);
   // Form-wide "highest possible" total (same math as Results). Drives the
@@ -246,7 +255,7 @@ export function QuestionSettings({
         <QuestionVariants step={step} index={index} steps={steps} onUpdate={onUpdate} m={em.variants} />
       </section>
 
-      {/* Behavior — terminal (disqualify) + reveal trigger */}
+      {/* Behavior — terminal (disqualify) + reveal position (V4-04/V4-12) */}
       <section className="flex flex-col gap-1 border-t border-border pt-4">
         <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {em.behavior.title}
@@ -258,13 +267,26 @@ export function QuestionSettings({
             aria-label={em.behavior.terminal}
           />
         </InlineField>
+        {/* The reveal POSITION lives in config.revealAfterStep (the draggable
+            spine marker is the primary control); this toggle is a convenience to
+            pin the reveal after THIS question. Clearing reverts to the default
+            (after the last question). */}
         <InlineField label={em.behavior.reveal} hint={em.behavior.revealHint}>
           <Switch
-            checked={!!step.triggersReveal}
-            onCheckedChange={(v) => onUpdate({ triggersReveal: v || undefined })}
+            checked={revealAfterStep === index + 1}
+            onCheckedChange={(v) => onRevealAfterStepChange(v ? index + 1 : undefined)}
             aria-label={em.behavior.reveal}
           />
         </InlineField>
+        <button
+          type="button"
+          data-testid="behavior-edit-reveal"
+          onClick={onOpenDesign}
+          className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-md text-xs font-medium text-secondary transition-colors hover:text-secondary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i aria-hidden className="pi pi-pencil" style={{ fontSize: 11 }} />
+          {em.behavior.editReveal}
+        </button>
       </section>
 
       {/* Scoring / contact hint */}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-spine.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-spine.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type HTMLAttributes, type ReactNode } from 'react';
 import type { FormStep } from '@quill/engine';
 import { cn } from '@/lib/cn';
 import { SortableList, SortableRow } from './sortable';
@@ -10,10 +10,13 @@ import type { BuilderMessages } from './builder-messages';
 import { tb } from './builder-messages';
 
 /**
- * Sortable id for the partial-submit-point marker. Never a real step key (step
- * keys are slugified question text), so it can share the dnd id space safely.
+ * Sortable ids for the flow markers. Never real step keys (step keys are
+ * slugified question text), so they share the dnd id space safely.
  */
 const PARTIAL_ID = '__partial_submit_point__';
+const REVEAL_ID = '__reveal_point__';
+
+const isMarker = (id: string): boolean => id === PARTIAL_ID || id === REVEAL_ID;
 
 /**
  * The left flow spine — numbered question cards (drag to reorder), a type icon,
@@ -22,10 +25,14 @@ const PARTIAL_ID = '__partial_submit_point__';
  * card gets a lime left rail. One dashed "+ Add question" at the bottom opens
  * the type gallery.
  *
- * When `partialAfterStep` is set (1..steps.length) a dashed, unnumbered
- * "Partial submit point" marker renders after that step, INSIDE the same
- * dnd-kit list (special id), so it drags exactly like a question. Drops are
- * translated back into domain updates in `handleReorder`.
+ * Two dashed, unnumbered markers can render INSIDE the same dnd-kit list (each
+ * with a special id) so they drag exactly like a question:
+ *  - the "Partial submit point" marker (`partialAfterStep`, 1..steps.length);
+ *  - the "Reveal screen" marker (V4-04): shown whenever the reveal is enabled in
+ *    Design, defaulting to AFTER THE LAST question (mirroring the engine's
+ *    `revealAfterKey` — revealAfterStep, else a legacy triggersReveal step, else
+ *    the end). Dragging it writes an explicit `revealAfterStep`.
+ * Drops are translated back into domain updates in `handleReorder`.
  */
 export function QuestionSpine({
   steps,
@@ -35,6 +42,10 @@ export function QuestionSpine({
   onAdd,
   partialAfterStep,
   onPartialChange,
+  revealEnabled,
+  revealAfterStep,
+  onRevealMove,
+  onRevealRemove,
   m,
 }: {
   steps: FormStep[];
@@ -46,45 +57,66 @@ export function QuestionSpine({
   partialAfterStep?: number;
   /** Set (1-based), move, or clear (`undefined`) the partial-submit threshold. */
   onPartialChange: (afterStep: number | undefined) => void;
+  /** Whether the reveal screen is enabled in Design (drives the reveal marker). */
+  revealEnabled: boolean;
+  /** 1-based explicit `config.revealAfterStep` (absent = default to the end). */
+  revealAfterStep?: number;
+  /** Move the reveal marker → set an explicit 1-based `revealAfterStep`. */
+  onRevealMove: (afterStep: number) => void;
+  /** Remove the reveal marker → turn the reveal off (Design owns enablement). */
+  onRevealRemove: () => void;
   m: BuilderMessages;
 }) {
-  const [infoOpen, setInfoOpen] = useState(false);
-
-  // Merged sortable ids: step keys with the marker spliced in at its 1-based
-  // position. An out-of-range threshold renders no marker (and the add
-  // affordance below offers to re-place it).
-  const markerIdx =
+  // Effective 1-based marker slots (null = not shown). The partial marker only
+  // shows for an in-range threshold; the reveal marker shows whenever the reveal
+  // is enabled, defaulting to the end (revealAfterKey's default) so an enabled
+  // reveal is always visible and draggable.
+  const partialIdx =
     partialAfterStep != null && partialAfterStep >= 1 && partialAfterStep <= steps.length
       ? partialAfterStep
       : null;
-  const ids = steps.map((s) => s.key);
-  if (markerIdx != null) ids.splice(markerIdx, 0, PARTIAL_ID);
+  const revealIdx =
+    revealEnabled && steps.length > 0
+      ? revealAfterStep != null && revealAfterStep >= 1 && revealAfterStep <= steps.length
+        ? revealAfterStep
+        : defaultRevealPos(steps)
+      : null;
+
+  // Merged sortable ids: step keys with the markers spliced in after their
+  // anchor step (partial before reveal when they share a slot).
+  const ids: string[] = [];
+  steps.forEach((s, i) => {
+    ids.push(s.key);
+    const pos = i + 1;
+    if (partialIdx === pos) ids.push(PARTIAL_ID);
+    if (revealIdx === pos) ids.push(REVEAL_ID);
+  });
 
   /**
    * Translate a merged-list drop back into a domain update:
-   * - the MARKER moved → the new threshold is however many questions ended up
-   *   above it, clamped to ≥ 1 (a partial point above every question is
+   * - a MARKER moved → its new position is however many QUESTIONS ended up above
+   *   it (markers don't count), clamped to ≥ 1 (a marker above every question is
    *   invalid — the minimum is "after question 1");
-   * - a QUESTION moved → a plain step reorder. The editor's `reorderSteps`
-   *   re-anchors the threshold to the step it was after, so the marker follows
-   *   its anchor question.
+   * - a QUESTION moved → a plain step reorder. The editor re-anchors both
+   *   thresholds to the step they sit after, so a marker follows its anchor.
    */
   function handleReorder(from: number, to: number) {
-    if (markerIdx == null) {
-      onReorder(from, to);
-      return;
-    }
     const next = [...ids];
     const [moved] = next.splice(from, 1);
     if (!moved) return;
     next.splice(to, 0, moved);
     if (moved === PARTIAL_ID) {
-      const threshold = Math.max(1, next.indexOf(PARTIAL_ID));
+      const threshold = Math.max(1, questionsAbove(next, PARTIAL_ID));
       if (threshold !== partialAfterStep) onPartialChange(threshold);
       return;
     }
-    const fromStep = ids.filter((x) => x !== PARTIAL_ID).indexOf(moved);
-    const toStep = next.filter((x) => x !== PARTIAL_ID).indexOf(moved);
+    if (moved === REVEAL_ID) {
+      const pos = Math.max(1, questionsAbove(next, REVEAL_ID));
+      if (pos !== revealAfterStep) onRevealMove(pos);
+      return;
+    }
+    const fromStep = questionIndex(ids, moved);
+    const toStep = questionIndex(next, moved);
     if (fromStep >= 0 && toStep >= 0 && fromStep !== toStep) onReorder(fromStep, toStep);
   }
 
@@ -98,69 +130,64 @@ export function QuestionSpine({
       <SortableList ids={ids} onReorder={handleReorder} className="flex flex-col gap-2">
         {(id, index) => {
           if (id === PARTIAL_ID) {
-            const atEnd = markerIdx === steps.length;
+            const atEnd = partialIdx === steps.length;
             return (
               <SortableRow key={id} id={id}>
                 {({ handleProps }) => (
-                  <div
-                    data-testid="partial-point-row"
-                    className="rounded-xl border border-dashed border-secondary/70 bg-secondary/[0.06] py-2 pl-2 pr-2.5"
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <button
-                        type="button"
-                        data-testid="partial-point-handle"
-                        aria-label={m.partial.move}
-                        className="shrink-0 cursor-grab touch-none rounded p-1 text-secondary/70 hover:text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
-                        {...handleProps}
-                      >
-                        <i aria-hidden className="pi pi-bars" style={{ fontSize: 12 }} />
-                      </button>
-                      <i aria-hidden className="pi pi-send shrink-0 text-secondary" style={{ fontSize: 12 }} />
-                      <span className="min-w-0 flex-1 text-[11px] font-semibold leading-tight text-secondary">
-                        {m.partial.label}
-                      </span>
-                      <button
-                        type="button"
-                        data-testid="partial-point-info"
-                        aria-label={m.partial.info}
-                        aria-expanded={infoOpen}
-                        onClick={() => setInfoOpen((v) => !v)}
-                        className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      >
-                        <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 12 }} />
-                      </button>
-                      <button
-                        type="button"
-                        data-testid="partial-point-remove"
-                        aria-label={m.partial.remove}
-                        onClick={() => {
-                          setInfoOpen(false);
-                          onPartialChange(undefined);
-                        }}
-                        className="shrink-0 rounded p-1 text-muted-foreground hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      >
-                        <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
-                      </button>
-                    </div>
-                    {infoOpen ? (
-                      <div className="mt-2 flex flex-col gap-1.5 rounded-lg bg-card/80 p-2 text-[11px] leading-snug text-muted-foreground">
+                  <SpineMarker
+                    testidPrefix="partial-point"
+                    icon="pi-send"
+                    label={m.partial.label}
+                    moveLabel={m.partial.move}
+                    infoLabel={m.partial.info}
+                    removeLabel={m.partial.remove}
+                    onRemove={() => onPartialChange(undefined)}
+                    handleProps={handleProps}
+                    tips={
+                      <>
                         <p>{m.partial.tipCapture}</p>
                         <p>{m.partial.tipStored}</p>
                         <p>{m.partial.tipNotify}</p>
                         {atEnd ? <p>{m.partial.tipAfterLast}</p> : null}
                         <p className="font-medium text-foreground">{m.partial.tipWhere}</p>
-                      </div>
-                    ) : null}
-                  </div>
+                      </>
+                    }
+                  />
                 )}
               </SortableRow>
             );
           }
 
-          // Question rows sit in the MERGED list — indices past the marker are
-          // shifted one slot; translate back to the step index.
-          const stepIndex = markerIdx != null && index > markerIdx ? index - 1 : index;
+          if (id === REVEAL_ID) {
+            const atEnd = revealIdx === steps.length;
+            return (
+              <SortableRow key={id} id={id}>
+                {({ handleProps }) => (
+                  <SpineMarker
+                    testidPrefix="reveal-point"
+                    icon="pi-sparkles"
+                    label={m.revealPoint.label}
+                    moveLabel={m.revealPoint.move}
+                    infoLabel={m.revealPoint.info}
+                    removeLabel={m.revealPoint.remove}
+                    onRemove={onRevealRemove}
+                    handleProps={handleProps}
+                    tips={
+                      <>
+                        <p>{m.revealPoint.tipPlays}</p>
+                        <p>{atEnd ? m.revealPoint.tipEnd : m.revealPoint.tipMid}</p>
+                        <p className="font-medium text-foreground">{m.revealPoint.tipEdit}</p>
+                      </>
+                    }
+                  />
+                )}
+              </SortableRow>
+            );
+          }
+
+          // Question rows sit in the MERGED list — translate the merged position
+          // back to the step index (count the questions above it).
+          const stepIndex = questionsBeforePosition(ids, index);
           const step = steps[stepIndex];
           if (!step) return null;
           const active = stepIndex === selectedIndex;
@@ -242,9 +269,9 @@ export function QuestionSpine({
         {m.shell.addQuestion}
       </button>
 
-      {markerIdx == null && steps.length > 0 ? (
-        // No visible marker (unset OR out-of-range) → offer to place one after
-        // the selected question (fallback: after question 1).
+      {partialIdx == null && steps.length > 0 ? (
+        // No visible partial marker (unset OR out-of-range) → offer to place one
+        // after the selected question (fallback: after question 1).
         <button
           type="button"
           data-testid="partial-point-add"
@@ -254,6 +281,118 @@ export function QuestionSpine({
           <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} />
           {m.partial.add}
         </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** The reveal marker's default slot: a legacy `triggersReveal` step, else the end. */
+function defaultRevealPos(steps: FormStep[]): number {
+  const ti = steps.findIndex((s) => s.triggersReveal);
+  return ti >= 0 ? ti + 1 : steps.length;
+}
+
+/** How many QUESTIONS (non-markers) sit above `markerId` in a merged id list. */
+function questionsAbove(list: string[], markerId: string): number {
+  const idx = list.indexOf(markerId);
+  if (idx < 0) return 0;
+  let count = 0;
+  for (let i = 0; i < idx; i += 1) if (!isMarker(list[i]!)) count += 1;
+  return count;
+}
+
+/** How many QUESTIONS (non-markers) sit strictly before merged index `pos`. */
+function questionsBeforePosition(list: string[], pos: number): number {
+  let count = 0;
+  for (let i = 0; i < pos; i += 1) if (!isMarker(list[i]!)) count += 1;
+  return count;
+}
+
+/** The 0-based step index of `key` among the QUESTIONS (ignoring markers). */
+function questionIndex(list: string[], key: string): number {
+  let count = 0;
+  for (const id of list) {
+    if (isMarker(id)) continue;
+    if (id === key) return count;
+    count += 1;
+  }
+  return -1;
+}
+
+/**
+ * A dashed, draggable flow marker row (partial-submit / reveal). Renders a drag
+ * grip, a type icon, the label, an info toggle with a popover, and a remove (×).
+ * Testids are derived from `testidPrefix` (`{prefix}-row|-handle|-info|-remove`)
+ * so each marker keeps a stable, distinct handle for the editor e2e specs.
+ */
+function SpineMarker({
+  testidPrefix,
+  icon,
+  label,
+  moveLabel,
+  infoLabel,
+  removeLabel,
+  tips,
+  onRemove,
+  handleProps,
+}: {
+  testidPrefix: string;
+  icon: string;
+  label: string;
+  moveLabel: string;
+  infoLabel: string;
+  removeLabel: string;
+  tips: ReactNode;
+  onRemove: () => void;
+  handleProps: HTMLAttributes<HTMLElement>;
+}) {
+  const [infoOpen, setInfoOpen] = useState(false);
+  return (
+    <div
+      data-testid={`${testidPrefix}-row`}
+      className="rounded-xl border border-dashed border-secondary/70 bg-secondary/[0.06] py-2 pl-2 pr-2.5"
+    >
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          data-testid={`${testidPrefix}-handle`}
+          aria-label={moveLabel}
+          className="shrink-0 cursor-grab touch-none rounded p-1 text-secondary/70 hover:text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+          {...handleProps}
+        >
+          <i aria-hidden className="pi pi-bars" style={{ fontSize: 12 }} />
+        </button>
+        <i aria-hidden className={cn('pi shrink-0 text-secondary', icon)} style={{ fontSize: 12 }} />
+        <span className="min-w-0 flex-1 text-[11px] font-semibold leading-tight text-secondary">
+          {label}
+        </span>
+        <button
+          type="button"
+          data-testid={`${testidPrefix}-info`}
+          aria-label={infoLabel}
+          aria-expanded={infoOpen}
+          onClick={() => setInfoOpen((v) => !v)}
+          className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 12 }} />
+        </button>
+        <button
+          type="button"
+          data-testid={`${testidPrefix}-remove`}
+          aria-label={removeLabel}
+          onClick={() => {
+            setInfoOpen(false);
+            onRemove();
+          }}
+          className="shrink-0 rounded p-1 text-muted-foreground hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
+        </button>
+      </div>
+      {infoOpen ? (
+        <div className="mt-2 flex flex-col gap-1.5 rounded-lg bg-card/80 p-2 text-[11px] leading-snug text-muted-foreground">
+          {tips}
+        </div>
       ) : null}
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-variants.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-variants.tsx
@@ -66,7 +66,14 @@ export function QuestionVariants({
     }
     const first = prior.find((s) => hasOptions(s.type)) ?? prior[0];
     if (!first) return;
-    onUpdate({ questionField: first.key, questionVariants: step.questionVariants ?? {} });
+    // Seed ONE empty variant row on enable so the pattern is visible (V4-09),
+    // but preserve any rows the author already authored (non-destructive
+    // re-enable) — only seed when there are none yet (ignoring the `*` fallback).
+    const existing = step.questionVariants ?? {};
+    const hasRows = Object.keys(existing).some((k) => k !== FALLBACK);
+    const firstOption = hasOptions(first.type) ? first.options?.[0]?.value : undefined;
+    const nextVariants = hasRows ? existing : { ...existing, [firstOption ?? 'value_1']: '' };
+    onUpdate({ questionField: first.key, questionVariants: nextVariants });
   }
 
   function setVariant(key: string, text: string) {
@@ -108,6 +115,10 @@ export function QuestionVariants({
   }
 
   function addVariant() {
+    // Don't stack empty rows: if a blank variant is already open, keep filling
+    // that one. This also absorbs the row seeded on enable, so clicking "Add
+    // variant" right after enabling reuses it instead of adding a second.
+    if (rows.some((k) => !(variants[k] ?? '').trim())) return;
     const taken = new Set(rows);
     const free = sourceOptions?.find((o) => !taken.has(o.value))?.value;
     const key = free ?? `value_${rows.length + 1}`;
@@ -224,6 +235,13 @@ export function QuestionVariants({
             <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
           </Button>
 
+          <p
+            className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground"
+            data-testid="variants-scope-note"
+          >
+            <i aria-hidden className="pi pi-info-circle mt-0.5" style={{ fontSize: 10 }} />
+            {m.scopeNote}
+          </p>
           <p className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
             <i aria-hidden className="pi pi-info-circle mt-0.5" style={{ fontSize: 10 }} />
             {m.interpolationHint}

--- a/apps/web/app/admin/forms/[id]/edit/_components/results-view.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/results-view.tsx
@@ -6,7 +6,7 @@ import { createEmptyOutcome } from '@quill/engine';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
-import { TextField, NumberField } from './fields';
+import { TextField, NumberField, TextArea } from './fields';
 import { iconForStep } from './question-types';
 import { maxScore, scoringSteps } from './scoring-util';
 import type { BuilderMessages } from './builder-messages';
@@ -144,9 +144,27 @@ export function ResultsView({
                     <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
                   </Button>
                 </div>
-                {/* The label above IS the message respondents see on the thank-you
+                {/* The label above IS the heading respondents see on the thank-you
                     screen when their score lands in this range. */}
                 <p className="mt-1.5 pl-[64px] text-[11px] text-muted-foreground">{rm.outcomeHeadingHelp}</p>
+                {/* Per-outcome thank-you BODY (V4-16): the editable "page" shown
+                    for this range; empty falls back to the shared thank-you body.
+                    Interpolation of [field] tokens happens in the renderer. */}
+                <div className="mt-2.5 flex flex-col gap-1 pl-[64px]">
+                  <label htmlFor={`outcome-message-${o.id}`} className="text-xs font-medium text-foreground">
+                    {rm.messageLabel}
+                  </label>
+                  <TextArea
+                    id={`outcome-message-${o.id}`}
+                    value={o.message ?? ''}
+                    rows={2}
+                    placeholder={m.results.messagePlaceholder}
+                    onChange={(e) => update(index, { message: e.target.value || null })}
+                    data-testid="outcome-message"
+                    className="text-xs"
+                  />
+                  <p className="text-[11px] text-muted-foreground">{rm.messageHelp}</p>
+                </div>
                 {/* Redirect is a clearly-separate, optional URL — normalized to
                     https:// on blur so a schemeless entry never 400s the save. */}
                 <div className="mt-2.5 flex flex-col gap-1 pl-[64px]">

--- a/apps/web/app/admin/forms/[id]/edit/_components/results-view.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/results-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import type { FormConfig, FormOutcome, FormStep } from '@quill/engine';
 import { createEmptyOutcome } from '@quill/engine';
 import { Switch } from '@/components/ui/switch';
@@ -10,6 +11,7 @@ import { iconForStep } from './question-types';
 import { maxScore, scoringSteps } from './scoring-util';
 import type { BuilderMessages } from './builder-messages';
 import { tb } from './builder-messages';
+import type { EditorMessages } from './messages';
 
 /**
  * Unified Scoring & Results — one coherent story: LEFT the points each question
@@ -23,15 +25,22 @@ export function ResultsView({
   onScoringChange,
   onOutcomesChange,
   m,
+  rm,
 }: {
   config: FormConfig;
   onScoringChange: (enabled: boolean) => void;
   onOutcomesChange: (next: FormOutcome[]) => void;
   m: BuilderMessages;
+  /** Results-tab clarity strings from the shared catalog (admin.editor.resultsHelp). */
+  rm: EditorMessages['resultsHelp'];
 }) {
   const enabled = config.scoring?.enabled !== false;
   const top = maxScore(config);
   const questions = scoringSteps(config);
+  // Real question numbers: map each step to its position in the FULL step list,
+  // so a scored slider at question 5 reads "5" — not its index in the filtered
+  // scoring list. Reference identity holds (filter doesn't clone the steps).
+  const stepIndex = new Map<FormStep, number>(config.steps.map((s, i) => [s, i]));
   const outcomes = [...(config.outcomes ?? [])].sort((a, b) => (a.minScore ?? 0) - (b.minScore ?? 0));
 
   function update(index: number, patch: Partial<FormOutcome>) {
@@ -69,8 +78,8 @@ export function ResultsView({
           </p>
         ) : (
           <div className="flex flex-col gap-3">
-            {questions.map((q, i) => (
-              <PointsCard key={q.key} step={q} index={i} m={m} />
+            {questions.map((q) => (
+              <PointsCard key={q.key} step={q} index={stepIndex.get(q) ?? 0} m={m} />
             ))}
           </div>
         )}
@@ -93,9 +102,12 @@ export function ResultsView({
             const lower = o.minScore ?? 0;
             const upper = outcomes[index + 1]?.minScore;
             const range = upper != null ? `${lower}–${upper - 1}` : `${lower}+`;
-            const isRedirect = !!o.redirectUrl;
             return (
-              <div key={o.id} className="rounded-xl border border-border bg-background p-3.5">
+              <div
+                key={o.id}
+                data-testid="outcome-row"
+                className="rounded-xl border border-border bg-background p-3.5"
+              >
                 <div className="flex items-center gap-3">
                   <span
                     className={cn(
@@ -112,12 +124,14 @@ export function ResultsView({
                     placeholder={m.results.rangeLabelPlaceholder}
                     onChange={(e) => update(index, { label: e.target.value })}
                     className="flex-1 font-medium"
+                    data-testid="outcome-label"
                   />
                   <div className="w-20 shrink-0">
                     <NumberField
                       aria-label={m.results.rangeLabel}
                       value={lower}
                       onChange={(e) => update(index, { minScore: Number(e.target.value) || 0 })}
+                      data-testid="outcome-minscore"
                     />
                   </div>
                   <Button
@@ -130,24 +144,22 @@ export function ResultsView({
                     <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
                   </Button>
                 </div>
-                <div className="mt-2.5 flex items-center gap-2 pl-[64px]">
-                  {isRedirect ? (
-                    <span className="inline-flex items-center gap-1 rounded-md bg-secondary/15 px-2 py-1 text-xs font-semibold text-secondary">
-                      <i aria-hidden className="pi pi-external-link" style={{ fontSize: 10 }} />
-                      {m.results.redirect}
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs font-semibold text-muted-foreground">
-                      <i aria-hidden className="pi pi-comment" style={{ fontSize: 10 }} />
-                      {m.results.thankYouMessage}
-                    </span>
-                  )}
-                  <TextField
-                    value={o.redirectUrl ?? ''}
+                {/* The label above IS the message respondents see on the thank-you
+                    screen when their score lands in this range. */}
+                <p className="mt-1.5 pl-[64px] text-[11px] text-muted-foreground">{rm.outcomeHeadingHelp}</p>
+                {/* Redirect is a clearly-separate, optional URL — normalized to
+                    https:// on blur so a schemeless entry never 400s the save. */}
+                <div className="mt-2.5 flex flex-col gap-1 pl-[64px]">
+                  <label htmlFor={`outcome-redirect-${o.id}`} className="text-xs font-medium text-foreground">
+                    {rm.redirectLabel}
+                  </label>
+                  <RedirectField
+                    id={`outcome-redirect-${o.id}`}
+                    value={o.redirectUrl ?? null}
                     placeholder={m.results.redirectPlaceholder}
-                    onChange={(e) => update(index, { redirectUrl: e.target.value || null })}
-                    className="flex-1 text-xs"
+                    onCommit={(url) => update(index, { redirectUrl: url })}
                   />
+                  <p className="text-[11px] text-muted-foreground">{rm.redirectHelp}</p>
                 </div>
               </div>
             );
@@ -156,6 +168,7 @@ export function ResultsView({
           <button
             type="button"
             onClick={addRange}
+            data-testid="results-add-range"
             className="flex items-center justify-center gap-2 rounded-xl border border-dashed border-border py-3 text-sm font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} />
@@ -203,14 +216,76 @@ function ScoreBar({ outcomes, top, m }: { outcomes: FormOutcome[]; top: number; 
   );
 }
 
+/**
+ * Normalize a user-typed redirect: prepend `https://` when the scheme is omitted
+ * (so `example.com` becomes a valid URL the schema accepts instead of 400-ing);
+ * an empty value → null (no redirect → the respondent sees the thank-you screen).
+ */
+function normalizeRedirect(raw: string): string | null {
+  const v = raw.trim();
+  if (!v) return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return v; // already carries a scheme
+  return `https://${v}`;
+}
+
+/**
+ * Redirect input that holds a local draft while typing and only commits a
+ * NORMALIZED URL on blur — so autosave never fires a schemeless (doomed) URL,
+ * and `example.com` is silently upgraded to `https://example.com`.
+ */
+function RedirectField({
+  id,
+  value,
+  placeholder,
+  onCommit,
+}: {
+  id: string;
+  value: string | null;
+  placeholder: string;
+  onCommit: (url: string | null) => void;
+}) {
+  const [draft, setDraft] = useState(value ?? '');
+  // Re-sync when the stored value changes elsewhere (e.g. ranges re-sorted).
+  useEffect(() => {
+    setDraft(value ?? '');
+  }, [value]);
+  return (
+    <TextField
+      id={id}
+      type="url"
+      inputMode="url"
+      value={draft}
+      placeholder={placeholder}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => {
+        const normalized = normalizeRedirect(draft);
+        if (normalized !== (value ?? null)) onCommit(normalized);
+        setDraft(normalized ?? '');
+      }}
+      className="text-xs"
+      data-testid="outcome-redirect"
+    />
+  );
+}
+
 /** One question's points, read-through from its options/slider ranges. */
 function PointsCard({ step, index, m }: { step: FormStep; index: number; m: BuilderMessages }) {
-  void index;
   return (
     <div className="rounded-xl border border-border bg-background p-3.5">
-      <p className="mb-2.5 flex items-center gap-2 text-sm font-semibold text-foreground">
+      <p
+        className="mb-2.5 flex items-center gap-2 text-sm font-semibold text-foreground"
+        data-testid="points-question"
+      >
+        {/* Real question number = position in the FULL step list, so a scored
+            slider that is question 5 reads "5" (not its filtered index). */}
+        <span
+          data-testid="points-question-number"
+          className="inline-flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded bg-muted px-1 text-xs font-bold tabular-nums text-muted-foreground"
+        >
+          {index + 1}
+        </span>
         <i aria-hidden className={`pi ${iconForStep(step)} text-muted-foreground`} style={{ fontSize: 12 }} />
-        {step.question?.trim() || tb(m.canvas.questionN, { n: index + 1 })}
+        <span className="min-w-0 truncate">{step.question?.trim() || tb(m.canvas.questionN, { n: index + 1 })}</span>
       </p>
       {step.type === 'slider' ? (
         <div className="flex flex-wrap gap-2">

--- a/apps/web/app/admin/forms/[id]/edit/_components/scoring-util.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scoring-util.ts
@@ -24,9 +24,16 @@ export function maxStepPoints(step: FormStep): number {
   return Math.max(0, step.points ?? 0);
 }
 
+/** The highest total score reachable across a list of steps (option/slider
+ *  points summed). Shared by {@link maxScore} and the builder's per-question
+ *  scoring hint, which receives the steps array but not the whole config. */
+export function maxScoreForSteps(steps: FormStep[]): number {
+  return steps.reduce((sum, s) => sum + maxStepPoints(s), 0);
+}
+
 /** The highest total score a respondent could reach across all scoring steps. */
 export function maxScore(config: FormConfig): number {
-  return config.steps.reduce((sum, s) => sum + maxStepPoints(s), 0);
+  return maxScoreForSteps(config.steps);
 }
 
 /** Steps that actually contribute points (for the Results points panel). */

--- a/apps/web/app/admin/forms/[id]/edit/_components/slider-scoring-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/slider-scoring-editor.tsx
@@ -20,6 +20,7 @@ export function SliderScoringEditor({
   }
   return (
     <div className="flex flex-col gap-2">
+      <p className="text-[11px] leading-relaxed text-muted-foreground">{m.hint}</p>
       {ranges.length === 0 ? (
         <p className="text-xs text-muted-foreground">{m.empty}</p>
       ) : (

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -13,7 +13,9 @@ import type {
 } from '@quill/engine';
 import { normalizeConfig } from '@quill/engine';
 import type { FormTracking } from '@quill/types';
+import { formConfigSchema } from '@quill/types';
 import { saveFormAction } from '@/app/admin/actions';
+import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
 import { QuestionSpine } from './_components/question-spine';
 import { CanvasQuestion } from './_components/canvas-question';
@@ -38,6 +40,10 @@ import './_components/builder.css';
 type Tab = 'build' | 'logic' | 'connect' | 'results' | 'design';
 type SaveStatus = 'saved' | 'saving' | 'draft' | 'error';
 const AUTOSAVE_MS = 900;
+/** One backoff retry after a failed/transient save so a blip self-heals. */
+const RETRY_MS = 1500;
+/** Same admin API base the server-side admin-api client uses (client-exposed). */
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 
 const TAB_IDS: readonly Tab[] = ['build', 'logic', 'connect', 'results', 'design'];
 /** Unknown/absent `?tab` → build (the default view). */
@@ -95,24 +101,116 @@ export function FormEditor({
   const [status, setStatus] = useState<SaveStatus>(initialConfig.steps.length ? 'saved' : 'draft');
   const [focusCanvas, setFocusCanvas] = useState(0);
   const [saveCount, setSaveCount] = useState(0);
+  // The server's reason for the last failed save — shown in the status tooltip.
+  const [lastError, setLastError] = useState<string | null>(null);
   const dirty = useRef(false);
+  const retry = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Freshest name/config for the leave handlers + retry (no stale closures).
+  const latest = useRef({ name, config });
+  const toast = useToast();
+  const toastRef = useRef(toast);
+  toastRef.current = toast;
 
   // --- Autosave (debounced; each successful save stores an unpublished draft) ---
+  // Bulletproofing: (1) surface WHY a save failed, (2) client-side pre-validate
+  // so a doomed PUT never fires, (4) auto-retry a transient failure once — and
+  // keep `dirty` true until a save actually SUCCEEDS so nothing is silently lost.
   const persist = useCallback(
-    async (nextName: string, nextConfig: FormConfig) => {
+    async (nextName: string, nextConfig: FormConfig, opts?: { isRetry?: boolean }): Promise<boolean> => {
+      const normalized = normalizeConfig(nextConfig);
+      const parsed = formConfigSchema.safeParse(normalized);
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0];
+        const field = issue?.path.join('.') || 'config';
+        const reason = `${field}: ${issue?.message ?? 'invalid value'}`;
+        setStatus('error');
+        setLastError(reason);
+        console.error('[forms] autosave blocked — config failed validation:', reason, parsed.error.issues);
+        toastRef.current.error(tb(m.saveInvalid, { reason }));
+        return false; // dirty stays true; the next edit re-attempts
+      }
       setStatus('saving');
-      const res = await saveFormAction(id, { name: nextName, config: normalizeConfig(nextConfig) });
-      setStatus(res.ok ? 'saved' : 'error');
-      if (res.ok) setSaveCount((n) => n + 1);
+      const res = await saveFormAction(id, { name: nextName, config: normalized });
+      if (res.ok) {
+        dirty.current = false;
+        setStatus('saved');
+        setLastError(null);
+        setSaveCount((n) => n + 1);
+        return true;
+      }
+      const reason = res.message ?? 'unknown error';
+      console.error('[forms] autosave failed:', reason);
+      setStatus('error');
+      setLastError(reason);
+      if (!opts?.isRetry) {
+        toastRef.current.error(tb(m.saveErrorReason, { reason }));
+        if (retry.current) clearTimeout(retry.current);
+        retry.current = setTimeout(() => {
+          void persist(latest.current.name, latest.current.config, { isRetry: true });
+        }, RETRY_MS);
+      }
+      return false; // dirty stays true until a save actually succeeds
     },
-    [id],
+    [id, m],
   );
+
+  useEffect(() => {
+    latest.current = { name, config };
+  }, [name, config]);
 
   useEffect(() => {
     if (!dirty.current) return;
     const t = setTimeout(() => void persist(name, config), AUTOSAVE_MS);
     return () => clearTimeout(t);
   }, [name, config, persist]);
+
+  // (3) Flush a pending (debounced) save on leave so a change still sitting in
+  // the debounce window is never dropped. `beacon` = a keepalive PUT that
+  // survives a hard tab close/reload; the SPA-nav + tab-hidden paths use the
+  // cookie-authed server action (the component is still able to fire it).
+  const flush = useCallback(
+    (beacon: boolean) => {
+      if (!dirty.current) return;
+      const { name: n, config: c } = latest.current;
+      const normalized = normalizeConfig(c);
+      if (!formConfigSchema.safeParse(normalized).success) return; // never flush invalid config
+      if (beacon) {
+        try {
+          void fetch(`${API_BASE}/v1/forms/${id}`, {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ name: n, config: normalized }),
+            keepalive: true,
+            credentials: 'include',
+          });
+        } catch {
+          /* best-effort on the unload path — nothing to recover to */
+        }
+      } else {
+        void persist(n, c);
+      }
+    },
+    [id, persist],
+  );
+  const flushRef = useRef(flush);
+  useEffect(() => {
+    flushRef.current = flush;
+  }, [flush]);
+
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') flushRef.current(false);
+    };
+    const onBeforeUnload = () => flushRef.current(true);
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      if (retry.current) clearTimeout(retry.current);
+      flushRef.current(false); // SPA nav / unmount → reliable server-action flush
+    };
+  }, []); // subscribe once; the cleanup flushes exactly once on real unmount
 
   function mutate(updater: (c: FormConfig) => FormConfig) {
     dirty.current = true;
@@ -188,7 +286,9 @@ export function FormEditor({
   function applyTemplate(tid: TemplateId) {
     const cfg = TEMPLATES[tid];
     dirty.current = true;
-    setName(bm.empty.templates[tid].name);
+    // Preserve a name the user already typed; only fall back to the template's
+    // name when the field is still blank (V4-11 — templates swap config, not name).
+    setName((n) => (n.trim() ? n : bm.empty.templates[tid].name));
     setConfig(cfg);
     setSelected(0);
     setTab('build');
@@ -251,7 +351,16 @@ export function FormEditor({
           aria-label={bm.shell.formNamePlaceholder}
           className="min-w-0 max-w-[38ch] flex-1 rounded-md border border-transparent bg-transparent px-1.5 py-1 text-base font-semibold tracking-tight hover:border-border focus-visible:border-input focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:flex-none sm:text-lg"
         />
-        <span className="hidden items-center gap-1.5 text-xs text-muted-foreground sm:inline-flex">
+        <span
+          className={cn(
+            'hidden items-center gap-1.5 text-xs text-muted-foreground sm:inline-flex',
+            status === 'error' && lastError ? 'cursor-help' : '',
+          )}
+          data-testid="editor-save-status"
+          data-status={status}
+          // Native tooltip: hover the "Not saved" indicator to read WHY it failed.
+          title={status === 'error' && lastError ? tb(m.saveErrorReason, { reason: lastError }) : undefined}
+        >
           <span className={cn('h-1.5 w-1.5 rounded-full', statusDot)} />
           {statusLabel}
         </span>
@@ -452,6 +561,7 @@ export function FormEditor({
               onScoringChange={setScoring}
               onOutcomesChange={setOutcomes}
               m={bm}
+              rm={m.resultsHelp}
             />
           </div>
         ) : (

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -51,6 +51,41 @@ const parseTab = (value: string | null): Tab =>
   TAB_IDS.includes(value as Tab) ? (value as Tab) : 'build';
 
 /**
+ * Re-anchor a 1-based flow marker position (partialSubmitAfterStep /
+ * revealAfterStep) after a step is DELETED, keeping it attached to the step it
+ * sits AFTER: a delete ABOVE the anchor shifts it up one; deleting the anchor
+ * itself re-attaches to the previous step (clearing when it was the first);
+ * deletes BELOW never move it. Absent/out-of-range positions pass through.
+ */
+function reanchorAfterDelete(
+  pos: number | undefined,
+  deletedIndex: number,
+  prevLen: number,
+): number | undefined {
+  if (pos == null || pos < 1 || pos > prevLen) return pos;
+  if (deletedIndex < pos - 1) return pos - 1;
+  if (deletedIndex === pos - 1) return pos > 1 ? pos - 1 : undefined;
+  return pos;
+}
+
+/**
+ * Re-anchor a 1-based flow marker position after a REORDER: resolve the step it
+ * was anchored after in the OLD order, then point at that step's NEW index so
+ * the marker follows its anchor question. Absent/out-of-range positions pass
+ * through unchanged.
+ */
+function reanchorAfterReorder(
+  pos: number | undefined,
+  oldSteps: FormStep[],
+  newSteps: FormStep[],
+): number | undefined {
+  if (pos == null || pos < 1 || pos > oldSteps.length) return pos;
+  const anchorKey = oldSteps[pos - 1]?.key;
+  const anchored = newSteps.findIndex((s) => s.key === anchorKey);
+  return anchored >= 0 ? anchored + 1 : pos;
+}
+
+/**
  * The redesigned builder shell: Build (spine · WYSIWYG canvas · settings),
  * Logic (editable map), Results (scoring + ranges), Design (cover + branding),
  * with debounced autosave and a Publish primary action. The guided empty state
@@ -241,16 +276,14 @@ export function FormEditor({
   function deleteStep(index: number) {
     mutate((c) => {
       const steps = c.steps.filter((_, i) => i !== index);
-      // Partial-submit threshold (1-based, anchored to the step it fires AFTER):
-      // deleting a step ABOVE the anchor shifts it up one; deleting the anchor
-      // ITSELF re-attaches to the previous step (or clears when the anchor was
-      // the first step); steps BELOW the anchor never move it.
-      let partial = c.partialSubmitAfterStep;
-      if (partial != null && partial >= 1 && partial <= c.steps.length) {
-        if (index < partial - 1) partial = partial - 1;
-        else if (index === partial - 1) partial = partial > 1 ? partial - 1 : undefined;
-      }
-      return { ...c, steps, partialSubmitAfterStep: partial };
+      // Keep both 1-based flow markers (partial-submit + reveal) anchored to the
+      // step they fire AFTER when a step is deleted.
+      return {
+        ...c,
+        steps,
+        partialSubmitAfterStep: reanchorAfterDelete(c.partialSubmitAfterStep, index, c.steps.length),
+        revealAfterStep: reanchorAfterDelete(c.revealAfterStep, index, c.steps.length),
+      };
     });
     setSelected((sel) => {
       const nextLen = config.steps.length - 1;
@@ -265,15 +298,13 @@ export function FormEditor({
       const [moved] = steps.splice(from, 1);
       if (!moved) return c;
       steps.splice(to, 0, moved);
-      // Keep the partial-submit threshold attached to the step it fires AFTER:
-      // resolve that step's key in the OLD order, then point at its NEW index.
-      let partial = c.partialSubmitAfterStep;
-      if (partial != null && partial >= 1 && partial <= c.steps.length) {
-        const anchorKey = c.steps[partial - 1]?.key;
-        const anchored = steps.findIndex((s) => s.key === anchorKey);
-        if (anchored >= 0) partial = anchored + 1;
-      }
-      return { ...c, steps, partialSubmitAfterStep: partial };
+      // Keep both 1-based flow markers attached to the step they fire AFTER.
+      return {
+        ...c,
+        steps,
+        partialSubmitAfterStep: reanchorAfterReorder(c.partialSubmitAfterStep, c.steps, steps),
+        revealAfterStep: reanchorAfterReorder(c.revealAfterStep, c.steps, steps),
+      };
     });
     setSelected((sel) => {
       if (sel == null) return null;
@@ -305,6 +336,14 @@ export function FormEditor({
     mutate((c) => ({ ...c, reveal: { ...c.reveal, ...patch } }));
   const setPartialSubmitAfterStep = (afterStep: number | undefined) =>
     mutate((c) => ({ ...c, partialSubmitAfterStep: afterStep }));
+  // WHERE the reveal plays (V4-04). Setting a value pins the reveal after that
+  // 1-based step; `undefined` reverts to the engine default (after the last
+  // step). Removing the marker turns the reveal OFF (Design owns enablement) and
+  // clears the position so a later re-enable defaults back to the end.
+  const setRevealAfterStep = (afterStep: number | undefined) =>
+    mutate((c) => ({ ...c, revealAfterStep: afterStep }));
+  const removeReveal = () =>
+    mutate((c) => ({ ...c, reveal: { ...c.reveal, enabled: false }, revealAfterStep: undefined }));
   // `tracking` is additive config the engine type omits; the autosave/publish
   // flow round-trips it (normalizeConfig passes unknown top-level keys through).
   const setTracking = (tracking: FormTracking | undefined) =>
@@ -312,6 +351,9 @@ export function FormEditor({
 
   const selectedStep = selected != null ? config.steps[selected] : undefined;
   const scoringEnabled = config.scoring?.enabled !== false;
+  // Mirrors the renderer/engine gate: the reveal marker shows when reveal exists
+  // AND is not explicitly disabled.
+  const revealEnabled = config.reveal != null && config.reveal.enabled !== false;
   const hasQuestions = config.steps.length > 0;
 
   const tabs: { id: Tab; label: string; icon: string }[] = [
@@ -442,6 +484,10 @@ export function FormEditor({
                   onAdd={() => setGalleryOpen(true)}
                   partialAfterStep={config.partialSubmitAfterStep}
                   onPartialChange={setPartialSubmitAfterStep}
+                  revealEnabled={revealEnabled}
+                  revealAfterStep={config.revealAfterStep}
+                  onRevealMove={setRevealAfterStep}
+                  onRevealRemove={removeReveal}
                   m={bm}
                 />
               </aside>
@@ -530,6 +576,9 @@ export function FormEditor({
                     formId={id}
                     locale={locale}
                     onOpenConnect={() => setTab('connect')}
+                    onOpenDesign={() => setTab('design')}
+                    revealAfterStep={config.revealAfterStep}
+                    onRevealAfterStepChange={setRevealAfterStep}
                   />
                 ) : null}
               </aside>

--- a/apps/web/components/public/phone-input.tsx
+++ b/apps/web/components/public/phone-input.tsx
@@ -37,6 +37,20 @@ function defaultCountryForLocale(locale: string): Country {
   return US;
 }
 
+/**
+ * The country the picker starts on: the form's configured `defaultCountry`
+ * (ISO alpha-2, e.g. "CO") when it resolves to a known country, else the
+ * locale-based default. A bad/unknown code can only fall back, never break.
+ */
+function initialCountry(defaultCountry: string | null | undefined, locale: string): Country {
+  if (defaultCountry) {
+    const code = defaultCountry.trim().toUpperCase();
+    const found = COUNTRIES.find((c) => c.code === code);
+    if (found) return found;
+  }
+  return defaultCountryForLocale(locale);
+}
+
 /** The country a value implies. Shared dials (+1 is US/CA/…) are ambiguous:
  *  keep the already-picked country when it fits, else fall back to US. */
 function deriveCountry(value: string, picked: Country): Country {
@@ -51,6 +65,7 @@ export function PhoneInput({
   onChange,
   locale = 'en',
   ariaLabel,
+  defaultCountry,
 }: {
   /** Full number including the dial code ('+525512345678'), or ''. */
   value: string;
@@ -59,12 +74,14 @@ export function PhoneInput({
   locale?: string;
   /** aria-label for the digits input (the step question). */
   ariaLabel?: string;
+  /** Per-form default country (ISO alpha-2, e.g. "CO"); falls back to locale. */
+  defaultCountry?: string | null;
 }) {
   const m = getMessages(locale).renderer.phonePicker;
   const listId = useId();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const [picked, setPicked] = useState<Country>(() => defaultCountryForLocale(locale));
+  const [picked, setPicked] = useState<Country>(() => initialCountry(defaultCountry, locale));
 
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -86,6 +86,7 @@ export function StepInput({
           onChange={onChange}
           locale={locale}
           ariaLabel={step.question ?? step.key}
+          defaultCountry={step.phoneDefaultCountry ?? undefined}
         />
       );
 

--- a/docs/feedback-v4/README.md
+++ b/docs/feedback-v4/README.md
@@ -1,0 +1,99 @@
+# July 20 2026 — bug-fix round (post manual QA)
+
+This round turns a session of hands-on manual testing (building forms A→D) into
+fixes: 6 failures, 5 blockers, and 16 improvements the tester logged. The root
+blocker — nothing in the Results/scoring panel would save — was fixed first,
+because it made the whole score→outcome chain untestable.
+
+Every change is additive to the versioned `formConfig` (no schema migration),
+covered by Playwright e2e, and validated end to end against a live server. The
+full evidence: 415 package tests, Postgres parity 52/52, 59 e2e green (0 product
+regressions), and a confirmed score→outcome→message chain.
+
+## The root blocker — autosave
+
+**Bug:** clicking "Add a range" in Results showed "Saving… → Not saved" and
+nothing persisted, so the tester could not exercise scoring at all.
+
+**Cause:** "Add a range" created an outcome with an empty `label`, which the
+config schema rejected (`label.min(1)`) → HTTP 400 on every autosave, and the
+invalid outcome stayed in state so **every** later edit also 400'd. The error
+was swallowed into a bare "Not saved".
+
+**Fix:** empty outcome labels are allowed (superset — every prior config still
+parses), and autosave is now reliable across **every** tab:
+- surfaces the real server error instead of a silent "Not saved";
+- client-pre-validates the config before the request;
+- retries a transient failure once;
+- **flushes a pending save when you leave mid-debounce** — SPA nav,
+  `visibilitychange`, and a `keepalive` `beforeunload` PUT — so no edit is lost;
+- normalizes a scheme-less redirect (`example.com` → `https://example.com`) so
+  autosave never fires a 400-ing URL.
+
+## Scoring (was blocked)
+
+- **Per-option points** are a wider, labeled, hinted column that accepts
+  **negatives**; the slider From/To/Points editor now shows for every slider
+  (no longer hidden behind the form-wide Scoring toggle, which is now labeled as
+  form-wide). A nudge appears when scoring is on but the max is still 0.
+- **`NumberField`** no longer leaves a leading zero (`01`→`1`), allows empty, and
+  accepts negatives — fixing every number box in the editor.
+- **Results numbering**: the Points card now uses each step's real position (a
+  slider at question 5 reads "5", not the filtered "2").
+
+**Verified end to end:** a scored form (MC 10/5/0 + slider ranges + 3 outcome
+ranges) saves cleanly, and three real submissions route correctly — score 0 →
+"Low fit", 10 → "Mid fit" (interpolating `[email]`), 20 → "High fit" — each with
+its own message.
+
+## Logic
+
+- **Operators by field type** (additive `op`/`value`/`min`/`max` on the
+  condition): choice fields keep "matches any of"; slider/number fields get
+  **equal / greater / less / between**. Back-compat: a bare `{field, values}`
+  still means "in".
+- **Contradiction guard**: an inline warning when show-when and hide-when
+  provably contradict on the same field.
+- **Dynamic question**: enabling "Vary the question by a field" seeds a default
+  variant so the pattern is clear (a variant only swaps the title; branch flow
+  with Logic).
+
+## Reveal + outcomes
+
+- **Reveal position** is an additive `config.revealAfterStep`, surfaced as a
+  **draggable marker in the question list** (like the partial-submit point) that
+  **defaults to the end** — fixing the bug where enabling the reveal on the
+  selected Q1 dropped it mid-form. `triggersReveal` is kept as a back-compat
+  fallback. A Behavior "Edit reveal screen" button jumps to Design.
+- **Per-outcome message**: outcomes gain an optional `message` body, editable per
+  score range and rendered (interpolated) on the done screen — each range can
+  show its own copy.
+
+## Fields + prefill
+
+- **Hidden questions** (`step.hidden`) + **real URL-parameter prefill**: open a
+  form with `?fieldkey=value` and that field is prefilled/submitted; a hidden
+  step isn't shown but its URL-supplied value rides into the submission. Scoped
+  to declared fields only, values capped, re-validated server-side.
+- **Per-form phone default country** (`step.phoneDefaultCountry`, ISO-2).
+- **`@` recall in the description**, backed by real engine interpolation of the
+  helper text (previously only the title interpolated).
+
+## Editor polish
+
+- **Template picker** preserves the name you typed (no more "Prueba QA" →
+  "Lead qualifier"); "Start from scratch" leads; clearer cursor/hover.
+- **Logic view** redesigned: distinct Start/question/ending nodes, labeled
+  "If X → …" branch edges, a traceable "Otherwise" path, calm connectors
+  (reduced-motion aware).
+- Name-step field keys are hinted as URL-prefill parameters; "Personal email
+  only" is hidden on the first question (impossible there).
+
+## Verification
+
+- **415** package tests, typecheck + lint 16/16.
+- **Postgres parity 52/52** (no new migration — all fields are additive on the
+  jsonb config).
+- **59** Playwright e2e green (26 new `v4-*` + 33 regression); the one non-pass
+  was an environmental flake that passed on isolated re-run. **0 product
+  regressions.**

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -85,6 +85,19 @@ describe('visibleSteps', () => {
     expect(visibleSteps(cfg, { skip: 'yes' })).toHaveLength(0);
     expect(visibleSteps(cfg, { skip: 'no' })).toHaveLength(1);
   });
+
+  it('skips a hidden step (never walked, never scored — its answer only rides along)', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: 'plan', type: 'text' }),
+        step({ key: 'source', type: 'text', hidden: true }),
+      ],
+    };
+    // The hidden step is absent from the walk even though it has an answer.
+    expect(visibleSteps(cfg, { source: 'ads' }).map((s) => s.key)).toEqual(['plan']);
+    expect(runtimeSteps(cfg, { source: 'ads' }).map((s) => s.key)).toEqual(['plan']);
+  });
 });
 
 describe('operatorsForFieldType (V4-07 — operators by field type)', () => {
@@ -550,6 +563,20 @@ describe('interpolate + resolveStepDisplay', () => {
     const resolved = resolveStepDisplay(s, { problem: 'leads', firstname: 'Sam' });
     expect(resolved.question).toBe('How many leads, Sam?');
     expect(resolved.sliderUnitLabel).toBe('leads / mo');
+  });
+
+  it('interpolates [key] tokens in the helper/description with the same sweep', () => {
+    const s = step({ key: 'x', type: 'text', question: 'Q', helper: 'Details for [firstname]' });
+    // Resolved: the token substitutes verbatim.
+    expect(resolveStepDisplay(s, { firstname: 'Sam' }).helper).toBe('Details for Sam');
+    // Trailing empty token sweeps the connector in front of it (no "Details for ").
+    expect(resolveStepDisplay(s, {}).helper).toBe('Details for');
+    // Embedded empty token keeps a following connector, drops the preceding space.
+    const s2 = step({ key: 'y', type: 'text', helper: 'Hi [firstname], read on' });
+    expect(resolveStepDisplay(s2, {}).helper).toBe('Hi, read on');
+    // A null/undefined helper is left untouched (not coerced to a string).
+    expect(resolveStepDisplay(step({ key: 'z', type: 'text' }), {}).helper).toBeUndefined();
+    expect(resolveStepDisplay(step({ key: 'z', type: 'text', helper: null }), {}).helper).toBeNull();
   });
 });
 

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -12,6 +12,7 @@ import {
   runtimeSteps,
   isMultiSelect,
   partialSubmitKey,
+  revealAfterKey,
   nameFields,
   isSafeHttpUrl,
   isSafeImageUrl,
@@ -610,6 +611,50 @@ describe('partialSubmitKey', () => {
   it('resolves the 1-based threshold step key or null', () => {
     expect(partialSubmitKey({ ...config, partialSubmitAfterStep: 4 })).toBe('email');
     expect(partialSubmitKey(config)).toBeNull();
+  });
+});
+
+describe('revealAfterKey (V4-04 — reveal position resolution)', () => {
+  const threeSteps: FormStep[] = [
+    step({ key: 'q1', type: 'text' }),
+    step({ key: 'q2', type: 'text' }),
+    step({ key: 'q3', type: 'text' }),
+  ];
+  const base: FormConfig = { version: 1, steps: threeSteps, reveal: { enabled: true } };
+
+  it('returns null when the reveal is absent or disabled', () => {
+    expect(revealAfterKey({ version: 1, steps: threeSteps })).toBeNull();
+    expect(revealAfterKey({ version: 1, steps: threeSteps, reveal: { enabled: false } })).toBeNull();
+    // Enabled but no steps → nothing to fire after.
+    expect(revealAfterKey({ version: 1, steps: [], reveal: { enabled: true } })).toBeNull();
+  });
+
+  it('defaults an enabled reveal to AFTER THE LAST step (never mid-form)', () => {
+    expect(revealAfterKey(base)).toBe('q3');
+    // `enabled` absent (but reveal present) is treated as on, mirroring the renderer gate.
+    expect(revealAfterKey({ version: 1, steps: threeSteps, reveal: {} })).toBe('q3');
+  });
+
+  it('honors revealAfterStep (1-based) when set + in range', () => {
+    expect(revealAfterKey({ ...base, revealAfterStep: 1 })).toBe('q1');
+    expect(revealAfterKey({ ...base, revealAfterStep: 2 })).toBe('q2');
+    expect(revealAfterKey({ ...base, revealAfterStep: 3 })).toBe('q3');
+  });
+
+  it('falls back to triggersReveal, then default-last, when revealAfterStep is unset/out-of-range', () => {
+    const withTrigger: FormConfig = {
+      version: 1,
+      reveal: { enabled: true },
+      steps: [threeSteps[0]!, { ...threeSteps[1]!, triggersReveal: true }, threeSteps[2]!],
+    };
+    // Back-compat: the legacy per-step boolean still places the reveal in place.
+    expect(revealAfterKey(withTrigger)).toBe('q2');
+    // revealAfterStep wins over triggersReveal when both are present.
+    expect(revealAfterKey({ ...withTrigger, revealAfterStep: 1 })).toBe('q1');
+    // Out-of-range revealAfterStep is ignored → falls back to triggersReveal.
+    expect(revealAfterKey({ ...withTrigger, revealAfterStep: 99 })).toBe('q2');
+    // Out-of-range with no trigger → default-last.
+    expect(revealAfterKey({ ...base, revealAfterStep: 0 })).toBe('q3');
   });
 });
 

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -15,8 +15,12 @@ import {
   nameFields,
   isSafeHttpUrl,
   isSafeImageUrl,
+  operatorsForFieldType,
+  conditionsContradict,
   type FormConfig,
   type FormStep,
+  type StepCondition,
+  type Answers,
 } from './form-logic';
 
 const step = (partial: Partial<FormStep> & Pick<FormStep, 'key' | 'type'>): FormStep => partial;
@@ -79,6 +83,162 @@ describe('visibleSteps', () => {
     };
     expect(visibleSteps(cfg, { skip: 'yes' })).toHaveLength(0);
     expect(visibleSteps(cfg, { skip: 'no' })).toHaveLength(1);
+  });
+});
+
+describe('operatorsForFieldType (V4-07 — operators by field type)', () => {
+  it('offers the numeric comparison set for slider', () => {
+    expect(operatorsForFieldType('slider')).toEqual(['eq', 'gt', 'lt', 'between']);
+  });
+
+  it('keeps "matches any of" (in) for choice / text / email', () => {
+    for (const t of ['multiple_choice', 'dropdown', 'text', 'email', 'name', 'phone'] as const) {
+      expect(operatorsForFieldType(t)).toEqual(['in']);
+    }
+  });
+});
+
+describe('conditionHolds operators (V4-07 — via visibleSteps)', () => {
+  /** A slider `n` followed by a text step gated by `cond` (show or hide). */
+  const gated = (cond: StepCondition, which: 'showWhen' | 'hideWhen' = 'showWhen'): FormConfig => ({
+    version: 1,
+    steps: [
+      step({ key: 'n', type: 'slider', min: 0, max: 100 }),
+      step(which === 'showWhen' ? { key: 'g', type: 'text', showWhen: cond } : { key: 'g', type: 'text', hideWhen: cond }),
+    ],
+  });
+  const showsG = (cfg: FormConfig, answers: Answers): boolean =>
+    visibleSteps(cfg, answers).some((s) => s.key === 'g');
+
+  it('eq: visible only on an exact numeric match (numeric strings parse)', () => {
+    const cfg = gated({ field: 'n', op: 'eq', value: 5 });
+    expect(showsG(cfg, { n: 5 })).toBe(true);
+    expect(showsG(cfg, { n: 6 })).toBe(false);
+    expect(showsG(cfg, { n: '5' })).toBe(true);
+  });
+
+  it('gt / lt compare the numeric answer', () => {
+    expect(showsG(gated({ field: 'n', op: 'gt', value: 50 }), { n: 60 })).toBe(true);
+    expect(showsG(gated({ field: 'n', op: 'gt', value: 50 }), { n: 40 })).toBe(false);
+    expect(showsG(gated({ field: 'n', op: 'gt', value: 50 }), { n: 50 })).toBe(false); // strict
+    expect(showsG(gated({ field: 'n', op: 'lt', value: 50 }), { n: 40 })).toBe(true);
+    expect(showsG(gated({ field: 'n', op: 'lt', value: 50 }), { n: 60 })).toBe(false);
+  });
+
+  it('between is inclusive on both bounds', () => {
+    const cfg = gated({ field: 'n', op: 'between', min: 10, max: 20 });
+    expect(showsG(cfg, { n: 10 })).toBe(true);
+    expect(showsG(cfg, { n: 20 })).toBe(true);
+    expect(showsG(cfg, { n: 15 })).toBe(true);
+    expect(showsG(cfg, { n: 9 })).toBe(false);
+    expect(showsG(cfg, { n: 21 })).toBe(false);
+  });
+
+  it('a numeric op never holds for a non-numeric answer or a missing operand', () => {
+    expect(showsG(gated({ field: 'n', op: 'gt', value: 50 }), { n: 'abc' })).toBe(false);
+    expect(showsG(gated({ field: 'n', op: 'gt', value: 50 }), {})).toBe(false);
+    expect(showsG(gated({ field: 'n', op: 'eq' }), { n: 5 })).toBe(false); // no operand
+    expect(showsG(gated({ field: 'n', op: 'between', min: 10 }), { n: 15 })).toBe(false); // half range
+  });
+
+  it('hideWhen honors numeric ops (hide when gt 50)', () => {
+    const cfg = gated({ field: 'n', op: 'gt', value: 50 }, 'hideWhen');
+    expect(showsG(cfg, { n: 60 })).toBe(false); // hidden
+    expect(showsG(cfg, { n: 40 })).toBe(true); // shown
+  });
+
+  it('back-compat: a condition with NO op behaves exactly as `in`', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [
+        step({
+          key: 'c',
+          type: 'multiple_choice',
+          options: [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ],
+        }),
+        step({ key: 'g', type: 'text', showWhen: { field: 'c', values: ['a'] } }),
+      ],
+    };
+    expect(visibleSteps(cfg, { c: 'a' }).some((s) => s.key === 'g')).toBe(true);
+    expect(visibleSteps(cfg, { c: 'b' }).some((s) => s.key === 'g')).toBe(false);
+  });
+});
+
+describe('conditionsContradict (V4-08 — trivial contradiction guard)', () => {
+  it('is false when a side is absent or the fields differ', () => {
+    expect(conditionsContradict(null, null)).toBe(false);
+    expect(conditionsContradict({ field: 'a', values: ['x'] }, null)).toBe(false);
+    expect(conditionsContradict({ field: 'a', values: ['x'] }, { field: 'b', values: ['x'] })).toBe(
+      false,
+    );
+  });
+
+  it('flags identical / subset choice sets on the same field', () => {
+    expect(conditionsContradict({ field: 'a', values: ['x'] }, { field: 'a', values: ['x'] })).toBe(
+      true,
+    );
+    // show ⊆ hide
+    expect(
+      conditionsContradict({ field: 'a', values: ['x'] }, { field: 'a', values: ['x', 'y'] }),
+    ).toBe(true);
+    // show ⊄ hide
+    expect(
+      conditionsContradict({ field: 'a', values: ['x', 'y'] }, { field: 'a', values: ['x'] }),
+    ).toBe(false);
+    // empty show never contradicts
+    expect(conditionsContradict({ field: 'a', values: [] }, { field: 'a', values: [] })).toBe(false);
+  });
+
+  it('flags overlapping numeric ranges (show interval ⊆ hide interval)', () => {
+    expect(
+      conditionsContradict({ field: 'n', op: 'eq', value: 5 }, { field: 'n', op: 'eq', value: 5 }),
+    ).toBe(true);
+    expect(
+      conditionsContradict({ field: 'n', op: 'eq', value: 5 }, { field: 'n', op: 'eq', value: 6 }),
+    ).toBe(false);
+    expect(
+      conditionsContradict(
+        { field: 'n', op: 'between', min: 50, max: 80 },
+        { field: 'n', op: 'between', min: 40, max: 100 },
+      ),
+    ).toBe(true);
+    expect(
+      conditionsContradict(
+        { field: 'n', op: 'between', min: 40, max: 100 },
+        { field: 'n', op: 'between', min: 50, max: 80 },
+      ),
+    ).toBe(false);
+    // x>50 ⊆ x>40 ; x>40 ⊄ x>50
+    expect(
+      conditionsContradict({ field: 'n', op: 'gt', value: 50 }, { field: 'n', op: 'gt', value: 40 }),
+    ).toBe(true);
+    expect(
+      conditionsContradict({ field: 'n', op: 'gt', value: 40 }, { field: 'n', op: 'gt', value: 50 }),
+    ).toBe(false);
+    // x<5 ⊆ x<10
+    expect(
+      conditionsContradict({ field: 'n', op: 'lt', value: 5 }, { field: 'n', op: 'lt', value: 10 }),
+    ).toBe(true);
+    // 60 ∈ [50,80]
+    expect(
+      conditionsContradict(
+        { field: 'n', op: 'eq', value: 60 },
+        { field: 'n', op: 'between', min: 50, max: 80 },
+      ),
+    ).toBe(true);
+  });
+
+  it('is conservative: mixed choice/numeric ops or missing operands never flag', () => {
+    expect(
+      conditionsContradict({ field: 'n', values: ['5'] }, { field: 'n', op: 'eq', value: 5 }),
+    ).toBe(false);
+    // show has no operand → not a well-formed interval
+    expect(conditionsContradict({ field: 'n', op: 'eq' }, { field: 'n', op: 'eq', value: 5 })).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -38,10 +38,38 @@ export interface SliderScoringRange {
   points: number;
 }
 
-/** A visibility condition: the answer to `field` must (not) be one of `values`. */
+/**
+ * Comparison operators a visibility condition can use, picked by the referenced
+ * field's TYPE (see {@link operatorsForFieldType}). `in` is the legacy
+ * "matches any of" set-membership test (choice/text sources); the numeric ops
+ * (`eq`/`gt`/`lt`/`between`) compare the answer parsed as a number.
+ */
+export const CONDITION_OPS = ['in', 'eq', 'gt', 'lt', 'between'] as const;
+export type ConditionOp = (typeof CONDITION_OPS)[number];
+
+/**
+ * A visibility condition on the answer to `field`. ADDITIVE + back-compat: with
+ * NO `op` (every config authored before operators existed) it is an `in` test —
+ * the answer's tokens must intersect `values`. `op` selects the comparison and
+ * which operand it reads:
+ *  - `in`            → `values` (choice "matches any of"; the default).
+ *  - `eq`/`gt`/`lt`  → `value` (the answer parsed as a number, compared to it).
+ *  - `between`       → `[min, max]` inclusive (numeric).
+ * Operands the active op doesn't use are ignored, so an older `{field, values}`
+ * still means exactly what it always did.
+ */
 export interface StepCondition {
   field: string;
-  values: string[];
+  /** `in` operands ("matches any of"). Optional so a numeric op can omit it. */
+  values?: string[];
+  /** Operator (absent = `in`, the legacy behavior). */
+  op?: ConditionOp;
+  /** Operand for `eq` / `gt` / `lt` (the answer is parsed as a number). */
+  value?: number;
+  /** Lower bound for `between` (inclusive). */
+  min?: number;
+  /** Upper bound for `between` (inclusive). */
+  max?: number;
 }
 
 /**
@@ -251,10 +279,50 @@ function tokens(value: AnswerValue): string[] {
   return [String(value)];
 }
 
-/** Does the current answer to `cond.field` intersect `cond.values`? */
+/**
+ * Parse an answer to a finite number, or `null` when it isn't numeric. Only a
+ * number or a non-blank numeric string qualifies — booleans/arrays/objects
+ * (which `Number()` would coerce) do not. Shared by the numeric condition ops.
+ */
+function numericAnswer(value: AnswerValue): number | null {
+  const n =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : NaN;
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Does the current answer to `cond.field` satisfy the condition? The operator
+ * (`cond.op`, default `in` for back-compat) selects the comparison:
+ *  - `in`   — the answer's tokens intersect `values` (the legacy choice match).
+ *  - `eq`/`gt`/`lt` — the answer, parsed as a number, compares to `value`.
+ *  - `between` — the numeric answer lies within `[min, max]` inclusive.
+ * A numeric op whose operand is missing, or whose answer isn't numeric, never
+ * holds (the step stays in its default visibility).
+ */
 function conditionHolds(cond: StepCondition, answers: Answers): boolean {
-  const got = new Set(tokens(answers[cond.field]));
-  return cond.values.some((v) => got.has(v));
+  const op = cond.op ?? 'in';
+  if (op === 'in') {
+    const got = new Set(tokens(answers[cond.field]));
+    return (cond.values ?? []).some((v) => got.has(v));
+  }
+  const n = numericAnswer(answers[cond.field]);
+  if (n == null) return false;
+  switch (op) {
+    case 'eq':
+      return cond.value != null && n === cond.value;
+    case 'gt':
+      return cond.value != null && n > cond.value;
+    case 'lt':
+      return cond.value != null && n < cond.value;
+    case 'between':
+      return cond.min != null && cond.max != null && n >= cond.min && n <= cond.max;
+    default:
+      return false;
+  }
 }
 
 /**
@@ -277,6 +345,91 @@ export function visibleSteps(config: FormConfig, answers: Answers): FormStep[] {
 /** The first `email`-typed step's key (the branch pivot for personal-email logic). */
 function findEmailKey(config: FormConfig): string | null {
   return config.steps.find((s) => s.type === 'email')?.key ?? null;
+}
+
+/**
+ * The visibility operators offered for a referenced field's TYPE — the builder
+ * shows exactly these in the operator dropdown, and they are the only ops the
+ * engine is asked to evaluate for that source. Numeric fields (`slider`) get the
+ * comparison set; every other type keeps the legacy "matches any of" (`in`).
+ * Shared so the editor and the engine can never drift on which op is valid where.
+ */
+export function operatorsForFieldType(type: FormFieldType): ConditionOp[] {
+  return type === 'slider' ? ['eq', 'gt', 'lt', 'between'] : ['in'];
+}
+
+/**
+ * A numeric condition's satisfying set as an interval with inclusivity flags
+ * (`±Infinity` for the open ends of `gt`/`lt`), or `null` when the condition is
+ * not a well-formed numeric op. Used only by the contradiction guard.
+ */
+interface NumInterval {
+  lo: number;
+  loInc: boolean;
+  hi: number;
+  hiInc: boolean;
+}
+
+function numInterval(cond: StepCondition): NumInterval | null {
+  switch (cond.op) {
+    case 'eq':
+      return cond.value == null ? null : { lo: cond.value, loInc: true, hi: cond.value, hiInc: true };
+    case 'gt':
+      return cond.value == null ? null : { lo: cond.value, loInc: false, hi: Infinity, hiInc: false };
+    case 'lt':
+      return cond.value == null ? null : { lo: -Infinity, loInc: false, hi: cond.value, hiInc: false };
+    case 'between':
+      return cond.min == null || cond.max == null
+        ? null
+        : { lo: cond.min, loInc: true, hi: cond.max, hiInc: true };
+    default:
+      return null;
+  }
+}
+
+/** Is numeric interval `a` fully contained in `b` (a ⊆ b)? */
+function intervalSubset(a: NumInterval, b: NumInterval): boolean {
+  // b's bounds must be no stricter than a's on each side (equal bound ⇒ b must be
+  // inclusive whenever a is, i.e. a-inclusive can't stick out past b-exclusive).
+  const lowerOk = b.lo < a.lo || (b.lo === a.lo && (b.loInc || !a.loInc));
+  const upperOk = b.hi > a.hi || (b.hi === a.hi && (b.hiInc || !a.hiInc));
+  return lowerOk && upperOk;
+}
+
+/** Is the choice condition `a`'s value-set a non-empty subset of `b`'s? */
+function choiceSubset(a: StepCondition, b: StepCondition): boolean {
+  const av = a.values ?? [];
+  if (av.length === 0) return false;
+  const bv = new Set(b.values ?? []);
+  return av.every((v) => bv.has(v));
+}
+
+/**
+ * True when a step's `showWhen` and `hideWhen` are mutually contradictory — the
+ * step could NEVER be visible because every answer that satisfies `showWhen`
+ * also satisfies `hideWhen` (hide always wins in {@link visibleSteps}). Detects
+ * the trivial, SAME-FIELD cases the builder guards against:
+ *  - both `in` and show's values are a subset of hide's (identical or fully
+ *    overlapping choice sets, e.g. show ⊇ requires `a`, hide swallows `a`);
+ *  - both numeric and show's interval is contained in hide's (e.g. show `eq 5`
+ *    with hide `eq 5`, or show `between [50,80]` inside hide `between [40,100]`).
+ * Conservative by design: returns `false` for anything it cannot PROVE empties
+ * the visible set (different fields, mixed choice/numeric ops, partial overlaps),
+ * so it never blocks a legitimate rule. Pure — no I/O, safe for client + server.
+ */
+export function conditionsContradict(
+  showWhen: StepCondition | null | undefined,
+  hideWhen: StepCondition | null | undefined,
+): boolean {
+  if (!showWhen || !hideWhen) return false;
+  if (showWhen.field !== hideWhen.field) return false;
+  const showOp = showWhen.op ?? 'in';
+  const hideOp = hideWhen.op ?? 'in';
+  if (showOp === 'in' && hideOp === 'in') return choiceSubset(showWhen, hideWhen);
+  const s = numInterval(showWhen);
+  const h = numInterval(hideWhen);
+  if (s && h) return intervalSubset(s, h);
+  return false;
 }
 
 /**

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -164,6 +164,19 @@ export interface FormStep {
   terminal?: boolean;
   /** Show the processing/reveal interstitial after this step completes. */
   triggersReveal?: boolean;
+  /**
+   * Hidden step (additive; back-compat). A hidden step is NEVER rendered as a
+   * visible question — {@link visibleSteps} skips it, so it is neither walked nor
+   * scored — but its answer can still be SEEDED (e.g. from a matching URL
+   * parameter in the public renderer) and carried along into the submission.
+   */
+  hidden?: boolean;
+  /**
+   * `phone` step: the ISO 3166-1 alpha-2 country the public phone picker starts
+   * on (e.g. "CO"). Absent = the locale-based default (en→US, es→MX). Purely a
+   * display default — the stored answer is still a full E.164 string.
+   */
+  phoneDefaultCountry?: string | null;
 }
 
 /**
@@ -341,11 +354,16 @@ function conditionHolds(cond: StepCondition, answers: Answers): boolean {
 
 /**
  * The steps to show given the answers so far, in config order. A step appears
- * when its `showWhen` holds (or is absent) AND its `hideWhen` does not hold —
- * and, for a personal-email-only branch step, only when the email is personal.
+ * when it is not `hidden`, its `showWhen` holds (or is absent) AND its `hideWhen`
+ * does not hold — and, for a personal-email-only branch step, only when the
+ * email is personal.
  */
 export function visibleSteps(config: FormConfig, answers: Answers): FormStep[] {
   return config.steps.filter((step) => {
+    // A hidden step is never rendered as a question — it is skipped in the walk
+    // (and therefore never scored). Its answer can still be seeded (e.g. from a
+    // URL parameter) and rides along into the submission via the answers map.
+    if (step.hidden) return false;
     if (step.showWhen && !conditionHolds(step.showWhen, answers)) return false;
     if (step.hideWhen && conditionHolds(step.hideWhen, answers)) return false;
     if (step.showForPersonalEmailOnly) {
@@ -914,18 +932,20 @@ export function resolveQuestion(step: FormStep, answers: Answers): string {
 
 /**
  * Resolve a step for display against the answers: pick the dynamic question
- * variant (via `resolveQuestion`), interpolate `[key]` tokens in the question,
+ * variant (via `resolveQuestion`), interpolate `[key]` tokens in the question
+ * AND the `helper`/description (both with the same orphaned-punctuation sweep),
  * and resolve the slider unit label variant. Returns a shallow copy — never
- * mutates the config.
+ * mutates the config. A null/undefined helper is left untouched.
  */
 export function resolveStepDisplay(step: FormStep, answers: Answers): FormStep {
   const question = resolveQuestion(step, answers);
+  const helper = typeof step.helper === 'string' ? interpolate(step.helper, answers) : step.helper;
   let sliderUnitLabel = step.sliderUnitLabel ?? null;
   if (step.questionField && step.sliderLabelVariants) {
     const key = variantKey(answers[step.questionField]);
     if (step.sliderLabelVariants[key]) sliderUnitLabel = step.sliderLabelVariants[key];
   }
-  return { ...step, question, sliderUnitLabel };
+  return { ...step, question, helper, sliderUnitLabel };
 }
 
 /**

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -197,6 +197,13 @@ export interface FormOutcome {
   /** Inclusive lower score bound for this bucket (highest matching wins). */
   minScore?: number;
   redirectUrl?: string | null;
+  /**
+   * The body copy shown on the thank-you screen for this outcome (additive;
+   * back-compat). When set it replaces the shared thank-you body; `[key]` tokens
+   * interpolate from the answers. `label` stays the heading. Absent = the shared
+   * thank-you body is used, so every existing outcome renders exactly as before.
+   */
+  message?: string | null;
   /** Scheduling handoff (HubSpot Meetings / Calendly) shown for this outcome. */
   booking?: OutcomeBooking | null;
   /** Answer-forced rules: any match makes this outcome win over score bucketing. */
@@ -260,6 +267,13 @@ export interface FormConfig {
    * no partial save.
    */
   partialSubmitAfterStep?: number;
+  /**
+   * WHERE the reveal interstitial plays: the reveal fires after the step at this
+   * 1-based position in `steps` (additive; back-compat). Absent = fall back to
+   * the legacy per-step `triggersReveal`, then default to AFTER THE LAST step, so
+   * an enabled reveal never plays mid-form by accident. See {@link revealAfterKey}.
+   */
+  revealAfterStep?: number;
 }
 
 export type AnswerValue =
@@ -932,6 +946,32 @@ export function partialSubmitKey(config: FormConfig): string | null {
   const n = config.partialSubmitAfterStep;
   if (n == null || n < 1) return null;
   return config.steps[n - 1]?.key ?? null;
+}
+
+/**
+ * The key of the step AFTER which the reveal interstitial plays, or `null` when
+ * the reveal is disabled/absent or the form has no steps. Position resolves in
+ * priority order (additive + back-compat), so the renderer and the builder agree
+ * on where the reveal fires:
+ *  1. `revealAfterStep` (1-based over `steps`) when set + in range — the
+ *     authoritative draggable-marker position.
+ *  2. else the first step flagged `triggersReveal` — the legacy per-step boolean
+ *     (configs published before the marker existed still play in place).
+ *  3. else the LAST step — the safe default so an ENABLED reveal plays right
+ *     before the result (thank-you / outcome), never mid-form by accident.
+ * The renderer decides "play then continue" vs "play then finalize" from whether
+ * the resolved step is the last VISIBLE step at runtime.
+ */
+export function revealAfterKey(config: FormConfig): string | null {
+  const reveal = config.reveal;
+  if (!reveal || reveal.enabled === false) return null;
+  const { steps } = config;
+  if (steps.length === 0) return null;
+  const n = config.revealAfterStep;
+  if (n != null && n >= 1 && n <= steps.length) return steps[n - 1]?.key ?? null;
+  const triggered = steps.find((s) => s.triggersReveal);
+  if (triggered) return triggered.key;
+  return steps[steps.length - 1]?.key ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -271,11 +271,14 @@ export interface FormsMessages {
       /** V4 autosave hardening: surface WHY a save failed + client pre-validation. */
       saveErrorReason: string;
       saveInvalid: string;
-      /** Results tab clarity (V4-16 outcome heading + redirect field). */
+      /** Results tab clarity (V4-16 outcome heading + message + redirect field). */
       resultsHelp: {
         outcomeHeadingHelp: string;
         redirectLabel: string;
         redirectHelp: string;
+        /** Label for the per-outcome thank-you body textarea. */
+        messageLabel: string;
+        messageHelp: string;
       };
       previewBtn: string;
       formNamePlaceholder: string;
@@ -395,13 +398,15 @@ export interface FormsMessages {
         tokenWarnLater: string;
         tokenWarnUnknown: string;
       };
-      /** Per-question behavior toggles (terminal / reveal trigger). */
+      /** Per-question behavior toggles (terminal / reveal position). */
       behavior: {
         title: string;
         terminal: string;
         terminalHint: string;
         reveal: string;
         revealHint: string;
+        /** "Edit reveal screen" button → jumps to the Design tab (V4-12). */
+        editReveal: string;
       };
       /** The `name` step's two collected fields + placeholders. */
       nameStep: {
@@ -992,6 +997,9 @@ export const en: FormsMessages = {
         redirectLabel: 'Redirect URL (optional)',
         redirectHelp:
           'Leave empty to show the thank-you screen. If set, respondents are sent here instead.',
+        messageLabel: 'Message shown for this outcome',
+        messageHelp:
+          'The thank-you body respondents see for this range. Use [field] to insert an answer. Leave empty to use the default message.',
       },
       previewBtn: 'Preview',
       formNamePlaceholder: 'Form name',
@@ -1112,7 +1120,9 @@ export const en: FormsMessages = {
         terminal: 'Ends the form',
         terminalHint: 'Completing this question ends the form immediately (disqualification).',
         reveal: 'Show reveal screen after',
-        revealHint: 'Plays the processing/reveal screen after this question. Set it up in Design.',
+        revealHint:
+          'Plays the reveal screen after this question. Otherwise it defaults to the end — drag the marker in the question list to move it.',
+        editReveal: 'Edit reveal screen',
       },
       nameStep: {
         title: 'Name fields',
@@ -1127,7 +1137,8 @@ export const en: FormsMessages = {
         title: 'Reveal screen',
         subtitle: 'A short processing interstitial shown before the result.',
         enabled: 'Enable the reveal screen',
-        stepHint: 'Pick which question triggers it under Build → Behavior.',
+        stepHint:
+          'Plays at the end by default. Drag the “Reveal screen” marker in the Build tab’s question list to move it.',
         headline: 'Headline',
         headlinePlaceholder: 'Reviewing your answers…',
         subtitleLabel: 'Subtitle',
@@ -1699,6 +1710,9 @@ export const es: FormsMessages = {
         redirectLabel: 'URL de redirección (opcional)',
         redirectHelp:
           'Déjalo vacío para mostrar la pantalla de agradecimiento. Si lo defines, se redirige ahí a los respondientes.',
+        messageLabel: 'Mensaje mostrado para este resultado',
+        messageHelp:
+          'El cuerpo de agradecimiento que ven los respondientes en este rango. Usa [campo] para insertar una respuesta. Déjalo vacío para usar el mensaje por defecto.',
       },
       previewBtn: 'Vista previa',
       formNamePlaceholder: 'Nombre del formulario',
@@ -1819,7 +1833,9 @@ export const es: FormsMessages = {
         terminal: 'Termina el formulario',
         terminalHint: 'Completar esta pregunta termina el formulario de inmediato (descalificación).',
         reveal: 'Mostrar pantalla de revelación después',
-        revealHint: 'Reproduce la pantalla de procesamiento/revelación tras esta pregunta. Configúrala en Diseño.',
+        revealHint:
+          'Reproduce la pantalla de revelación tras esta pregunta. Si no, se muestra al final por defecto — arrastra el marcador en la lista de preguntas para moverla.',
+        editReveal: 'Editar pantalla de revelación',
       },
       nameStep: {
         title: 'Campos del nombre',
@@ -1834,7 +1850,8 @@ export const es: FormsMessages = {
         title: 'Pantalla de revelación',
         subtitle: 'Un breve intermedio de procesamiento antes del resultado.',
         enabled: 'Activar la pantalla de revelación',
-        stepHint: 'Elige qué pregunta la activa en Construir → Comportamiento.',
+        stepHint:
+          'Se muestra al final por defecto. Arrastra el marcador «Pantalla de revelación» en la lista de preguntas de la pestaña Construir para moverla.',
         headline: 'Titular',
         headlinePlaceholder: 'Revisando tus respuestas…',
         subtitleLabel: 'Subtítulo',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -268,6 +268,15 @@ export interface FormsMessages {
       saving: string;
       saved: string;
       saveError: string;
+      /** V4 autosave hardening: surface WHY a save failed + client pre-validation. */
+      saveErrorReason: string;
+      saveInvalid: string;
+      /** Results tab clarity (V4-16 outcome heading + redirect field). */
+      resultsHelp: {
+        outcomeHeadingHelp: string;
+        redirectLabel: string;
+        redirectHelp: string;
+      };
       previewBtn: string;
       formNamePlaceholder: string;
       tabs: { build: string; cover: string; outcomes: string; flow: string };
@@ -321,6 +330,8 @@ export interface FormsMessages {
         label: string;
         value: string;
         points: string;
+        /** One-line explainer under the options list tying points to scoring. */
+        pointsHint: string;
         icon: string;
         remove: string;
         empty: string;
@@ -349,6 +360,17 @@ export interface FormsMessages {
         hideNone: string;
         personalEmailOnly: string;
         personalEmailHint: string;
+        /** V4 — operator dropdown (numeric fields) + operand labels. */
+        operator: string;
+        opEq: string;
+        opGt: string;
+        opLt: string;
+        opBetween: string;
+        value: string;
+        betweenMin: string;
+        betweenMax: string;
+        /** V4 — contradiction guard warning (show + hide cancel out). */
+        contradiction: string;
       };
       variants: {
         title: string;
@@ -362,6 +384,8 @@ export interface FormsMessages {
         fallback: string;
         remove: string;
         interpolationHint: string;
+        /** Clarifies that a variant only swaps the title; branching is Logic. */
+        scopeNote: string;
         sliderLabel: string;
         /** The `@` recall-information picker inside variant textareas. */
         tokenPickerLabel: string;
@@ -386,6 +410,8 @@ export interface FormsMessages {
         first: string;
         second: string;
         fieldKey: string;
+        /** Explains the field key doubles as a URL parameter for prefill. */
+        fieldKeyHint: string;
         placeholder: string;
       };
       /** The reveal/processing interstitial settings (Design tab). */
@@ -958,6 +984,15 @@ export const en: FormsMessages = {
       saving: 'Saving…',
       saved: 'Saved.',
       saveError: 'Could not save — please try again.',
+      saveErrorReason: 'Couldn’t save: {reason}',
+      saveInvalid: 'Can’t save yet — {reason}',
+      resultsHelp: {
+        outcomeHeadingHelp:
+          'Shown to respondents as the heading on the thank-you screen when their score lands in this range.',
+        redirectLabel: 'Redirect URL (optional)',
+        redirectHelp:
+          'Leave empty to show the thank-you screen. If set, respondents are sent here instead.',
+      },
       previewBtn: 'Preview',
       formNamePlaceholder: 'Form name',
       tabs: { build: 'Build', cover: 'Cover', outcomes: 'Outcomes', flow: 'Flow' },
@@ -1011,6 +1046,7 @@ export const en: FormsMessages = {
         label: 'Label',
         value: 'Value',
         points: 'Points',
+        pointsHint: 'Added to the score when this option is picked. Use a negative number to subtract.',
         icon: 'Icon',
         remove: 'Remove option',
         empty: 'No options yet.',
@@ -1040,6 +1076,16 @@ export const en: FormsMessages = {
         personalEmailOnly: 'Personal email only',
         personalEmailHint:
           'Show this question only when the respondent entered a personal (non-work) email.',
+        operator: 'Condition',
+        opEq: 'Equal to',
+        opGt: 'Greater than',
+        opLt: 'Less than',
+        opBetween: 'Between',
+        value: 'Value',
+        betweenMin: 'Min',
+        betweenMax: 'Max',
+        contradiction:
+          'These show and hide rules cancel out — this question could never appear. Adjust one of them.',
       },
       variants: {
         title: 'Dynamic question',
@@ -1053,6 +1099,7 @@ export const en: FormsMessages = {
         fallback: 'Fallback (any other answer)',
         remove: 'Remove variant',
         interpolationHint: 'Type @ (or [field]) to insert an earlier answer into the question.',
+        scopeNote: 'This only changes the question’s title — not its options. To send people to a different question, use Logic.',
         sliderLabel: 'Slider unit label',
         tokenPickerLabel: 'Insert a previous answer',
         tokenPickerEmpty: 'No earlier answers yet — this is the first question.',
@@ -1073,6 +1120,7 @@ export const en: FormsMessages = {
         first: 'First field',
         second: 'Second field',
         fieldKey: 'Field key',
+        fieldKeyHint: 'Used as a URL parameter to prefill this field.',
         placeholder: 'Placeholder',
       },
       reveal: {
@@ -1643,6 +1691,15 @@ export const es: FormsMessages = {
       saving: 'Guardando…',
       saved: 'Guardado.',
       saveError: 'No se pudo guardar — inténtalo de nuevo.',
+      saveErrorReason: 'No se pudo guardar: {reason}',
+      saveInvalid: 'Aún no se puede guardar — {reason}',
+      resultsHelp: {
+        outcomeHeadingHelp:
+          'Se muestra a los respondientes como el encabezado de la pantalla de agradecimiento cuando su puntaje cae en este rango.',
+        redirectLabel: 'URL de redirección (opcional)',
+        redirectHelp:
+          'Déjalo vacío para mostrar la pantalla de agradecimiento. Si lo defines, se redirige ahí a los respondientes.',
+      },
       previewBtn: 'Vista previa',
       formNamePlaceholder: 'Nombre del formulario',
       tabs: { build: 'Construir', cover: 'Portada', outcomes: 'Resultados', flow: 'Flujo' },
@@ -1696,6 +1753,7 @@ export const es: FormsMessages = {
         label: 'Etiqueta',
         value: 'Valor',
         points: 'Puntos',
+        pointsHint: 'Se suma al puntaje cuando se elige esta opción. Usa un número negativo para restar.',
         icon: 'Ícono',
         remove: 'Quitar opción',
         empty: 'Aún no hay opciones.',
@@ -1725,6 +1783,16 @@ export const es: FormsMessages = {
         personalEmailOnly: 'Solo correo personal',
         personalEmailHint:
           'Muestra esta pregunta solo cuando la persona ingresó un correo personal (no corporativo).',
+        operator: 'Condición',
+        opEq: 'Igual a',
+        opGt: 'Mayor que',
+        opLt: 'Menor que',
+        opBetween: 'Entre',
+        value: 'Valor',
+        betweenMin: 'Mín',
+        betweenMax: 'Máx',
+        contradiction:
+          'Estas reglas de mostrar y ocultar se anulan — esta pregunta nunca aparecería. Ajusta una de ellas.',
       },
       variants: {
         title: 'Pregunta dinámica',
@@ -1738,6 +1806,7 @@ export const es: FormsMessages = {
         fallback: 'Alternativa (cualquier otra respuesta)',
         remove: 'Quitar variante',
         interpolationHint: 'Escribe @ (o [campo]) para insertar una respuesta anterior en la pregunta.',
+        scopeNote: 'Esto solo cambia el título de la pregunta — no sus opciones. Para enviar a otra pregunta, usa Lógica.',
         sliderLabel: 'Etiqueta de unidad del deslizador',
         tokenPickerLabel: 'Insertar una respuesta anterior',
         tokenPickerEmpty: 'Aún no hay respuestas anteriores — esta es la primera pregunta.',
@@ -1758,6 +1827,7 @@ export const es: FormsMessages = {
         first: 'Primer campo',
         second: 'Segundo campo',
         fieldKey: 'Clave del campo',
+        fieldKeyHint: 'Se usa como parámetro de URL para prellenar este campo.',
         placeholder: 'Texto de ejemplo',
       },
       reveal: {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -322,6 +322,10 @@ export interface FormsMessages {
         corporateEmailOnly: string;
         corporateEmailHint: string;
         phoneMinDigits: string;
+        /** Phone step: label for the per-form default-country picker (V4-14). */
+        phoneDefaultCountry: string;
+        /** The "auto (locale-based)" option in the default-country picker. */
+        phoneDefaultCountryAuto: string;
         sliderMin: string;
         sliderMax: string;
         sliderStep: string;
@@ -398,7 +402,7 @@ export interface FormsMessages {
         tokenWarnLater: string;
         tokenWarnUnknown: string;
       };
-      /** Per-question behavior toggles (terminal / reveal position). */
+      /** Per-question behavior toggles (terminal / reveal position / hidden). */
       behavior: {
         title: string;
         terminal: string;
@@ -407,6 +411,9 @@ export interface FormsMessages {
         revealHint: string;
         /** "Edit reveal screen" button → jumps to the Design tab (V4-12). */
         editReveal: string;
+        /** Hidden-question toggle — filled via a URL parameter (V4-13). */
+        hidden: string;
+        hiddenHint: string;
       };
       /** The `name` step's two collected fields + placeholders. */
       nameStep: {
@@ -1043,6 +1050,8 @@ export const en: FormsMessages = {
         corporateEmailOnly: 'Require work email',
         corporateEmailHint: 'Blocks Gmail, Hotmail, Yahoo and other personal domains.',
         phoneMinDigits: 'Minimum digits',
+        phoneDefaultCountry: 'Default country',
+        phoneDefaultCountryAuto: 'Automatic (based on visitor language)',
         sliderMin: 'Min',
         sliderMax: 'Max',
         sliderStep: 'Step',
@@ -1123,6 +1132,8 @@ export const en: FormsMessages = {
         revealHint:
           'Plays the reveal screen after this question. Otherwise it defaults to the end — drag the marker in the question list to move it.',
         editReveal: 'Edit reveal screen',
+        hidden: 'Hidden question',
+        hiddenHint: 'Not shown to respondents — its answer is filled from a matching URL parameter (?key=value).',
       },
       nameStep: {
         title: 'Name fields',
@@ -1756,6 +1767,8 @@ export const es: FormsMessages = {
         corporateEmailOnly: 'Exigir correo corporativo',
         corporateEmailHint: 'Bloquea Gmail, Hotmail, Yahoo y otros dominios personales.',
         phoneMinDigits: 'Dígitos mínimos',
+        phoneDefaultCountry: 'País predeterminado',
+        phoneDefaultCountryAuto: 'Automático (según el idioma del visitante)',
         sliderMin: 'Mín',
         sliderMax: 'Máx',
         sliderStep: 'Paso',
@@ -1836,6 +1849,8 @@ export const es: FormsMessages = {
         revealHint:
           'Reproduce la pantalla de revelación tras esta pregunta. Si no, se muestra al final por defecto — arrastra el marcador en la lista de preguntas para moverla.',
         editReveal: 'Editar pantalla de revelación',
+        hidden: 'Pregunta oculta',
+        hiddenHint: 'No se muestra a los respondientes — su respuesta se rellena desde un parámetro de URL coincidente (?clave=valor).',
       },
       nameStep: {
         title: 'Campos del nombre',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,7 +5,7 @@
  * from the same schema (never trust the client; validate on both sides).
  */
 import { z } from 'zod';
-import { FORM_FIELD_TYPES, isSafeHttpUrl, isSafeImageUrl } from '@quill/engine';
+import { CONDITION_OPS, FORM_FIELD_TYPES, isSafeHttpUrl, isSafeImageUrl } from '@quill/engine';
 
 /** A URL rendered into `<img src>` — reject script protocols (XSS defense-in-depth). */
 const safeImageUrl = z
@@ -45,9 +45,32 @@ const optionSchema = z.object({
   icon: z.string().max(64).nullable().optional(),
 });
 
+/**
+ * Visibility-condition operators (mirrors the engine's `CONDITION_OPS`). Absent
+ * on a stored condition = `in`, so every pre-operator config still parses.
+ */
+export const conditionOp = z.enum(CONDITION_OPS);
+export type ConditionOp = z.infer<typeof conditionOp>;
+
+/**
+ * A show/hide condition. ADDITIVE, back-compat: `op`/`value`/`min`/`max` are all
+ * optional and a bare `{field, values}` keeps its original `in` ("matches any
+ * of") meaning. `values` is optional (numeric ops eq/gt/lt/between omit it); the
+ * engine's `conditionHolds` treats an absent `values` as an empty match. Kept
+ * optional (not `.default([])`) so the inferred type matches the engine's
+ * `StepCondition.values?: string[]` — otherwise FormConfig fails to assign.
+ */
 const conditionSchema = z.object({
   field: z.string().min(1),
-  values: z.array(z.string()),
+  values: z.array(z.string()).optional(),
+  /** Comparison operator; absent = `in`. Numeric ops apply to slider/number fields. */
+  op: conditionOp.optional(),
+  /** Operand for `eq` / `gt` / `lt`. */
+  value: z.number().optional(),
+  /** Lower bound for `between` (inclusive). */
+  min: z.number().optional(),
+  /** Upper bound for `between` (inclusive). */
+  max: z.number().optional(),
 });
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -132,6 +132,18 @@ export const formStepSchema = z.object({
   showForPersonalEmailOnly: z.boolean().optional(),
   terminal: z.boolean().optional(),
   triggersReveal: z.boolean().optional(),
+  /**
+   * Hidden step (ADDITIVE): never rendered as a visible question — the engine's
+   * `visibleSteps` skips it — but its answer can be supplied via a matching URL
+   * parameter and carried into the submission. Not shown for `message` steps.
+   */
+  hidden: z.boolean().optional(),
+  /**
+   * `phone` step: ISO 3166-1 alpha-2 the public country picker defaults to
+   * (e.g. "CO"). ADDITIVE — absent = the locale-based default. Two-char cap so a
+   * bad value can only fall back, never break the lookup.
+   */
+  phoneDefaultCountry: z.string().max(2).nullable().optional(),
 });
 export type FormStepInput = z.infer<typeof formStepSchema>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -206,7 +206,11 @@ export type OutcomeOverride = z.infer<typeof outcomeOverrideSchema>;
 
 export const formOutcomeSchema = z.object({
   id: z.string().min(1).max(64),
-  label: z.string().min(1).max(200),
+  // Empty label is allowed: the builder creates a range before the user names it,
+  // and the renderer/ScoreBar fall back to `#<n>`. Relaxing min(1) is a superset
+  // (every previously-valid config still parses) and keeps autosave from 400-ing
+  // the moment "Add a range" is clicked.
+  label: z.string().max(200),
   minScore: z.number().int().optional(),
   // http(s) only: the renderer navigates here (`window.location`), so a
   // `javascript:`/`data:` URL — which `.url()` alone would accept — is a stored

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -245,6 +245,12 @@ export const formOutcomeSchema = z.object({
     .nullable()
     .optional(),
   // --- Outcome extensions (all optional; back-compat) ------------------------
+  /**
+   * Per-outcome thank-you body (V4-16). Rendered as the done-screen body when
+   * set (falling back to the shared thank-you body); `label` stays the heading.
+   * Plain text with `[field]` tokens interpolated by the renderer.
+   */
+  message: z.string().max(2000).nullable().optional(),
   /** Scheduling handoff (HubSpot Meetings / Calendly) shown for this outcome. */
   booking: outcomeBookingSchema.nullable().optional(),
   /**
@@ -512,6 +518,13 @@ export const formConfigSchema = z.object({
   /** Third-party tracking ids (ADDITIVE — absent on every legacy config). */
   tracking: formTrackingSchema.nullable().optional(),
   partialSubmitAfterStep: z.number().int().positive().optional(),
+  /**
+   * WHERE the reveal interstitial plays (1-based over `steps`; ADDITIVE —
+   * mirrors partialSubmitAfterStep). Absent = the engine falls back to the
+   * legacy `triggersReveal`, then defaults to after the last step. See
+   * `revealAfterKey` in @quill/engine.
+   */
+  revealAfterStep: z.number().int().positive().optional(),
 });
 export type FormConfig = z.infer<typeof formConfigSchema>;
 

--- a/qa/e2e/v4-fields2.spec.ts
+++ b/qa/e2e/v4-fields2.spec.ts
@@ -1,0 +1,266 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * V4-13 / V4-14 / V4-15 — the "field II" batch on the public form + builder.
+ *
+ *  (a) V4-13 — URL-parameter prefill + hidden question. A VISIBLE text step
+ *      keyed `plan` opened at `?plan=enterprise` renders pre-filled and submits
+ *      "enterprise"; a HIDDEN step keyed `source` opened at `?source=ads` is
+ *      never shown yet still rides its answer ("ads") into the submission. Only
+ *      DECLARED field keys are read from the query string (scoped in the
+ *      renderer's `capturePrefill`); the engine re-validates on submit.
+ *  (b) V4-14 — per-form phone default country. A phone step with
+ *      `phoneDefaultCountry: "CO"` starts the public country picker on Colombia
+ *      (+57) even under the default (en) locale, which would otherwise default
+ *      to US.
+ *  (c) V4-15 — description interpolation + the `@` recall picker on the
+ *      description. A step whose description is "Details for [firstname]" renders
+ *      the interpolated helper on the public form once firstname is captured;
+ *      and in the builder, typing `@` in the description opens the token picker.
+ *
+ * Forms are created via the admin API under unique `v4f2-` names (per-run token
+ * + counter, never Date.now) so slugs never collide and DB assertions stay
+ * scoped to each fresh form id. The public API is rate-limited and its bucket is
+ * SHARED across suites — every public open backs off + reloads on a transient
+ * miss instead of failing.
+ */
+
+const API = 'http://localhost:4400';
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(specDir, '../..');
+const DB_PATH = path.join(repoRoot, '.data', 'qa.db');
+
+// better-sqlite3 is hoisted into packages/db (pnpm), not the repo root.
+const dbRequire = createRequire(path.join(repoRoot, 'packages/db/package.json'));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Database: any = dbRequire('better-sqlite3');
+
+/** Run a query on a fresh readonly connection (always sees latest commits). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function q<T>(fn: (db: any) => T): T {
+  const db = new Database(DB_PATH, { readonly: true });
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+const RUN = Math.random().toString(36).slice(2, 8);
+let seq = 0;
+function uniqueName(label: string): string {
+  seq += 1;
+  return `v4f2-${label}-${RUN}-${seq}`;
+}
+
+/**
+ * POST /v1/forms (create writes LIVE config) → the form id (for DB assertions)
+ * and the public path /<accountCode>/me/<slug>. The account code is resolved
+ * from GET /v1/me — the local-stub principal is not a hardcoded account.
+ */
+async function createForm(
+  request: APIRequestContext,
+  name: string,
+  config: Record<string, unknown>,
+): Promise<{ id: string; formPath: string }> {
+  const me = await request.get(`${API}/v1/me`);
+  expect(me.ok(), `GET /v1/me failed: ${me.status()}`).toBeTruthy();
+  const { accountCode } = (await me.json()) as { accountCode: string };
+
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config } });
+  expect(res.ok(), `form creation failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string; slug: string };
+  return { id: body.id, formPath: `/${accountCode}/me/${body.slug}` };
+}
+
+/**
+ * Open a public form URL (path may carry a query string) and click through the
+ * cover to the first step. Backs off + reloads on a transient rate-limit miss
+ * (the SSR fetch can 429 when the shared bucket is drained by other suites).
+ */
+async function openToFirstStep(page: Page, url: string): Promise<void> {
+  await page.goto(url);
+  const start = page.getByRole('button', { name: 'Start' });
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const visible = await start
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (visible) break;
+    await page.waitForTimeout(1_500);
+    await page.reload();
+  }
+  await start.click();
+}
+
+// --- (a) URL-parameter prefill + hidden question ----------------------------
+
+test('V4-13: a visible step prefills from ?key=…; a hidden step is never shown yet still submits its URL value', async ({
+  page,
+  request,
+}) => {
+  const config = {
+    version: 1,
+    cover: { enabled: true, headline: 'Prefill QA', ctaText: 'Start' },
+    steps: [
+      { key: 'plan', type: 'text', question: 'Which plan?', required: false },
+      { key: 'source', type: 'text', question: 'Where did you hear about us?', hidden: true },
+    ],
+  };
+  const { id, formPath } = await createForm(request, uniqueName('prefill'), config);
+
+  await openToFirstStep(page, `${formPath}?plan=enterprise&source=ads`);
+
+  // The VISIBLE `plan` step renders pre-filled from the query string…
+  const input = page.locator('.pf-input');
+  await expect(input).toHaveValue('enterprise');
+
+  // …and the HIDDEN `source` step never renders as a question — `plan` is the
+  // only visible step, so submitting it lands the done screen immediately.
+  await expect(page.getByText('Where did you hear about us?')).toHaveCount(0);
+  await page.locator('.pf__btn--inline').click();
+  await expect(page.locator('.pf-done__title')).toBeVisible({ timeout: 15_000 });
+
+  // Both answers persist: the visible prefill AND the hidden step's URL value.
+  await expect
+    .poll(
+      () => {
+        const row = q((db) =>
+          db.prepare('SELECT completed_at FROM submission WHERE form_id = ?').get(id),
+        ) as { completed_at: number | null } | undefined;
+        return row?.completed_at ? 'completed' : 'waiting';
+      },
+      { timeout: 10_000, message: 'submission never completed for the prefill form' },
+    )
+    .toBe('completed');
+
+  const row = q((db) =>
+    db.prepare('SELECT data FROM submission WHERE form_id = ?').get(id),
+  ) as { data: string };
+  const data = JSON.parse(row.data) as Record<string, unknown>;
+  expect(data.plan).toBe('enterprise');
+  expect(data.source).toBe('ads'); // hidden field carried into the submission
+});
+
+test('V4-13: an undeclared query key is NOT seeded (prefill is scoped to declared fields)', async ({
+  page,
+  request,
+}) => {
+  const config = {
+    version: 1,
+    cover: { enabled: true, headline: 'Scoped prefill QA', ctaText: 'Start' },
+    steps: [{ key: 'plan', type: 'text', question: 'Which plan?', required: true }],
+  };
+  const { id, formPath } = await createForm(request, uniqueName('scoped'), config);
+
+  // `evil` matches no declared field → ignored; `plan` is declared → seeded.
+  await openToFirstStep(page, `${formPath}?plan=pro&evil=INJECTED`);
+  await expect(page.locator('.pf-input')).toHaveValue('pro');
+  await page.locator('.pf__btn--inline').click();
+  await expect(page.locator('.pf-done__title')).toBeVisible({ timeout: 15_000 });
+
+  await expect
+    .poll(
+      () => {
+        const row = q((db) =>
+          db.prepare('SELECT completed_at FROM submission WHERE form_id = ?').get(id),
+        ) as { completed_at: number | null } | undefined;
+        return row?.completed_at ? 'done' : 'waiting';
+      },
+      { timeout: 10_000 },
+    )
+    .toBe('done');
+
+  const row = q((db) =>
+    db.prepare('SELECT data FROM submission WHERE form_id = ?').get(id),
+  ) as { data: string };
+  const data = JSON.parse(row.data) as Record<string, unknown>;
+  expect(data.plan).toBe('pro');
+  expect('evil' in data).toBe(false); // never seeded from an arbitrary query key
+});
+
+// --- (b) per-form phone default country --------------------------------------
+
+test('V4-14: phoneDefaultCountry "CO" starts the public phone picker on Colombia (+57)', async ({
+  page,
+  request,
+}) => {
+  const config = {
+    version: 1,
+    cover: { enabled: true, headline: 'Phone default QA', ctaText: 'Start' },
+    steps: [
+      { key: 'phone', type: 'phone', question: 'Your phone?', required: true, phoneDefaultCountry: 'CO' },
+    ],
+  };
+  const { formPath } = await createForm(request, uniqueName('phone-co'), config);
+
+  // Default (en) locale would normally pick US (+1); the per-form default wins.
+  await openToFirstStep(page, formPath);
+  await expect(page.locator('.pf-phone')).toBeVisible();
+  await expect(page.locator('.pf-phone__dial')).toHaveText('+57');
+});
+
+// --- (c) description interpolation (public) + @ picker (editor) ---------------
+
+test('V4-15: a description with [firstname] interpolates on the public form after the name step', async ({
+  page,
+  request,
+}) => {
+  const config = {
+    version: 1,
+    cover: { enabled: true, headline: 'Desc interp QA', ctaText: 'Start' },
+    steps: [
+      { key: 'fullname', type: 'name', question: "What's your name?", required: false, fields: ['firstname', 'lastname'] },
+      { key: 'topic', type: 'text', question: 'Tell us more', helper: 'Details for [firstname]' },
+    ],
+  };
+  const { formPath } = await createForm(request, uniqueName('desc-interp'), config);
+
+  await openToFirstStep(page, formPath);
+
+  // Capture the first name on the name step, then advance.
+  await expect(page.getByRole('heading', { name: /what.s your name/i })).toBeVisible();
+  await page.getByLabel('First name').fill('Sam');
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // The next step's description interpolates the just-captured firstname.
+  await expect(page.locator('.pf__question')).toHaveText('Tell us more');
+  await expect(page.locator('.pf__helper')).toHaveText('Details for Sam');
+});
+
+test('V4-15: typing @ in the builder description opens the token picker (fields captured before the step)', async ({
+  page,
+  request,
+}) => {
+  const config = {
+    version: 1,
+    cover: { enabled: true, headline: 'Desc picker QA', ctaText: 'Start' },
+    steps: [
+      { key: 'fullname', type: 'name', question: "What's your name?", required: false, fields: ['firstname', 'lastname'] },
+      { key: 'topic', type: 'text', question: 'Tell us more' },
+    ],
+  };
+  const { id } = await createForm(request, uniqueName('desc-picker'), config);
+
+  await page.goto(`/admin/forms/${id}/edit`);
+  // q1 (name) is auto-selected; switch to q2 (the text step) via its spine row.
+  await expect(page.getByTestId('canvas-title-input')).toHaveValue("What's your name?");
+  await page.getByRole('button', { name: 'Tell us more' }).first().click();
+  await expect(page.getByTestId('canvas-title-input')).toHaveValue('Tell us more');
+
+  // Typing `@` in the description opens the picker listing the earlier name
+  // subfields, and Enter inserts the engine token.
+  const description = page.getByTestId('canvas-description-input');
+  await description.click();
+  await description.pressSequentially('@');
+  await expect(page.getByTestId('token-picker')).toBeVisible();
+  const options = page.getByTestId('token-option');
+  await expect(options).toHaveCount(2);
+  await expect(options.nth(0)).toHaveAttribute('data-key', 'firstname');
+  await page.keyboard.press('Enter');
+  await expect(description).toHaveValue('[firstname]');
+});

--- a/qa/e2e/v4-logic-ops.spec.ts
+++ b/qa/e2e/v4-logic-ops.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * V4-07 / V4-08 — conditional-visibility OPERATORS by field type, and the
+ * contradiction guard.
+ *
+ * Two loops prove the feature end to end:
+ *   1. (public runtime) A slider question gates a later question with a NUMERIC
+ *      operator (`show when score > 50`). Set the slider to 60 → the gated
+ *      question appears; set it to 40 → it is skipped and the next always-on
+ *      question is reached. This exercises the engine's new `gt` op on the exact
+ *      client path the renderer walks (`runtimeSteps` → `visibleSteps`).
+ *   2. (editor) In the Visibility panel, referencing a slider field reveals the
+ *      operator dropdown with the numeric comparison set (equal/greater/less/
+ *      between) — the V4-07 UI. Setting Show and Hide to the SAME field + value
+ *      trips the V4-08 contradiction guard: a prominent inline warning
+ *      (`logic-contradiction`) that clears once the overlap is removed.
+ *
+ * Conventions (mirroring the V3 specs): a fresh form per test via the admin API
+ * with a `v4logic-` slug prefix (per-run nonce + counter — never `Date.now`);
+ * accountCode resolved from GET /v1/me (never hardcoded); the public cover is
+ * retried past the shared per-IP rate-limit bucket.
+ */
+
+const API = 'http://localhost:4400';
+
+/** Per-run nonce so reruns mint distinct forms (Date.now is banned in specs). */
+const RUN = randomUUID().slice(0, 8);
+let seq = 0;
+function uniqueName(label: string): string {
+  seq += 1;
+  return `v4logic-${label}-${RUN}-${seq}`;
+}
+
+/** The admin principal's public account code (NOT hardcoded). */
+async function accountCode(request: APIRequestContext): Promise<string> {
+  const res = await request.get(`${API}/v1/me`);
+  expect(res.ok(), `GET /v1/me failed: ${res.status()}`).toBeTruthy();
+  const me = (await res.json()) as { accountCode: string };
+  expect(me.accountCode, '/v1/me must expose an account code').toBeTruthy();
+  return me.accountCode;
+}
+
+/** POST /v1/forms (create writes LIVE config) → the form id + public path. */
+async function createForm(
+  request: APIRequestContext,
+  name: string,
+  config: unknown,
+): Promise<{ id: string; path: string }> {
+  const code = await accountCode(request);
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config } });
+  expect(res.ok(), `create failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string; slug: string };
+  return { id: body.id, path: `/${code}/me/${body.slug}` };
+}
+
+/**
+ * Public: a slider `score` gates `why` with a NUMERIC operator (> 50); an
+ * always-on `email` follows so a hidden `why` still lands on a concrete next
+ * question (a crisp positive assertion in both branches).
+ */
+function publicConfig() {
+  return {
+    version: 1,
+    cover: { enabled: true, headline: 'V4 logic ops', ctaText: 'Start' },
+    steps: [
+      { key: 'score', type: 'slider', question: 'Rate it', min: 0, max: 100, default: 50 },
+      {
+        key: 'why',
+        type: 'text',
+        question: 'Why so high?',
+        showWhen: { field: 'score', op: 'gt', value: 50 },
+      },
+      { key: 'email', type: 'email', question: 'Your email?', required: true },
+    ],
+  };
+}
+
+/** A slider `score` + a text `reason` — `reason` carries the show/hide rules. */
+function editorConfig() {
+  return {
+    version: 1,
+    steps: [
+      { key: 'score', type: 'slider', question: 'Rate it', min: 0, max: 100, default: 50 },
+      { key: 'reason', type: 'text', question: 'Reason?' },
+    ],
+  };
+}
+
+/** Open the public form and click through the cover to the first question,
+ *  retrying the cover past the shared per-IP rate-limit bucket (~1 token/s). */
+async function openToFirstQuestion(page: Page, formPath: string) {
+  await page.goto(formPath);
+  const start = page.getByRole('button', { name: 'Start' });
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const visible = await start
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (visible) break;
+    await page.waitForTimeout(1_500);
+    await page.reload();
+  }
+  await start.click();
+  await expect(page.locator('.pf__question')).toHaveText('Rate it');
+}
+
+/**
+ * Set the range slider to an exact value. Playwright cannot `fill` a range
+ * input, so set the value through the React-compatible native setter and fire
+ * `input`/`change` — the pill assertion proves React's onChange ran.
+ */
+async function setSlider(page: Page, value: number) {
+  const slider = page.locator('input[type="range"]');
+  await expect(slider).toBeVisible();
+  await slider.evaluate((el, v) => {
+    const input = el as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    setter?.call(input, String(v));
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+  await expect(page.locator('.pf-slider__pill-num')).toHaveText(String(value));
+}
+
+/** Open a branded Select (a `button[aria-haspopup=listbox]`) by its accessible
+ *  name and click one of its options (scoped to that Select's listbox). */
+async function pickFromSelect(page: Page, name: string, optionName: string) {
+  const trigger = page.getByRole('button', { name });
+  await trigger.scrollIntoViewIfNeeded();
+  const listbox = page.getByRole('listbox', { name });
+  for (let i = 0; i < 4; i += 1) {
+    await trigger.click();
+    if (await listbox.isVisible().catch(() => false)) break;
+    await page.waitForTimeout(200);
+  }
+  await listbox.getByRole('option', { name: optionName, exact: true }).click();
+}
+
+test.describe('V4-07 — numeric operators drive conditional visibility (public form)', () => {
+  test('slider value 60 (> 50) SHOWS the gated question', async ({ page, request }) => {
+    const { path } = await createForm(request, uniqueName('show'), publicConfig());
+    await openToFirstQuestion(page, path);
+
+    await setSlider(page, 60);
+    await page.locator('.pf__btn--inline').first().click();
+
+    // score 60 > 50 → the `why` branch is visible.
+    await expect(page.locator('.pf__question')).toHaveText('Why so high?');
+  });
+
+  test('slider value 40 (≤ 50) HIDES the gated question', async ({ page, request }) => {
+    const { path } = await createForm(request, uniqueName('hide'), publicConfig());
+    await openToFirstQuestion(page, path);
+
+    await setSlider(page, 40);
+    await page.locator('.pf__btn--inline').first().click();
+
+    // score 40 ≤ 50 → `why` is skipped; the next visible question is `email`.
+    await expect(page.locator('.pf__question')).toHaveText('Your email?');
+  });
+});
+
+test.describe('V4-08 — contradiction guard + operator UI (editor)', () => {
+  test('slider field exposes numeric operators; identical show/hide rules warn', async ({
+    page,
+    request,
+  }) => {
+    const { id } = await createForm(request, uniqueName('guard'), editorConfig());
+    await page.goto(`/admin/forms/${id}/edit`);
+
+    // Select the second question — the one that will carry the show/hide rules.
+    await page.getByTestId('question-spine').getByRole('button', { name: /Reason/ }).click();
+
+    // The Visibility panel's Show/Hide field selects are present.
+    await expect(page.getByRole('button', { name: 'Show when — Field' })).toBeVisible();
+
+    // Show when references the slider → the numeric operator dropdown appears…
+    await pickFromSelect(page, 'Show when — Field', 'Rate it');
+    await expect(page.getByTestId('logic-show-op')).toBeVisible();
+
+    // …and it offers the numeric comparison set (V4-07), not "matches any of".
+    const showOpTrigger = page.getByRole('button', { name: 'Show when — Condition' });
+    await showOpTrigger.click();
+    const showOpList = page.getByRole('listbox', { name: 'Show when — Condition' });
+    await expect(showOpList.getByRole('option', { name: 'Greater than', exact: true })).toBeVisible();
+    await expect(showOpList.getByRole('option', { name: 'Between', exact: true })).toBeVisible();
+    await showOpList.getByRole('option', { name: 'Equal to', exact: true }).click();
+    await page.getByTestId('logic-show-value').fill('5');
+
+    // No contradiction yet — the hide rule is still empty.
+    await expect(page.getByTestId('logic-contradiction')).toHaveCount(0);
+
+    // Hide when the SAME field equals the SAME value → the step could never show.
+    await pickFromSelect(page, 'Hide when — Field', 'Rate it');
+    await page.getByTestId('logic-hide-value').fill('5');
+
+    // V4-08 guard fires: a prominent inline warning (role=alert).
+    const warning = page.getByTestId('logic-contradiction');
+    await expect(warning).toBeVisible();
+    await expect(warning).toHaveAttribute('role', 'alert');
+
+    // Removing the overlap (hide value 6) resolves it — the guard is reactive.
+    await page.getByTestId('logic-hide-value').fill('6');
+    await expect(page.getByTestId('logic-contradiction')).toHaveCount(0);
+  });
+});

--- a/qa/e2e/v4-logicview.spec.ts
+++ b/qa/e2e/v4-logicview.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * V4-17 — the redesigned Logic view (read-only routing map).
+ *
+ * Builds a form with a branching question (two `goto` rules: one that skips
+ * straight to the end, one that jumps to a later question) plus scored outcomes,
+ * opens the editor's Logic tab, and asserts the map renders the expected node
+ * graph: a Start node, one card per question, the labelled purple branch edges
+ * (including the skip-to-end ending and the jump target), the traceable
+ * "Otherwise" default path, and the lime outcome/ending nodes. A screenshot of
+ * the map is captured for visual review.
+ *
+ * Forms are created per test via the admin API with a `v4lv-` slug prefix so the
+ * spec is self-contained and independent of seeded data.
+ */
+
+const API = 'http://localhost:4400';
+
+let seq = 0;
+function formName(label: string, workerIndex: number): string {
+  seq += 1;
+  return `v4lv logic ${label} w${workerIndex}-${seq}`;
+}
+
+/** A form whose first question branches (skip-to-end + forward jump) and that
+ *  resolves to two scored outcome buckets. Created as the LIVE config. */
+const branchingConfig = {
+  version: 1,
+  cover: { enabled: true, headline: 'Logic view QA', ctaText: 'Start' },
+  steps: [
+    {
+      key: 'company_size',
+      type: 'multiple_choice',
+      selectionMode: 'single',
+      question: 'How big is your company?',
+      options: [
+        { label: 'Just me', value: 'solo', points: 0 },
+        { label: '2–10', value: 'smb', points: 3 },
+        { label: '1000+', value: 'ent', points: 10 },
+      ],
+      goto: [
+        { values: ['solo'], target: null }, // skip straight to the end
+        { values: ['ent'], target: 'budget' }, // jump forward to the budget slider
+      ],
+    },
+    { key: 'role', type: 'text', question: 'What is your role?' },
+    { key: 'budget', type: 'slider', question: 'Monthly budget?', min: 0, max: 100, default: 10 },
+    { key: 'work_email', type: 'email', question: 'Work email', required: true },
+  ],
+  scoring: { enabled: true },
+  outcomes: [
+    { id: 'hot', label: 'Hot lead', minScore: 5, redirectUrl: 'https://example.com/book' },
+    { id: 'nurture', label: 'Nurture', minScore: -100 },
+  ],
+};
+
+async function createForm(request: APIRequestContext, name: string): Promise<{ id: string }> {
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config: branchingConfig } });
+  expect(res.ok(), `create form failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string; slug: string };
+  expect(body.slug.startsWith('v4lv'), `slug should be v4lv-prefixed, got ${body.slug}`).toBeTruthy();
+  return { id: body.id };
+}
+
+test('Logic tab renders the routing map: nodes, branch edges, otherwise path and endings', async ({
+  page,
+  request,
+}, testInfo) => {
+  const { id } = await createForm(request, formName('map', testInfo.workerIndex));
+
+  await page.goto(`/admin/forms/${id}/edit?tab=logic`);
+
+  // The map mounts and the Logic tab is the active section.
+  const map = page.getByTestId('logic-map');
+  await expect(map).toBeVisible();
+  await expect(page.getByTestId('editor-tab-logic')).toHaveAttribute('aria-current', 'true');
+
+  // Start capsule + one card per authored question.
+  await expect(page.getByTestId('logic-start')).toBeVisible();
+  await expect(page.getByTestId('logic-node')).toHaveCount(4);
+  await expect(map.getByText('How big is your company?')).toBeVisible();
+
+  // Two branch edges off the first question: a skip-to-end ending and a jump.
+  await expect(page.getByTestId('logic-branch')).toHaveCount(2);
+  // The skip-to-end edge is labelled with the human option label, and renders a
+  // lime ending node ("Thank you").
+  await expect(map.getByText('If Just me → skip to end')).toBeVisible();
+  await expect(page.getByTestId('logic-end')).toHaveCount(1);
+  // The jump edge points forward to the budget slider question.
+  await expect(map.getByText('If 1000+ → Monthly budget?')).toBeVisible();
+  await expect(page.getByTestId('logic-jump')).toHaveCount(1);
+
+  // The default ("Otherwise") path is labelled so the flow is traceable.
+  await expect(page.getByTestId('logic-otherwise')).toHaveCount(1);
+  await expect(map.getByText('Otherwise', { exact: false })).toBeVisible();
+
+  // The scored outcomes render as terminal ending nodes (one carries a redirect).
+  await expect(page.getByTestId('logic-outcome')).toHaveCount(2);
+  await expect(map.getByText('Hot lead')).toBeVisible();
+  await expect(map.getByText('Nurture')).toBeVisible();
+  await expect(map.getByText('example.com/book', { exact: false })).toBeVisible();
+
+  // Capture the whole map for visual review. The map lives in a scroll
+  // container, so grow the viewport first to bring every node into paint
+  // (otherwise the below-the-fold endings stitch in blank).
+  await page.setViewportSize({ width: 1200, height: 1500 });
+  await page.getByTestId('logic-outcome').last().scrollIntoViewIfNeeded();
+  await expect(map.getByText('Nurture')).toBeVisible();
+  await map.screenshot({ path: 'qa/shots/v4-logic-view.png' });
+});

--- a/qa/e2e/v4-qsettings.spec.ts
+++ b/qa/e2e/v4-qsettings.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+/**
+ * V4 — question-settings builder fixes (all editor-only, admin API + builder UI):
+ *
+ *  V4-10  NumberField no longer keeps a leading zero: typing "1" onto the
+ *         default "0" of an option Points field shows "1", not "01"; negatives
+ *         ("-3") are accepted. The numeric onChange contract is unchanged, so
+ *         the value still round-trips to the autosaved draft.
+ *  V4-02  Per-option MC Points are visible + editable and reflected; a hint
+ *         ties them to scoring; when scoring is on but nothing scores yet a
+ *         "assign points" nudge shows near the toggle and clears once points
+ *         are assigned.
+ *  V4-09  Enabling "Vary the question by a field" seeds one empty variant row
+ *         automatically; a scope note clarifies a variant only swaps the title.
+ *  V4-13  The name-step Field Key inputs are labeled as URL parameters for
+ *         prefill; the "Personal email only" visibility toggle is hidden on the
+ *         FIRST question (no earlier email could exist).
+ *
+ * Each test creates its own form via the admin API under a unique `v4qs-`
+ * prefixed name (per-run token + counter, never Date.now) so slugs don't
+ * collide and reruns stay idempotent. Editor-only — no public navigation, so
+ * the shared public rate-limit bucket is untouched.
+ */
+
+const API = 'http://localhost:4400';
+
+const RUN = Math.random().toString(36).slice(2, 8);
+let seq = 0;
+function uniqueName(label: string): string {
+  seq += 1;
+  return `v4qs-${label}-${RUN}-${seq}`;
+}
+
+const cover = (headline: string) => ({ enabled: true, headline, ctaText: 'Start' });
+
+/** POST /v1/forms (create writes LIVE config) → the form id + slug. */
+async function createForm(
+  request: APIRequestContext,
+  name: string,
+  config: Record<string, unknown>,
+): Promise<{ id: string; slug: string }> {
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config: { version: 1, ...config } } });
+  expect(res.ok(), `form creation failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string; slug: string };
+  return { id: body.id, slug: body.slug };
+}
+
+/** Open the builder and wait for the shell (Publish button) to render. */
+async function openEditor(page: Page, id: string): Promise<void> {
+  await page.goto(`/admin/forms/${id}/edit`);
+  await expect(page.getByRole('button', { name: 'Publish', exact: true })).toBeVisible({ timeout: 20_000 });
+}
+
+/** Read the autosaved DRAFT config back from the admin API. */
+async function draftConfig(request: APIRequestContext, id: string): Promise<Record<string, unknown> | undefined> {
+  const res = await request.get(`${API}/v1/forms/${id}`);
+  if (!res.ok()) return undefined;
+  const form = (await res.json()) as { draftConfig?: unknown };
+  return typeof form.draftConfig === 'string'
+    ? (JSON.parse(form.draftConfig) as Record<string, unknown>)
+    : (form.draftConfig as Record<string, unknown> | undefined);
+}
+
+test.describe('V4 question settings', () => {
+  test.setTimeout(60_000);
+
+  test('MC option Points: visible, no leading zero, negatives accepted, and persisted (V4-10 + V4-02)', async ({
+    page,
+    request,
+  }) => {
+    const { id } = await createForm(request, uniqueName('mc-points'), {
+      cover: cover('MC points QA'),
+      steps: [
+        {
+          key: 'pick',
+          type: 'multiple_choice',
+          question: 'Pick one',
+          options: [
+            { label: 'Alpha', value: 'a', points: 0 },
+            { label: 'Beta', value: 'b', points: 0 },
+          ],
+        },
+      ],
+    });
+    await openEditor(page, id);
+
+    // The pick step is auto-selected (index 0). Its first option's Points field
+    // is visible, and the scoring hint under the list renders (new i18n copy).
+    const p0 = page.getByTestId('option-points-0');
+    await expect(p0).toBeVisible();
+    await expect(p0).toHaveValue('0');
+    await expect(page.getByTestId('option-points-hint')).toBeVisible();
+
+    // V4-10 — leading zero fix: pressing "1" at the end of the default "0"
+    // shows "1", not "01" (the exact bug the redesign left behind).
+    await p0.click();
+    await p0.press('End');
+    await p0.press('1');
+    await expect(p0).toHaveValue('1');
+
+    // V4-02 — negative points are accepted (no min on the input; "-" types).
+    await p0.fill('');
+    await p0.pressSequentially('-3');
+    await expect(p0).toHaveValue('-3');
+
+    // A clean positive round-trips into the autosaved draft (editable + no crash).
+    await p0.fill('7');
+    await expect(p0).toHaveValue('7');
+    await expect
+      .poll(
+        async () => {
+          const draft = await draftConfig(request, id);
+          const steps = (draft?.steps ?? []) as { options?: { points?: number }[] }[];
+          return steps[0]?.options?.[0]?.points ?? 'missing';
+        },
+        { timeout: 15_000, message: 'autosaved draft never carried the option points' },
+      )
+      .toBe(7);
+  });
+
+  test('scoring-on-with-no-points shows the "assign points" nudge; adding points clears it (V4-02)', async ({
+    page,
+    request,
+  }) => {
+    const { id } = await createForm(request, uniqueName('zero-hint'), {
+      cover: cover('Zero hint QA'),
+      scoring: { enabled: true },
+      steps: [
+        {
+          key: 'pick',
+          type: 'multiple_choice',
+          question: 'Pick one',
+          options: [
+            { label: 'Alpha', value: 'a', points: 0 },
+            { label: 'Beta', value: 'b', points: 0 },
+          ],
+        },
+      ],
+    });
+    await openEditor(page, id);
+
+    // Scoring is on but the highest possible total is 0 → the nudge shows.
+    await expect(page.getByTestId('scoring-zero-hint')).toBeVisible();
+
+    // Assigning positive points recomputes the max live → the nudge disappears.
+    await page.getByTestId('option-points-0').fill('5');
+    await expect(page.getByTestId('scoring-zero-hint')).toHaveCount(0);
+  });
+
+  test('enabling the dynamic question seeds one variant row + shows the scope note (V4-09)', async ({
+    page,
+    request,
+  }) => {
+    const { id } = await createForm(request, uniqueName('variants'), {
+      cover: cover('Variants QA'),
+      steps: [
+        {
+          key: 'role',
+          type: 'multiple_choice',
+          question: 'Your role',
+          options: [
+            { label: 'Founder', value: 'founder', points: 0 },
+            { label: 'Student', value: 'student', points: 0 },
+          ],
+        },
+        { key: 'topic', type: 'text', question: 'Tell us more' },
+      ],
+    });
+    await openEditor(page, id);
+
+    // Select q2 (index 1) so a prior field exists and the toggle is enabled.
+    await page.getByRole('button', { name: /Tell us more/ }).first().click();
+    const enable = page.getByRole('switch', { name: 'Vary the question by a field' });
+    await expect(enable).toBeEnabled();
+
+    // No variant rows before enabling.
+    await expect(page.getByLabel('Ask instead')).toHaveCount(0);
+
+    // Enabling seeds exactly one empty variant row (the pattern is now visible).
+    await enable.click();
+    await expect(page.getByLabel('Ask instead')).toHaveCount(1);
+
+    // The scope note clarifies a variant only swaps the title.
+    await expect(page.getByTestId('variants-scope-note')).toBeVisible();
+  });
+
+  test('the "Personal email only" toggle is hidden on the first question (V4-13)', async ({
+    page,
+    request,
+  }) => {
+    const { id } = await createForm(request, uniqueName('personal-email'), {
+      cover: cover('Personal email QA'),
+      steps: [
+        {
+          key: 'role',
+          type: 'multiple_choice',
+          question: 'Your role',
+          options: [{ label: 'Founder', value: 'founder', points: 0 }],
+        },
+        { key: 'topic', type: 'text', question: 'Tell us more' },
+      ],
+    });
+    await openEditor(page, id);
+
+    // Q1 (index 0) is auto-selected and is NOT an email step, yet the
+    // personal-email branch is impossible here (no earlier email) → hidden.
+    await expect(page.getByRole('switch', { name: 'Personal email only' })).toHaveCount(0);
+
+    // Q2 (index 1, non-email) → the toggle is available again.
+    await page.getByRole('button', { name: /Tell us more/ }).first().click();
+    await expect(page.getByRole('switch', { name: 'Personal email only' })).toHaveCount(1);
+  });
+
+  test('name-step field keys are labeled as URL parameters for prefill (V4-13)', async ({
+    page,
+    request,
+  }) => {
+    const { id } = await createForm(request, uniqueName('namekey'), {
+      cover: cover('Name key QA'),
+      steps: [{ key: 'fullname', type: 'name', question: 'Your name' }],
+    });
+    await openEditor(page, id);
+
+    // The name step is auto-selected → the Field Key hint about URL-param
+    // prefill renders under the two field-key inputs.
+    const hint = page.getByTestId('name-fieldkey-hint');
+    await expect(hint).toBeVisible();
+    await expect(hint).toContainText('URL parameter');
+  });
+});

--- a/qa/e2e/v4-reveal.spec.ts
+++ b/qa/e2e/v4-reveal.spec.ts
@@ -1,0 +1,272 @@
+import { test, expect, type APIRequestContext, type Locator, type Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * V4-04 / V4-16 — the reveal screen has a POSITION (config.revealAfterStep) that
+ * is authoritative, visible, and draggable, defaulting to the END of the form so
+ * an enabled reveal never plays mid-form by accident; and each outcome can carry
+ * its own thank-you body (config.outcomes[].message).
+ *
+ * Three independent journeys prove it through the real HTTP surface (fresh form
+ * per test via the admin API; slug prefixed `v4rev-`; accountCode resolved from
+ * GET /v1/me — never hardcoded; the DB is only written through the app):
+ *
+ *  (a) A reveal-enabled 3-question form shows the "Reveal screen" marker in the
+ *      question spine defaulted to AFTER THE LAST question, and the public form
+ *      plays NO reveal between questions — only after the final question, right
+ *      before the result (the mid-form-reveal bug is gone).
+ *  (b) Dragging the marker up one slot (dnd-kit keyboard path) autosaves an
+ *      explicit revealAfterStep (asserted via GET /v1/forms/:id draftConfig).
+ *  (c) A per-outcome message typed in Results autosaves, and after publishing a
+ *      submission that lands in that outcome shows the message (interpolated) as
+ *      the done-screen body.
+ */
+
+const API = 'http://localhost:4400';
+
+/** Per-run nonce so reruns mint distinct forms (Date.now is banned in specs). */
+const RUN = randomUUID().slice(0, 8);
+let formSeq = 0;
+
+/** The admin principal's public account code (NOT hardcoded `acme`). */
+async function accountCode(request: APIRequestContext): Promise<string> {
+  const res = await request.get(`${API}/v1/me`);
+  expect(res.ok(), 'GET /v1/me should resolve the local principal').toBeTruthy();
+  const me = (await res.json()) as { accountCode?: string; accountShortCode?: string };
+  const code = me.accountCode ?? me.accountShortCode;
+  expect(code, '/v1/me must expose an account code').toBeTruthy();
+  return code as string;
+}
+
+/** Create a fresh, immediately-live form (POST writes live config). */
+async function createForm(
+  request: APIRequestContext,
+  config: Record<string, unknown>,
+): Promise<{ id: string; slug: string }> {
+  formSeq += 1;
+  const name = `v4rev-${RUN}-w${test.info().workerIndex}-${formSeq}`;
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config } });
+  expect(res.ok(), `form creation failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string; slug: string };
+  expect(body.slug.startsWith('v4rev-'), `slug must carry the v4rev- prefix: ${body.slug}`).toBe(true);
+  return body;
+}
+
+/** A reveal-enabled form with three plain text questions (no explicit position). */
+function revealConfig(): Record<string, unknown> {
+  return {
+    version: 1,
+    cover: { enabled: true, headline: 'Reveal position QA', ctaText: 'Start' },
+    steps: [
+      { key: 'q1', type: 'text', question: 'First question', required: true },
+      { key: 'q2', type: 'text', question: 'Second question', required: true },
+      { key: 'q3', type: 'text', question: 'Third question', required: true },
+    ],
+    scoring: { enabled: true },
+    outcomes: [{ id: 'default', label: 'All done', minScore: -100 }],
+    // Enabled, but NO revealAfterStep and NO triggersReveal → engine defaults it
+    // to after the last question.
+    reveal: { enabled: true, headline: 'Reviewing your answers…', durationMs: 1200 },
+  };
+}
+
+/** The pending draft's revealAfterStep (null = no draft yet, 'unset' = absent). */
+async function draftReveal(
+  request: APIRequestContext,
+  formId: string,
+): Promise<number | 'no-draft' | 'unset'> {
+  const res = await request.get(`${API}/v1/forms/${formId}`);
+  if (!res.ok()) return 'no-draft';
+  const body = (await res.json()) as { draftConfig?: { revealAfterStep?: number } | null };
+  if (body.draftConfig == null) return 'no-draft';
+  return body.draftConfig.revealAfterStep ?? 'unset';
+}
+
+/** Vertical center of a locator — used to assert the marker's slot in the spine. */
+async function centerY(loc: Locator): Promise<number> {
+  const box = await loc.boundingBox();
+  expect(box, 'element should be laid out').toBeTruthy();
+  return box!.y + box!.height / 2;
+}
+
+/**
+ * The public surface is per-IP rate-limited and every concurrent QA spec shares
+ * the browser-origin bucket; a transient 429 leaves the cover unrendered. Retry
+ * the initial fetch with a refill pause, then start the flow.
+ */
+async function openCover(page: Page, url: string): Promise<void> {
+  const start = page.getByRole('button', { name: 'Start' });
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    await page.goto(url);
+    const visible = await start
+      .waitFor({ state: 'visible', timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (visible) {
+      await start.click();
+      return;
+    }
+    await page.waitForTimeout(2_000); // let the shared token bucket refill
+  }
+  throw new Error('form cover never rendered (public form fetch likely rate-limited)');
+}
+
+/** Fill the current text step and click its inline Continue button. */
+async function fillAndContinue(page: Page, value: string): Promise<void> {
+  const input = page.locator('input[type="text"]');
+  await expect(input).toBeVisible();
+  await input.fill(value);
+  await page.locator('.pf__btn--inline').first().click();
+}
+
+test('reveal marker defaults to the END; the public form plays no mid-form reveal', async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+  const code = await accountCode(request);
+  const form = await createForm(request, revealConfig());
+
+  // --- Editor: the reveal marker renders defaulted AFTER the last question ----
+  await page.goto(`/admin/forms/${form.id}/edit`);
+  const spine = page.getByTestId('question-spine');
+  const marker = page.getByTestId('reveal-point-row');
+  await expect(marker).toBeVisible();
+
+  const q1 = spine.getByText('First question', { exact: true });
+  const q3 = spine.getByText('Third question', { exact: true });
+  // Defaulted to the end: the marker sits BELOW the last question card.
+  expect(await centerY(marker)).toBeGreaterThan(await centerY(q3));
+  expect(await centerY(marker)).toBeGreaterThan(await centerY(q1));
+
+  // --- Public: no reveal between questions, only after the LAST one -----------
+  await openCover(page, `/${code}/me/${form.slug}`);
+  await expect(page.locator('.pf__question')).toHaveText('First question');
+  await fillAndContinue(page, 'one');
+  // Straight to Q2 — the reveal must NOT play mid-form.
+  await expect(page.locator('.pf__question')).toHaveText('Second question');
+  await expect(page.locator('.pf-reveal__headline')).toHaveCount(0);
+  await fillAndContinue(page, 'two');
+  await expect(page.locator('.pf__question')).toHaveText('Third question');
+  await expect(page.locator('.pf-reveal__headline')).toHaveCount(0);
+
+  // Completing the LAST question plays the reveal as the pre-result interstitial…
+  await fillAndContinue(page, 'three');
+  await expect(page.locator('.pf-reveal__headline')).toBeVisible({ timeout: 3_000 });
+  // …then it hands off to the thank-you screen on its own.
+  await expect(page.locator('.pf-done__title')).toBeVisible({ timeout: 8_000 });
+});
+
+test('dragging the reveal marker up one slot autosaves an explicit revealAfterStep', async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(90_000);
+  const form = await createForm(request, revealConfig());
+
+  await page.goto(`/admin/forms/${form.id}/edit`);
+  const spine = page.getByTestId('question-spine');
+  const marker = page.getByTestId('reveal-point-row');
+  await expect(marker).toBeVisible();
+
+  const q2 = spine.getByText('Second question', { exact: true });
+  const q3 = spine.getByText('Third question', { exact: true });
+  // Starts at the end (below Q3).
+  expect(await centerY(marker)).toBeGreaterThan(await centerY(q3));
+
+  // Move the marker one slot UP via dnd-kit's keyboard path (deterministic).
+  const handle = page.getByTestId('reveal-point-handle');
+  await handle.focus();
+  await page.keyboard.press('Space'); // pick up
+  await page.waitForTimeout(300);
+  await page.keyboard.press('ArrowUp'); // over question 3
+  await page.waitForTimeout(300);
+  await page.keyboard.press('Space'); // drop → now after question 2
+
+  await expect
+    .poll(() => draftReveal(request, form.id), {
+      message: 'moving the marker up one slot should autosave revealAfterStep: 2',
+      timeout: 15_000,
+      intervals: [500, 1_000],
+    })
+    .toBe(2);
+
+  // The marker now sits between Q2 and Q3.
+  expect(await centerY(marker)).toBeGreaterThan(await centerY(q2));
+  expect(await centerY(marker)).toBeLessThan(await centerY(q3));
+});
+
+test('a per-outcome message is editable, autosaves, and shows on the done screen', async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+  const code = await accountCode(request);
+  // email + a scored choice; two ranges so a 10-point pick lands in "High".
+  const form = await createForm(request, {
+    version: 1,
+    cover: { enabled: true, headline: 'Outcome message QA', ctaText: 'Start' },
+    steps: [
+      { key: 'email', type: 'email', question: 'Your email?', required: true },
+      {
+        key: 'pick',
+        type: 'multiple_choice',
+        question: 'Pick one',
+        flowGroup: 'qualification',
+        options: [
+          { label: 'Alpha', value: 'alpha', points: 10 },
+          { label: 'Beta', value: 'beta', points: 0 },
+        ],
+      },
+    ],
+    scoring: { enabled: true },
+    outcomes: [
+      { id: 'low', label: 'Nurture', minScore: 0 },
+      { id: 'high', label: 'Priority lead', minScore: 5 },
+    ],
+  });
+
+  // --- Editor: type a message on the HIGH range in Results --------------------
+  await page.goto(`/admin/forms/${form.id}/edit?tab=results`);
+  const rows = page.getByTestId('outcome-row');
+  await expect(rows).toHaveCount(2); // sorted ascending → [Nurture(0), Priority(5)]
+  const message = 'You booked a spot at [email] — talk soon!';
+  await rows.nth(1).getByTestId('outcome-message').fill(message);
+
+  // Autosaves onto the HIGH outcome's draft.
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get(`${API}/v1/forms/${form.id}`);
+        if (!res.ok()) return null;
+        const body = (await res.json()) as {
+          draftConfig?: { outcomes?: Array<{ id: string; message?: string }> } | null;
+        };
+        return body.draftConfig?.outcomes?.find((o) => o.id === 'high')?.message ?? null;
+      },
+      { message: 'the message should autosave on the high outcome', timeout: 15_000, intervals: [500, 1_000] },
+    )
+    .toBe(message);
+
+  // Publish the draft so the public form serves the message.
+  const pub = await request.post(`${API}/v1/forms/${form.id}/publish`);
+  expect(pub.ok(), `publish failed: ${pub.status()}`).toBeTruthy();
+
+  // --- Public: a high-scoring submission shows the interpolated message -------
+  const email = `qa-outcome-msg-${RUN}@example.com`;
+  await openCover(page, `/${code}/me/${form.slug}`);
+  await expect(page.locator('.pf__question')).toHaveText('Your email?');
+  const emailInput = page.locator('input[type="email"]');
+  await emailInput.fill(email);
+  await page.locator('.pf__btn--inline').first().click();
+
+  // The choice auto-advances on select; the 10-point pick lands in "Priority".
+  await expect(page.locator('.pf__question')).toHaveText('Pick one');
+  await page.getByRole('radio', { name: 'Alpha' }).click();
+
+  // Done screen: heading = outcome label, body = the interpolated message.
+  await expect(page.locator('.pf-done__title')).toHaveText('Priority lead', { timeout: 12_000 });
+  await expect(page.locator('.pf-done__body')).toHaveText(
+    `You booked a spot at ${email} — talk soon!`,
+  );
+});

--- a/qa/e2e/v4-save.spec.ts
+++ b/qa/e2e/v4-save.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * V4 — the editor autosave is now BULLETPROOF and the Results panel is clear.
+ *
+ * Four independent journeys prove the round-trip through the real HTTP surface
+ * (fresh form per test via the admin API; slug prefixed `v4save-`; the DB is only
+ * ever written through the app):
+ *
+ *   (a) Add a score range in Results → it AUTOSAVES (the empty-label outcome that
+ *       used to 400 the whole config now persists to draftConfig; no error state).
+ *   (b) An outcome heading + a SCHEMELESS redirect (`example.com`) → saves, with
+ *       the redirect normalized to `https://example.com` (no doomed request).
+ *   (c) Numbering: a lead-capture step + an earlier scored choice + a scored
+ *       slider at question 5 → the read-only Points card shows the REAL question
+ *       number ("5"), not its index in the filtered scoring list ("2").
+ *   (d) Leave-while-dirty: mutate an outcome then click Back before the debounce
+ *       fires → the flush-on-leave still persists the change (polled via the API).
+ */
+
+const API = 'http://localhost:4400';
+
+/** Per-run nonce so reruns mint distinct forms (Date.now is banned in specs). */
+const RUN = randomUUID().slice(0, 8);
+let formSeq = 0;
+
+type Cfg = Record<string, unknown>;
+
+/** A scored form with one slider + one outcome — the Results panel has content. */
+function scoredConfig(): Cfg {
+  return {
+    version: 1,
+    cover: { enabled: true, headline: 'V4 save QA', ctaText: 'Start' },
+    steps: [
+      {
+        key: 'budget',
+        type: 'slider',
+        question: 'Budget?',
+        min: 0,
+        max: 100,
+        default: 10,
+        sliderScoring: [
+          { min: 0, max: 50, points: 1 },
+          { min: 51, max: 100, points: 5 },
+        ],
+        flowGroup: 'qualification',
+      },
+    ],
+    scoring: { enabled: true },
+    outcomes: [{ id: 'base', label: 'Base', minScore: -100 }],
+  };
+}
+
+/**
+ * A form whose SCORED slider is question 5: an email (lead-capture, unscored), a
+ * scored choice at Q2, two text steps (unscored), then the slider at Q5. The
+ * filtered scoring list is [choice(Q2), slider(Q5)] — so the OLD filtered index
+ * would render the slider as "Question 2"; the fix renders its real number "5".
+ */
+function numberingConfig(): Cfg {
+  return {
+    version: 1,
+    cover: { enabled: true, headline: 'V4 numbering QA', ctaText: 'Start' },
+    steps: [
+      { key: 'email', type: 'email', question: 'Your email?', required: true, flowGroup: 'lead_capture' },
+      {
+        key: 'segment',
+        type: 'multiple_choice',
+        question: 'Segment?',
+        flowGroup: 'qualification',
+        options: [
+          { label: 'SMB', value: 'smb', points: 1 },
+          { label: 'Enterprise', value: 'ent', points: 5 },
+        ],
+      },
+      { key: 'role', type: 'text', question: 'Your role?' },
+      { key: 'notes', type: 'textarea', question: 'Anything else?' },
+      {
+        key: 'budget',
+        type: 'slider',
+        question: 'Budget?',
+        min: 0,
+        max: 100,
+        default: 10,
+        sliderScoring: [{ min: 0, max: 100, points: 3 }],
+        flowGroup: 'qualification',
+      },
+    ],
+    scoring: { enabled: true },
+    outcomes: [{ id: 'base', label: 'Base', minScore: -100 }],
+  };
+}
+
+/** The admin principal's public account code (NOT hardcoded `acme`). */
+async function accountCode(request: APIRequestContext): Promise<string> {
+  const res = await request.get(`${API}/v1/me`);
+  expect(res.ok(), 'GET /v1/me should resolve the local principal').toBeTruthy();
+  const me = (await res.json()) as { accountCode?: string; accountShortCode?: string };
+  const code = me.accountCode ?? me.accountShortCode;
+  expect(code, '/v1/me must expose an account code').toBeTruthy();
+  return code as string;
+}
+
+/** Create a fresh, immediately-live form (POST writes live config). */
+async function createForm(request: APIRequestContext, label: string, config: Cfg): Promise<string> {
+  formSeq += 1;
+  const name = `v4save-${label}-${RUN}-w${test.info().workerIndex}-${formSeq}`;
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config } });
+  expect(res.ok(), `form creation failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string; slug: string };
+  expect(body.slug.startsWith('v4save-'), `slug must carry the v4save- prefix: ${body.slug}`).toBe(true);
+  return body.id;
+}
+
+/** The pending draft's outcomes (null when no draft has been written yet). */
+async function draftOutcomes(
+  request: APIRequestContext,
+  id: string,
+): Promise<Array<{ id: string; label: string; minScore?: number; redirectUrl?: string | null }> | null> {
+  const res = await request.get(`${API}/v1/forms/${id}`);
+  if (!res.ok()) return null;
+  const body = (await res.json()) as { draftConfig?: { outcomes?: unknown[] } | null };
+  if (body.draftConfig == null) return null;
+  return (body.draftConfig.outcomes ?? []) as Array<{
+    id: string;
+    label: string;
+    minScore?: number;
+    redirectUrl?: string | null;
+  }>;
+}
+
+/** Open the editor on a given tab and wait for the shell to be interactive. */
+async function openEditor(page: Page, id: string, tab: string): Promise<void> {
+  await page.goto(`/admin/forms/${id}/edit?tab=${tab}`);
+  await expect(page.getByTestId('editor-save-status')).toBeVisible();
+}
+
+test('(a) adding a score range autosaves — the empty-label outcome persists, no error', async ({
+  page,
+  request,
+}) => {
+  const id = await createForm(request, 'add-range', scoredConfig());
+  await openEditor(page, id, 'results');
+
+  await expect(page.getByTestId('outcome-row')).toHaveCount(1); // the seeded "Base"
+  await page.getByTestId('results-add-range').click();
+  await expect(page.getByTestId('outcome-row')).toHaveCount(2); // new range appears
+
+  // Durable: the draft now carries TWO outcomes (the new one has an empty label,
+  // which used to 400 the whole PUT and poison every later save).
+  await expect
+    .poll(async () => (await draftOutcomes(request, id))?.length ?? 0, {
+      message: 'autosave must persist the newly-added range to draftConfig',
+      timeout: 15_000,
+      intervals: [500, 1_000],
+    })
+    .toBe(2);
+
+  // And the editor settled on "saved", never the error state.
+  await expect(page.getByTestId('editor-save-status')).toHaveAttribute('data-status', 'saved');
+});
+
+test('(b) outcome heading + schemeless redirect saves — redirect normalized to https://', async ({
+  page,
+  request,
+}) => {
+  const id = await createForm(request, 'redirect', scoredConfig());
+  await openEditor(page, id, 'results');
+
+  // The label is the heading respondents see for this range.
+  await page.getByTestId('outcome-label').first().fill('Hot lead — thanks!');
+  // A schemeless redirect: it must be upgraded to https:// on blur, not sent raw.
+  const redirect = page.getByTestId('outcome-redirect').first();
+  await redirect.fill('example.com');
+  await redirect.blur();
+
+  await expect
+    .poll(
+      async () => {
+        const o = (await draftOutcomes(request, id))?.[0];
+        return o ? `${o.label}|${o.redirectUrl ?? ''}` : '';
+      },
+      {
+        message: 'the heading + normalized redirect must persist to the draft',
+        timeout: 15_000,
+        intervals: [500, 1_000],
+      },
+    )
+    .toBe('Hot lead — thanks!|https://example.com');
+
+  await expect(page.getByTestId('editor-save-status')).toHaveAttribute('data-status', 'saved');
+});
+
+test('(c) Results numbering: a slider at question 5 shows "5", not its filtered index "2"', async ({
+  page,
+  request,
+}) => {
+  const id = await createForm(request, 'numbering', numberingConfig());
+  await openEditor(page, id, 'results');
+
+  // Two Points cards render (the scored choice at Q2, then the scored slider at
+  // Q5) — in step order. Their number chips must be the REAL positions.
+  const numbers = page.getByTestId('points-question-number');
+  await expect(numbers).toHaveCount(2);
+  await expect(numbers.nth(0)).toHaveText('2'); // the choice is question 2
+  await expect(numbers.nth(1)).toHaveText('5'); // the slider is question 5, not "2"
+});
+
+test('(d) leave-while-dirty: mutate then click Back fast — the change is still persisted', async ({
+  page,
+  request,
+}) => {
+  const id = await createForm(request, 'leave', scoredConfig());
+  await openEditor(page, id, 'results');
+
+  // Mutate an outcome, then navigate away BEFORE the ~900ms debounce fires.
+  await page.getByTestId('outcome-label').first().fill('LeaveSaved');
+  await page.locator('a[href="/admin/forms"]').first().click(); // Back — SPA nav unmounts the editor
+
+  // The flush-on-leave (effect cleanup → server action) still persisted it.
+  await expect
+    .poll(async () => (await draftOutcomes(request, id))?.[0]?.label ?? '', {
+      message: 'flush-on-leave must persist the mutation made just before navigating away',
+      timeout: 15_000,
+      intervals: [500, 1_000],
+    })
+    .toBe('LeaveSaved');
+});

--- a/qa/e2e/v4-template.spec.ts
+++ b/qa/e2e/v4-template.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+/**
+ * V4-11 — the guided empty-state template picker
+ * (apps/web/app/admin/forms/[id]/edit/_components/empty-state.tsx).
+ *
+ * A brand-new form (zero questions) shows the guided empty state: a clear
+ * "Start from scratch" option FIRST, then four template cards (Lead qualifier /
+ * Contact / Feedback / RSVP). This spec locks in:
+ *  a. the scratch option + every template card are real buttons (role=button)
+ *     and clickable;
+ *  b. picking the Lead qualifier template APPLIES its steps — the WYSIWYG canvas
+ *     leaves the empty state and shows the template's first question;
+ *  c. picking a template PRESERVES the name the user already gave the form — it
+ *     is NOT replaced by the template's name ("Lead qualifier"). The name guard
+ *     lives in form-editor.tsx `applyTemplate` (templates swap `config` only).
+ *
+ * Forms are created via the admin API with unique `v4tpl-` names and EMPTY
+ * steps so the editor renders the guided empty state.
+ */
+
+const API = 'http://localhost:4400';
+
+const RUN = Math.random().toString(36).slice(2, 8);
+let seq = 0;
+function uniqueName(label: string): string {
+  seq += 1;
+  return `v4tpl-${label}-${RUN}-${seq}`;
+}
+
+/** Create a form with NO questions so the editor shows the guided empty state. */
+async function createEmptyForm(request: APIRequestContext, name: string): Promise<string> {
+  const res = await request.post(`${API}/v1/forms`, {
+    data: { name, config: { version: 1, steps: [] } },
+  });
+  expect(res.ok(), `form creation failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+/** Open the editor and wait for the guided empty state to render. */
+async function openEmptyState(page: Page, id: string): Promise<void> {
+  await page.goto(`/admin/forms/${id}/edit`);
+  await expect(page.getByTestId('empty-scratch')).toBeVisible({ timeout: 20_000 });
+}
+
+/** The form-name input in the editor header — a plain textbox (only the canvas
+ *  title became a combobox). Scoped to <header> so it is locale-independent and
+ *  never collides with the type-gallery search input. */
+function nameInput(page: Page) {
+  return page.locator('header input').first();
+}
+
+const TEMPLATE_IDS = ['lead', 'contact', 'feedback', 'rsvp'] as const;
+
+test('the scratch option and every template card are buttons and are clickable', async ({
+  page,
+  request,
+}) => {
+  const id = await createEmptyForm(request, uniqueName('semantics'));
+  await openEmptyState(page, id);
+
+  // Start-from-scratch is the clear first option, and a real button.
+  const scratch = page.getByRole('button', { name: /start from scratch/i });
+  await expect(scratch).toBeVisible();
+  await expect(page.getByTestId('empty-scratch')).toHaveJSProperty('tagName', 'BUTTON');
+
+  // All four template cards are native buttons (implicit role=button).
+  for (const tid of TEMPLATE_IDS) {
+    const card = page.getByTestId(`empty-template-${tid}`);
+    await expect(card).toBeVisible();
+    await expect(card).toHaveJSProperty('tagName', 'BUTTON');
+  }
+
+  // The card exposes its label to assistive tech (role + accessible name).
+  await expect(page.getByRole('button', { name: /lead qualifier/i })).toBeVisible();
+
+  // Clickable: the scratch option opens the type gallery (an a11y dialog).
+  await scratch.click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+});
+
+test('picking the Lead qualifier template applies its steps to the canvas', async ({
+  page,
+  request,
+}) => {
+  const id = await createEmptyForm(request, uniqueName('applies'));
+  await openEmptyState(page, id);
+
+  await page.getByTestId('empty-template-lead').click();
+
+  // The empty state is replaced by the WYSIWYG build canvas, and the selected
+  // question is the template's first step (the corporate-email question).
+  const title = page.getByTestId('canvas-title-input');
+  await expect(title).toBeVisible({ timeout: 15_000 });
+  await expect(title).toHaveValue(/work email/i);
+  await expect(page.getByTestId('empty-scratch')).toHaveCount(0);
+});
+
+test('picking a template preserves the user-given form name (not replaced by the template name)', async ({
+  page,
+  request,
+}) => {
+  const original = uniqueName('keepname');
+  const id = await createEmptyForm(request, original);
+  await openEmptyState(page, id);
+
+  // Sanity: the header shows the name the form was created with.
+  await expect(nameInput(page)).toHaveValue(original);
+
+  await page.getByTestId('empty-template-lead').click();
+
+  // Steps were applied…
+  await expect(page.getByTestId('canvas-title-input')).toBeVisible({ timeout: 15_000 });
+  // …but the form KEEPS its name — it must NOT become "Lead qualifier".
+  await expect(nameInput(page)).toHaveValue(original);
+  await expect(nameInput(page)).not.toHaveValue('Lead qualifier');
+});

--- a/qa/e2e/v4-tokens.spec.ts
+++ b/qa/e2e/v4-tokens.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+/**
+ * V4-06 + V4-15 — the `@`/`[` recall-information picker on the canvas
+ * (TokenTextarea in
+ * apps/web/app/admin/forms/[id]/edit/_components/token-textarea.tsx).
+ *
+ * V4-06 (warning misclassification): a `[token]` whose field IS captured by a
+ * step but that step comes AFTER the current one must warn `later` ("asked
+ * after this step — it will be empty here"), NOT `unknown` ("doesn't exist").
+ * `unknown` is reserved for a token no step captures anywhere in the form. The
+ * real reported case: a Q2 email titled `Usa tu correo del trabajo
+ * [presupuesto]` where `presupuesto` is a LATER multiple_choice (Q4).
+ *
+ * V4-15 (picker on the description): the engine's `resolveStepDisplay` only
+ * interpolates the `question` (+ slider label) — the description/`helper` is
+ * rendered RAW by the public renderer (form-renderer.tsx: `{step.helper}`), so
+ * a `[token]` in the description would publish literally. The picker is
+ * therefore deliberately NOT wired on the description; this spec locks that in
+ * (typing `@` there opens no picker).
+ *
+ * Forms are created via the admin API with unique `v4tok-` names.
+ */
+
+const API = 'http://localhost:4400';
+
+const RUN = Math.random().toString(36).slice(2, 8);
+let seq = 0;
+function uniqueName(label: string): string {
+  seq += 1;
+  return `v4tok-${label}-${RUN}-${seq}`;
+}
+
+const Q_NAME = '¿Cómo te llamas?';
+const Q_EMAIL = 'Tu correo de trabajo';
+const Q_COMPANY = '¿En qué empresa trabajas?';
+const Q_BUDGET = '¿Cuál es tu presupuesto?';
+
+/**
+ * Q1 name (firstname/lastname) · Q2 email `email` · Q3 text `empresa` ·
+ * Q4 multiple_choice `presupuesto` — so `presupuesto` is captured LATER than
+ * the Q2 email whose title references `[presupuesto]`.
+ */
+function config() {
+  return {
+    version: 1,
+    cover: { enabled: true, headline: 'V4 tokens QA', ctaText: 'Start' },
+    steps: [
+      { key: 'fullname', type: 'name', question: Q_NAME, required: false, fields: ['firstname', 'lastname'] },
+      { key: 'email', type: 'email', question: Q_EMAIL, required: true },
+      { key: 'empresa', type: 'text', question: Q_COMPANY },
+      {
+        key: 'presupuesto',
+        type: 'multiple_choice',
+        question: Q_BUDGET,
+        options: [
+          { label: 'Menos de 10k', value: 'low', points: 0 },
+          { label: 'Más de 10k', value: 'high', points: 5 },
+        ],
+      },
+    ],
+  };
+}
+
+async function createForm(request: APIRequestContext, name: string): Promise<string> {
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config: config() } });
+  expect(res.ok(), `form creation failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+function title(page: Page) {
+  return page.getByTestId('canvas-title-input');
+}
+
+async function selectStep(page: Page, questionText: string): Promise<void> {
+  await page.getByRole('button', { name: questionText }).first().click();
+}
+
+async function openEditor(page: Page, id: string): Promise<void> {
+  await page.goto(`/admin/forms/${id}/edit`);
+  await expect(title(page)).toHaveValue(Q_NAME);
+}
+
+test('V4-06: a token captured by a LATER step warns `later`, not `unknown`; a token no step captures warns `unknown`', async ({
+  page,
+  request,
+}) => {
+  const id = await createForm(request, uniqueName('later-vs-unknown'));
+  await openEditor(page, id);
+
+  // Select Q2 (the email) and reference `[presupuesto]` — captured at Q4.
+  await selectStep(page, Q_EMAIL);
+  await expect(title(page)).toHaveValue(Q_EMAIL);
+
+  await title(page).fill('Usa tu correo del trabajo [presupuesto]');
+  const warning = page.getByTestId('token-warning');
+  await expect(warning).toHaveCount(1);
+  // The core of V4-06: it exists (later), so the kind is `later`, NOT `unknown`.
+  await expect(warning).toHaveAttribute('data-kind', 'later');
+  await expect(warning).toContainText('[presupuesto]');
+  await expect(warning).toContainText('after this step');
+
+  // A token that matches NO step's field key → `unknown`.
+  await title(page).fill('Hola [nonexistent]');
+  await expect(warning).toHaveCount(1);
+  await expect(warning).toHaveAttribute('data-kind', 'unknown');
+  await expect(warning).toContainText('[nonexistent]');
+
+  // Referencing an EARLIER-captured field (firstname, from Q1) → no warning.
+  await title(page).fill('Hola [firstname]');
+  await expect(page.getByTestId('token-warning')).toHaveCount(0);
+
+  // Clearing the token clears the chip entirely.
+  await title(page).fill('Hola');
+  await expect(page.getByTestId('token-warning')).toHaveCount(0);
+});
+
+test('V4-15: the description textarea has NO token picker (the engine never interpolates the description)', async ({
+  page,
+  request,
+}) => {
+  const id = await createForm(request, uniqueName('no-desc-picker'));
+  await openEditor(page, id);
+
+  await selectStep(page, Q_EMAIL);
+  await expect(title(page)).toHaveValue(Q_EMAIL);
+
+  // Typing `@` in the title DOES open the picker (control: the picker works).
+  await title(page).click();
+  await page.keyboard.press('End');
+  await title(page).pressSequentially('@');
+  await expect(page.getByTestId('token-picker')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('token-picker')).toHaveCount(0);
+
+  // Typing `@` in the description does NOT — the description publishes raw, so
+  // a picker there would be misleading.
+  const description = page.getByLabel('Add a description (optional)');
+  await description.click();
+  await description.pressSequentially('@');
+  await expect(page.getByTestId('token-picker')).toHaveCount(0);
+});

--- a/qa/e2e/v4-tokens.spec.ts
+++ b/qa/e2e/v4-tokens.spec.ts
@@ -12,12 +12,13 @@ import { test, expect, type APIRequestContext, type Page } from '@playwright/tes
  * real reported case: a Q2 email titled `Usa tu correo del trabajo
  * [presupuesto]` where `presupuesto` is a LATER multiple_choice (Q4).
  *
- * V4-15 (picker on the description): the engine's `resolveStepDisplay` only
- * interpolates the `question` (+ slider label) — the description/`helper` is
- * rendered RAW by the public renderer (form-renderer.tsx: `{step.helper}`), so
- * a `[token]` in the description would publish literally. The picker is
- * therefore deliberately NOT wired on the description; this spec locks that in
- * (typing `@` there opens no picker).
+ * V4-15 (picker on the description): the engine's `resolveStepDisplay` now
+ * interpolates `[key]` tokens in the `helper`/description too (with the same
+ * orphaned-punctuation sweep as the title), and the public renderer paints the
+ * resolved helper — so the `@`/`[` recall picker IS wired on the description,
+ * exactly like the title. This spec locks that in (typing `@` there opens the
+ * picker and inserts a token). The runtime interpolation itself is covered by
+ * the engine unit tests + v4-fields2.spec.ts.
  *
  * Forms are created via the admin API with unique `v4tok-` names.
  */
@@ -116,17 +117,17 @@ test('V4-06: a token captured by a LATER step warns `later`, not `unknown`; a to
   await expect(page.getByTestId('token-warning')).toHaveCount(0);
 });
 
-test('V4-15: the description textarea has NO token picker (the engine never interpolates the description)', async ({
+test('V4-15: the description textarea HAS the token picker (the engine now interpolates the description)', async ({
   page,
   request,
 }) => {
-  const id = await createForm(request, uniqueName('no-desc-picker'));
+  const id = await createForm(request, uniqueName('desc-picker'));
   await openEditor(page, id);
 
   await selectStep(page, Q_EMAIL);
   await expect(title(page)).toHaveValue(Q_EMAIL);
 
-  // Typing `@` in the title DOES open the picker (control: the picker works).
+  // Typing `@` in the title opens the picker (control: the picker works).
   await title(page).click();
   await page.keyboard.press('End');
   await title(page).pressSequentially('@');
@@ -134,10 +135,20 @@ test('V4-15: the description textarea has NO token picker (the engine never inte
   await page.keyboard.press('Escape');
   await expect(page.getByTestId('token-picker')).toHaveCount(0);
 
-  // Typing `@` in the description does NOT — the description publishes raw, so
-  // a picker there would be misleading.
-  const description = page.getByLabel('Add a description (optional)');
+  // Typing `@` in the description ALSO opens the picker now — the engine
+  // interpolates `[key]` tokens in the description, so the recall affordance is
+  // wired there too. Tokens = fields captured BEFORE Q2: the Q1 name subfields.
+  const description = page.getByTestId('canvas-description-input');
   await description.click();
   await description.pressSequentially('@');
+  await expect(page.getByTestId('token-picker')).toBeVisible();
+  const options = page.getByTestId('token-option');
+  await expect(options).toHaveCount(2);
+  await expect(options.nth(0)).toHaveAttribute('data-key', 'firstname');
+  await expect(options.nth(1)).toHaveAttribute('data-key', 'lastname');
+
+  // Enter inserts the engine token into the description value.
+  await page.keyboard.press('Enter');
+  await expect(description).toHaveValue('[firstname]');
   await expect(page.getByTestId('token-picker')).toHaveCount(0);
 });


### PR DESCRIPTION
Turns a session of hands-on manual QA (building forms) into fixes: the tester logged 6 failures, 5 blockers, and 16 improvements. Full changelog: [`docs/feedback-v4/`](https://github.com/Dapta-Tech/dapta-forms/blob/feature/bug-fixes-07-20/docs/feedback-v4/README.md). Base is `develop` (which now has #27); this is the V4 delta only — 10 commits, 31 files, additive `formConfig` (no migration).

## The root blocker — autosave

Adding a score range created an outcome with an empty `label`; the config schema rejected it (`label.min(1)`) → **HTTP 400 on every autosave**, and the invalid outcome stayed in state so every later Results/scoring edit also 400'd, surfaced only as a silent "Not saved". This made the whole score→outcome chain untestable.

Fix: empty outcome labels allowed (superset — every prior config still parses), and autosave is now reliable across **every** tab — surfaces the real error, client-pre-validates before the PUT, retries a transient failure once, **flushes a pending save when you leave mid-debounce** (SPA nav + `visibilitychange` + `keepalive` `beforeunload`), and normalizes a scheme-less redirect to `https://`.

## Everything else

- **Scoring usable**: per-option points are wider/labeled/negative-capable; slider points always visible; "assign points" nudge when max is 0; `NumberField` no longer shows `01`; Results numbers by real step position (slider Q5 reads "5", not "2").
- **Logic**: additive condition operators by field type — choice keeps "matches any of"; slider/number get equal/greater/less/between; a contradiction guard warns on show/hide conflicts. Dynamic questions seed a default variant.
- **Reveal**: positioned by additive `config.revealAfterStep`, a **draggable marker in the question list defaulting to the end** (fixes the mid-form reveal bug); `triggersReveal` kept as fallback; "Edit reveal screen" button. Outcomes gain an editable per-range `message` rendered on the done screen.
- **Fields**: hidden questions (`step.hidden`) + real `?fieldkey=value` URL prefill (declared keys only, capped, re-validated server-side); per-form phone default country; `@` recall in the description backed by real helper interpolation.
- **Editor polish**: template picker preserves the user's form name (scratch-first); Logic view redesigned (distinct nodes, labeled branch edges, "Otherwise" path, reduced-motion connectors); name-field URL-param hints; "Personal email only" hidden on Q1.

## Verification

- **415** package tests, typecheck + lint **16/16**.
- **Postgres parity 52/52** (no new migration — additive jsonb config fields).
- **59** Playwright e2e green (26 new `v4-*` + 33 regression); 1 environmental flake passed on isolated re-run; **0 product regressions**.
- Confirmed end to end (what the tester couldn't run): a scored form saves via "Add a range", and real submissions route score **0 → "Low fit"**, **10 → "Mid fit"** (interpolating `[email]`), **20 → "High fit"**, each with its own message.

## Notes for reviewers

- The `@`-token "doesn't exist" warning the tester saw was already correct in this code (locked with a test) — that screenshot was from the older deployed build.
- Behavior change (intentional): the reveal screen now defaults to the end and is positioned by the spine marker; `triggersReveal` stays as a back-compat fallback.
- Additive fields this round: `revealAfterStep`, `outcome.message`, `step.hidden`, `step.phoneDefaultCountry`, condition `op/value/min/max` — all optional, every stored config still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
