### PR TITLE
feat: editor topbar fix, cover banner/marquee toggles, and option cards with an icon picker

### DIFF
--- a/.changeset/cover-toggles-and-topbar.md
+++ b/.changeset/cover-toggles-and-topbar.md
@@ -1,0 +1,19 @@
+---
+'@quill/types': minor
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+Two new cover toggles, and an editor topbar that stops overflowing.
+
+`cover.bannerScope` chooses where the promo banner renders — every screen (the
+default, and what every existing config keeps doing) or the cover alone.
+`cover.showClientLogos` switches the "trusted by" marquee off without deleting
+the logos; only an explicit `false` hides it, so existing configs still show
+theirs. Both are additive optional fields, resolved by the new pure helpers
+`showBanner` and `showClientLogos`.
+
+The editor topbar no longer wraps its controls onto a second line or pushes
+Publish off-screen: the form-name input is now the bar's only elastic child,
+and the tab labels, link labels and publish pill each reveal at the width where
+they actually fit rather than all at once.

--- a/.changeset/option-cards-layout.md
+++ b/.changeset/option-cards-layout.md
@@ -1,0 +1,24 @@
+---
+'@quill/types': minor
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+Choice questions can now render their options as a card grid, on purpose.
+
+The grid already existed but was reachable only through `showIcons`, a flag no
+editor control ever set — so in practice only the seeded demo form had it. It is
+now `optionLayout: 'list' | 'cards'`, chosen from a "Show options as" toggle on
+the question. `showIcons` is deprecated and still read as the fallback by the new
+`resolveOptionLayout`, so a config saved before this keeps its grid.
+
+Each option's `icon` may be an emoji or an image URL, and the two are rendered
+differently rather than identically: `isImageIcon` tells them apart, a glyph
+centres in a circle, and an image gets a rectangle it letterboxes into with
+`object-fit: contain` — so a wide logo is no longer cropped to its middle by a
+circular mask. A broken image URL falls back to the glyph treatment instead of a
+torn-image box. The icon cap grew from 64 to 512 characters to fit a real CDN
+URL, and any icon that looks like an image must also pass `isSafeImageUrl`.
+
+Uploading an image is not part of this — icons are an emoji or a URL, matching
+how the form logo and client logos already work.

--- a/.changeset/option-icon-picker.md
+++ b/.changeset/option-icon-picker.md
@@ -1,0 +1,26 @@
+---
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+Finishes the option-card work: a real icon picker, centred cards, a canvas that
+matches the chosen layout, and logos confined to cards.
+
+The Icon field was a raw text box, which told an author nothing about emoji or
+initials being valid — so it only ever received URLs. It is now a picker with a
+tab per kind: an emoji library (a curated local set, no new dependency), one or
+two letters, and an image URL.
+
+`resolveOptionIcon` becomes the single answer to "what do I draw for this
+option", shared by the public renderer, the builder canvas and the live preview
+so the three cannot disagree. It also enforces that images are card-only: in a
+list an image URL degrades to the label's initials rather than rendering as a
+sliver, which means an already-saved list+URL config can't show the broken
+combination either. The editor matches by dropping the Image tab under List.
+
+Cards are laid out with wrapping centred flex instead of a fixed three-track
+grid, which had stranded a single card in the left third and pinned two cards to
+the left edge. Any count now centres, and the per-row count adapts to the width.
+
+`optionInitials` supplies the fallback glyph: up to two letters from the first
+two words ("HubSpot Sales" → "HS", "Hubspot" → "H").

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -24,8 +24,11 @@ import {
   nameFields,
   isMultiSelect,
   isSafeHttpUrl,
+  showBanner,
+  showClientLogos,
   type Answers,
   type AnswerValue,
+  type FormCover,
   type FormStep,
   type FormOutcome,
 } from '@quill/engine';
@@ -138,22 +141,28 @@ function capturePrefill(steps: FormStep[]): Answers {
 /**
  * Per-phase page shell. The promo banner (`cover.bannerText`) renders ONCE here
  * as the first child of `.pf`, so it is a full-width strip pinned to the top of
- * the viewport in EVERY phase; everything else lives in `.pf__main`, which owns
- * the remaining height. Desktop's per-phase vertical centering is applied to
- * `.pf__main` (public-form.css), so centering the content group can never drag
- * the banner toward the middle of the page.
+ * the viewport; everything else lives in `.pf__main`, which owns the remaining
+ * height. Desktop's per-phase vertical centering is applied to `.pf__main`
+ * (public-form.css), so centering the content group can never drag the banner
+ * toward the middle of the page.
+ *
+ * WHICH phases show it is `cover.bannerScope` (see `showBanner`): every phase by
+ * default, or the cover alone — hence `isCover`, set only by the cover phase.
  */
 function PhaseShell({
-  bannerText,
+  cover,
+  isCover = false,
   children,
   ...rootProps
 }: {
-  bannerText?: string | null;
+  cover?: FormCover | null;
+  isCover?: boolean;
   children: React.ReactNode;
 } & React.HTMLAttributes<HTMLDivElement>) {
+  const banner = showBanner(cover, isCover) ? cover?.bannerText : null;
   return (
     <div {...rootProps}>
-      {bannerText ? <div className="pf__banner">{bannerText}</div> : null}
+      {banner ? <div className="pf__banner">{banner}</div> : null}
       <div className="pf__main">{children}</div>
     </div>
   );
@@ -554,7 +563,7 @@ export function FormRenderer({
     const ending = resolveEnding(engineConfig, outcome);
     const cta = signupHref('confirmation', accountCode);
     return (
-      <PhaseShell className="pf pf--done" style={accentVars} bannerText={cover?.bannerText}>
+      <PhaseShell className="pf pf--done" style={accentVars} cover={cover}>
         <div className="pf-done__inner pf-animate">
           <div className="pf-done__check" aria-hidden="true">
             ✓
@@ -584,7 +593,7 @@ export function FormRenderer({
 
   if (phase === 'booking' && booking?.outcome.booking) {
     return (
-      <PhaseShell className="pf pf--booking-page" style={accentVars} bannerText={cover?.bannerText}>
+      <PhaseShell className="pf pf--booking-page" style={accentVars} cover={cover}>
         <BookingScreen
           booking={booking.outcome.booking}
           answers={answersRef.current}
@@ -603,7 +612,7 @@ export function FormRenderer({
         style={accentVars}
         role="status"
         aria-live="polite"
-        bannerText={cover?.bannerText}
+        cover={cover}
       >
         <RevealScreen
           reveal={config.reveal}
@@ -622,7 +631,7 @@ export function FormRenderer({
         style={accentVars}
         role="status"
         aria-live="polite"
-        bannerText={cover?.bannerText}
+        cover={cover}
       >
         <div className="pf-reveal__inner">
           <div className="pf-reveal__spinner" aria-hidden="true" />
@@ -634,14 +643,15 @@ export function FormRenderer({
 
   if (phase === 'cover' && cover) {
     const logo = cover.logo ?? config.branding?.logo ?? null;
-    const logos = cover.clientLogos ?? config.branding?.clientLogos ?? [];
+    const logos = showClientLogos(cover) ? (cover.clientLogos ?? config.branding?.clientLogos ?? []) : [];
     return (
       <PhaseShell
         className="pf pf--cover"
         style={accentVars}
         onKeyDown={(e) => e.key === 'Enter' && start()}
         tabIndex={-1}
-        bannerText={cover.bannerText}
+        cover={cover}
+        isCover
       >
         <header className="pf__cover-header">
           <FormLogo src={logo} name={name} />
@@ -688,7 +698,7 @@ export function FormRenderer({
         style={accentVars}
         role="status"
         aria-live="polite"
-        bannerText={cover?.bannerText}
+        cover={cover}
       >
         <RevealScreen
           reveal={step.reveal ?? { enabled: true }}
@@ -726,7 +736,7 @@ export function FormRenderer({
       : null;
     const schedLogo = cover?.logo ?? config.branding?.logo ?? null;
     return (
-      <PhaseShell className="pf" style={accentVars} bannerText={cover?.bannerText}>
+      <PhaseShell className="pf" style={accentVars} cover={cover}>
         <header className="pf__topbar">
           <div className="pf__topbar-inner">
             {index > 0 || cover ? (
@@ -788,7 +798,7 @@ export function FormRenderer({
   const logo = cover?.logo ?? config.branding?.logo ?? null;
 
   return (
-    <PhaseShell className="pf" style={accentVars} onKeyDown={onKeyDown} bannerText={cover?.bannerText}>
+    <PhaseShell className="pf" style={accentVars} onKeyDown={onKeyDown} cover={cover}>
       <header className="pf__topbar">
         <div className="pf__topbar-inner">
           {index > 0 || cover ? (

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -349,7 +349,9 @@
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
 }
-.pf-choice-list__icon {
+/* An emoji or initial: a square glyph, so a circle fits it. */
+.pf-choice-list__icon,
+.pf-choice-list__circle {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -360,6 +362,28 @@
   flex-shrink: 0;
   font-size: 19px;
   line-height: 1;
+}
+/* An image: arbitrary aspect ratio, so give it a rectangle to letterbox into
+   rather than a circle that would crop a wordmark to its middle. */
+.pf-choice-list__img-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 38px;
+  border-radius: 8px;
+  background: var(--muted);
+  flex-shrink: 0;
+  padding: 4px 6px;
+  overflow: hidden;
+}
+.pf-choice-list__img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  display: block;
 }
 .pf-choice-list__text {
   flex: 1;
@@ -414,6 +438,29 @@
   background: var(--muted);
   font-size: 23px;
   line-height: 1;
+}
+/* Card-grid image icon. Same reasoning as the list variant: a logo is not a
+   square glyph, so it gets a rectangle and letterboxes inside it. Wider than
+   it is tall, because wordmarks are the common case. */
+.pf-choice-icon__img-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 88px;
+  height: 46px;
+  border-radius: 8px;
+  background: var(--muted);
+  padding: 5px 8px;
+  overflow: hidden;
+}
+.pf-choice-icon__img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  display: block;
 }
 .pf-choice-icon__label {
   font-size: 14px;

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -363,28 +363,8 @@
   font-size: 19px;
   line-height: 1;
 }
-/* An image: arbitrary aspect ratio, so give it a rectangle to letterbox into
-   rather than a circle that would crop a wordmark to its middle. */
-.pf-choice-list__img-wrap {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 38px;
-  border-radius: 8px;
-  background: var(--muted);
-  flex-shrink: 0;
-  padding: 4px 6px;
-  overflow: hidden;
-}
-.pf-choice-list__img {
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
-  object-fit: contain;
-  display: block;
-}
+/* No image variant here on purpose: `resolveOptionIcon` confines logos to the
+   card layout, so a list row only ever draws the glyph circle above. */
 .pf-choice-list__text {
   flex: 1;
   line-height: 1.35;
@@ -444,19 +424,19 @@
   font-size: 23px;
   line-height: 1;
 }
-/* Card-grid image icon. Same reasoning as the list variant: a logo is not a
-   square glyph, so it gets a rectangle and letterboxes inside it. Wider than
-   it is tall, because wordmarks are the common case. */
+/* Card image icon. NO background, border or padding: a logo already carries its
+   own shape and fill — Facebook's blue disc, Instagram's gradient tile — so a
+   grey rounded box behind it reads as a chip stuck onto the card rather than as
+   the card's icon, and the padding pushes the mark off-centre.
+   The element still RESERVES the same 46px band as the glyph circle, so logos
+   of differing proportions stay on one baseline and the cards line up. */
 .pf-choice-icon__img-wrap {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
-  max-width: 88px;
+  max-width: 96px;
   height: 46px;
-  border-radius: 8px;
-  background: var(--muted);
-  padding: 5px 8px;
   overflow: hidden;
 }
 .pf-choice-icon__img {

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -390,18 +390,23 @@
   line-height: 1.35;
 }
 
-/* ── Choices — icon grid ── */
+/* ── Choices — card grid ──
+   Flex, not `grid-template-columns: repeat(3, 1fr)`: a fixed 3-track grid left a
+   single card stranded in the left third and two cards hugging the left edge.
+   Wrapping flex items with `justify-content: center` centre ANY count — one card
+   sits in the middle, two sit centred as a pair, and beyond three they wrap into
+   centred rows. The basis targets three per row at full width while `min-width`
+   forces fewer as the viewport narrows, so the count adapts to the screen. */
 .pf-choices--icons {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: var(--pf-gap);
 }
-@media (max-width: 400px) {
-  .pf-choices--icons {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
 .pf-choice-icon {
+  flex: 0 1 calc((100% - 2 * var(--pf-gap)) / 3);
+  min-width: 132px;
+  max-width: 220px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -132,6 +132,11 @@ export interface BuilderMessages {
     required: string;
     options: string;
     addOption: string;
+    /** How a choice question lays its options out: a list, or a card grid. */
+    optionLayout: string;
+    optionLayoutHint: string;
+    optionLayoutList: string;
+    optionLayoutCards: string;
     logic: string;
     addRule: string;
     noRules: string;
@@ -374,6 +379,10 @@ const en: BuilderMessages = {
     required: 'Required',
     options: 'Options',
     addOption: 'Add option',
+    optionLayout: 'Show options as',
+    optionLayoutHint: 'Cards add an icon to each option — an emoji, or an image URL.',
+    optionLayoutList: 'List',
+    optionLayoutCards: 'Cards',
     logic: 'Logic',
     addRule: 'Add rule',
     noRules: 'No rules — everyone sees this question.',
@@ -635,6 +644,10 @@ const es: BuilderMessages = {
     required: 'Obligatoria',
     options: 'Opciones',
     addOption: 'Añadir opción',
+    optionLayout: 'Mostrar opciones como',
+    optionLayoutHint: 'Las tarjetas añaden un ícono a cada opción — un emoji, o la URL de una imagen.',
+    optionLayoutList: 'Lista',
+    optionLayoutCards: 'Tarjetas',
     logic: 'Lógica',
     addRule: 'Añadir regla',
     noRules: 'Sin reglas — todos ven esta pregunta.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -380,7 +380,8 @@ const en: BuilderMessages = {
     options: 'Options',
     addOption: 'Add option',
     optionLayout: 'Show options as',
-    optionLayoutHint: 'Cards add an icon to each option — an emoji, or an image URL.',
+    optionLayoutHint:
+      'Each option can carry an emoji or initials in both layouts. Cards lay them out in a centred grid and are the only layout that can show a logo.',
     optionLayoutList: 'List',
     optionLayoutCards: 'Cards',
     logic: 'Logic',
@@ -645,7 +646,8 @@ const es: BuilderMessages = {
     options: 'Opciones',
     addOption: 'Añadir opción',
     optionLayout: 'Mostrar opciones como',
-    optionLayoutHint: 'Las tarjetas añaden un ícono a cada opción — un emoji, o la URL de una imagen.',
+    optionLayoutHint:
+      'Cada opción puede llevar un emoji o iniciales en ambos diseños. Las tarjetas los ordenan en una cuadrícula centrada y son el único diseño que puede mostrar un logo.',
     optionLayoutList: 'Lista',
     optionLayoutCards: 'Tarjetas',
     logic: 'Lógica',

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -7,8 +7,7 @@ import {
   sliderBounds,
   clampSliderValue,
   resolveOptionLayout,
-  isImageIcon,
-  isSafeImageUrl,
+  resolveOptionIcon,
 } from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import { cn } from '@/lib/cn';
@@ -189,53 +188,97 @@ export function CanvasQuestion({
         {/* Body: the real rendered input */}
         <div className="mt-6">
           {hasOptions(step.type) ? (
-            <div className="flex flex-col gap-2.5">
-              {(step.options ?? []).map((opt, i) => (
-                <div
-                  key={i}
-                  className="group flex items-center gap-3 rounded-xl border border-border bg-background px-4 py-3.5 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
-                >
-                  {/* The canvas stays a vertical list even for the card layout —
-                      it is an inline EDITOR, not a preview. Swapping the A/B/C
-                      badge for the option's own icon is enough to see what each
-                      card will carry; Preview shows the real grid. */}
-                  <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border text-[11px] font-semibold text-muted-foreground">
-                    {cardLayout && opt.icon ? (
-                      isImageIcon(opt.icon) && isSafeImageUrl(opt.icon) ? (
-                        <img src={opt.icon} alt="" className="max-h-full max-w-full object-contain" />
-                      ) : (
-                        <span className="text-[13px] leading-none">{opt.icon}</span>
-                      )
-                    ) : (
-                      String.fromCharCode(65 + i)
-                    )}
-                  </span>
-                  <input
-                    value={opt.label}
-                    onChange={(e) => updateOption(i, { label: e.target.value })}
-                    placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
-                    aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
-                    className="min-w-0 flex-1 bg-transparent text-[15px] font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
-                  />
-                  {showsPoints ? (
-                    <span className="shrink-0 rounded-full bg-primary/15 px-2.5 py-1 text-xs font-semibold text-primary">
-                      {tb(m.canvas.pts, { n: opt.points ?? 0 })}
-                    </span>
-                  ) : null}
-                  <button
-                    type="button"
-                    aria-label={m.settings.delete}
-                    onClick={() => removeOption(i)}
-                    className="shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground hover:!text-destructive focus-visible:!text-muted-foreground focus-visible:outline-none"
+            // The canvas mirrors the CHOSEN layout — picking Cards and still
+            // seeing a radio list here is the builder contradicting the form.
+            // Both branches keep the label editable inline; only the shell and
+            // the icon treatment differ, exactly as the public renderer does.
+            <div
+              className={
+                cardLayout
+                  ? 'flex flex-wrap justify-center gap-2.5'
+                  : 'flex flex-col gap-2.5'
+              }
+            >
+              {(step.options ?? []).map((opt, i) => {
+                const icon = resolveOptionIcon(opt, cardLayout ? 'cards' : 'list');
+                return cardLayout ? (
+                  <div
+                    key={i}
+                    className="group relative flex min-h-[104px] w-[calc((100%-1.25rem)/3)] min-w-[132px] max-w-[220px] flex-col items-center gap-2 rounded-xl border border-border bg-background px-2 py-4 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
                   >
-                    <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
-                  </button>
-                </div>
-              ))}
+                    {icon.kind === 'image' ? (
+                      <span className="flex h-[46px] w-full max-w-[88px] items-center justify-center overflow-hidden rounded-lg bg-muted px-2">
+                        <img src={icon.src} alt="" className="max-h-full max-w-full object-contain" />
+                      </span>
+                    ) : (
+                      <span className="flex h-[46px] w-[46px] items-center justify-center rounded-full bg-muted text-[23px] leading-none">
+                        {icon.text}
+                      </span>
+                    )}
+                    <input
+                      value={opt.label}
+                      onChange={(e) => updateOption(i, { label: e.target.value })}
+                      placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
+                      aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
+                      className="w-full min-w-0 bg-transparent text-center text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
+                    />
+                    {showsPoints ? (
+                      <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-semibold text-primary">
+                        {tb(m.canvas.pts, { n: opt.points ?? 0 })}
+                      </span>
+                    ) : null}
+                    <button
+                      type="button"
+                      aria-label={m.settings.delete}
+                      onClick={() => removeOption(i)}
+                      className="absolute right-1.5 top-1.5 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground hover:!text-destructive focus-visible:!text-muted-foreground focus-visible:outline-none"
+                    >
+                      <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
+                    </button>
+                  </div>
+                ) : (
+                  <div
+                    key={i}
+                    className="group flex items-center gap-3 rounded-xl border border-border bg-background px-4 py-3.5 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
+                  >
+                    <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border text-[11px] font-semibold text-muted-foreground">
+                      {opt.icon && icon.kind === 'glyph' ? (
+                        <span className="text-[13px] leading-none">{icon.text}</span>
+                      ) : (
+                        String.fromCharCode(65 + i)
+                      )}
+                    </span>
+                    <input
+                      value={opt.label}
+                      onChange={(e) => updateOption(i, { label: e.target.value })}
+                      placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
+                      aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
+                      className="min-w-0 flex-1 bg-transparent text-[15px] font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
+                    />
+                    {showsPoints ? (
+                      <span className="shrink-0 rounded-full bg-primary/15 px-2.5 py-1 text-xs font-semibold text-primary">
+                        {tb(m.canvas.pts, { n: opt.points ?? 0 })}
+                      </span>
+                    ) : null}
+                    <button
+                      type="button"
+                      aria-label={m.settings.delete}
+                      onClick={() => removeOption(i)}
+                      className="shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground hover:!text-destructive focus-visible:!text-muted-foreground focus-visible:outline-none"
+                    >
+                      <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
+                    </button>
+                  </div>
+                );
+              })}
               <button
                 type="button"
                 onClick={addOption}
-                className="flex items-center gap-3 rounded-xl border border-dashed border-border px-4 py-3.5 text-left text-[15px] text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className={
+                  cardLayout
+                    ? 'flex min-h-[104px] w-[calc((100%-1.25rem)/3)] min-w-[132px] max-w-[220px] flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border px-2 py-4 text-sm text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                    : 'flex items-center gap-3 rounded-xl border border-dashed border-border px-4 py-3.5 text-left text-[15px] text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                }
               >
                 <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-dashed border-border">
                   <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} />

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { FormConfig, FormStep, FormOption } from '@quill/engine';
-import { nameFields, sliderBounds, clampSliderValue } from '@quill/engine';
+import {
+  nameFields,
+  sliderBounds,
+  clampSliderValue,
+  resolveOptionLayout,
+  isImageIcon,
+  isSafeImageUrl,
+} from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import { cn } from '@/lib/cn';
 import { iconForStep, hasOptions } from './question-types';
@@ -92,6 +99,7 @@ export function CanvasQuestion({
   const progress = total > 0 ? Math.round(((index + 1) / total) * 100) : 0;
   const showsPoints =
     (config.scoring?.enabled ?? false) !== false && step.flowGroup !== 'lead_capture' && maxStepPoints(step) >= 0;
+  const cardLayout = step.type === 'multiple_choice' && resolveOptionLayout(step) === 'cards';
 
   function updateOption(i: number, patch: Partial<FormOption>) {
     onUpdate({ options: (step.options ?? []).map((o, oi) => (oi === i ? { ...o, ...patch } : o)) });
@@ -187,8 +195,20 @@ export function CanvasQuestion({
                   key={i}
                   className="group flex items-center gap-3 rounded-xl border border-border bg-background px-4 py-3.5 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
                 >
-                  <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border text-[11px] font-semibold text-muted-foreground">
-                    {String.fromCharCode(65 + i)}
+                  {/* The canvas stays a vertical list even for the card layout —
+                      it is an inline EDITOR, not a preview. Swapping the A/B/C
+                      badge for the option's own icon is enough to see what each
+                      card will carry; Preview shows the real grid. */}
+                  <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border text-[11px] font-semibold text-muted-foreground">
+                    {cardLayout && opt.icon ? (
+                      isImageIcon(opt.icon) && isSafeImageUrl(opt.icon) ? (
+                        <img src={opt.icon} alt="" className="max-h-full max-w-full object-contain" />
+                      ) : (
+                        <span className="text-[13px] leading-none">{opt.icon}</span>
+                      )
+                    ) : (
+                      String.fromCharCode(65 + i)
+                    )}
                   </span>
                   <input
                     value={opt.label}

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -207,7 +207,9 @@ export function CanvasQuestion({
                     className="group relative flex min-h-[104px] w-[calc((100%-1.25rem)/3)] min-w-[132px] max-w-[220px] flex-col items-center gap-2 rounded-xl border border-border bg-background px-2 py-4 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
                   >
                     {icon.kind === 'image' ? (
-                      <span className="flex h-[46px] w-full max-w-[88px] items-center justify-center overflow-hidden rounded-lg bg-muted px-2">
+                      // No plate behind a logo — it carries its own shape. The
+                      // band is only reserved so cards keep one baseline.
+                      <span className="flex h-[46px] w-full max-w-[96px] items-center justify-center overflow-hidden">
                         <img src={icon.src} alt="" className="max-h-full max-w-full object-contain" />
                       </span>
                     ) : (

--- a/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
@@ -5,7 +5,7 @@ import { isSafeImageUrl } from '@quill/engine';
 import { clampAccent, accentWasAdjusted, DEFAULT_ACCENT } from '@quill/shared';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Field, TextField, TextArea, InlineField, PanelSection } from './fields';
+import { Field, TextField, TextArea, InlineField, PanelSection, SegmentedToggle } from './fields';
 import { LivePreview } from './live-preview';
 import type { EditorMessages } from './messages';
 
@@ -48,6 +48,19 @@ export function CoverPanel({
           <Field label={m.cover.bannerText}>
             <TextField value={cover.bannerText ?? ''} onChange={(e) => onCoverChange({ bannerText: e.target.value || null })} />
           </Field>
+          {cover.bannerText ? (
+            <InlineField label={m.cover.bannerScope}>
+              <SegmentedToggle
+                value={cover.bannerScope ?? 'form'}
+                onChange={(bannerScope) => onCoverChange({ bannerScope })}
+                options={[
+                  { value: 'form', label: m.cover.bannerScopeForm },
+                  { value: 'cover', label: m.cover.bannerScopeCover },
+                ]}
+                ariaLabel={m.cover.bannerScope}
+              />
+            </InlineField>
+          ) : null}
           <Field label={m.cover.eyebrow}>
             <TextField value={cover.eyebrow ?? ''} onChange={(e) => onCoverChange({ eyebrow: e.target.value || null })} />
           </Field>
@@ -112,6 +125,13 @@ export function CoverPanel({
         </PanelSection>
 
         <PanelSection title={m.cover.clientLogos} subtitle={m.cover.clientLogosHint}>
+          <InlineField label={m.cover.showClientLogos}>
+            <Switch
+              checked={cover.showClientLogos !== false}
+              onCheckedChange={(v) => onCoverChange({ showClientLogos: v })}
+              aria-label={m.cover.showClientLogos}
+            />
+          </InlineField>
           <ClientLogosEditor
             logos={cover.clientLogos ?? []}
             onChange={(clientLogos) => onCoverChange({ clientLogos: clientLogos.length ? clientLogos : undefined })}

--- a/apps/web/app/admin/forms/[id]/edit/_components/emoji-catalog.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/emoji-catalog.ts
@@ -1,0 +1,67 @@
+/**
+ * A curated emoji set for option icons — hand-picked for the things forms
+ * actually ask about (reactions, roles, business, tooling, status) rather than
+ * the full Unicode table.
+ *
+ * Deliberately a local constant, not a package: pulling a full emoji-picker
+ * dependency in for one field would add a payload far larger than the builder
+ * itself, and the repo keeps its dependency surface small. Groups are only used
+ * to break the grid into labelled sections.
+ */
+export interface EmojiGroup {
+  /** i18n key under `admin.editor.options.emojiGroups`. */
+  key: 'reactions' | 'people' | 'business' | 'tech' | 'comms' | 'status' | 'places';
+  emojis: string[];
+}
+
+export const EMOJI_GROUPS: EmojiGroup[] = [
+  {
+    key: 'reactions',
+    emojis: [
+      '😍', '😀', '🙂', '😐', '🙁', '😡', '🤔', '😎', '🥳', '😴',
+      '🤯', '🤩', '😅', '🙌', '👏', '💪', '🫶', '🤝',
+    ],
+  },
+  {
+    key: 'people',
+    emojis: [
+      '👤', '👥', '🧑‍💼', '👨‍💼', '👩‍💼', '🧑‍💻', '🧑‍🔧', '🧑‍🏫',
+      '🧑‍⚕️', '🧑‍🍳', '🧑‍🌾', '👶', '🧑', '👴', '🏃', '🧠',
+    ],
+  },
+  {
+    key: 'business',
+    emojis: [
+      '💼', '🏢', '🏭', '🏪', '🏦', '📈', '📉', '📊', '💰', '💵',
+      '💳', '🧾', '🎯', '🚀', '📋', '🗂️', '📁', '✍️',
+    ],
+  },
+  {
+    key: 'tech',
+    emojis: [
+      '💻', '🖥️', '📱', '⌨️', '🖱️', '🌐', '☁️', '🔌', '🔒', '🔑',
+      '🤖', '⚡', '⚙️', '🔧', '🛠️', '🧩', '🗄️', '📡',
+    ],
+  },
+  {
+    key: 'comms',
+    emojis: [
+      '📧', '✉️', '📨', '📞', '☎️', '💬', '🗨️', '📣', '🔔', '📢',
+      '📝', '📮', '🤙', '📬',
+    ],
+  },
+  {
+    key: 'status',
+    emojis: [
+      '✅', '❌', '⭐', '❤️', '👍', '👎', '➕', '➖', '❓', '❗',
+      '🔥', '💡', '🏆', '🎁', '📌', '🔍', '⏰', '⌛', '📅', '⏳',
+    ],
+  },
+  {
+    key: 'places',
+    emojis: [
+      '🏠', '🏥', '🏫', '🏨', '🚗', '✈️', '🚚', '🌍', '🛒', '📦',
+      '🎓', '⚖️', '🏗️', '🌱',
+    ],
+  },
+];

--- a/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/fields.tsx
@@ -192,6 +192,47 @@ export function SelectField({
   );
 }
 
+/**
+ * A two-or-more-way segmented picker, for settings where a bare on/off switch
+ * would hide what each state means (e.g. "banner on every screen" vs "cover
+ * only"). Renders as a radio group so arrow keys and screen readers work.
+ */
+export function SegmentedToggle<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: {
+  value: T;
+  onChange: (value: T) => void;
+  options: { value: T; label: string }[];
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-card p-0.5"
+    >
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          role="radio"
+          aria-checked={value === o.value}
+          onClick={() => onChange(o.value)}
+          className={cn(
+            'whitespace-nowrap rounded-md px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            value === o.value ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 /** A row that pairs a label with an inline control (e.g. a switch). */
 export function InlineField({
   label,

--- a/apps/web/app/admin/forms/[id]/edit/_components/icon-picker.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/icon-picker.tsx
@@ -103,7 +103,14 @@ export function IconPicker({
         onClick={() => setOpen((v) => !v)}
         className="flex h-9 w-full items-center gap-2 rounded-md border border-input bg-background px-2 text-left text-sm transition-colors hover:border-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-[13px] leading-none">
+        {/* The glyph keeps its muted disc (it needs a surface to sit on); a
+            logo does not — same reasoning as the card icon. */}
+        <span
+          className={cn(
+            'flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden text-[13px] leading-none',
+            showImagePreview ? '' : 'rounded-md bg-muted',
+          )}
+        >
           {showImagePreview ? (
             <img src={current} alt="" className="max-h-full max-w-full object-contain" />
           ) : (

--- a/apps/web/app/admin/forms/[id]/edit/_components/icon-picker.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/icon-picker.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  isImageIcon,
+  isSafeImageUrl,
+  optionInitials,
+  OPTION_ICON_GLYPH_MAX,
+  type FormOptionLayout,
+} from '@quill/engine';
+import { cn } from '@/lib/cn';
+import { TextField } from './fields';
+import { EMOJI_GROUPS } from './emoji-catalog';
+import type { EditorMessages } from './messages';
+
+type Mode = 'emoji' | 'letters' | 'image';
+
+/**
+ * Picks an option's icon: an emoji from a small library, one or two letters
+ * (HubSpot → "HS"), or an image URL.
+ *
+ * A raw text box could technically hold any of those, but nothing about it told
+ * an author that an emoji or initials were even options — so the field only ever
+ * got URLs. Each kind gets its own tab and its own input instead.
+ *
+ * `layout` gates the image tab: a logo in a list row renders as an illegible
+ * sliver, so images are card-only in the editor as well as at render time
+ * (`resolveOptionIcon`). Switching a question back to List therefore can't leave
+ * an unreachable image behind — the tab is gone and the value falls back to
+ * initials.
+ */
+export function IconPicker({
+  value,
+  onChange,
+  label,
+  layout,
+  m,
+}: {
+  value: string | null | undefined;
+  onChange: (icon: string | null) => void;
+  /** The option's label — drives the initials preview. */
+  label: string;
+  layout: FormOptionLayout;
+  m: EditorMessages['options'];
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const current = value?.trim() ?? '';
+  const currentIsImage = isImageIcon(current);
+  const imageAllowed = layout === 'cards';
+
+  // Open on the tab that owns the CURRENT value: initials are ASCII letters,
+  // anything else non-empty (an emoji) belongs to the emoji tab. Landing on
+  // "Letters" while showing 😍 makes the picker look like it lost the value.
+  const initialMode: Mode = currentIsImage
+    ? 'image'
+    : /^[A-Za-z]{1,2}$/.test(current)
+      ? 'letters'
+      : 'emoji';
+  const [mode, setMode] = useState<Mode>(initialMode);
+
+  // An image on a list question is unreachable: drop the tab and land on emoji.
+  useEffect(() => {
+    if (!imageAllowed && mode === 'image') setMode('emoji');
+  }, [imageAllowed, mode]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const tabs = useMemo(() => {
+    const all: { id: Mode; label: string }[] = [
+      { id: 'emoji', label: m.iconTabEmoji },
+      { id: 'letters', label: m.iconTabLetters },
+    ];
+    if (imageAllowed) all.push({ id: 'image', label: m.iconTabImage });
+    return all;
+  }, [imageAllowed, m]);
+
+  const previewGlyph = current && !currentIsImage ? current : optionInitials(label);
+  const showImagePreview = currentIsImage && imageAllowed && isSafeImageUrl(current);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={m.icon}
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-9 w-full items-center gap-2 rounded-md border border-input bg-background px-2 text-left text-sm transition-colors hover:border-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-[13px] leading-none">
+          {showImagePreview ? (
+            <img src={current} alt="" className="max-h-full max-w-full object-contain" />
+          ) : (
+            previewGlyph
+          )}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+          {current ? (currentIsImage ? current : current) : m.iconEmpty}
+        </span>
+        <i aria-hidden className="pi pi-chevron-down shrink-0 text-muted-foreground" style={{ fontSize: 10 }} />
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-label={m.icon}
+          className="absolute right-0 z-50 mt-1 w-[19rem] rounded-lg border border-border bg-popover p-2 shadow-lg"
+        >
+          <div className="mb-2 flex items-center gap-0.5 rounded-md border border-border bg-card p-0.5">
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setMode(t.id)}
+                aria-pressed={mode === t.id}
+                className={cn(
+                  'flex-1 whitespace-nowrap rounded px-2 py-1 text-xs font-medium transition-colors',
+                  mode === t.id
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                onChange(null);
+                setOpen(false);
+              }}
+              className="shrink-0 rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-destructive"
+            >
+              {m.iconClear}
+            </button>
+          </div>
+
+          {mode === 'emoji' ? (
+            <div className="max-h-56 overflow-y-auto pr-1">
+              {EMOJI_GROUPS.map((g) => (
+                <div key={g.key} className="mb-2 last:mb-0">
+                  <p className="mb-1 px-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {m.emojiGroups[g.key]}
+                  </p>
+                  <div className="grid grid-cols-8 gap-0.5">
+                    {g.emojis.map((e) => (
+                      <button
+                        key={e}
+                        type="button"
+                        aria-label={e}
+                        aria-pressed={current === e}
+                        onClick={() => {
+                          onChange(e);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          'flex h-8 items-center justify-center rounded text-lg leading-none transition-colors hover:bg-muted',
+                          current === e && 'bg-muted ring-1 ring-ring',
+                        )}
+                      >
+                        {e}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {mode === 'letters' ? (
+            <div className="flex flex-col gap-1.5 p-1">
+              <TextField
+                autoFocus
+                aria-label={m.iconTabLetters}
+                data-testid="icon-picker-letters"
+                maxLength={OPTION_ICON_GLYPH_MAX}
+                placeholder={optionInitials(label) || 'HS'}
+                value={currentIsImage ? '' : current}
+                onChange={(e) => onChange(e.target.value.toUpperCase() || null)}
+              />
+              <p className="text-[11px] leading-relaxed text-muted-foreground">{m.iconLettersHint}</p>
+            </div>
+          ) : null}
+
+          {mode === 'image' && imageAllowed ? (
+            <div className="flex flex-col gap-1.5 p-1">
+              <TextField
+                autoFocus
+                aria-label={m.iconTabImage}
+                data-testid="icon-picker-url"
+                placeholder="https://…"
+                value={currentIsImage ? current : ''}
+                onChange={(e) => onChange(e.target.value || null)}
+              />
+              {current && currentIsImage && !isSafeImageUrl(current) ? (
+                <p className="text-[11px] text-destructive" role="alert">
+                  {m.iconUrlInvalid}
+                </p>
+              ) : (
+                <p className="text-[11px] leading-relaxed text-muted-foreground">{m.iconImageHint}</p>
+              )}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -1,8 +1,16 @@
 'use client';
 
 import { useState } from 'react';
-import type { FormConfig, FormCover, FormStep } from '@quill/engine';
-import { resolveQuestion, sliderBounds, clampSliderValue, showBanner } from '@quill/engine';
+import type { FormConfig, FormCover, FormOption, FormStep } from '@quill/engine';
+import {
+  resolveQuestion,
+  sliderBounds,
+  clampSliderValue,
+  showBanner,
+  resolveOptionLayout,
+  isImageIcon,
+  isSafeImageUrl,
+} from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import type { EditorMessages } from './messages';
 
@@ -78,6 +86,23 @@ function CoverPreview({
   );
 }
 
+/** The card layout's option icon — a circle for a glyph, a box for an image. */
+function PreviewOptionIcon({ option }: { option: FormOption }) {
+  const src = option.icon ?? '';
+  if (isImageIcon(src) && isSafeImageUrl(src)) {
+    return (
+      <span className="flex h-8 w-full max-w-[64px] items-center justify-center overflow-hidden rounded-md bg-muted px-1">
+        <img src={src} alt="" className="max-h-full max-w-full object-contain" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-base leading-none">
+      {option.icon || option.label.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
 function StepPreview({
   step,
   cover,
@@ -100,6 +125,7 @@ function StepPreview({
   // Only when the banner is scoped to the whole form — this is what makes the
   // cover/form scope toggle visible without leaving the editor.
   const banner = showBanner(cover, false) ? cover?.bannerText : null;
+  const cards = step.type === 'multiple_choice' && resolveOptionLayout(step) === 'cards';
 
   return (
     <div className="flex flex-col gap-4 rounded-md border border-border bg-card p-6">
@@ -138,7 +164,13 @@ function StepPreview({
       </div>
 
       {step.type === 'message' ? null : step.type === 'dropdown' || step.type === 'multiple_choice' ? (
-        <div className="flex flex-col gap-2">
+        // Mirror the public renderer's two layouts, so picking Cards in the
+        // settings panel is visible without opening the form.
+        <div
+          className={
+            cards ? 'grid grid-cols-3 gap-2' : 'flex flex-col gap-2'
+          }
+        >
           {(step.options ?? []).map((o) => {
             const on = value === o.value;
             return (
@@ -146,13 +178,18 @@ function StepPreview({
                 key={o.value}
                 type="button"
                 onClick={() => setValue(o.value)}
-                className="rounded-md border px-4 py-3 text-left text-sm transition-colors"
+                className={
+                  cards
+                    ? 'flex flex-col items-center gap-2 rounded-md border px-2 py-3 text-center text-xs transition-colors'
+                    : 'rounded-md border px-4 py-3 text-left text-sm transition-colors'
+                }
                 style={
                   on
                     ? { borderColor: accent, background: 'color-mix(in srgb, ' + accent + ' 15%, transparent)' }
                     : { borderColor: 'var(--border)' }
                 }
               >
+                {cards ? <PreviewOptionIcon option={o} /> : null}
                 {o.label}
               </button>
             );

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -89,8 +89,10 @@ function CoverPreview({
 function PreviewOptionIcon({ option }: { option: FormOption }) {
   const icon = resolveOptionIcon(option, 'cards');
   if (icon.kind === 'image') {
+    // No plate: a logo brings its own shape, and a grey box behind it reads as
+    // a chip rather than the card's icon.
     return (
-      <span className="flex h-8 w-full max-w-[64px] items-center justify-center overflow-hidden rounded-md bg-muted px-1">
+      <span className="flex h-8 w-full max-w-[64px] items-center justify-center overflow-hidden">
         <img src={icon.src} alt="" className="max-h-full max-w-full object-contain" />
       </span>
     );

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -8,8 +8,7 @@ import {
   clampSliderValue,
   showBanner,
   resolveOptionLayout,
-  isImageIcon,
-  isSafeImageUrl,
+  resolveOptionIcon,
 } from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import type { EditorMessages } from './messages';
@@ -88,17 +87,17 @@ function CoverPreview({
 
 /** The card layout's option icon — a circle for a glyph, a box for an image. */
 function PreviewOptionIcon({ option }: { option: FormOption }) {
-  const src = option.icon ?? '';
-  if (isImageIcon(src) && isSafeImageUrl(src)) {
+  const icon = resolveOptionIcon(option, 'cards');
+  if (icon.kind === 'image') {
     return (
       <span className="flex h-8 w-full max-w-[64px] items-center justify-center overflow-hidden rounded-md bg-muted px-1">
-        <img src={src} alt="" className="max-h-full max-w-full object-contain" />
+        <img src={icon.src} alt="" className="max-h-full max-w-full object-contain" />
       </span>
     );
   }
   return (
     <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-base leading-none">
-      {option.icon || option.label.charAt(0).toUpperCase()}
+      {icon.text}
     </span>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { FormConfig, FormStep } from '@quill/engine';
-import { resolveQuestion, sliderBounds, clampSliderValue } from '@quill/engine';
+import type { FormConfig, FormCover, FormStep } from '@quill/engine';
+import { resolveQuestion, sliderBounds, clampSliderValue, showBanner } from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import type { EditorMessages } from './messages';
 
@@ -29,7 +29,7 @@ export function LivePreview({
       {selected === 'cover' ? (
         <CoverPreview config={config} accent={accent} accentText={accentText} m={m} />
       ) : step ? (
-        <StepPreview step={step} accent={accent} accentText={accentText} m={m} index={selected} total={config.steps.length} />
+        <StepPreview step={step} cover={config.cover} accent={accent} accentText={accentText} m={m} index={selected} total={config.steps.length} />
       ) : (
         <p className="py-8 text-center text-sm text-muted-foreground">{m.empty}</p>
       )}
@@ -80,6 +80,7 @@ function CoverPreview({
 
 function StepPreview({
   step,
+  cover,
   accent,
   accentText,
   index,
@@ -87,6 +88,7 @@ function StepPreview({
   m,
 }: {
   step: FormStep;
+  cover?: FormCover | null;
   accent: string;
   accentText: string;
   index: number;
@@ -95,9 +97,20 @@ function StepPreview({
 }) {
   const [value, setValue] = useState<string | number>('');
   const question = resolveQuestion(step, {}) || step.key;
+  // Only when the banner is scoped to the whole form — this is what makes the
+  // cover/form scope toggle visible without leaving the editor.
+  const banner = showBanner(cover, false) ? cover?.bannerText : null;
 
   return (
     <div className="flex flex-col gap-4 rounded-md border border-border bg-card p-6">
+      {banner ? (
+        <div
+          className="-mt-1 w-full rounded-md px-3 py-1.5 text-center text-xs font-medium"
+          style={{ background: accent, color: accentText }}
+        >
+          {banner}
+        </div>
+      ) : null}
       <div className="flex items-center gap-1.5" aria-hidden>
         {Array.from({ length: Math.max(total, 1) }).map((_, i) => (
           <span

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -18,6 +18,7 @@ export function OptionsEditor({
   options,
   onChange,
   showPoints = true,
+  showIcon = false,
   m,
 }: {
   options: FormOption[];
@@ -28,6 +29,12 @@ export function OptionsEditor({
    * does nothing — and each remaining field gets the width back.
    */
   showPoints?: boolean;
+  /**
+   * Render the Icon column. Same reasoning as `showPoints`: only the card
+   * layout displays an icon, so in a plain list the column would be a field
+   * that changes nothing.
+   */
+  showIcon?: boolean;
   m: EditorMessages['options'];
 }) {
   const ids = options.map((_, i) => `opt-${i}`);
@@ -62,7 +69,11 @@ export function OptionsEditor({
             return (
               <SortableRow key={id} id={id}>
                 {({ handleProps }) => (
-                  <div className="flex items-end gap-2 rounded-md border border-border bg-background p-2">
+                  // Icon gets its OWN row rather than a fifth column: the panel
+                  // is ~420px, and squeezing label/value/icon/points side by
+                  // side clipped every header and cut the labels to 3 letters.
+                  <div className="flex flex-col gap-2 rounded-md border border-border bg-background p-2">
+                  <div className="flex items-end gap-2">
                     <button
                       type="button"
                       aria-label={m.title}
@@ -122,6 +133,22 @@ export function OptionsEditor({
                     >
                       <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
                     </Button>
+                  </div>
+                  {showIcon ? (
+                    <label className="flex min-w-0 flex-col gap-1 pl-7">
+                      <span className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                        {m.icon}
+                        <HelpTip text={m.iconHelp} label={m.icon} />
+                      </span>
+                      <TextField
+                        aria-label={m.icon}
+                        data-testid={`option-icon-${index}`}
+                        placeholder={m.iconPlaceholder}
+                        value={o.icon ?? ''}
+                        onChange={(e) => update(index, { icon: e.target.value || null })}
+                      />
+                    </label>
+                  ) : null}
                   </div>
                 )}
               </SortableRow>

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import type { FormOption } from '@quill/engine';
+import type { FormOption, FormOptionLayout } from '@quill/engine';
 import { slugify } from '@quill/engine';
 import { Button } from '@/components/ui/button';
 import { HelpTip } from '@/components/ui/help-tip';
 import { TextField, NumberField } from './fields';
+import { IconPicker } from './icon-picker';
 import { SortableList, SortableRow } from './sortable';
 import type { EditorMessages } from './messages';
 
@@ -19,6 +20,7 @@ export function OptionsEditor({
   onChange,
   showPoints = true,
   showIcon = false,
+  layout = 'list',
   m,
 }: {
   options: FormOption[];
@@ -30,11 +32,13 @@ export function OptionsEditor({
    */
   showPoints?: boolean;
   /**
-   * Render the Icon column. Same reasoning as `showPoints`: only the card
-   * layout displays an icon, so in a plain list the column would be a field
-   * that changes nothing.
+   * Render the Icon field. Choice questions draw an icon in BOTH layouts (a
+   * list row shows an emoji or initials where the radio would be), so this
+   * tracks the question type, not the layout.
    */
   showIcon?: boolean;
+  /** Gates which icon kinds the picker offers — images are card-only. */
+  layout?: FormOptionLayout;
   m: EditorMessages['options'];
 }) {
   const ids = options.map((_, i) => `opt-${i}`);
@@ -135,19 +139,19 @@ export function OptionsEditor({
                     </Button>
                   </div>
                   {showIcon ? (
-                    <label className="flex min-w-0 flex-col gap-1 pl-7">
+                    <div className="flex min-w-0 flex-col gap-1 pl-7" data-testid={`option-icon-${index}`}>
                       <span className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
                         {m.icon}
                         <HelpTip text={m.iconHelp} label={m.icon} />
                       </span>
-                      <TextField
-                        aria-label={m.icon}
-                        data-testid={`option-icon-${index}`}
-                        placeholder={m.iconPlaceholder}
-                        value={o.icon ?? ''}
-                        onChange={(e) => update(index, { icon: e.target.value || null })}
+                      <IconPicker
+                        value={o.icon}
+                        label={o.label}
+                        layout={layout}
+                        onChange={(icon) => update(index, { icon })}
+                        m={m}
                       />
-                    </label>
+                    </div>
                   ) : null}
                   </div>
                 )}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -6,6 +6,7 @@ import {
   clampSliderValue,
   defaultFlowGroup,
   nameFields,
+  resolveOptionLayout,
   sanitizeStepKey,
   sliderBounds,
   sliderHasNoTravel,
@@ -16,7 +17,7 @@ import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Select, type SelectOption } from '@/components/ui/select';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
-import { Field, NumberField, SelectField, InlineField, TextField } from './fields';
+import { Field, NumberField, SelectField, InlineField, TextField, SegmentedToggle } from './fields';
 import { OptionsEditor } from './options-editor';
 import { SliderScoringEditor } from './slider-scoring-editor';
 import { maxScoreForSteps } from './scoring-util';
@@ -205,10 +206,24 @@ export function QuestionSettings({
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {bm.settings.options}
           </p>
+          {step.type === 'multiple_choice' ? (
+            <InlineField label={bm.settings.optionLayout} hint={bm.settings.optionLayoutHint}>
+              <SegmentedToggle
+                value={resolveOptionLayout(step)}
+                onChange={(optionLayout) => onUpdate({ optionLayout })}
+                options={[
+                  { value: 'list' as const, label: bm.settings.optionLayoutList },
+                  { value: 'cards' as const, label: bm.settings.optionLayoutCards },
+                ]}
+                ariaLabel={bm.settings.optionLayout}
+              />
+            </InlineField>
+          ) : null}
           <OptionsEditor
             options={step.options ?? []}
             onChange={(options) => onUpdate({ options })}
             showPoints={stepScores}
+            showIcon={step.type === 'multiple_choice' && resolveOptionLayout(step) === 'cards'}
             m={em.options}
           />
           <div className="border-t border-border/60 pt-3">

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -223,7 +223,8 @@ export function QuestionSettings({
             options={step.options ?? []}
             onChange={(options) => onUpdate({ options })}
             showPoints={stepScores}
-            showIcon={step.type === 'multiple_choice' && resolveOptionLayout(step) === 'cards'}
+            showIcon={step.type === 'multiple_choice'}
+            layout={resolveOptionLayout(step)}
             m={em.options}
           />
           <div className="border-t border-border/60 pt-3">

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -447,7 +447,10 @@ export function FormEditor({
           onChange={(e) => rename(e.target.value)}
           placeholder={bm.shell.formNamePlaceholder}
           aria-label={bm.shell.formNamePlaceholder}
-          className="min-w-0 max-w-[38ch] flex-1 rounded-md border border-transparent bg-transparent px-1.5 py-1 text-base font-semibold tracking-tight hover:border-border focus-visible:border-input focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:flex-none sm:text-lg"
+          // The topbar's only elastic child: it absorbs the slack so the fixed
+          // controls on the right keep their intrinsic width. `sm:flex-none`
+          // used to pin it wide, which pushed the actions past the viewport.
+          className="min-w-[8ch] max-w-[38ch] flex-1 rounded-md border border-transparent bg-transparent px-1.5 py-1 text-base font-semibold tracking-tight hover:border-border focus-visible:border-input focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:text-lg"
         />
         <span
           className={cn(
@@ -463,9 +466,16 @@ export function FormEditor({
           {statusLabel}
         </span>
 
-        <div className="ml-auto flex items-center gap-2">
-          {/* Tabs (segmented) */}
-          <nav className="hidden items-center gap-0.5 rounded-lg border border-border bg-card p-0.5 md:flex" aria-label="Sections">
+        {/* `shrink-0`: the name input above owns the slack (`min-w-0 flex-1`), so
+            the actions keep their intrinsic width instead of squeezing their
+            labels onto a second line inside the fixed-height controls. */}
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          {/* Tabs (segmented). Everything in this bar reveals on a DIFFERENT
+              breakpoint on purpose: five labelled tabs (~425px), the two link
+              labels and the publish pill all appearing at once overflowed the
+              bar. Icons from `lg`, labels only at `2xl`; below `lg` the tab row
+              under the header takes over. */}
+          <nav className="hidden items-center gap-0.5 rounded-lg border border-border bg-card p-0.5 lg:flex" aria-label="Sections">
             {tabs.map((t) => (
               <button
                 key={t.id}
@@ -473,13 +483,14 @@ export function FormEditor({
                 data-testid={`editor-tab-${t.id}`}
                 onClick={() => setTab(t.id)}
                 aria-current={tab === t.id}
+                title={t.label}
                 className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                  'inline-flex items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1.5 text-sm font-medium transition-colors 2xl:px-3',
                   tab === t.id ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground',
                 )}
               >
                 <i aria-hidden className={`pi ${t.icon}`} style={{ fontSize: 12 }} />
-                {t.label}
+                <span className="sr-only 2xl:not-sr-only">{t.label}</span>
               </button>
             ))}
           </nav>
@@ -487,7 +498,7 @@ export function FormEditor({
           <button
             type="button"
             onClick={() => setPreviewOpen(true)}
-            className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <i aria-hidden className="pi pi-eye" style={{ fontSize: 13 }} />
             <span className="hidden sm:inline">{bm.shell.preview}</span>
@@ -506,7 +517,7 @@ export function FormEditor({
       </header>
 
       {/* Mobile tab bar */}
-      <nav className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5 md:hidden" aria-label="Sections">
+      <nav className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5 lg:hidden" aria-label="Sections">
         {tabs.map((t) => (
           <button
             key={t.id}

--- a/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
@@ -26,11 +26,14 @@ export function LinkActions({
     }
   };
 
+  // `shrink-0` + `whitespace-nowrap`: these live in a flex topbar that gets tight
+  // between the `lg` label breakpoint and a roomy viewport. Without both, the
+  // label wraps to a second line inside a fixed `h-9` box and the button breaks.
   const btn =
-    'inline-flex h-9 items-center gap-1.5 rounded-lg border border-border px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+    'inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex shrink-0 items-center gap-2">
       <button
         type="button"
         onClick={copy}
@@ -40,7 +43,7 @@ export function LinkActions({
         data-testid="editor-copy-link"
       >
         <i aria-hidden className={`pi ${copied ? 'pi-check' : 'pi-link'}`} style={{ fontSize: 13 }} />
-        <span className="hidden lg:inline">{copied ? labels.copied : labels.copyLink}</span>
+        <span className="hidden xl:inline">{copied ? labels.copied : labels.copyLink}</span>
       </button>
       <a
         href={publicPath}
@@ -52,7 +55,7 @@ export function LinkActions({
         data-testid="editor-open-form"
       >
         <i aria-hidden className="pi pi-external-link" style={{ fontSize: 13 }} />
-        <span className="hidden lg:inline">{labels.openForm}</span>
+        <span className="hidden xl:inline">{labels.openForm}</span>
       </a>
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/publish-button.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/publish-button.tsx
@@ -56,11 +56,18 @@ export function PublishButton({
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex shrink-0 items-center gap-2">
       {hasDraft && !publishing ? (
-        <span className="hidden items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground sm:inline-flex">
-          <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-primary" />
-          {m.unpublishedChanges}
+        // The full label only fits once the topbar is wide (`2xl`); below that
+        // it collapses to the dot — still announced, via `sr-only`, and titled
+        // for sighted users. `whitespace-nowrap` keeps the label on one line
+        // rather than wrapping inside this fixed-height pill.
+        <span
+          title={m.unpublishedChanges}
+          className="hidden h-9 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-border bg-muted px-2.5 text-xs font-medium text-muted-foreground sm:inline-flex 2xl:px-3"
+        >
+          <span aria-hidden className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+          <span className="sr-only 2xl:not-sr-only">{m.unpublishedChanges}</span>
         </span>
       ) : null}
       <button
@@ -69,7 +76,7 @@ export function PublishButton({
         disabled={!hasDraft || publishing}
         title={hasDraft ? undefined : m.noChanges}
         className={cn(
-          'inline-flex h-9 items-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-transform hover:brightness-105 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          'inline-flex h-9 shrink-0 items-center whitespace-nowrap rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-transform hover:brightness-105 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           (!hasDraft || publishing) && 'cursor-not-allowed opacity-50 hover:brightness-100 active:scale-100',
         )}
       >

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -8,8 +8,8 @@ import {
   sliderBounds,
   clampSliderValue,
   resolveOptionLayout,
-  isImageIcon,
-  isSafeImageUrl,
+  resolveOptionIcon,
+  optionInitials,
 } from '@quill/engine';
 import { getMessages } from '@quill/shared';
 import { SearchableDropdown } from './searchable-dropdown';
@@ -37,33 +37,42 @@ function asArray(value: AnswerValue): string[] {
 }
 
 /**
- * An option's icon. An emoji (or the label's initial) is a square glyph, so it
- * centres in a circle; an uploaded logo has an arbitrary aspect ratio and would
- * be cropped by one, so images get a rectangle to letterbox into instead.
+ * An option's icon. An emoji or initials are square glyphs, so they centre in a
+ * circle; a logo has an arbitrary aspect ratio a circle would crop, so images
+ * get a rectangle to letterbox into. `resolveOptionIcon` decides which — and
+ * confines images to the card layout.
  *
- * A broken image URL falls back to the glyph treatment rather than leaving a
- * torn-image box — the option must stay pickable whatever the icon does.
- * `isSafeImageUrl` re-guards the `src` here: the config may predate the schema
- * check, or arrive from a looser source.
+ * A broken image URL falls back to the glyph rather than leaving a torn-image
+ * box: the option must stay pickable whatever the icon does.
  */
-function OptionIcon({ option, variant }: { option: FormOption; variant: 'card' | 'row' }) {
+function OptionIcon({
+  option,
+  layout,
+}: {
+  option: FormOption;
+  layout: 'cards' | 'list';
+}) {
   const [failed, setFailed] = useState(false);
-  const src = option.icon ?? '';
-  const isImage = isImageIcon(src) && isSafeImageUrl(src) && !failed;
-  const base = variant === 'card' ? 'pf-choice-icon' : 'pf-choice-list';
+  const resolved = resolveOptionIcon(option, layout);
+  const base = layout === 'cards' ? 'pf-choice-icon' : 'pf-choice-list';
 
-  if (isImage) {
+  if (resolved.kind === 'image' && !failed) {
     return (
       <span className={`${base}__img-wrap`} aria-hidden>
-        <img src={src} alt="" className={`${base}__img`} onError={() => setFailed(true)} />
+        <img
+          src={resolved.src}
+          alt=""
+          className={`${base}__img`}
+          onError={() => setFailed(true)}
+        />
       </span>
     );
   }
+  const glyph =
+    resolved.kind === 'glyph' ? resolved.text : optionInitials(option.label);
   return (
     <span className={`${base}__circle`} aria-hidden>
-      {option.icon && !isImageIcon(option.icon)
-        ? option.icon
-        : option.label.charAt(0).toUpperCase()}
+      {glyph}
     </span>
   );
 }
@@ -208,7 +217,7 @@ export function StepInput({
                 className={`pf-choice-icon${value === opt.value ? ' pf-choice-icon--selected' : ''}`}
                 onClick={() => onSelect(opt.value)}
               >
-                <OptionIcon option={opt} variant="card" />
+                <OptionIcon option={opt} layout="cards" />
                 <span className="pf-choice-icon__label">{opt.label}</span>
               </button>
             ))}
@@ -227,7 +236,7 @@ export function StepInput({
               onClick={() => onSelect(opt.value)}
             >
               {opt.icon ? (
-                <OptionIcon option={opt} variant="row" />
+                <OptionIcon option={opt} layout="list" />
               ) : (
                 <span className="pf-choice-list__radio" aria-hidden="true" />
               )}

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -1,8 +1,16 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import type { Answers, AnswerValue, FormStep } from '@quill/engine';
-import { nameFields, isMultiSelect, sliderBounds, clampSliderValue } from '@quill/engine';
+import { useEffect, useRef, useState } from 'react';
+import type { Answers, AnswerValue, FormOption, FormStep } from '@quill/engine';
+import {
+  nameFields,
+  isMultiSelect,
+  sliderBounds,
+  clampSliderValue,
+  resolveOptionLayout,
+  isImageIcon,
+  isSafeImageUrl,
+} from '@quill/engine';
 import { getMessages } from '@quill/shared';
 import { SearchableDropdown } from './searchable-dropdown';
 import { PhoneInput } from './phone-input';
@@ -26,6 +34,38 @@ function asArray(value: AnswerValue): string[] {
   if (Array.isArray(value)) return value.map(String);
   if (value == null || value === '') return [];
   return [String(value)];
+}
+
+/**
+ * An option's icon. An emoji (or the label's initial) is a square glyph, so it
+ * centres in a circle; an uploaded logo has an arbitrary aspect ratio and would
+ * be cropped by one, so images get a rectangle to letterbox into instead.
+ *
+ * A broken image URL falls back to the glyph treatment rather than leaving a
+ * torn-image box — the option must stay pickable whatever the icon does.
+ * `isSafeImageUrl` re-guards the `src` here: the config may predate the schema
+ * check, or arrive from a looser source.
+ */
+function OptionIcon({ option, variant }: { option: FormOption; variant: 'card' | 'row' }) {
+  const [failed, setFailed] = useState(false);
+  const src = option.icon ?? '';
+  const isImage = isImageIcon(src) && isSafeImageUrl(src) && !failed;
+  const base = variant === 'card' ? 'pf-choice-icon' : 'pf-choice-list';
+
+  if (isImage) {
+    return (
+      <span className={`${base}__img-wrap`} aria-hidden>
+        <img src={src} alt="" className={`${base}__img`} onError={() => setFailed(true)} />
+      </span>
+    );
+  }
+  return (
+    <span className={`${base}__circle`} aria-hidden>
+      {option.icon && !isImageIcon(option.icon)
+        ? option.icon
+        : option.label.charAt(0).toUpperCase()}
+    </span>
+  );
 }
 
 /** Renders the input for a single step. `message` renders info copy, no input. */
@@ -156,7 +196,7 @@ export function StepInput({
           </div>
         );
       }
-      if (step.showIcons) {
+      if (resolveOptionLayout(step) === 'cards') {
         return (
           <div className="pf-choices--icons" role="radiogroup" aria-label={step.question ?? step.key}>
             {(step.options ?? []).map((opt) => (
@@ -168,9 +208,7 @@ export function StepInput({
                 className={`pf-choice-icon${value === opt.value ? ' pf-choice-icon--selected' : ''}`}
                 onClick={() => onSelect(opt.value)}
               >
-                <span className="pf-choice-icon__circle" aria-hidden="true">
-                  {opt.icon ?? opt.label.charAt(0).toUpperCase()}
-                </span>
+                <OptionIcon option={opt} variant="card" />
                 <span className="pf-choice-icon__label">{opt.label}</span>
               </button>
             ))}
@@ -189,9 +227,7 @@ export function StepInput({
               onClick={() => onSelect(opt.value)}
             >
               {opt.icon ? (
-                <span className="pf-choice-list__icon" aria-hidden="true">
-                  {opt.icon}
-                </span>
+                <OptionIcon option={opt} variant="row" />
               ) : (
                 <span className="pf-choice-list__radio" aria-hidden="true" />
               )}

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -17,6 +17,8 @@ import {
   nameFields,
   isSafeHttpUrl,
   isSafeImageUrl,
+  showBanner,
+  showClientLogos,
   operatorsForFieldType,
   conditionsContradict,
   conditionsNarrow,
@@ -732,6 +734,48 @@ describe('URL safety guards (XSS)', () => {
     expect(isSafeImageUrl('javascript:alert(1)')).toBe(false);
     expect(isSafeImageUrl('vbscript:msgbox(1)')).toBe(false);
     expect(isSafeImageUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+});
+
+describe('cover presentation toggles', () => {
+  it('showBanner needs banner text before anything else', () => {
+    expect(showBanner(undefined, true)).toBe(false);
+    expect(showBanner(null, true)).toBe(false);
+    expect(showBanner({}, true)).toBe(false);
+    expect(showBanner({ bannerText: '' }, true)).toBe(false);
+    expect(showBanner({ bannerScope: 'form' }, false)).toBe(false);
+  });
+
+  it("showBanner defaults to every screen — a config saved before the toggle can't lose its banner", () => {
+    const legacy = { bannerText: 'Limited spots' };
+    expect(showBanner(legacy, true)).toBe(true);
+    expect(showBanner(legacy, false)).toBe(true);
+  });
+
+  it("showBanner scoped to 'cover' hides it on every other screen", () => {
+    const scoped = { bannerText: 'Limited spots', bannerScope: 'cover' as const };
+    expect(showBanner(scoped, true)).toBe(true);
+    expect(showBanner(scoped, false)).toBe(false);
+  });
+
+  it("showBanner scoped to 'form' shows it everywhere", () => {
+    const scoped = { bannerText: 'Limited spots', bannerScope: 'form' as const };
+    expect(showBanner(scoped, true)).toBe(true);
+    expect(showBanner(scoped, false)).toBe(true);
+  });
+
+  it('showClientLogos hides the marquee only on an explicit false', () => {
+    expect(showClientLogos(undefined)).toBe(true);
+    expect(showClientLogos(null)).toBe(true);
+    expect(showClientLogos({})).toBe(true);
+    expect(showClientLogos({ showClientLogos: true })).toBe(true);
+    expect(showClientLogos({ showClientLogos: false })).toBe(false);
+  });
+
+  it('showClientLogos off keeps the logos in the config — it hides, never deletes', () => {
+    const cover = { clientLogos: [{ name: 'Acme' }], showClientLogos: false };
+    expect(showClientLogos(cover)).toBe(false);
+    expect(cover.clientLogos).toHaveLength(1);
   });
 });
 

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -17,6 +17,8 @@ import {
   nameFields,
   isSafeHttpUrl,
   isSafeImageUrl,
+  isImageIcon,
+  resolveOptionLayout,
   showBanner,
   showClientLogos,
   operatorsForFieldType,
@@ -776,6 +778,56 @@ describe('cover presentation toggles', () => {
     const cover = { clientLogos: [{ name: 'Acme' }], showClientLogos: false };
     expect(showClientLogos(cover)).toBe(false);
     expect(cover.clientLogos).toHaveLength(1);
+  });
+});
+
+describe('choice option presentation', () => {
+  it('resolveOptionLayout defaults to a list', () => {
+    expect(resolveOptionLayout(undefined)).toBe('list');
+    expect(resolveOptionLayout(null)).toBe('list');
+    expect(resolveOptionLayout({})).toBe('list');
+    expect(resolveOptionLayout({ showIcons: false })).toBe('list');
+  });
+
+  it("resolveOptionLayout still honours the deprecated showIcons, so a pre-optionLayout config keeps its grid", () => {
+    expect(resolveOptionLayout({ showIcons: true })).toBe('cards');
+  });
+
+  it('resolveOptionLayout lets optionLayout win over showIcons', () => {
+    expect(resolveOptionLayout({ optionLayout: 'list', showIcons: true })).toBe('list');
+    expect(resolveOptionLayout({ optionLayout: 'cards', showIcons: false })).toBe('cards');
+  });
+
+  it('isImageIcon spots image references', () => {
+    expect(isImageIcon('https://cdn.example.com/logo.png')).toBe(true);
+    expect(isImageIcon('http://example.com/a.svg')).toBe(true);
+    expect(isImageIcon('//cdn.example.com/logo.png')).toBe(true);
+    expect(isImageIcon('/assets/logo.svg')).toBe(true);
+    expect(isImageIcon('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+    expect(isImageIcon('  HTTPS://Example.com/a.png ')).toBe(true);
+  });
+
+  it('isImageIcon treats emoji, letters and empties as glyphs', () => {
+    expect(isImageIcon('🚀')).toBe(false);
+    expect(isImageIcon('😍')).toBe(false);
+    expect(isImageIcon('A')).toBe(false);
+    expect(isImageIcon('')).toBe(false);
+    expect(isImageIcon(null)).toBe(false);
+    expect(isImageIcon(undefined)).toBe(false);
+  });
+
+  it('isImageIcon does not classify script protocols as images — they never reach an <img src>', () => {
+    expect(isImageIcon('javascript:alert(1)')).toBe(false);
+    expect(isImageIcon('vbscript:msgbox(1)')).toBe(false);
+    expect(isImageIcon('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('an icon that looks like an image must also be a safe one', () => {
+    // The renderer requires BOTH; this pins the pair that guards the src.
+    const hostile = 'data:text/html,<script>alert(1)</script>';
+    expect(isImageIcon(hostile) && isSafeImageUrl(hostile)).toBe(false);
+    const ok = 'https://cdn.example.com/logo.png';
+    expect(isImageIcon(ok) && isSafeImageUrl(ok)).toBe(true);
   });
 });
 

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -18,6 +18,8 @@ import {
   isSafeHttpUrl,
   isSafeImageUrl,
   isImageIcon,
+  optionInitials,
+  resolveOptionIcon,
   resolveOptionLayout,
   showBanner,
   showClientLogos,
@@ -828,6 +830,67 @@ describe('choice option presentation', () => {
     expect(isImageIcon(hostile) && isSafeImageUrl(hostile)).toBe(false);
     const ok = 'https://cdn.example.com/logo.png';
     expect(isImageIcon(ok) && isSafeImageUrl(ok)).toBe(true);
+  });
+
+  it('optionInitials takes up to two letters from the first two words', () => {
+    expect(optionInitials('Hubspot')).toBe('H');
+    expect(optionInitials('HubSpot Sales')).toBe('HS');
+    expect(optionInitials('one two three')).toBe('OT');
+    expect(optionInitials('  spaced   out  ')).toBe('SO');
+    expect(optionInitials('')).toBe('');
+    expect(optionInitials('   ')).toBe('');
+  });
+});
+
+describe('resolveOptionIcon — one answer for every surface', () => {
+  const IMG = 'https://cdn.example.com/logo.png';
+
+  it('draws an image on cards', () => {
+    expect(resolveOptionIcon({ icon: IMG, label: 'Hubspot' }, 'cards')).toEqual({
+      kind: 'image',
+      src: IMG,
+    });
+  });
+
+  it('degrades an image to initials on a list — logos are card-only', () => {
+    expect(resolveOptionIcon({ icon: IMG, label: 'Hubspot' }, 'list')).toEqual({
+      kind: 'glyph',
+      text: 'H',
+    });
+  });
+
+  it('an unsafe image never becomes an <img>, on either layout', () => {
+    const hostile = 'data:text/html,<script>alert(1)</script>';
+    // `isImageIcon` already rejects this, so it is treated as a glyph verbatim.
+    expect(resolveOptionIcon({ icon: hostile, label: 'X' }, 'cards').kind).toBe('glyph');
+  });
+
+  it('keeps an emoji or letters as a glyph on both layouts', () => {
+    for (const layout of ['cards', 'list'] as const) {
+      expect(resolveOptionIcon({ icon: '😍', label: 'Love it' }, layout)).toEqual({
+        kind: 'glyph',
+        text: '😍',
+      });
+      expect(resolveOptionIcon({ icon: 'HS', label: 'Hubspot' }, layout)).toEqual({
+        kind: 'glyph',
+        text: 'HS',
+      });
+    }
+  });
+
+  it('falls back to the label initials when there is no icon', () => {
+    expect(resolveOptionIcon({ label: 'Team lead' }, 'cards')).toEqual({
+      kind: 'glyph',
+      text: 'TL',
+    });
+    expect(resolveOptionIcon({ icon: null, label: 'Founder' }, 'list')).toEqual({
+      kind: 'glyph',
+      text: 'F',
+    });
+    expect(resolveOptionIcon({ icon: '   ', label: 'Founder' }, 'cards')).toEqual({
+      kind: 'glyph',
+      text: 'F',
+    });
   });
 });
 

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -266,10 +266,19 @@ export interface FormClientLogo {
   src?: string | null;
 }
 
+/** Where the cover's promo banner is allowed to render. */
+export const FORM_BANNER_SCOPES = ['form', 'cover'] as const;
+export type FormBannerScope = (typeof FORM_BANNER_SCOPES)[number];
+
 export interface FormCover {
   enabled?: boolean;
-  /** A sticky banner line (promo strip) shown above every screen throughout the flow. */
+  /** A sticky banner line (promo strip) shown above the form — see `bannerScope`. */
   bannerText?: string | null;
+  /**
+   * Where `bannerText` shows: `'form'` pins it above every screen (the legacy
+   * behaviour, and the default when absent), `'cover'` limits it to the cover.
+   */
+  bannerScope?: FormBannerScope;
   eyebrow?: string | null;
   /** Alias for eyebrow (pilot `badge`); eyebrow wins when both are set. */
   badge?: string | null;
@@ -281,6 +290,11 @@ export interface FormCover {
   logo?: string | null;
   /** Optional "trusted by" marquee shown on the cover. */
   clientLogos?: FormClientLogo[];
+  /**
+   * Whether the "trusted by" marquee renders. Absent means shown (the legacy
+   * behaviour), so the logos can be switched off without deleting them.
+   */
+  showClientLogos?: boolean;
 }
 
 /** Per-form branding — the accent color threads the banner/CTA/selected states. */
@@ -1507,6 +1521,31 @@ export function revealAfterKey(config: FormConfig): string | null {
   const triggered = steps.find((s) => s.triggersReveal);
   if (triggered) return triggered.key;
   return steps[steps.length - 1]?.key ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Cover presentation. Both helpers answer "should this chrome render on this
+// screen?" and both default to the pre-toggle behaviour, so a config saved
+// before the toggles existed renders exactly as it always did.
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the promo banner renders on a given screen. `bannerScope: 'cover'`
+ * confines it to the cover; anything else (including absent) keeps the legacy
+ * behaviour of pinning it above every screen in the flow.
+ */
+export function showBanner(cover: FormCover | null | undefined, isCover: boolean): boolean {
+  if (!cover?.bannerText) return false;
+  return isCover || cover.bannerScope !== 'cover';
+}
+
+/**
+ * Whether the "trusted by" marquee renders. Only an explicit `false` hides it,
+ * so the logos can be switched off without deleting them — and a config saved
+ * before the toggle existed still shows them.
+ */
+export function showClientLogos(cover: FormCover | null | undefined): boolean {
+  return cover?.showClientLogos !== false;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -29,11 +29,20 @@ export const FORM_FIELD_TYPES = [
 ] as const;
 export type FormFieldType = (typeof FORM_FIELD_TYPES)[number];
 
+/** How a choice step lays its options out. */
+export const FORM_OPTION_LAYOUTS = ['list', 'cards'] as const;
+export type FormOptionLayout = (typeof FORM_OPTION_LAYOUTS)[number];
+
 /** A single option for a choice/dropdown step; `points` feeds the score. */
 export interface FormOption {
   label: string;
   value: string;
   points?: number;
+  /**
+   * Either an emoji/short glyph or an image URL — `isImageIcon` tells them
+   * apart, because the two need opposite treatment when rendered (a glyph
+   * centres in a circle; a logo needs a rectangle it can letterbox into).
+   */
   icon?: string | null;
 }
 
@@ -156,7 +165,16 @@ export interface FormStep {
   sliderLabelVariants?: Record<string, string>;
   /** Static unit label shown next to the slider value (e.g. "leads / mo"). */
   sliderUnitLabel?: string | null;
-  /** `multiple_choice`: render as an icon grid instead of a radio list. */
+  /**
+   * `multiple_choice`: render options as a card grid instead of a radio list.
+   * Absent falls back to `showIcons` — see `resolveOptionLayout`.
+   */
+  optionLayout?: FormOptionLayout;
+  /**
+   * @deprecated Superseded by `optionLayout` — the flag named its content
+   * (icons) rather than what it actually switched (the layout). Still read as
+   * the fallback so configs saved before `optionLayout` keep their card grid.
+   */
   showIcons?: boolean;
   /**
    * Branch insertion: show this step ONLY when the `email` answer is a personal/
@@ -1546,6 +1564,35 @@ export function showBanner(cover: FormCover | null | undefined, isCover: boolean
  */
 export function showClientLogos(cover: FormCover | null | undefined): boolean {
   return cover?.showClientLogos !== false;
+}
+
+// ---------------------------------------------------------------------------
+// Choice-option presentation. An option's `icon` may be an emoji OR an image
+// URL, and the two render differently, so the renderer asks here rather than
+// sniffing the string in JSX.
+// ---------------------------------------------------------------------------
+
+/**
+ * How a choice step lays its options out. `optionLayout` wins; absent, the
+ * deprecated `showIcons` still selects the card grid, so a config saved before
+ * `optionLayout` existed renders exactly as it always did.
+ */
+export function resolveOptionLayout(
+  step: Pick<FormStep, 'optionLayout' | 'showIcons'> | null | undefined,
+): FormOptionLayout {
+  if (step?.optionLayout) return step.optionLayout;
+  return step?.showIcons ? 'cards' : 'list';
+}
+
+/**
+ * True when an option's `icon` is an image reference rather than an emoji or
+ * letter: http(s), protocol-relative, a root path, or a `data:image/…` URI.
+ * Safety is a SEPARATE question — pair this with `isSafeImageUrl` before the
+ * value reaches an `<img src>`.
+ */
+export function isImageIcon(icon: string | null | undefined): boolean {
+  if (!icon) return false;
+  return /^(?:https?:\/\/|\/\/|\/|data:image\/)/i.test(icon.trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -1595,6 +1595,51 @@ export function isImageIcon(icon: string | null | undefined): boolean {
   return /^(?:https?:\/\/|\/\/|\/|data:image\/)/i.test(icon.trim());
 }
 
+/** Longest glyph an option icon may be: an emoji, or initials like "HS". */
+export const OPTION_ICON_GLYPH_MAX = 2;
+
+/**
+ * The initials a label falls back to when it has no icon: up to two letters,
+ * taken from the first two words ("HubSpot Sales" → "HS", "Hubspot" → "H").
+ */
+export function optionInitials(label: string): string {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '';
+  if (words.length === 1) return (words[0]?.charAt(0) ?? '').toUpperCase();
+  return words
+    .slice(0, OPTION_ICON_GLYPH_MAX)
+    .map((w) => w.charAt(0).toUpperCase())
+    .join('');
+}
+
+/** What an option's icon resolves to on a given layout. */
+export type ResolvedOptionIcon =
+  | { kind: 'image'; src: string }
+  | { kind: 'glyph'; text: string };
+
+/**
+ * The single answer to "what do I draw for this option?", shared by the public
+ * renderer, the builder canvas and the live preview so all three agree.
+ *
+ * An image is a CARD-ONLY affordance. A list row gives an icon 38px of height
+ * and sits inline with the label, where a wordmark renders as an illegible
+ * sliver — so under `list` an image URL degrades to the label's initials rather
+ * than drawing badly. That also means an OLD config pairing a URL with a list
+ * can't produce the broken combination.
+ */
+export function resolveOptionIcon(
+  option: Pick<FormOption, 'icon' | 'label'>,
+  layout: FormOptionLayout,
+): ResolvedOptionIcon {
+  const icon = option.icon?.trim() ?? '';
+  if (icon && isImageIcon(icon)) {
+    if (layout === 'cards' && isSafeImageUrl(icon)) return { kind: 'image', src: icon };
+    return { kind: 'glyph', text: optionInitials(option.label) };
+  }
+  if (icon) return { kind: 'glyph', text: icon };
+  return { kind: 'glyph', text: optionInitials(option.label) };
+}
+
 // ---------------------------------------------------------------------------
 // URL safety (XSS). Shared by the zod config schema (server-side validation on
 // save) AND the public renderer (a runtime guard before navigating). Belt-and-

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -367,6 +367,9 @@ export interface FormsMessages {
         /** One-line explainer under the options list tying points to scoring. */
         pointsHint: string;
         icon: string;
+        /** What may go in the Icon column: an emoji, or an image URL. */
+        iconHelp: string;
+        iconPlaceholder: string;
         remove: string;
         empty: string;
         /** V5 — what the `value` column is for, vs the visible label (B5). */
@@ -1195,6 +1198,9 @@ export const en: FormsMessages = {
         points: 'Points',
         pointsHint: 'Added to the score when this option is picked. Use a negative number to subtract.',
         icon: 'Icon',
+        iconHelp:
+          'An emoji, or the URL of an image. Emoji show in a circle; images get a box they fit inside, so a wide logo is not cropped.',
+        iconPlaceholder: '🚀 or https://…',
         remove: 'Remove option',
         empty: 'No options yet.',
         labelHelp: 'What respondents read on the option. Safe to reword at any time.',
@@ -1980,6 +1986,9 @@ export const es: FormsMessages = {
         valueHelp:
           'Lo que se guarda en la respuesta y se envía a HubSpot o al webhook. Mantenlo estable — cambiarlo rompe las respuestas anteriores y cualquier mapeo que lo use.',
         icon: 'Ícono',
+        iconHelp:
+          'Un emoji, o la URL de una imagen. Los emoji se muestran en un círculo; las imágenes reciben una caja donde entran completas, así un logo ancho no se recorta.',
+        iconPlaceholder: '🚀 o https://…',
         remove: 'Quitar opción',
         empty: 'Aún no hay opciones.',
       },

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -367,9 +367,28 @@ export interface FormsMessages {
         /** One-line explainer under the options list tying points to scoring. */
         pointsHint: string;
         icon: string;
-        /** What may go in the Icon column: an emoji, or an image URL. */
+        /** What may go in the Icon column: an emoji, initials, or an image. */
         iconHelp: string;
         iconPlaceholder: string;
+        /** Icon picker: the three kinds, plus its empty/clear affordances. */
+        iconTabEmoji: string;
+        iconTabLetters: string;
+        iconTabImage: string;
+        iconClear: string;
+        iconEmpty: string;
+        iconLettersHint: string;
+        iconImageHint: string;
+        iconUrlInvalid: string;
+        /** Section headings inside the emoji grid. */
+        emojiGroups: {
+          reactions: string;
+          people: string;
+          business: string;
+          tech: string;
+          comms: string;
+          status: string;
+          places: string;
+        };
         remove: string;
         empty: string;
         /** V5 — what the `value` column is for, vs the visible label (B5). */
@@ -1199,8 +1218,25 @@ export const en: FormsMessages = {
         pointsHint: 'Added to the score when this option is picked. Use a negative number to subtract.',
         icon: 'Icon',
         iconHelp:
-          'An emoji, or the URL of an image. Emoji show in a circle; images get a box they fit inside, so a wide logo is not cropped.',
+          'An emoji, one or two letters, or an image. Emoji and letters show in a circle; images get a box they fit inside, so a wide logo is not cropped. Images are available on the card layout only.',
         iconPlaceholder: '🚀 or https://…',
+        iconTabEmoji: 'Emoji',
+        iconTabLetters: 'Letters',
+        iconTabImage: 'Image',
+        iconClear: 'Clear',
+        iconEmpty: 'Pick an icon',
+        iconLettersHint: 'Up to two letters, e.g. HS for HubSpot. Empty falls back to the label’s initials.',
+        iconImageHint: 'An https:// image URL. Logos keep their shape — they are fit inside a box, not cropped to a circle.',
+        iconUrlInvalid: 'This URL protocol is not allowed for images.',
+        emojiGroups: {
+          reactions: 'Reactions',
+          people: 'People',
+          business: 'Business',
+          tech: 'Tech',
+          comms: 'Communication',
+          status: 'Status',
+          places: 'Places',
+        },
         remove: 'Remove option',
         empty: 'No options yet.',
         labelHelp: 'What respondents read on the option. Safe to reword at any time.',
@@ -1987,8 +2023,25 @@ export const es: FormsMessages = {
           'Lo que se guarda en la respuesta y se envía a HubSpot o al webhook. Mantenlo estable — cambiarlo rompe las respuestas anteriores y cualquier mapeo que lo use.',
         icon: 'Ícono',
         iconHelp:
-          'Un emoji, o la URL de una imagen. Los emoji se muestran en un círculo; las imágenes reciben una caja donde entran completas, así un logo ancho no se recorta.',
+          'Un emoji, una o dos letras, o una imagen. Los emoji y las letras se muestran en un círculo; las imágenes reciben una caja donde entran completas, así un logo ancho no se recorta. Las imágenes solo están disponibles en el diseño de tarjetas.',
         iconPlaceholder: '🚀 o https://…',
+        iconTabEmoji: 'Emoji',
+        iconTabLetters: 'Letras',
+        iconTabImage: 'Imagen',
+        iconClear: 'Quitar',
+        iconEmpty: 'Elige un ícono',
+        iconLettersHint: 'Hasta dos letras, por ejemplo HS para HubSpot. Si lo dejas vacío se usan las iniciales de la etiqueta.',
+        iconImageHint: 'Una URL de imagen https://. Los logos conservan su forma — entran completos en una caja, no se recortan en un círculo.',
+        iconUrlInvalid: 'Este protocolo de URL no está permitido para imágenes.',
+        emojiGroups: {
+          reactions: 'Reacciones',
+          people: 'Personas',
+          business: 'Negocio',
+          tech: 'Tecnología',
+          comms: 'Comunicación',
+          status: 'Estado',
+          places: 'Lugares',
+        },
         remove: 'Quitar opción',
         empty: 'Aún no hay opciones.',
       },

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -527,6 +527,9 @@ export interface FormsMessages {
         subtitle: string;
         enabled: string;
         bannerText: string;
+        bannerScope: string;
+        bannerScopeForm: string;
+        bannerScopeCover: string;
         eyebrow: string;
         badge: string;
         headline: string;
@@ -541,6 +544,7 @@ export interface FormsMessages {
         logoInvalid: string;
         clientLogos: string;
         clientLogosHint: string;
+        showClientLogos: string;
         clientLogoName: string;
         clientLogoSrc: string;
         addClientLogo: string;
@@ -1309,6 +1313,9 @@ export const en: FormsMessages = {
         subtitle: 'The intro screen shown before the first step.',
         enabled: 'Show a cover screen',
         bannerText: 'Banner text',
+        bannerScope: 'Show the banner on',
+        bannerScopeForm: 'Every screen',
+        bannerScopeCover: 'Cover only',
         eyebrow: 'Eyebrow',
         badge: 'Badge',
         headline: 'Headline',
@@ -1323,6 +1330,7 @@ export const en: FormsMessages = {
         logoInvalid: 'This URL protocol is not allowed for images.',
         clientLogos: 'Client logos',
         clientLogosHint: 'A “trusted by” marquee on the cover. The name shows when no image is set.',
+        showClientLogos: 'Show the marquee',
         clientLogoName: 'Name',
         clientLogoSrc: 'Image URL',
         addClientLogo: 'Add logo',
@@ -2087,6 +2095,9 @@ export const es: FormsMessages = {
         subtitle: 'La pantalla de introducción antes del primer paso.',
         enabled: 'Mostrar una portada',
         bannerText: 'Texto del banner',
+        bannerScope: 'Mostrar el banner en',
+        bannerScopeForm: 'Todas las pantallas',
+        bannerScopeCover: 'Solo la portada',
         eyebrow: 'Antetítulo',
         badge: 'Insignia',
         headline: 'Titular',
@@ -2101,6 +2112,7 @@ export const es: FormsMessages = {
         logoInvalid: 'Este protocolo de URL no está permitido para imágenes.',
         clientLogos: 'Logos de clientes',
         clientLogosHint: 'Una marquesina de «confían en nosotros» en la portada. El nombre se muestra si no hay imagen.',
+        showClientLogos: 'Mostrar la marquesina',
         clientLogoName: 'Nombre',
         clientLogoSrc: 'URL de la imagen',
         addClientLogo: 'Añadir logo',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,7 +5,13 @@
  * from the same schema (never trust the client; validate on both sides).
  */
 import { z } from 'zod';
-import { CONDITION_OPS, FORM_FIELD_TYPES, isSafeHttpUrl, isSafeImageUrl } from '@quill/engine';
+import {
+  CONDITION_OPS,
+  FORM_BANNER_SCOPES,
+  FORM_FIELD_TYPES,
+  isSafeHttpUrl,
+  isSafeImageUrl,
+} from '@quill/engine';
 
 /** A URL rendered into `<img src>` — reject script protocols (XSS defense-in-depth). */
 const safeImageUrl = z
@@ -217,8 +223,13 @@ export type FormStepInput = z.infer<typeof formStepSchema>;
 
 export const formCoverSchema = z.object({
   enabled: z.boolean().optional(),
-  /** A sticky banner line shown above the form throughout the flow. */
+  /** A sticky banner line shown above the form — scoped by `bannerScope`. */
   bannerText: z.string().max(200).nullable().optional(),
+  /**
+   * Where `bannerText` renders (ADDITIVE): `'cover'` confines it to the cover
+   * screen; absent — every legacy config — keeps it above every screen.
+   */
+  bannerScope: z.enum(FORM_BANNER_SCOPES).optional(),
   eyebrow: z.string().max(200).nullable().optional(),
   badge: z.string().max(200).nullable().optional(),
   headline: z.string().max(300).nullable().optional(),
@@ -227,6 +238,11 @@ export const formCoverSchema = z.object({
   trustBadge: z.string().max(200).nullable().optional(),
   logo: safeImageUrl.nullable().optional(),
   clientLogos: z.array(clientLogoSchema).max(24).optional(),
+  /**
+   * Whether the "trusted by" marquee renders (ADDITIVE). Absent — every legacy
+   * config — means shown, so switching it off never deletes the logos.
+   */
+  showClientLogos: z.boolean().optional(),
 });
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,8 @@ import {
   CONDITION_OPS,
   FORM_BANNER_SCOPES,
   FORM_FIELD_TYPES,
+  FORM_OPTION_LAYOUTS,
+  isImageIcon,
   isSafeHttpUrl,
   isSafeImageUrl,
 } from '@quill/engine';
@@ -48,7 +50,20 @@ const optionSchema = z.object({
   label: z.string().min(1).max(200),
   value: z.string().min(1).max(200),
   points: z.number().int().optional(),
-  icon: z.string().max(64).nullable().optional(),
+  /**
+   * An emoji/short glyph OR an image URL. The cap is generous enough for a real
+   * CDN URL (it was 64 — emoji-sized — before images were an option), and any
+   * value that LOOKS like an image must also be a safe one, so a hostile config
+   * cannot reach the renderer's `<img src>` with a script protocol.
+   */
+  icon: z
+    .string()
+    .max(512)
+    .refine((v) => !isImageIcon(v) || isSafeImageUrl(v), {
+      message: 'Icon image URL protocol not allowed.',
+    })
+    .nullable()
+    .optional(),
 });
 
 /**
@@ -183,6 +198,9 @@ export const formStepSchema = z.object({
   placeholders: z.record(z.string(), z.string().max(200)).optional(),
   sliderLabelVariants: z.record(z.string(), z.string().max(80)).optional(),
   sliderUnitLabel: z.string().max(80).nullable().optional(),
+  /** ADDITIVE. Absent falls back to `showIcons` — see `resolveOptionLayout`. */
+  optionLayout: z.enum(FORM_OPTION_LAYOUTS).optional(),
+  /** @deprecated Superseded by `optionLayout`; still read as the fallback. */
   showIcons: z.boolean().optional(),
   showForPersonalEmailOnly: z.boolean().optional(),
   terminal: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Editor + renderer UI round: the topbar stops breaking at laptop widths, the cover gets two toggles it was missing, and choice options can finally be laid out as cards with a real icon per option.

Everything here is **additive** — three new optional config fields, each resolving in its absence to exactly what the app did before — so no published form changes appearance from this PR.

---

### 1. The editor topbar overflowed at real laptop widths

Labels wrapped onto a second line inside fixed-height controls, and **Publish was pushed off-screen** — 173px of overflow at 1180px wide.

Root cause was not padding: the form-name input carried `sm:flex-none`, so it refused to give up space and the controls absorbed the squeeze instead. It is now the bar's only elastic child, every control is `whitespace-nowrap`, and the tab labels, link labels and publish pill each reveal at the width where they actually fit rather than all landing at once.

Two deliberate layout consequences:
- Below `lg` the tabs move to the standalone row under the header (which already existed); between `lg` and `2xl` they are icon-only, with `title` + `sr-only` labels.
- Below `2xl` the "Unpublished changes" pill collapses to its dot — still titled and announced. At 170px with text it simply does not fit alongside everything else.

Verified at **768 / 820 / 1024 / 1180 / 1280 / 1440 / 1536** with a pending draft: zero overflow, nothing wrapped.

### 2. Cover: where the banner shows, and whether the marquee shows

- **`cover.bannerScope`** (`'form' | 'cover'`) — the promo banner was pinned above every screen with no way to confine it to the cover. Absent = every screen, the legacy behaviour.
- **`cover.showClientLogos`** — the "trusted by" marquee rendered whenever logos existed; the only way to hide it was to delete them. Only an explicit `false` hides it, so it hides without deleting.

The step preview mirrors the banner scope, so the choice is visible without leaving the editor.

### 3. Choice options as cards, with an icon per option

The card grid already existed in the renderer but the only way in was `showIcons` — a flag no editor control ever set, so in practice only the seeded demo form had it. Every question an author created fell to the radio list with no way out.

- **`optionLayout`** (`'list' | 'cards'`) from a "Show options as" toggle. `showIcons` is deprecated and still read as the fallback by `resolveOptionLayout`.
- **Icon picker** with a tab per kind: an emoji library (a curated local set — no new dependency), one or two letters (HubSpot → HS), or an image URL. The field used to be a raw text box, which told an author nothing about emoji or initials being valid, so it only ever received URLs.
- **Logos are card-only, on both sides.** A wordmark in a 38px list row renders as an illegible sliver, so `resolveOptionIcon` degrades an image to the label's initials under `list` **and** the editor drops the Image tab there. An already-saved list+URL config therefore cannot show the broken combination either.
- **Cards centre at any count.** The fixed three-track grid stranded a single card in the left third and pinned two to the left edge; wrapping centred flex replaces it. Verified at 1, 2 and 5 options — group centre matches container centre, and five wrap 3 + 2 with the second row centred.
- **A logo is the icon, not something on a plate.** A logo carries its own shape and fill, so the muted rounded box behind it read as a chip stuck onto the card. Background/radius/padding are gone; the element still reserves the same 46px band, so a square 46×46 mark and TikTok's 96×28 wordmark share one baseline with equal card heights.
- Glyph vs image treatment: an emoji or initials centre in a circle; an image letterboxes with `object-fit: contain`. A broken URL falls back to the glyph rather than a torn-image box, so the option stays pickable.

`resolveOptionIcon` is the single answer to "what do I draw for this option", shared by the public renderer, the builder canvas and the live preview so the three cannot drift apart. The canvas also mirrors the chosen layout — it used to draw a radio list while the form drew cards.

---

### New config fields (all additive, all optional)

| Field | Values | Absent means |
|---|---|---|
| `cover.bannerScope` | `'form'` \| `'cover'` | `'form'` — banner on every screen |
| `cover.showClientLogos` | boolean | shown |
| `step.optionLayout` | `'list'` \| `'cards'` | falls back to `showIcons`, else `'list'` |

`option.icon` also grew from a 64-char cap to 512 to fit a real CDN URL, and anything that looks like an image must pass `isSafeImageUrl` before it can reach an `<img src>`.

## Test plan

- [x] `pnpm test` green — 550 tests, 13 new in `@quill/engine` covering the resolvers and their legacy defaults
- [x] `pnpm typecheck` / `pnpm lint` clean
- [x] `pnpm build` (full CI build) green
- [x] i18n EN + ES for every new string
- [x] Changesets for the three behavioural changes
- [x] Verified live against a running instance, not just unit tests:
  - topbar measured at 7 widths with a pending draft (`scrollWidth − clientWidth === 0`, no wrapped elements)
  - banner scope and marquee toggle published and checked on the real public form
  - card centring measured at 1 / 2 / 5 options; icon band alignment measured across mixed logo proportions
  - image-in-list confirmed degrading to initials (`imagesInList: 0`)
  - broken image URL confirmed falling back to the glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
