### PR TITLE
feat: vertical one-page form layout + embed on any site

### DIFF
--- a/.changeset/vertical-form-layout.md
+++ b/.changeset/vertical-form-layout.md
@@ -1,0 +1,30 @@
+---
+'@quill/engine': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+Forms can now render as a single vertical page, not only as slides.
+
+`config.layout: 'slides' | 'vertical'` (additive — absent means `'slides'`, so
+every published form renders exactly as before; `resolveFormLayout` is the one
+place that default lives). The vertical renderer walks the same pure engine
+(`runtimeSteps` recomputed on every answer), so skip-logic, goto jumps, dynamic
+question variants and branch closing all apply live on the one page.
+
+Layout-specific behavior: the cover renders as a hero header (no Start gate,
+its CTA text is unused), reveal steps never play mid-page (one reveal plays
+after Submit, before the result), a terminal step with an answer hides
+everything after it instead of auto-submitting, schedulers embed inline and
+lazy-mount near the viewport, and validation is inline on blur plus a
+submit-time sweep that scrolls to the first invalid question.
+
+Funnel events keep their metric semantics across layouts: `step_view` fires
+when a question enters the viewport (index 0 on load matches a cover-less
+slides form, so Starts stays comparable), `step_complete` when a question first
+holds a valid answer, `partial_submit` when the threshold answer becomes valid.
+
+The builder follows: a layout picker in the create dialog and the Design tab,
+the canvas drops the per-step progress bar and Next button on vertical, the
+cover CTA field is replaced by a note, the reveal switch explains where it
+actually plays, and the Design-tab preview sketches the one-page shape.

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ qa/test-results/
 test-results/
 qa/shots/
 .next-qa/
+.next-*/
 
 # Throwaway QA agent artifacts (screenshots + scratch specs)
 qa/tmp-shots/

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -20,7 +20,6 @@ import {
   computeScore,
   partialSubmitKey,
   revealAfterKey,
-  interpolate,
   nameFields,
   isMultiSelect,
   isSafeHttpUrl,
@@ -30,8 +29,7 @@ import {
   type FormOutcome,
 } from '@quill/engine';
 import { onAccent, getMessages } from '@quill/shared';
-import type { FormConfig, OutcomeBooking } from '@quill/types';
-import { signupHref } from '@/lib/growth';
+import type { FormConfig } from '@quill/types';
 import { FormLogo } from '@/components/public/form-logo';
 import { FormProgress } from '@/components/public/form-progress';
 import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
@@ -41,123 +39,17 @@ import { RevealScreen } from '@/components/public/reveal-screen';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
 import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
+import {
+  useSessionId,
+  captureUtm,
+  capturePrefill,
+  schedulerToBooking,
+  PhaseShell,
+  DoneScreen,
+} from './renderer-shared';
 import './public-form.css';
 
 type Phase = 'cover' | 'steps' | 'reveal' | 'submitting' | 'booking' | 'done';
-
-function useSessionId(key: string): string {
-  const [id] = useState(() => {
-    if (typeof window === 'undefined') return '';
-    const existing = window.sessionStorage.getItem(key);
-    if (existing) return existing;
-    const fresh = crypto.randomUUID();
-    window.sessionStorage.setItem(key, fresh);
-    return fresh;
-  });
-  return id;
-}
-
-/** Read `utm_*` query params from the current URL into a flat string map. */
-function captureUtm(): Record<string, string> {
-  if (typeof window === 'undefined') return {};
-  const params = new URLSearchParams(window.location.search);
-  const utm: Record<string, string> = {};
-  for (const [k, v] of params.entries()) {
-    if (k.toLowerCase().startsWith('utm_') && v) utm[k] = v;
-  }
-  return utm;
-}
-
-/** A query value can never be longer than this once seeded (defense-in-depth). */
-const PREFILL_MAX_LEN = 512;
-
-/**
- * Map a `scheduler` step's config to the booking shape the shared BookingScreen
- * embeds, or `null` when no event type has been picked yet (renders a fallback).
- * "Show event details? → No" becomes Calendly's `hide_event_type_details=1`.
- * The URL is re-guarded to http(s) — it flows into an embed (XSS defense).
- */
-function schedulerToBooking(
-  scheduler: NonNullable<FormStep['scheduler']>,
-  customAnswers: Record<string, string> = {},
-): OutcomeBooking | null {
-  const url = scheduler.url?.trim();
-  if (!url || !isSafeHttpUrl(url)) return null;
-  const provider = scheduler.provider ?? 'calendly';
-  let finalUrl = url;
-  if (provider === 'calendly') {
-    try {
-      const u = new URL(url);
-      if (scheduler.hideEventDetails) u.searchParams.set('hide_event_type_details', '1');
-      // The event type's custom questions are prefilled by their positional id,
-      // so they ride the URL as-is (the embed builder preserves existing query
-      // params). Built-in name/email travel through the overlaid answers.
-      for (const [field, value] of Object.entries(customAnswers)) {
-        if (value) u.searchParams.set(field, value);
-      }
-      finalUrl = u.toString();
-    } catch {
-      /* keep the original url */
-    }
-  }
-  return { provider, url: finalUrl, prefill: scheduler.prefill !== false };
-}
-
-/**
- * URL-parameter prefill (V4-13): read the query string and seed the answer for
- * each param whose key matches a DECLARED field — a step's own key, or a `name`
- * step's subfields (`nameFields`). Security-scoped by design:
- *  - only keys that correspond to a declared step field are ever read (an
- *    arbitrary `?anything=` is ignored — never trust the URL to name new fields);
- *  - `utm_*` is captured separately (`captureUtm`) and skipped here;
- *  - values are treated as PLAIN answer strings, capped in length, never eval'd
- *    or interpreted as markup — and the engine re-validates every answer on
- *    submit, so a bad value can only be rejected, never trusted.
- * A prefilled HIDDEN step carries its answer into the submission though it is
- * never shown; a prefilled VISIBLE step simply renders pre-filled.
- */
-function capturePrefill(steps: FormStep[]): Answers {
-  if (typeof window === 'undefined') return {};
-  const declared = new Set<string>();
-  for (const step of steps) {
-    if (step.type === 'message') continue; // message steps capture no answer
-    for (const key of nameFields(step)) declared.add(key);
-  }
-  if (declared.size === 0) return {};
-  const params = new URLSearchParams(window.location.search);
-  const seed: Answers = {};
-  for (const [key, value] of params.entries()) {
-    if (key.toLowerCase().startsWith('utm_')) continue;
-    if (!declared.has(key)) continue;
-    if (typeof value !== 'string' || value === '') continue;
-    seed[key] = value.slice(0, PREFILL_MAX_LEN);
-  }
-  return seed;
-}
-
-/**
- * Per-phase page shell. The promo banner (`cover.bannerText`) renders ONCE here
- * as the first child of `.pf`, so it is a full-width strip pinned to the top of
- * the viewport in EVERY phase; everything else lives in `.pf__main`, which owns
- * the remaining height. Desktop's per-phase vertical centering is applied to
- * `.pf__main` (public-form.css), so centering the content group can never drag
- * the banner toward the middle of the page.
- */
-function PhaseShell({
-  bannerText,
-  children,
-  ...rootProps
-}: {
-  bannerText?: string | null;
-  children: React.ReactNode;
-} & React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div {...rootProps}>
-      {bannerText ? <div className="pf__banner">{bannerText}</div> : null}
-      <div className="pf__main">{children}</div>
-    </div>
-  );
-}
 
 export function FormRenderer({
   accountCode,
@@ -552,33 +444,15 @@ export function FormRenderer({
     const outcome = resolveOutcome(engineConfig, done.score, answersRef.current);
     // V5-B1: outcome copy → form-level ending copy → the built-in localized copy.
     const ending = resolveEnding(engineConfig, outcome);
-    const cta = signupHref('confirmation', accountCode);
     return (
-      <PhaseShell className="pf pf--done" style={accentVars} bannerText={cover?.bannerText}>
-        <div className="pf-done__inner pf-animate">
-          <div className="pf-done__check" aria-hidden="true">
-            ✓
-          </div>
-          {/* The heading interpolates too. It did not, so a `[firstname]` typed
-              into a range's heading reached the respondent as literal text —
-              while the body right beneath it resolved correctly. */}
-          <h1 className="pf-done__title">
-            {ending.headline ? interpolate(ending.headline, answersRef.current) : m.thankYouTitle}
-          </h1>
-          <p className="pf-done__body">
-            {ending.body ? interpolate(ending.body, answersRef.current) : m.thankYouBody}
-          </p>
-          {cta ? (
-            <>
-              <p className="pf-done__cta-question">{m.ctaQuestion}</p>
-              <a className="pf-done__cta" href={cta} target="_blank" rel="noopener noreferrer">
-                {m.ctaAction}
-                <span className="sr-only"> {m.newTab}</span>
-              </a>
-            </>
-          ) : null}
-        </div>
-      </PhaseShell>
+      <DoneScreen
+        ending={ending}
+        answers={answersRef.current}
+        m={m}
+        accountCode={accountCode}
+        bannerText={cover?.bannerText}
+        style={accentVars}
+      />
     );
   }
 

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { MadeWithBadge } from '@/components/made-with-badge';
 import { resolveFormLayout } from '@quill/engine';
 import { resolveTracking } from '@/components/tracking/resolve-tracking';
 import { TrackingScripts } from '@/components/tracking/tracking-scripts';
+import { EmbedHeightReporter } from '@/components/public/embed-height-reporter';
 import { FormRenderer } from './form-renderer';
 import { VerticalFormRenderer } from './vertical-form-renderer';
 
@@ -41,11 +42,14 @@ export default async function PublicFormPage({
   searchParams,
 }: {
   params: Promise<{ accountCode: string; handle: string; slug: string }>;
-  searchParams: Promise<{ lang?: string }>;
+  searchParams: Promise<{ lang?: string; embed?: string }>;
 }) {
   const { accountCode, slug } = await params;
-  const { lang } = await searchParams;
+  const { lang, embed } = await searchParams;
   const locale = await publicLocale(lang);
+  // Embedded render (?embed=1): same form, sized by its content instead of the
+  // viewport, reporting its height to the host page's embed.js (iframe embeds).
+  const embedded = embed === '1';
 
   const form = await getPublicForm(accountCode, slug);
   if (!form) notFound();
@@ -62,13 +66,18 @@ export default async function PublicFormPage({
   return (
     <>
       <TrackingScripts tracking={tracking} />
-      <Renderer
-        accountCode={accountCode}
-        slug={slug}
-        name={form.name}
-        config={form.config}
-        locale={locale}
-      />
+      {embedded ? <EmbedHeightReporter /> : null}
+      {/* The wrapper class relaxes the renderers' viewport-height rules so the
+          document's height IS the content's — what the reporter measures. */}
+      <div className={embedded ? 'pf-embed-root' : undefined}>
+        <Renderer
+          accountCode={accountCode}
+          slug={slug}
+          name={form.name}
+          config={form.config}
+          locale={locale}
+        />
+      </div>
       <MadeWithBadge locale={locale} accountCode={accountCode} />
     </>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -4,9 +4,11 @@ import { getPublicForm } from '@/lib/api';
 import { publicLocale } from '@/lib/locale';
 import { getMessages, t } from '@quill/shared';
 import { MadeWithBadge } from '@/components/made-with-badge';
+import { resolveFormLayout } from '@quill/engine';
 import { resolveTracking } from '@/components/tracking/resolve-tracking';
 import { TrackingScripts } from '@/components/tracking/tracking-scripts';
 import { FormRenderer } from './form-renderer';
+import { VerticalFormRenderer } from './vertical-form-renderer';
 
 /**
  * SEO/OG metadata for the public form — the form name as the title and a
@@ -53,10 +55,14 @@ export default async function PublicFormPage({
   // renders nothing (zero third-party requests).
   const tracking = resolveTracking(form.config.tracking);
 
+  // The config decides the presentation: slides (the original one-question-per-
+  // screen walk) or vertical (one page). Same engine, same submit contract.
+  const Renderer = resolveFormLayout(form.config) === 'vertical' ? VerticalFormRenderer : FormRenderer;
+
   return (
     <>
       <TrackingScripts tracking={tracking} />
-      <FormRenderer
+      <Renderer
         accountCode={accountCode}
         slug={slug}
         name={form.name}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1027,7 +1027,7 @@
      card's page padding live on .pf__main — the area BELOW the pinned banner —
      never on .pf itself, which would drag the banner down with the group (and
      the padding would inset the banner off the viewport edges). */
-  .pf:not(.pf--cover):not(.pf--reveal):not(.pf--done) .pf__main {
+  .pf:not(.pf--cover):not(.pf--reveal):not(.pf--done):not(.pf--vertical) .pf__main {
     justify-content: center;
     padding: 40px 24px;
   }
@@ -1111,3 +1111,139 @@
   margin-top: 12px;
 }
 .pf-booking__trouble a { color: inherit; text-decoration: underline; }
+
+/* ── Vertical layout (config.layout = 'vertical') ─────────────────────────────
+   One page, natural document flow. Deliberately NO viewport-height tricks
+   beyond the root min-height: this is the layout an embed (iframe auto-height)
+   will reuse, so content must size itself. Question typography reuses the
+   slides tokens but left-aligned — a stacked page reads as a document, not a
+   stage. All rules scoped under .pf--vertical / .pf-v__*. */
+
+/* The banner joins the progress bar in ONE sticky group (`.pf-v__sticky`);
+   its own stickiness is neutralized so the two never fight for the top edge. */
+.pf--vertical .pf__banner {
+  position: static;
+}
+.pf-v__sticky {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+}
+.pf-v__progressbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+}
+.pf-v__progressbar .pf-progress {
+  max-width: 420px;
+  flex: 1;
+}
+.pf-v__progress-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Natural top-aligned flow — the desktop media block's per-phase centering is
+   excluded for this layout (see the :not(.pf--vertical) in that selector). */
+.pf--vertical .pf__main {
+  justify-content: flex-start;
+}
+
+.pf-v__page {
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 20px calc(56px + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+}
+.pf-v__header {
+  display: flex;
+  justify-content: center;
+  padding: 22px 0 2px;
+}
+
+/* Cover-as-hero: same badge/title/subheadline/trust classes as the cover
+   screen, centered, with the logos marquee — but no Start gate. */
+.pf-v__hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 22px 0 26px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Question blocks: a quiet stacked list separated by hairlines. */
+.pf-v__question {
+  padding: 26px 0;
+  border-bottom: 1px solid var(--border);
+}
+.pf-v__question:last-of-type {
+  border-bottom: none;
+}
+.pf-v__question .pf__question-wrap {
+  max-width: none;
+  margin: 0;
+}
+.pf-v__question .pf__question {
+  text-align: left;
+  font-size: clamp(17px, 3vw, 21px);
+}
+.pf-v__question .pf__helper {
+  text-align: left;
+  margin-top: 6px;
+}
+.pf-v__question .pf__fields {
+  margin-top: 16px;
+}
+.pf-v__question .pf__error {
+  text-align: left;
+  margin-top: 10px;
+}
+.pf-v__required {
+  color: var(--pf-primary);
+  margin-left: 2px;
+}
+.pf-v__question--error .pf-input {
+  border-color: var(--destructive);
+}
+
+/* Lazy scheduler embed: hold the space quietly until it mounts. */
+.pf-v__embed-placeholder {
+  min-height: 480px;
+  border: 1px dashed var(--border);
+  border-radius: var(--pf-radius);
+  background: var(--muted);
+}
+
+/* Footer: the single Submit for the whole page. */
+.pf-v__footer {
+  padding-top: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.pf-v__footer .pf__error {
+  margin-top: 0;
+}
+
+@media (min-width: 769px) {
+  .pf-v__page {
+    padding-bottom: 88px;
+  }
+  .pf-v__question {
+    padding: 30px 0;
+  }
+}
+@media (max-width: 480px) {
+  .pf-v__progressbar {
+    padding: 8px 14px;
+  }
+}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1247,3 +1247,16 @@
     padding: 8px 14px;
   }
 }
+
+/* ── Embedded mode (?embed=1, inside a host page's iframe) ────────────────────
+   The page's height must BE the content's height — the embed reporter measures
+   the document and the host's embed.js sizes the iframe to match, so any
+   viewport-height rule here would turn into a feedback loop (iframe grows →
+   dvh grows → content "grows" → iframe grows…). Slides keeps a comfortable
+   floor so a single question doesn't render as a cramped strip. */
+.pf-embed-root .pf {
+  min-height: 480px;
+}
+.pf-embed-root .pf--vertical {
+  min-height: 0;
+}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/renderer-shared.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/renderer-shared.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+/**
+ * Pieces shared by BOTH public renderers — slides (`form-renderer.tsx`) and
+ * vertical (`vertical-form-renderer.tsx`). Extracted so the two layouts can
+ * never drift on session identity, UTM/prefill capture, the scheduler→booking
+ * mapping, the banner shell, or the thank-you screen. Pure presentation +
+ * browser-only capture helpers; every flow decision stays in `@quill/engine`.
+ */
+import { useState } from 'react';
+import type { Answers, FormStep, ResolvedEnding } from '@quill/engine';
+import { nameFields, isSafeHttpUrl, interpolate } from '@quill/engine';
+import type { OutcomeBooking } from '@quill/types';
+import type { getMessages } from '@quill/shared';
+import { signupHref } from '@/lib/growth';
+
+export function useSessionId(key: string): string {
+  const [id] = useState(() => {
+    if (typeof window === 'undefined') return '';
+    const existing = window.sessionStorage.getItem(key);
+    if (existing) return existing;
+    const fresh = crypto.randomUUID();
+    window.sessionStorage.setItem(key, fresh);
+    return fresh;
+  });
+  return id;
+}
+
+/** Read `utm_*` query params from the current URL into a flat string map. */
+export function captureUtm(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  const utm: Record<string, string> = {};
+  for (const [k, v] of params.entries()) {
+    if (k.toLowerCase().startsWith('utm_') && v) utm[k] = v;
+  }
+  return utm;
+}
+
+/** A query value can never be longer than this once seeded (defense-in-depth). */
+export const PREFILL_MAX_LEN = 512;
+
+/**
+ * URL-parameter prefill (V4-13): read the query string and seed the answer for
+ * each param whose key matches a DECLARED field — a step's own key, or a `name`
+ * step's subfields (`nameFields`). Security-scoped by design:
+ *  - only keys that correspond to a declared step field are ever read (an
+ *    arbitrary `?anything=` is ignored — never trust the URL to name new fields);
+ *  - `utm_*` is captured separately (`captureUtm`) and skipped here;
+ *  - values are treated as PLAIN answer strings, capped in length, never eval'd
+ *    or interpreted as markup — and the engine re-validates every answer on
+ *    submit, so a bad value can only be rejected, never trusted.
+ * A prefilled HIDDEN step carries its answer into the submission though it is
+ * never shown; a prefilled VISIBLE step simply renders pre-filled.
+ */
+export function capturePrefill(steps: FormStep[]): Answers {
+  if (typeof window === 'undefined') return {};
+  const declared = new Set<string>();
+  for (const step of steps) {
+    if (step.type === 'message') continue; // message steps capture no answer
+    for (const key of nameFields(step)) declared.add(key);
+  }
+  if (declared.size === 0) return {};
+  const params = new URLSearchParams(window.location.search);
+  const seed: Answers = {};
+  for (const [key, value] of params.entries()) {
+    if (key.toLowerCase().startsWith('utm_')) continue;
+    if (!declared.has(key)) continue;
+    if (typeof value !== 'string' || value === '') continue;
+    seed[key] = value.slice(0, PREFILL_MAX_LEN);
+  }
+  return seed;
+}
+
+/**
+ * Map a `scheduler` step's config to the booking shape the shared BookingScreen
+ * embeds, or `null` when no event type has been picked yet (renders a fallback).
+ * "Show event details? → No" becomes Calendly's `hide_event_type_details=1`.
+ * The URL is re-guarded to http(s) — it flows into an embed (XSS defense).
+ */
+export function schedulerToBooking(
+  scheduler: NonNullable<FormStep['scheduler']>,
+  customAnswers: Record<string, string> = {},
+): OutcomeBooking | null {
+  const url = scheduler.url?.trim();
+  if (!url || !isSafeHttpUrl(url)) return null;
+  const provider = scheduler.provider ?? 'calendly';
+  let finalUrl = url;
+  if (provider === 'calendly') {
+    try {
+      const u = new URL(url);
+      if (scheduler.hideEventDetails) u.searchParams.set('hide_event_type_details', '1');
+      // The event type's custom questions are prefilled by their positional id,
+      // so they ride the URL as-is (the embed builder preserves existing query
+      // params). Built-in name/email travel through the overlaid answers.
+      for (const [field, value] of Object.entries(customAnswers)) {
+        if (value) u.searchParams.set(field, value);
+      }
+      finalUrl = u.toString();
+    } catch {
+      /* keep the original url */
+    }
+  }
+  return { provider, url: finalUrl, prefill: scheduler.prefill !== false };
+}
+
+/**
+ * Per-phase page shell. The promo banner (`cover.bannerText`) renders ONCE here
+ * as the first child of `.pf`, so it is a full-width strip pinned to the top of
+ * the viewport in EVERY phase; everything else lives in `.pf__main`, which owns
+ * the remaining height. Desktop's per-phase vertical centering is applied to
+ * `.pf__main` (public-form.css), so centering the content group can never drag
+ * the banner toward the middle of the page.
+ */
+export function PhaseShell({
+  bannerText,
+  children,
+  ...rootProps
+}: {
+  bannerText?: string | null;
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...rootProps}>
+      {bannerText ? <div className="pf__banner">{bannerText}</div> : null}
+      <div className="pf__main">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * The thank-you screen, shared verbatim by both layouts: outcome/ending copy
+ * (with `[key]` interpolation), the optional growth CTA, inside the banner
+ * shell. The caller resolves the ending (outcome → form-level → built-in copy)
+ * so this stays a dumb view.
+ */
+export function DoneScreen({
+  ending,
+  answers,
+  m,
+  accountCode,
+  bannerText,
+  style,
+}: {
+  ending: ResolvedEnding;
+  answers: Answers;
+  m: ReturnType<typeof getMessages>['renderer'];
+  accountCode: string;
+  bannerText?: string | null;
+  style?: React.CSSProperties;
+}) {
+  const cta = signupHref('confirmation', accountCode);
+  return (
+    <PhaseShell className="pf pf--done" style={style} bannerText={bannerText}>
+      <div className="pf-done__inner pf-animate">
+        <div className="pf-done__check" aria-hidden="true">
+          ✓
+        </div>
+        {/* The heading interpolates too. It did not, so a `[firstname]` typed
+            into a range's heading reached the respondent as literal text —
+            while the body right beneath it resolved correctly. */}
+        <h1 className="pf-done__title">
+          {ending.headline ? interpolate(ending.headline, answers) : m.thankYouTitle}
+        </h1>
+        <p className="pf-done__body">
+          {ending.body ? interpolate(ending.body, answers) : m.thankYouBody}
+        </p>
+        {cta ? (
+          <>
+            <p className="pf-done__cta-question">{m.ctaQuestion}</p>
+            <a className="pf-done__cta" href={cta} target="_blank" rel="noopener noreferrer">
+              {m.ctaAction}
+              <span className="sr-only"> {m.newTab}</span>
+            </a>
+          </>
+        ) : null}
+      </div>
+    </PhaseShell>
+  );
+}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -1,0 +1,773 @@
+'use client';
+
+/**
+ * The public form experience for `config.layout = 'vertical'` — every visible
+ * question on ONE page, answered in any order and submitted once, driven by the
+ * SAME engine walk as the slides layout (`runtimeSteps` recomputed on every
+ * answer), so skip-logic, goto jumps, dynamic question variants and branch
+ * closing all apply live: questions show and hide as the respondent types.
+ *
+ * Layout-specific decisions (vs `form-renderer.tsx`):
+ *  - The cover renders as a HERO header (headline/subheadline/logos) — there is
+ *    no gate screen and its `ctaText` is ignored.
+ *  - Reveal steps never render mid-page; one reveal (a reveal step's config,
+ *    else the legacy form-level reveal) plays AFTER Submit, before the result.
+ *  - A `terminal` step with an answer hides everything after it (the respondent
+ *    can still change their answer); it never auto-submits.
+ *  - Validation is inline: blur validates a touched question, Submit validates
+ *    the whole walk and scrolls to the first invalid question.
+ *
+ * Funnel events keep their metric semantics (see packages/db/src/analytics.ts):
+ *  - `step_view` fires when a question ENTERS THE VIEWPORT (once per step) —
+ *    index 0 on load matches a cover-less slides form, where the first question
+ *    is also visible immediately, so "Starts" stays comparable across layouts.
+ *  - `step_complete` fires when a question first holds a VALID answer (instant
+ *    inputs on change, free-text inputs on blur).
+ *  - `partial_submit` fires when the threshold step's answer becomes valid.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  runtimeSteps,
+  validateAnswerCode,
+  resolveOutcome,
+  resolveEnding,
+  computeScore,
+  partialSubmitKey,
+  revealAfterKey,
+  nameFields,
+  isSafeHttpUrl,
+  type Answers,
+  type AnswerValue,
+  type FormStep,
+  type FormOutcome,
+  type FormReveal,
+} from '@quill/engine';
+import { onAccent, getMessages, t } from '@quill/shared';
+import type { FormConfig } from '@quill/types';
+import { FormLogo } from '@/components/public/form-logo';
+import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
+import { StepInput } from '@/components/public/step-input';
+import { BookingScreen } from '@/components/public/booking-screen';
+import { RevealScreen } from '@/components/public/reveal-screen';
+import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
+import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
+import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
+import {
+  useSessionId,
+  captureUtm,
+  capturePrefill,
+  schedulerToBooking,
+  PhaseShell,
+  DoneScreen,
+} from './renderer-shared';
+import './public-form.css';
+
+type Phase = 'form' | 'reveal' | 'submitting' | 'booking' | 'done';
+
+/**
+ * Does the respondent's answer to this step hold ANY content yet? Drives the
+ * progress counter, the terminal cut and the completion events — deliberately
+ * weaker than validity (a half-typed email "has content" but isn't complete).
+ */
+function hasContent(step: FormStep, answers: Answers): boolean {
+  if (step.type === 'name') {
+    return nameFields(step).some((f) => String(answers[f] ?? '').trim() !== '');
+  }
+  const v = answers[step.key];
+  if (Array.isArray(v)) return v.length > 0;
+  return v != null && String(v).trim() !== '';
+}
+
+/**
+ * Fire `cb` once, the first time the element is meaningfully on screen. The
+ * step_view signal for the vertical layout: visibility replaces "became the
+ * current slide". Falls back to firing immediately where IntersectionObserver
+ * is unavailable (old embeds/test DOMs) so the funnel never silently loses rows.
+ */
+function useFirstVisible(cb: () => void) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const fired = useRef(false);
+  const cbRef = useRef(cb);
+  cbRef.current = cb;
+  useEffect(() => {
+    if (fired.current || !ref.current) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      fired.current = true;
+      cbRef.current();
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting && !fired.current) {
+            fired.current = true;
+            obs.disconnect();
+            cbRef.current();
+          }
+        }
+      },
+      // Low threshold on purpose: a question taller than the viewport (a
+      // scheduler embed) may never reach a high visible ratio.
+      { threshold: 0.2 },
+    );
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, []);
+  return ref;
+}
+
+/** Mounts children only once the wrapper is NEAR the viewport (lazy embeds). */
+function NearViewport({ children, placeholder }: { children: React.ReactNode; placeholder: React.ReactNode }) {
+  const [near, setNear] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (near || !ref.current) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setNear(true);
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setNear(true);
+          obs.disconnect();
+        }
+      },
+      // Start loading a screen ahead so the embed is usually ready on arrival.
+      { rootMargin: '600px 0px' },
+    );
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, [near]);
+  return <div ref={ref}>{near ? children : placeholder}</div>;
+}
+
+export function VerticalFormRenderer({
+  accountCode,
+  slug,
+  name,
+  config,
+  locale = 'en',
+}: {
+  accountCode: string;
+  slug: string;
+  name: string;
+  config: FormConfig;
+  locale?: string;
+}) {
+  const m = getMessages(locale).renderer;
+  const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
+  const cover = config.cover && config.cover.enabled !== false ? config.cover : null;
+
+  const [phase, setPhase] = useState<Phase>('form');
+  const [answers, setAnswers] = useState<Answers>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [done, setDone] = useState<{ score: number; outcome: string | null } | null>(null);
+  const [booking, setBooking] = useState<{ outcome: FormOutcome; score: number } | null>(null);
+
+  const utmRef = useRef<Record<string, string>>({});
+  const redirected = useRef(false); // a deferred redirect fires exactly once
+  const viewTracked = useRef(false);
+  const startTracked = useRef(false);
+  // Keys whose answer was SEEDED, not typed (a slider's mount-time default).
+  // A seeded value submits, but it is not "answered by the respondent": it must
+  // not tick the progress counter and must never trip a terminal cut on load.
+  // Any real interaction with the step removes it from this set.
+  const seededKeys = useRef<Set<string>>(new Set());
+  const partialSent = useRef(false);
+  const completeSent = useRef<Set<string>>(new Set()); // one step_complete per step
+  const stepViewSent = useRef<Set<string>>(new Set()); // one step_view per step
+  const bookedRef = useRef(false); // one booking → one callback + one redirect
+  const schedulerBooked = useRef<Set<string>>(new Set()); // one booking per scheduler step
+  const engineConfig = config as unknown as Parameters<typeof runtimeSteps>[0];
+
+  // The engine decides the ordered, visible, display-resolved steps — recomputed
+  // on every answer, which is what makes show/hide live on one page.
+  const steps = useMemo<FormStep[]>(
+    () => runtimeSteps(engineConfig, answers),
+    [engineConfig, answers],
+  );
+
+  /** Answered by the RESPONDENT — a seeded (untouched) default doesn't count. */
+  const answeredByUser = (s: FormStep) => hasContent(s, answers) && !seededKeys.current.has(s.key);
+
+  // Terminal cut (disqualify): once a terminal step holds an answer, everything
+  // after it leaves the page. Unlike slides it does NOT auto-finalize — the
+  // respondent keeps the Submit button and may still change their answer.
+  const walk = useMemo<FormStep[]>(() => {
+    const cut = steps.findIndex((s) => s.terminal && hasContent(s, answers) && !seededKeys.current.has(s.key));
+    return cut >= 0 ? steps.slice(0, cut + 1) : steps;
+  }, [steps, answers]);
+
+  // Reveal steps are interstitials — never inline questions on this layout.
+  const questions = useMemo(() => walk.filter((s) => s.type !== 'reveal'), [walk]);
+  const answerable = useMemo(() => questions.filter((s) => s.type !== 'message'), [questions]);
+  const answeredCount = answerable.filter(answeredByUser).length;
+
+  // The one reveal that may play after Submit: a reveal STEP in the current walk
+  // (its own copy/duration), else the legacy form-level reveal when enabled.
+  const pendingReveal = useMemo<FormReveal | null>(() => {
+    const revealStep = steps.find((s) => s.type === 'reveal');
+    if (revealStep) return revealStep.reveal ?? { enabled: true };
+    return revealAfterKey(engineConfig) ? (config.reveal ?? null) : null;
+  }, [steps, engineConfig, config.reveal]);
+
+  const thresholdKey = useMemo(() => partialSubmitKey(engineConfig), [engineConfig]);
+
+  // Accent branding (only override the local default when a color is configured).
+  const primary = config.branding?.primaryColor ?? null;
+  const accentVars = primary
+    ? ({ ['--pf-primary']: primary, ['--pf-primary-contrast']: onAccent(primary) } as React.CSSProperties)
+    : undefined;
+
+  const err = (code: string) => m.errors[code as keyof typeof m.errors] ?? m.errors.required;
+
+  const track = useCallback(
+    (type: string, stepIndex?: number, stepKey?: string) => {
+      if (!sessionId) return;
+      void recordEventAction(accountCode, slug, {
+        sessionId,
+        type,
+        stepIndex: stepIndex ?? null,
+        stepKey: stepKey ?? null,
+      });
+    },
+    [accountCode, slug, sessionId],
+  );
+
+  // Latest answers via a ref for callbacks armed once (reveal, booking, done).
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
+
+  function withData(a: Answers): Record<string, unknown> {
+    const utm = utmRef.current;
+    return Object.keys(utm).length > 0 ? { ...a, utm } : { ...a };
+  }
+
+  // Capture UTM + declared-field URL prefill once on mount (client-only, so a
+  // seeded visible step never causes an SSR/hydration mismatch).
+  useEffect(() => {
+    utmRef.current = captureUtm();
+    const seed = capturePrefill(engineConfig.steps);
+    if (Object.keys(seed).length > 0) setAnswers((a) => ({ ...seed, ...a }));
+  }, []);
+  useEffect(() => {
+    if (!sessionId || viewTracked.current) return;
+    viewTracked.current = true;
+    track('view');
+  }, [sessionId, track]);
+
+  const finalize = useCallback(
+    async (finalAnswers: Answers) => {
+      setPhase('submitting');
+      const res = await submitFormAction(accountCode, slug, {
+        sessionId,
+        data: withData(finalAnswers),
+      });
+      if (!res.ok) {
+        setSubmitError(res.message ?? err('submit'));
+        setPhase('form');
+        return;
+      }
+      // Await the `submit` funnel event (best-effort) BEFORE any outcome
+      // redirect — a fire-and-forget request would be aborted by the immediate
+      // window.location navigation (same pattern as the slides layout).
+      if (sessionId) {
+        await recordEventAction(accountCode, slug, {
+          sessionId,
+          type: 'submit',
+          stepIndex: null,
+        }).catch(() => {});
+      }
+      const score = res.score ?? 0;
+      const outcome = resolveOutcome(engineConfig, score, finalAnswers);
+      if (outcome?.booking) {
+        setDone({ score, outcome: res.outcome ?? null }); // pre-arm the done screen
+        setBooking({ outcome, score });
+        setPhase('booking');
+        return;
+      }
+      const ending = resolveEnding(engineConfig, outcome);
+      if (ending.redirectUrl) {
+        if (isSafeHttpUrl(ending.redirectUrl)) {
+          if (ending.redirectDelayMs > 0) {
+            setDone({ score, outcome: res.outcome ?? null });
+            setPhase('done');
+            return;
+          }
+          window.location.href = ending.redirectUrl;
+          return;
+        }
+        console.warn('[forms] ignored non-http(s) redirectUrl');
+      }
+      setDone({ score, outcome: res.outcome ?? null });
+      setPhase('done');
+    },
+    [accountCode, slug, sessionId, engineConfig],
+  );
+  const finalizeRef = useRef(finalize);
+  finalizeRef.current = finalize;
+
+  // Deferred redirect (V5-B1): show the thank-you for N ms, then leave.
+  useEffect(() => {
+    if (phase !== 'done' || !done || redirected.current) return;
+    const outcome = resolveOutcome(engineConfig, done.score, answersRef.current);
+    const ending = resolveEnding(engineConfig, outcome);
+    if (!ending.redirectUrl || ending.redirectDelayMs <= 0) return;
+    if (!isSafeHttpUrl(ending.redirectUrl)) return;
+    const url = ending.redirectUrl;
+    const timer = setTimeout(() => {
+      redirected.current = true;
+      window.location.href = url;
+    }, ending.redirectDelayMs);
+    return () => clearTimeout(timer);
+  }, [phase, done, engineConfig]);
+
+  // Pre-warm the booking embed while the interstitial plays (reveal.prewarm).
+  useEffect(() => {
+    if (phase !== 'reveal') return;
+    if (!pendingReveal?.prewarm) return;
+    const a = answersRef.current;
+    const pending = resolveOutcome(engineConfig, computeScore(engineConfig, a), a);
+    if (pending?.booking) warmBookingEmbed(pending.booking.provider, pending.booking.url);
+  }, [phase, pendingReveal?.prewarm, engineConfig]);
+
+  /**
+   * A question first holds a valid answer → `step_complete` (once), and the
+   * threshold question → `partial_submit` + the partial save. Called with the
+   * NEXT answers (state updates are async) from instant inputs on change and
+   * from free-text inputs on blur.
+   */
+  const markCompleteIfValid = useCallback(
+    (step: FormStep, nextAnswers: Answers) => {
+      if (step.type === 'message' || step.type === 'reveal') return;
+      if (!hasContent(step, nextAnswers)) return;
+      if (!validateAnswerCode(step, nextAnswers[step.key], nextAnswers).ok) return;
+      const idx = runtimeSteps(engineConfig, nextAnswers).findIndex((s) => s.key === step.key);
+      if (!completeSent.current.has(step.key)) {
+        completeSent.current.add(step.key);
+        track('step_complete', idx >= 0 ? idx : undefined, step.key);
+      }
+      if (thresholdKey && step.key === thresholdKey && !partialSent.current) {
+        partialSent.current = true;
+        track('partial_submit', idx >= 0 ? idx : undefined, step.key);
+        void submitFormAction(accountCode, slug, {
+          sessionId,
+          data: withData(nextAnswers),
+          partial: true,
+        });
+      }
+    },
+    [engineConfig, thresholdKey, accountCode, slug, sessionId, track],
+  );
+
+  /** Every answer mutation funnels through here: start signal + error clearing. */
+  function setAnswer(step: FormStep, key: string, value: AnswerValue, instant: boolean) {
+    seededKeys.current.delete(step.key); // a real interaction "claims" the answer
+    if (!startTracked.current) {
+      startTracked.current = true;
+      track('start');
+    }
+    const next = { ...answersRef.current, [key]: value };
+    // Keep the ref fresh SYNCHRONOUSLY: a blur handler can run before React
+    // re-renders (where the ref is normally reassigned), and it must validate
+    // the value just typed, not the previous one.
+    answersRef.current = next;
+    setAnswers(next);
+    setSubmitError(null);
+    setErrors((e) => {
+      if (!(step.key in e)) return e;
+      const rest = { ...e };
+      delete rest[step.key];
+      return rest;
+    });
+    // Instant inputs (choice/dropdown/slider) complete on selection; free-text
+    // inputs complete on blur so a half-typed value never fires the event.
+    if (instant) markCompleteIfValid(step, next);
+  }
+
+  /** Blur leaves a question: validate it if it holds content or already errored. */
+  function onQuestionBlur(step: FormStep, e: React.FocusEvent<HTMLDivElement>) {
+    // Moving focus WITHIN the question (name's two fields) is not leaving it.
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    if (step.type === 'message' || step.type === 'reveal' || step.type === 'scheduler') return;
+    const a = answersRef.current;
+    if (hasContent(step, a) || errors[step.key]) {
+      const check = validateAnswerCode(step, a[step.key], a);
+      setErrors((prev) => {
+        const rest = { ...prev };
+        if (check.ok) delete rest[step.key];
+        else rest[step.key] = check.code;
+        return rest;
+      });
+      if (check.ok) markCompleteIfValid(step, a);
+    }
+  }
+
+  // A booking on a SCHEDULER step: record the meeting (best-effort), make the
+  // booked slot this step's answer. No advancing here — submission is still the
+  // respondent's explicit Submit at the end of the page.
+  const handleSchedulerBooked = useCallback(
+    async (schedStep: FormStep, details: BookingScheduledDetails) => {
+      if (schedulerBooked.current.has(schedStep.key)) return;
+      schedulerBooked.current.add(schedStep.key);
+      await recordBookingAction(accountCode, slug, {
+        sessionId,
+        provider: details.provider,
+        ...(details.eventUri ? { eventUri: details.eventUri } : {}),
+        ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
+        ...(details.startTime ? { startTime: details.startTime } : {}),
+      }).catch(() => {});
+      setAnswer(schedStep, schedStep.key, details.startTime ?? 'booked', true);
+    },
+    [accountCode, slug, sessionId],
+  );
+
+  // Report the post-submit outcome booking, THEN redirect/finish (same as slides).
+  const handleBooked = useCallback(
+    async (details: BookingScheduledDetails) => {
+      if (bookedRef.current) return;
+      bookedRef.current = true;
+      const outcome = booking?.outcome ?? null;
+      await recordBookingAction(accountCode, slug, {
+        sessionId,
+        provider: details.provider,
+        ...(details.eventUri ? { eventUri: details.eventUri } : {}),
+        ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
+        ...(details.startTime ? { startTime: details.startTime } : {}),
+      });
+      if (outcome?.redirectUrl && isSafeHttpUrl(outcome.redirectUrl)) {
+        window.location.href = outcome.redirectUrl;
+        return;
+      }
+      setPhase('done'); // `done` state was set in finalize
+    },
+    [accountCode, slug, sessionId, booking],
+  );
+
+  /** Submit the whole page: validate the walk, scroll to the first error. */
+  async function submitAll() {
+    const a = answersRef.current;
+    const errs: Record<string, string> = {};
+    let firstBad: string | null = null;
+    for (const s of walk) {
+      if (s.type === 'message' || s.type === 'reveal') continue;
+      const check = validateAnswerCode(s, a[s.key], a);
+      if (!check.ok) {
+        errs[s.key] = check.code;
+        firstBad = firstBad ?? s.key;
+      }
+    }
+    setErrors(errs);
+    if (firstBad) {
+      setSubmitError(m.verticalErrors);
+      document
+        .querySelector(`[data-vf-step="${CSS.escape(firstBad)}"]`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+    setSubmitError(null);
+    // Every valid answer is now definitively complete — sweep the walk so a
+    // question the respondent filled but never blurred (typed then hit Submit)
+    // still records its step_complete / partial_submit before the submission.
+    for (const s of walk) markCompleteIfValid(s, a);
+    if (pendingReveal && pendingReveal.enabled !== false) {
+      setPhase('reveal');
+      return;
+    }
+    await finalize(a);
+  }
+
+  const onRevealComplete = useCallback(() => {
+    void finalizeRef.current(answersRef.current);
+  }, []);
+
+  // --- Screens --------------------------------------------------------------
+
+  if (phase === 'done' && done) {
+    const outcome = resolveOutcome(engineConfig, done.score, answersRef.current);
+    const ending = resolveEnding(engineConfig, outcome);
+    return (
+      <DoneScreen
+        ending={ending}
+        answers={answersRef.current}
+        m={m}
+        accountCode={accountCode}
+        bannerText={cover?.bannerText}
+        style={accentVars}
+      />
+    );
+  }
+
+  if (phase === 'booking' && booking?.outcome.booking) {
+    return (
+      <PhaseShell className="pf pf--booking-page" style={accentVars} bannerText={cover?.bannerText}>
+        <BookingScreen
+          booking={booking.outcome.booking}
+          answers={answersRef.current}
+          sessionId={sessionId}
+          locale={locale}
+          onBooked={(details) => void handleBooked(details)}
+        />
+      </PhaseShell>
+    );
+  }
+
+  if (phase === 'reveal') {
+    return (
+      <PhaseShell
+        className="pf pf--reveal"
+        style={accentVars}
+        role="status"
+        aria-live="polite"
+        bannerText={cover?.bannerText}
+      >
+        <RevealScreen
+          reveal={pendingReveal ?? { enabled: true }}
+          answers={answers}
+          messages={{ headline: m.revealHeadline, subtitle: m.revealSubtitle }}
+          onComplete={onRevealComplete}
+        />
+      </PhaseShell>
+    );
+  }
+
+  if (phase === 'submitting') {
+    return (
+      <PhaseShell
+        className="pf pf--reveal"
+        style={accentVars}
+        role="status"
+        aria-live="polite"
+        bannerText={cover?.bannerText}
+      >
+        <div className="pf-reveal__inner">
+          <div className="pf-reveal__spinner" aria-hidden="true" />
+          <p className="pf-reveal__subtitle">{m.submitting}</p>
+        </div>
+      </PhaseShell>
+    );
+  }
+
+  const logo = cover?.logo ?? config.branding?.logo ?? null;
+  const logos = cover?.clientLogos ?? config.branding?.clientLogos ?? [];
+  const total = answerable.length;
+
+  return (
+    <div className="pf pf--vertical" style={accentVars}>
+      {/* Banner + progress share ONE sticky group so they never fight for the
+          viewport top; the banner's own sticky is neutralized on this layout. */}
+      <div className="pf-v__sticky">
+        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        {total > 0 ? (
+          <div className="pf-v__progressbar">
+            <div className="pf-progress" aria-hidden="true">
+              <div className="pf-progress__track">
+                <div
+                  className="pf-progress__fill"
+                  style={{ width: `${total > 0 ? Math.round((answeredCount / total) * 100) : 0}%` }}
+                />
+              </div>
+            </div>
+            <span className="pf-v__progress-label" aria-live="polite">
+              {t(m.verticalProgress, { answered: answeredCount, total })}
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="pf__main">
+        <div className="pf-v__page">
+          <header className="pf-v__header">
+            <FormLogo src={logo} name={name} />
+          </header>
+
+          {cover ? (
+            <section className="pf-v__hero pf-animate">
+              {cover.eyebrow || cover.badge ? (
+                <p className="pf__badge">{cover.eyebrow ?? cover.badge}</p>
+              ) : null}
+              <h1 className="pf__title">{cover.headline ?? name}</h1>
+              {cover.subheadline ? <p className="pf__subheadline">{cover.subheadline}</p> : null}
+              {cover.trustBadge ? <p className="pf__trust">{cover.trustBadge}</p> : null}
+              <ClientLogosMarquee logos={logos} label={m.trustedBy} />
+            </section>
+          ) : null}
+
+          {questions.length === 0 ? (
+            <p className="pf__helper">{m.noSteps}</p>
+          ) : (
+            questions.map((step) => (
+              <VerticalQuestion
+                key={step.key}
+                step={step}
+                index={steps.findIndex((s) => s.key === step.key)}
+                error={errors[step.key] ? err(errors[step.key] as string) : null}
+                stepViewSent={stepViewSent}
+                track={track}
+                onBlur={(e) => onQuestionBlur(step, e)}
+              >
+                {step.type === 'scheduler' ? (
+                  <SchedulerQuestion
+                    step={step}
+                    config={config}
+                    answers={answers}
+                    sessionId={sessionId}
+                    locale={locale}
+                    unconfiguredLabel={m.schedulerUnconfigured}
+                    onBooked={(details) => void handleSchedulerBooked(step, details)}
+                  />
+                ) : (
+                  <StepInput
+                    step={step}
+                    value={answers[step.key]}
+                    answers={answers}
+                    autoFocus={false}
+                    // Mount-time seeding (slider default) is not an interaction:
+                    // write the answer silently — no start/complete events, no
+                    // progress tick, no terminal cut (seededKeys).
+                    onSeed={(v: AnswerValue) => {
+                      seededKeys.current.add(step.key);
+                      setAnswers((a) => ({ ...a, [step.key]: v }));
+                    }}
+                    onChange={(v: AnswerValue) =>
+                      setAnswer(step, step.key, v, step.type === 'slider' || step.type === 'multiple_choice')
+                    }
+                    onFieldChange={(field, v) => setAnswer(step, field, v, false)}
+                    onSelect={(v) => setAnswer(step, step.key, v, true)}
+                    dropdownPlaceholder={m.dropdownPlaceholder}
+                    dropdownEmpty={m.dropdownEmpty}
+                    locale={locale}
+                  />
+                )}
+              </VerticalQuestion>
+            ))
+          )}
+
+          {questions.length > 0 ? (
+            <div className="pf-v__footer">
+              {submitError ? (
+                <p className="pf__error" role="alert">
+                  {submitError}
+                </p>
+              ) : null}
+              <button type="button" className="pf__btn" onClick={() => void submitAll()}>
+                {m.submit}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One question block: heading, helper, the input, its inline error — and the
+ * once-per-step `step_view` fired when the block first enters the viewport.
+ */
+function VerticalQuestion({
+  step,
+  index,
+  error,
+  stepViewSent,
+  track,
+  onBlur,
+  children,
+}: {
+  step: FormStep;
+  index: number;
+  error: string | null;
+  stepViewSent: React.MutableRefObject<Set<string>>;
+  track: (type: string, stepIndex?: number, stepKey?: string) => void;
+  onBlur: (e: React.FocusEvent<HTMLDivElement>) => void;
+  children: React.ReactNode;
+}) {
+  const ref = useFirstVisible(() => {
+    if (stepViewSent.current.has(step.key)) return;
+    stepViewSent.current.add(step.key);
+    track('step_view', index >= 0 ? index : undefined, step.key);
+  });
+
+  return (
+    <section
+      ref={ref}
+      className={`pf-v__question${error ? ' pf-v__question--error' : ''}`}
+      data-vf-step={step.key}
+      onBlur={onBlur}
+    >
+      <div className="pf__question-wrap">
+        <h2 className="pf__question">
+          {step.question ?? step.key}
+          {step.required && step.type !== 'message' ? (
+            <span aria-hidden className="pf-v__required">
+              *
+            </span>
+          ) : null}
+        </h2>
+        {step.helper && step.type !== 'message' ? <p className="pf__helper">{step.helper}</p> : null}
+      </div>
+      <div className="pf__fields">
+        {children}
+        {error ? (
+          <p className="pf__error" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * A scheduler step inline on the page. The provider iframe is heavy, so it
+ * mounts lazily as the block approaches the viewport; until then a quiet
+ * placeholder holds the layout. Booking answers the step (no auto-advance).
+ */
+function SchedulerQuestion({
+  step,
+  config,
+  answers,
+  sessionId,
+  locale,
+  unconfiguredLabel,
+  onBooked,
+}: {
+  step: FormStep;
+  config: FormConfig;
+  answers: Answers;
+  sessionId: string;
+  locale: string;
+  unconfiguredLabel: string;
+  onBooked: (details: BookingScheduledDetails) => void;
+}) {
+  const schedPrefill = resolveSchedulerPrefill(
+    answers,
+    step.scheduler?.prefillMap,
+    config.steps as FormStep[],
+  );
+  const booking = step.scheduler
+    ? schedulerToBooking(step.scheduler, schedPrefill.customAnswers)
+    : null;
+  if (!booking) {
+    return (
+      <p className="pf__error" role="alert" data-testid="scheduler-unconfigured">
+        {unconfiguredLabel}
+      </p>
+    );
+  }
+  return (
+    <NearViewport placeholder={<div className="pf-v__embed-placeholder" aria-hidden="true" />}>
+      <BookingScreen
+        booking={booking}
+        answers={schedPrefill.answers}
+        extraCustomAnswers={schedPrefill.customAnswers}
+        sessionId={sessionId}
+        locale={locale}
+        hideHeader
+        onBooked={onBooked}
+      />
+    </NearViewport>
+  );
+}

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -7,7 +7,14 @@ import { adminApi } from '@/lib/admin-api';
 /** Create a form and jump straight into its editor. */
 export async function createFormAction(formData: FormData): Promise<void> {
   const name = String(formData.get('name') ?? '').trim() || 'Untitled form';
-  const created = await adminApi.createForm({ name });
+  // Layout picked in the create dialog. Only 'vertical' is stored — an absent
+  // `layout` already means slides (the engine's back-compat default), so a
+  // slides form keeps the exact config shape every existing form has.
+  const layout = String(formData.get('layout') ?? '');
+  const created = await adminApi.createForm({
+    name,
+    ...(layout === 'vertical' ? { config: { version: 1, steps: [], layout: 'vertical' } } : {}),
+  });
   revalidatePath('/admin');
   revalidatePath('/admin/forms');
   redirect(`/admin/forms/${created.id}/edit`);

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -206,6 +206,8 @@ export interface BuilderMessages {
     hint: string;
     close: string;
     noResults: string;
+    /** Vertical layout: why the reveal tile is off once the form has one. */
+    revealVerticalTaken: string;
     items: Record<GalleryItemId, { title: string; desc: string }>;
   };
   map: {
@@ -468,6 +470,7 @@ const en: BuilderMessages = {
     hint: 'Picking a type drops the question in and focuses the canvas to edit it.',
     close: 'Close',
     noResults: 'No matching types.',
+    revealVerticalTaken: 'Already added — a one-page form plays its reveal once, after Submit.',
     items: {
       name: { title: 'Name', desc: 'Full name field' },
       email: { title: 'Email', desc: 'Validated email' },
@@ -732,6 +735,7 @@ const es: BuilderMessages = {
     hint: 'Al elegir un tipo se añade la pregunta y se enfoca el lienzo para editarla.',
     close: 'Cerrar',
     noResults: 'No hay tipos que coincidan.',
+    revealVerticalTaken: 'Ya añadida — un formulario de una página muestra su revelación una vez, después de Enviar.',
     items: {
       name: { title: 'Nombre', desc: 'Campo de nombre completo' },
       email: { title: 'Correo', desc: 'Correo validado' },

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -87,9 +87,7 @@ export interface BuilderMessages {
     revealHeadlinePlaceholder: string;
     revealSubtitlePlaceholder: string;
     revealPlays: string;
-    /** Vertical layout: the canvas note replacing the per-question Next button. */
-    verticalNote: string;
-    /** Vertical layout: where the reveal actually plays. */
+    /** Vertical layout: where the reveal actually plays (page-canvas block). */
     revealVerticalNote: string;
     /** V6 — the scheduler's live Calendly embed on the canvas. */
     schedulerUnset: string;
@@ -367,8 +365,7 @@ const en: BuilderMessages = {
     revealHeadlinePlaceholder: 'Reviewing your answers…',
     revealSubtitlePlaceholder: 'Add a line of reassurance (optional)',
     revealPlays: 'Plays for {ms} ms, then the form continues on its own.',
-    verticalNote: 'One-page form — respondents answer everything and press one Submit at the end.',
-    revealVerticalNote: 'One-page form — this plays once, after Submit, before the result.',
+    revealVerticalNote: 'Plays once, after Submit, before the result.',
     schedulerUnset: 'No event type picked yet',
     schedulerNote: 'Respondents pick a time here. Booking answers this question and moves the form on.',
     schedulerLoading: 'Loading the calendar…',
@@ -631,8 +628,7 @@ const es: BuilderMessages = {
     revealHeadlinePlaceholder: 'Revisando tus respuestas…',
     revealSubtitlePlaceholder: 'Añade una línea que tranquilice (opcional)',
     revealPlays: 'Se muestra {ms} ms y luego el formulario continúa solo.',
-    verticalNote: 'Formulario de una página — se responde todo y hay un solo Enviar al final.',
-    revealVerticalNote: 'Formulario de una página — se muestra una vez, después de Enviar y antes del resultado.',
+    revealVerticalNote: 'Se muestra una vez, después de Enviar y antes del resultado.',
     schedulerUnset: 'Aún no eliges un tipo de evento',
     schedulerNote: 'Aquí eligen un horario. Agendar responde esta pregunta y avanza el formulario.',
     schedulerLoading: 'Cargando el calendario…',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -33,6 +33,12 @@ export interface BuilderMessages {
     mobile: string;
     settings: string;
     copyLink: string;
+    /** Embed-in-your-site dialog (iframe snippet + auto-height script). */
+    embed: string;
+    embedTitle: string;
+    embedIntro: string;
+    embedCopy: string;
+    embedCopied: string;
     copied: string;
     openForm: string;
   };
@@ -327,6 +333,12 @@ const en: BuilderMessages = {
     mobile: 'Mobile',
     settings: 'Settings',
     copyLink: 'Copy link',
+    embed: 'Embed',
+    embedTitle: 'Embed this form on your site',
+    embedIntro:
+      'Paste this snippet into your page. The form loads inside it and grows to fit its content — the script keeps the height in sync, so there is never an inner scrollbar.',
+    embedCopy: 'Copy snippet',
+    embedCopied: 'Copied',
     copied: 'Copied',
     openForm: 'Open form',
   },
@@ -589,6 +601,12 @@ const es: BuilderMessages = {
     mobile: 'Móvil',
     settings: 'Ajustes',
     copyLink: 'Copiar enlace',
+    embed: 'Insertar',
+    embedTitle: 'Inserta este formulario en tu sitio',
+    embedIntro:
+      'Pega este fragmento en tu página. El formulario carga dentro y crece según su contenido — el script mantiene la altura sincronizada, así nunca hay scroll interno.',
+    embedCopy: 'Copiar fragmento',
+    embedCopied: 'Copiado',
     copied: 'Copiado',
     openForm: 'Abrir formulario',
   },

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -87,6 +87,10 @@ export interface BuilderMessages {
     revealHeadlinePlaceholder: string;
     revealSubtitlePlaceholder: string;
     revealPlays: string;
+    /** Vertical layout: the canvas note replacing the per-question Next button. */
+    verticalNote: string;
+    /** Vertical layout: where the reveal actually plays. */
+    revealVerticalNote: string;
     /** V6 — the scheduler's live Calendly embed on the canvas. */
     schedulerUnset: string;
     schedulerNote: string;
@@ -361,6 +365,8 @@ const en: BuilderMessages = {
     revealHeadlinePlaceholder: 'Reviewing your answers…',
     revealSubtitlePlaceholder: 'Add a line of reassurance (optional)',
     revealPlays: 'Plays for {ms} ms, then the form continues on its own.',
+    verticalNote: 'One-page form — respondents answer everything and press one Submit at the end.',
+    revealVerticalNote: 'One-page form — this plays once, after Submit, before the result.',
     schedulerUnset: 'No event type picked yet',
     schedulerNote: 'Respondents pick a time here. Booking answers this question and moves the form on.',
     schedulerLoading: 'Loading the calendar…',
@@ -622,6 +628,8 @@ const es: BuilderMessages = {
     revealHeadlinePlaceholder: 'Revisando tus respuestas…',
     revealSubtitlePlaceholder: 'Añade una línea que tranquilice (opcional)',
     revealPlays: 'Se muestra {ms} ms y luego el formulario continúa solo.',
+    verticalNote: 'Formulario de una página — se responde todo y hay un solo Enviar al final.',
+    revealVerticalNote: 'Formulario de una página — se muestra una vez, después de Enviar y antes del resultado.',
     schedulerUnset: 'Aún no eliges un tipo de evento',
     schedulerNote: 'Aquí eligen un horario. Agendar responde esta pregunta y avanza el formulario.',
     schedulerLoading: 'Cargando el calendario…',

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import type { FormConfig, FormStep, FormOption, FormLayout } from '@quill/engine';
+import type { FormConfig, FormStep, FormOption } from '@quill/engine';
 import { nameFields, sliderBounds, clampSliderValue } from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import { cn } from '@/lib/cn';
@@ -76,7 +76,6 @@ export function CanvasQuestion({
   index,
   total,
   device,
-  layout = 'slides',
   onUpdate,
   m,
 }: {
@@ -85,33 +84,12 @@ export function CanvasQuestion({
   index: number;
   total: number;
   device: 'desktop' | 'mobile';
-  /**
-   * The form's presentation layout. On 'vertical' the canvas drops the chrome
-   * that never exists on a one-page form — the per-step progress bar and the
-   * per-question Next button — so the builder shows what actually publishes.
-   */
-  layout?: FormLayout;
   onUpdate: (patch: Partial<FormStep>) => void;
   m: BuilderMessages;
 }) {
-  const vertical = layout === 'vertical';
   const accent = clampAccent(config.branding?.primaryColor || DEFAULT_ACCENT);
   const accentText = onAccent(accent);
   const progress = total > 0 ? Math.round(((index + 1) / total) * 100) : 0;
-  const showsPoints =
-    (config.scoring?.enabled ?? false) !== false && step.flowGroup !== 'lead_capture' && maxStepPoints(step) >= 0;
-
-  function updateOption(i: number, patch: Partial<FormOption>) {
-    onUpdate({ options: (step.options ?? []).map((o, oi) => (oi === i ? { ...o, ...patch } : o)) });
-  }
-  function addOption() {
-    const n = (step.options ?? []).length + 1;
-    onUpdate({ options: [...(step.options ?? []), { label: `Option ${n}`, value: `option_${n}`, points: 0 }] });
-  }
-  function removeOption(i: number) {
-    onUpdate({ options: (step.options ?? []).filter((_, oi) => oi !== i) });
-  }
-
   const isLast = index + 1 >= total;
 
   // A reveal is not a question — it asks nothing, has no title, no description
@@ -125,7 +103,6 @@ export function CanvasQuestion({
         step={step}
         accent={accent}
         device={device}
-        vertical={vertical}
         onUpdate={onUpdate}
         m={m}
       />
@@ -140,138 +117,25 @@ export function CanvasQuestion({
           device === 'mobile' ? 'max-w-[380px]' : 'max-w-[640px]',
         )}
       >
-        {/* Respondent progress bar — slides only; a one-page form has no
-            per-step position, its bar counts ANSWERED questions instead. */}
-        {!vertical ? (
-          <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-            <div className="h-full rounded-full transition-all" style={{ width: `${progress}%`, background: accent }} />
-          </div>
-        ) : null}
+        {/* Respondent progress bar */}
+        <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div className="h-full rounded-full transition-all" style={{ width: `${progress}%`, background: accent }} />
+        </div>
 
-        {/* Eyebrow */}
-        <p className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <i aria-hidden className={`pi ${iconForStep(step)}`} style={{ fontSize: 12 }} />
-          {tb(m.canvas.questionN, { n: index + 1 })}
-        </p>
-
-        {/* Inline editable title — with the @ recall-information picker. The
-            engine interpolates `[key]` tokens in BOTH `question` and the
-            description/`helper` from EARLIER answers (resolveStepDisplay), so
-            both fields get the picker. */}
-        <TokenTextarea
-          value={step.question ?? ''}
-          onChange={(v) => onUpdate({ question: v })}
-          placeholder={m.canvas.titlePlaceholder}
-          ariaLabel={m.canvas.titlePlaceholder}
-          autoGrow
-          tokens={tokenOptionsBefore(config.steps, index)}
-          allKeys={allTokenKeys(config.steps)}
-          m={m.tokens}
-          hint={m.tokens.hint}
-          testId="canvas-title-input"
-          className="canvas-title text-2xl font-semibold tracking-tight text-foreground sm:text-[28px]"
+        <QuestionEditableBody
+          config={config}
+          step={step}
+          index={index}
+          accent={accent}
+          onUpdate={onUpdate}
+          m={m}
         />
-
-        {/* Inline editable description — same @ picker as the title (tokens =
-            fields captured before this step). No hint here so the single
-            discoverability chip stays under the title. */}
-        <div className="mt-1.5">
-          <TokenTextarea
-            value={step.helper ?? ''}
-            onChange={(v) => onUpdate({ helper: v || null })}
-            placeholder={m.canvas.descriptionPlaceholder}
-            ariaLabel={m.canvas.descriptionPlaceholder}
-            autoGrow
-            tokens={tokenOptionsBefore(config.steps, index)}
-            allKeys={allTokenKeys(config.steps)}
-            m={m.tokens}
-            testId="canvas-description-input"
-            className="text-[15px] leading-relaxed text-muted-foreground"
-          />
-        </div>
-
-        {/* Body: the real rendered input */}
-        <div className="mt-6">
-          {hasOptions(step.type) ? (
-            <div className="flex flex-col gap-2.5">
-              {(step.options ?? []).map((opt, i) => (
-                <div
-                  key={i}
-                  className="group flex items-center gap-3 rounded-xl border border-border bg-background px-4 py-3.5 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
-                >
-                  <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border text-[11px] font-semibold text-muted-foreground">
-                    {String.fromCharCode(65 + i)}
-                  </span>
-                  <input
-                    value={opt.label}
-                    onChange={(e) => updateOption(i, { label: e.target.value })}
-                    placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
-                    aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
-                    className="min-w-0 flex-1 bg-transparent text-[15px] font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
-                  />
-                  {showsPoints ? (
-                    <span className="shrink-0 rounded-full bg-primary/15 px-2.5 py-1 text-xs font-semibold text-primary">
-                      {tb(m.canvas.pts, { n: opt.points ?? 0 })}
-                    </span>
-                  ) : null}
-                  <button
-                    type="button"
-                    aria-label={m.settings.delete}
-                    onClick={() => removeOption(i)}
-                    className="shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground hover:!text-destructive focus-visible:!text-muted-foreground focus-visible:outline-none"
-                  >
-                    <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
-                  </button>
-                </div>
-              ))}
-              <button
-                type="button"
-                onClick={addOption}
-                className="flex items-center gap-3 rounded-xl border border-dashed border-border px-4 py-3.5 text-left text-[15px] text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-dashed border-border">
-                  <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} />
-                </span>
-                {m.canvas.addOption}
-              </button>
-            </div>
-          ) : step.type === 'slider' ? (
-            <SliderPreview step={step} accent={accent} />
-          ) : step.type === 'message' ? (
-            <AutoTextarea
-              value={step.helper ?? ''}
-              onChange={(v) => onUpdate({ helper: v || null })}
-              placeholder={m.canvas.messagePlaceholder}
-              ariaLabel={m.canvas.messagePlaceholder}
-              rows={2}
-              className="text-[15px] leading-relaxed text-foreground"
-            />
-          ) : step.type === 'textarea' ? (
-            <div className="rounded-xl border border-border bg-background px-4 py-3 text-[15px] text-muted-foreground/60">
-              {step.placeholder || m.canvas.messagePlaceholder}
-            </div>
-          ) : step.type === 'name' ? (
-            <NamePreview step={step} m={m} />
-          ) : step.type === 'scheduler' ? (
-            <SchedulerEmbedPreview step={step} m={m} />
-          ) : (
-            <div className="rounded-xl border border-border bg-background px-4 py-3 text-[15px] text-muted-foreground/60">
-              {step.placeholder ||
-                (step.type === 'email' ? 'you@company.com' : step.type === 'phone' ? '+1 555 000 0000' : '…')}
-            </div>
-          )}
-        </div>
 
         {/* Respondent's Next button (label editable for message/content). A
             scheduler has none: booking IS the answer, so the public form
             advances itself — showing a Submit here promised a button that never
-            renders. A ONE-PAGE form has no per-question button at all (one
-            Submit at the end of the page), so the canvas says that instead. */}
-        {vertical ? (
-          <p className="mt-7 text-xs text-muted-foreground" data-testid="canvas-vertical-note">
-            <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.canvas.verticalNote}
-          </p>
-        ) : step.type !== 'dropdown' && step.type !== 'scheduler' ? (
+            renders. */}
+        {step.type !== 'dropdown' && step.type !== 'scheduler' ? (
           <div className="mt-7">
             <button
               type="button"
@@ -284,6 +148,311 @@ export function CanvasQuestion({
           </div>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+/**
+ * The editable heart of a question — eyebrow, inline title/description with the
+ * @ token picker, and the type-specific body (options, slider, name fields…).
+ * Shared verbatim by the slides card (`CanvasQuestion`) and the one-page canvas
+ * (`CanvasPage`), so the two layouts can never drift on how editing works.
+ */
+function QuestionEditableBody({
+  config,
+  step,
+  index,
+  accent,
+  onUpdate,
+  m,
+}: {
+  config: FormConfig;
+  step: FormStep;
+  index: number;
+  accent: string;
+  onUpdate: (patch: Partial<FormStep>) => void;
+  m: BuilderMessages;
+}) {
+  const showsPoints =
+    (config.scoring?.enabled ?? false) !== false && step.flowGroup !== 'lead_capture' && maxStepPoints(step) >= 0;
+
+  function updateOption(i: number, patch: Partial<FormOption>) {
+    onUpdate({ options: (step.options ?? []).map((o, oi) => (oi === i ? { ...o, ...patch } : o)) });
+  }
+  function addOption() {
+    const n = (step.options ?? []).length + 1;
+    onUpdate({ options: [...(step.options ?? []), { label: `Option ${n}`, value: `option_${n}`, points: 0 }] });
+  }
+  function removeOption(i: number) {
+    onUpdate({ options: (step.options ?? []).filter((_, oi) => oi !== i) });
+  }
+
+  return (
+    <>
+      {/* Eyebrow */}
+      <p className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <i aria-hidden className={`pi ${iconForStep(step)}`} style={{ fontSize: 12 }} />
+        {tb(m.canvas.questionN, { n: index + 1 })}
+      </p>
+
+      {/* Inline editable title — with the @ recall-information picker. The
+          engine interpolates `[key]` tokens in BOTH `question` and the
+          description/`helper` from EARLIER answers (resolveStepDisplay), so
+          both fields get the picker. */}
+      <TokenTextarea
+        value={step.question ?? ''}
+        onChange={(v) => onUpdate({ question: v })}
+        placeholder={m.canvas.titlePlaceholder}
+        ariaLabel={m.canvas.titlePlaceholder}
+        autoGrow
+        tokens={tokenOptionsBefore(config.steps, index)}
+        allKeys={allTokenKeys(config.steps)}
+        m={m.tokens}
+        hint={m.tokens.hint}
+        testId="canvas-title-input"
+        className="canvas-title text-2xl font-semibold tracking-tight text-foreground sm:text-[28px]"
+      />
+
+      {/* Inline editable description — same @ picker as the title (tokens =
+          fields captured before this step). No hint here so the single
+          discoverability chip stays under the title. */}
+      <div className="mt-1.5">
+        <TokenTextarea
+          value={step.helper ?? ''}
+          onChange={(v) => onUpdate({ helper: v || null })}
+          placeholder={m.canvas.descriptionPlaceholder}
+          ariaLabel={m.canvas.descriptionPlaceholder}
+          autoGrow
+          tokens={tokenOptionsBefore(config.steps, index)}
+          allKeys={allTokenKeys(config.steps)}
+          m={m.tokens}
+          testId="canvas-description-input"
+          className="text-[15px] leading-relaxed text-muted-foreground"
+        />
+      </div>
+
+      {/* Body: the real rendered input */}
+      <div className="mt-6">
+        {hasOptions(step.type) ? (
+          <div className="flex flex-col gap-2.5">
+            {(step.options ?? []).map((opt, i) => (
+              <div
+                key={i}
+                className="group flex items-center gap-3 rounded-xl border border-border bg-background px-4 py-3.5 transition-colors focus-within:border-primary/60 hover:border-muted-foreground/60"
+              >
+                <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border text-[11px] font-semibold text-muted-foreground">
+                  {String.fromCharCode(65 + i)}
+                </span>
+                <input
+                  value={opt.label}
+                  onChange={(e) => updateOption(i, { label: e.target.value })}
+                  placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
+                  aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
+                  className="min-w-0 flex-1 bg-transparent text-[15px] font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
+                />
+                {showsPoints ? (
+                  <span className="shrink-0 rounded-full bg-primary/15 px-2.5 py-1 text-xs font-semibold text-primary">
+                    {tb(m.canvas.pts, { n: opt.points ?? 0 })}
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  aria-label={m.settings.delete}
+                  onClick={() => removeOption(i)}
+                  className="shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground hover:!text-destructive focus-visible:!text-muted-foreground focus-visible:outline-none"
+                >
+                  <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addOption}
+              className="flex items-center gap-3 rounded-xl border border-dashed border-border px-4 py-3.5 text-left text-[15px] text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-dashed border-border">
+                <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} />
+              </span>
+              {m.canvas.addOption}
+            </button>
+          </div>
+        ) : step.type === 'slider' ? (
+          <SliderPreview step={step} accent={accent} />
+        ) : step.type === 'message' ? (
+          <AutoTextarea
+            value={step.helper ?? ''}
+            onChange={(v) => onUpdate({ helper: v || null })}
+            placeholder={m.canvas.messagePlaceholder}
+            ariaLabel={m.canvas.messagePlaceholder}
+            rows={2}
+            className="text-[15px] leading-relaxed text-foreground"
+          />
+        ) : step.type === 'textarea' ? (
+          <div className="rounded-xl border border-border bg-background px-4 py-3 text-[15px] text-muted-foreground/60">
+            {step.placeholder || m.canvas.messagePlaceholder}
+          </div>
+        ) : step.type === 'name' ? (
+          <NamePreview step={step} m={m} />
+        ) : step.type === 'scheduler' ? (
+          <SchedulerEmbedPreview step={step} m={m} />
+        ) : (
+          <div className="rounded-xl border border-border bg-background px-4 py-3 text-[15px] text-muted-foreground/60">
+            {step.placeholder ||
+              (step.type === 'email' ? 'you@company.com' : step.type === 'phone' ? '+1 555 000 0000' : '…')}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+/**
+ * The one-page WYSIWYG canvas (`layout = 'vertical'`): the WHOLE form as the
+ * respondent sees it — every question stacked on one page, each editable in
+ * place, one Submit at the end. No per-question card, progress bar or Next
+ * button, because the published page has none. Selecting a question (spine,
+ * mobile strip, or clicking a block) highlights it and scrolls it into view,
+ * so switching questions FEELS like moving down one page — which is exactly
+ * what it is.
+ */
+export function CanvasPage({
+  config,
+  selected,
+  device,
+  focusSignal = 0,
+  onSelect,
+  onUpdateStep,
+  m,
+}: {
+  config: FormConfig;
+  selected: number;
+  device: 'desktop' | 'mobile';
+  /** Increments when a question was just added — focus its title. */
+  focusSignal?: number;
+  onSelect: (index: number) => void;
+  onUpdateStep: (index: number, patch: Partial<FormStep>) => void;
+  m: BuilderMessages;
+}) {
+  const accent = clampAccent(config.branding?.primaryColor || DEFAULT_ACCENT);
+  const accentText = onAccent(accent);
+  const blockRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  // Selection navigates the page: scroll the picked block into view. Skipped
+  // for plain in-page clicks (the block is already on screen — jumping would
+  // yank the page under the author's cursor); a click's own scroll is a no-op
+  // because the browser only scrolls to something out of view.
+  const selectedKey = config.steps[selected]?.key;
+  useEffect(() => {
+    if (!selectedKey) return;
+    blockRefs.current.get(selectedKey)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [selectedKey]);
+
+  // A just-added question lands selected at the end — put the caret in its title.
+  useEffect(() => {
+    if (!focusSignal || !selectedKey) return;
+    const el = blockRefs.current.get(selectedKey)?.querySelector('textarea');
+    (el as HTMLTextAreaElement | null)?.focus();
+  }, [focusSignal]);
+
+  return (
+    <div className="flex justify-center">
+      <div
+        data-testid="canvas-page"
+        className={cn(
+          'w-full overflow-hidden rounded-2xl border border-border bg-card shadow-xl',
+          device === 'mobile' ? 'max-w-[400px]' : 'max-w-[720px]',
+        )}
+      >
+        <div className="flex flex-col divide-y divide-border">
+          {config.steps.map((step, i) => (
+            <section
+              key={step.key}
+              ref={(el) => {
+                if (el) blockRefs.current.set(step.key, el);
+                else blockRefs.current.delete(step.key);
+              }}
+              data-testid={`page-block-${i}`}
+              aria-current={i === selected || undefined}
+              // Focus/click anywhere in a block selects it, so the settings
+              // panel always describes the question under the caret.
+              onMouseDownCapture={() => onSelect(i)}
+              onFocusCapture={() => onSelect(i)}
+              className={cn(
+                'scroll-my-16 px-6 py-6 transition-colors sm:px-8',
+                i === selected ? 'bg-primary/5 ring-1 ring-inset ring-primary/40' : 'hover:bg-muted/40',
+              )}
+            >
+              {step.type === 'reveal' ? (
+                <RevealPageBlock step={step} onUpdate={(patch) => onUpdateStep(i, patch)} m={m} />
+              ) : (
+                <QuestionEditableBody
+                  config={config}
+                  step={step}
+                  index={i}
+                  accent={accent}
+                  onUpdate={(patch) => onUpdateStep(i, patch)}
+                  m={m}
+                />
+              )}
+            </section>
+          ))}
+
+          {/* The page's ONE Submit — static chrome, exactly like the real form. */}
+          <div className="px-6 py-6 sm:px-8">
+            <button
+              type="button"
+              className="w-full rounded-xl px-6 py-3.5 text-sm font-semibold"
+              style={{ background: accent, color: accentText }}
+            >
+              {m.canvas.submit}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The end reveal as a block ON the page canvas: compact, editable in place,
+ * clearly not a question. It sits last (the layout anchors it there) and the
+ * note says when it actually plays — after Submit, before the result.
+ */
+function RevealPageBlock({
+  step,
+  onUpdate,
+  m,
+}: {
+  step: FormStep;
+  onUpdate: (patch: Partial<FormStep>) => void;
+  m: BuilderMessages;
+}) {
+  return (
+    <div data-testid="page-reveal-block">
+      <p className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <i aria-hidden className="pi pi-sparkles" style={{ fontSize: 12 }} />
+        {m.gallery.items.reveal.title}
+      </p>
+      <AutoTextarea
+        value={step.reveal?.headline ?? ''}
+        onChange={(v) => onUpdate({ reveal: { ...step.reveal, headline: v || null } })}
+        placeholder={m.canvas.revealHeadlinePlaceholder}
+        ariaLabel={m.canvas.revealHeadlinePlaceholder}
+        className="canvas-title text-xl font-bold tracking-tight text-foreground"
+      />
+      <div className="mt-1">
+        <AutoTextarea
+          value={step.reveal?.subtitle ?? ''}
+          onChange={(v) => onUpdate({ reveal: { ...step.reveal, subtitle: v || null } })}
+          placeholder={m.canvas.revealSubtitlePlaceholder}
+          ariaLabel={m.canvas.revealSubtitlePlaceholder}
+          rows={1}
+          className="text-sm leading-relaxed text-muted-foreground"
+        />
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.canvas.revealVerticalNote}
+      </p>
     </div>
   );
 }
@@ -303,15 +472,12 @@ function RevealCanvas({
   step,
   accent,
   device,
-  vertical = false,
   onUpdate,
   m,
 }: {
   step: FormStep;
   accent: string;
   device: 'desktop' | 'mobile';
-  /** One-page form: the reveal plays after Submit, never mid-page — say so. */
-  vertical?: boolean;
   onUpdate: (patch: Partial<FormStep>) => void;
   m: BuilderMessages;
 }) {
@@ -357,11 +523,6 @@ function RevealCanvas({
         <p className="mt-5 text-xs text-muted-foreground">
           {tb(m.canvas.revealPlays, { ms: durationMs })}
         </p>
-        {vertical ? (
-          <p className="mt-1.5 text-xs text-muted-foreground" data-testid="canvas-reveal-vertical-note">
-            <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.canvas.revealVerticalNote}
-          </p>
-        ) : null}
       </div>
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import type { FormConfig, FormStep, FormOption } from '@quill/engine';
+import type { FormConfig, FormStep, FormOption, FormLayout } from '@quill/engine';
 import { nameFields, sliderBounds, clampSliderValue } from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import { cn } from '@/lib/cn';
@@ -76,6 +76,7 @@ export function CanvasQuestion({
   index,
   total,
   device,
+  layout = 'slides',
   onUpdate,
   m,
 }: {
@@ -84,9 +85,16 @@ export function CanvasQuestion({
   index: number;
   total: number;
   device: 'desktop' | 'mobile';
+  /**
+   * The form's presentation layout. On 'vertical' the canvas drops the chrome
+   * that never exists on a one-page form — the per-step progress bar and the
+   * per-question Next button — so the builder shows what actually publishes.
+   */
+  layout?: FormLayout;
   onUpdate: (patch: Partial<FormStep>) => void;
   m: BuilderMessages;
 }) {
+  const vertical = layout === 'vertical';
   const accent = clampAccent(config.branding?.primaryColor || DEFAULT_ACCENT);
   const accentText = onAccent(accent);
   const progress = total > 0 ? Math.round(((index + 1) / total) * 100) : 0;
@@ -117,6 +125,7 @@ export function CanvasQuestion({
         step={step}
         accent={accent}
         device={device}
+        vertical={vertical}
         onUpdate={onUpdate}
         m={m}
       />
@@ -131,10 +140,13 @@ export function CanvasQuestion({
           device === 'mobile' ? 'max-w-[380px]' : 'max-w-[640px]',
         )}
       >
-        {/* Respondent progress bar */}
-        <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-          <div className="h-full rounded-full transition-all" style={{ width: `${progress}%`, background: accent }} />
-        </div>
+        {/* Respondent progress bar — slides only; a one-page form has no
+            per-step position, its bar counts ANSWERED questions instead. */}
+        {!vertical ? (
+          <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full transition-all" style={{ width: `${progress}%`, background: accent }} />
+          </div>
+        ) : null}
 
         {/* Eyebrow */}
         <p className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
@@ -253,8 +265,13 @@ export function CanvasQuestion({
         {/* Respondent's Next button (label editable for message/content). A
             scheduler has none: booking IS the answer, so the public form
             advances itself — showing a Submit here promised a button that never
-            renders. */}
-        {step.type !== 'dropdown' && step.type !== 'scheduler' ? (
+            renders. A ONE-PAGE form has no per-question button at all (one
+            Submit at the end of the page), so the canvas says that instead. */}
+        {vertical ? (
+          <p className="mt-7 text-xs text-muted-foreground" data-testid="canvas-vertical-note">
+            <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.canvas.verticalNote}
+          </p>
+        ) : step.type !== 'dropdown' && step.type !== 'scheduler' ? (
           <div className="mt-7">
             <button
               type="button"
@@ -286,12 +303,15 @@ function RevealCanvas({
   step,
   accent,
   device,
+  vertical = false,
   onUpdate,
   m,
 }: {
   step: FormStep;
   accent: string;
   device: 'desktop' | 'mobile';
+  /** One-page form: the reveal plays after Submit, never mid-page — say so. */
+  vertical?: boolean;
   onUpdate: (patch: Partial<FormStep>) => void;
   m: BuilderMessages;
 }) {
@@ -337,6 +357,11 @@ function RevealCanvas({
         <p className="mt-5 text-xs text-muted-foreground">
           {tb(m.canvas.revealPlays, { ms: durationMs })}
         </p>
+        {vertical ? (
+          <p className="mt-1.5 text-xs text-muted-foreground" data-testid="canvas-reveal-vertical-note">
+            <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.canvas.revealVerticalNote}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/cover-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FormConfig, FormCover, FormBranding, FormClientLogo } from '@quill/engine';
+import type { FormConfig, FormCover, FormBranding, FormClientLogo, FormLayout } from '@quill/engine';
 import { isSafeImageUrl } from '@quill/engine';
 import { clampAccent, accentWasAdjusted, DEFAULT_ACCENT } from '@quill/shared';
 import { Switch } from '@/components/ui/switch';
@@ -20,16 +20,20 @@ const MAX_CLIENT_LOGOS = 24;
  */
 export function CoverPanel({
   config,
+  layout = 'slides',
   onCoverChange,
   onBrandingChange,
   m,
 }: {
   config: FormConfig;
+  /** The form's presentation layout — vertical renders the cover as a hero. */
+  layout?: FormLayout;
   onCoverChange: (patch: Partial<FormCover>) => void;
   onBrandingChange: (patch: Partial<FormBranding>) => void;
   m: EditorMessages;
 }) {
   const cover = config.cover ?? {};
+  const vertical = layout === 'vertical';
   const raw = config.branding?.primaryColor || DEFAULT_ACCENT;
   const clamped = clampAccent(raw);
   const adjusted = accentWasAdjusted(raw);
@@ -60,9 +64,18 @@ export function CoverPanel({
           <Field label={m.cover.subheadline}>
             <TextArea value={cover.subheadline ?? ''} rows={2} onChange={(e) => onCoverChange({ subheadline: e.target.value || null })} />
           </Field>
-          <Field label={m.cover.ctaText}>
-            <TextField value={cover.ctaText ?? ''} onChange={(e) => onCoverChange({ ctaText: e.target.value || null })} />
-          </Field>
+          {/* No Start gate on a one-page form: the cover is a header, so the
+              CTA text is a control that changes nothing — say so instead of
+              offering it (impossible-combination rule). */}
+          {vertical ? (
+            <p className="text-xs text-muted-foreground" data-testid="cover-cta-vertical-note">
+              <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.layout.coverCtaNote}
+            </p>
+          ) : (
+            <Field label={m.cover.ctaText}>
+              <TextField value={cover.ctaText ?? ''} onChange={(e) => onCoverChange({ ctaText: e.target.value || null })} />
+            </Field>
+          )}
           <Field label={m.cover.trustBadge}>
             <TextField value={cover.trustBadge ?? ''} onChange={(e) => onCoverChange({ trustBadge: e.target.value || null })} />
           </Field>
@@ -122,7 +135,7 @@ export function CoverPanel({
 
       <div className="lg:sticky lg:top-[7.5rem] lg:self-start">
         <p className="mb-2 text-sm font-semibold text-foreground">{m.preview.title}</p>
-        <LivePreview config={config} selected="cover" m={m.preview} />
+        <LivePreview config={config} selected="cover" layout={layout} m={m.preview} />
       </div>
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { FormConfig, FormStep } from '@quill/engine';
+import type { FormConfig, FormStep, FormLayout } from '@quill/engine';
 import { resolveQuestion, sliderBounds, clampSliderValue } from '@quill/engine';
 import { clampAccent, onAccent, DEFAULT_ACCENT } from '@quill/shared';
 import type { EditorMessages } from './messages';
@@ -10,14 +10,21 @@ import type { EditorMessages } from './messages';
  * A faithful, read-only preview of the cover or a single step, styled with the
  * form's branding accent so the editor reflects the public surface. Interactive
  * within the preview (you can tap options / drag the slider) but never submits.
+ *
+ * `layout` keeps the preview honest to the published form: on a VERTICAL form
+ * the cover has no Start gate — it renders as a page hero with the first
+ * questions stacked beneath it — so previewing the slides cover there would
+ * show a screen that never exists.
  */
 export function LivePreview({
   config,
   selected,
+  layout = 'slides',
   m,
 }: {
   config: FormConfig;
   selected: number | 'cover';
+  layout?: FormLayout;
   m: EditorMessages['preview'];
 }) {
   const accent = clampAccent(config.branding?.primaryColor || DEFAULT_ACCENT);
@@ -27,12 +34,82 @@ export function LivePreview({
   return (
     <div className="rounded-lg border border-border bg-background p-4">
       {selected === 'cover' ? (
-        <CoverPreview config={config} accent={accent} accentText={accentText} m={m} />
+        layout === 'vertical' ? (
+          <VerticalPagePreview config={config} accent={accent} accentText={accentText} m={m} />
+        ) : (
+          <CoverPreview config={config} accent={accent} accentText={accentText} m={m} />
+        )
       ) : step ? (
         <StepPreview step={step} accent={accent} accentText={accentText} m={m} index={selected} total={config.steps.length} />
       ) : (
         <p className="py-8 text-center text-sm text-muted-foreground">{m.empty}</p>
       )}
+    </div>
+  );
+}
+
+/** How many questions the vertical page preview sketches before eliding. */
+const VERTICAL_PREVIEW_STEPS = 3;
+
+/**
+ * The one-page shape at a glance: hero (banner → eyebrow → headline →
+ * subheadline → trust) with NO Start button, the first questions stacked as
+ * quiet stubs, and the single Submit. A sketch, not a simulation — the device
+ * preview modal shows the real page.
+ */
+function VerticalPagePreview({
+  config,
+  accent,
+  accentText,
+  m,
+}: {
+  config: FormConfig;
+  accent: string;
+  accentText: string;
+  m: EditorMessages['preview'];
+}) {
+  const cover = config.cover ?? {};
+  const questions = config.steps.filter((s) => s.type !== 'reveal' && !s.hidden);
+  const shown = questions.slice(0, VERTICAL_PREVIEW_STEPS);
+  const elided = questions.length - shown.length;
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-border bg-card p-6" data-testid="vertical-page-preview">
+      {cover.bannerText ? (
+        <div
+          className="w-full rounded-md px-3 py-1.5 text-center text-xs font-medium"
+          style={{ background: accent, color: accentText }}
+        >
+          {cover.bannerText}
+        </div>
+      ) : null}
+      <div className="flex flex-col items-center gap-2 border-b border-border pb-4 text-center">
+        {cover.eyebrow ? (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {cover.eyebrow}
+          </span>
+        ) : null}
+        <h1 className="text-xl font-semibold tracking-tight">{cover.headline || m.coverTitle}</h1>
+        {cover.subheadline ? <p className="text-sm text-muted-foreground">{cover.subheadline}</p> : null}
+        {cover.trustBadge ? <p className="text-xs text-muted-foreground">{cover.trustBadge}</p> : null}
+      </div>
+      {shown.map((s) => (
+        <div key={s.key} className="flex flex-col gap-1.5 border-b border-border pb-3">
+          <p className="text-sm font-medium text-foreground">{resolveQuestion(s, {}) || s.key}</p>
+          <div className="h-8 rounded-md border border-border bg-background" aria-hidden />
+        </div>
+      ))}
+      {elided > 0 ? (
+        <p className="text-center text-xs text-muted-foreground" aria-hidden>
+          ⋯ +{elided}
+        </p>
+      ) : null}
+      <button
+        type="button"
+        className="mt-1 self-start rounded-md px-5 py-2.5 text-sm font-semibold"
+        style={{ background: accent, color: accentText }}
+      >
+        {m.verticalSubmit}
+      </button>
     </div>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-util.spec.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-util.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import type { FormStep } from '@quill/engine';
+import { anchorRevealsLast } from './logic-util';
+
+const q = (key: string): FormStep => ({ key, type: 'text' });
+const reveal = (key: string): FormStep => ({ key, type: 'reveal' });
+
+describe('anchorRevealsLast (vertical layout — reveals always at the end)', () => {
+  it('moves a mid-list reveal to the end, preserving question order', () => {
+    const steps = [q('a'), reveal('r1'), q('b'), q('c')];
+    expect(anchorRevealsLast(steps).map((s) => s.key)).toEqual(['a', 'b', 'c', 'r1']);
+  });
+
+  it('groups multiple reveals at the end in their original relative order', () => {
+    const steps = [reveal('r1'), q('a'), reveal('r2'), q('b')];
+    expect(anchorRevealsLast(steps).map((s) => s.key)).toEqual(['a', 'b', 'r1', 'r2']);
+  });
+
+  it('returns the SAME array when already anchored (identity = unchanged)', () => {
+    const anchored = [q('a'), q('b'), reveal('r1')];
+    expect(anchorRevealsLast(anchored)).toBe(anchored);
+  });
+
+  it('returns the SAME array when there are no reveals', () => {
+    const steps = [q('a'), q('b')];
+    expect(anchorRevealsLast(steps)).toBe(steps);
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-util.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-util.ts
@@ -98,3 +98,19 @@ export function describeCondition(
     }
   }
 }
+
+/**
+ * Vertical layout: reveal cards live at the END of the list — on a one-page
+ * form a reveal plays once, after Submit, never between questions, so a card
+ * sitting mid-list would promise an interstitial that never happens there.
+ * Every steps mutation in the editor funnels through this on vertical (add,
+ * reorder, switching the layout) so the list always tells the truth.
+ * Returns the SAME array when nothing needs to move (callers use identity to
+ * know whether anything changed — e.g. to avoid dirtying an untouched form).
+ */
+export function anchorRevealsLast(steps: FormStep[]): FormStep[] {
+  const reveals = steps.filter((s) => s.type === 'reveal');
+  if (reveals.length === 0) return steps;
+  const anchored = [...steps.filter((s) => s.type !== 'reveal'), ...reveals];
+  return anchored.every((s, i) => s === steps[i]) ? steps : anchored;
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -535,15 +535,12 @@ export function QuestionSettings({
             after a HIDDEN question never plays — the respondent never completes
             the step it follows — so the pair isn't offered (V5-QA). Nor after a
             reveal: back-to-back interstitials are never what an author means. */}
-        {step.hidden || step.type === 'reveal' ? null : (
-          <InlineField
-            label={em.behavior.reveal}
-            // On a one-page form the reveal never plays mid-page — it shows
-            // once, after Submit. The switch still works (it inserts the card),
-            // but the hint must not promise an interstitial "after this
-            // question" that vertical will never render there.
-            hint={layout === 'vertical' ? em.behavior.revealVerticalHint : em.behavior.revealHint}
-          >
+        {/* On VERTICAL the switch is not offered at all: "after this question"
+            is a position, and the one-page reveal has none — it plays once,
+            after Submit. Its switch lives in Design, next to the layout picker
+            (impossible-combination rule: don't offer a control that lies). */}
+        {step.hidden || step.type === 'reveal' || layout === 'vertical' ? null : (
+          <InlineField label={em.behavior.reveal} hint={em.behavior.revealHint}>
             <Switch
               checked={revealAfter}
               onCheckedChange={onRevealAfterChange}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import type { FormStep } from '@quill/engine';
+import type { FormStep, FormLayout } from '@quill/engine';
 import {
   clampSliderValue,
   defaultFlowGroup,
@@ -65,6 +65,7 @@ export function QuestionSettings({
   step,
   index,
   steps,
+  layout = 'slides',
   scoringEnabled,
   onUpdate,
   onDelete,
@@ -80,6 +81,8 @@ export function QuestionSettings({
   step: FormStep;
   index: number;
   steps: FormStep[];
+  /** The form's presentation layout — a reveal behaves differently on vertical. */
+  layout?: FormLayout;
   scoringEnabled: boolean;
   onUpdate: (patch: Partial<FormStep>) => void;
   onDelete: () => void;
@@ -533,7 +536,14 @@ export function QuestionSettings({
             the step it follows — so the pair isn't offered (V5-QA). Nor after a
             reveal: back-to-back interstitials are never what an author means. */}
         {step.hidden || step.type === 'reveal' ? null : (
-          <InlineField label={em.behavior.reveal} hint={em.behavior.revealHint}>
+          <InlineField
+            label={em.behavior.reveal}
+            // On a one-page form the reveal never plays mid-page — it shows
+            // once, after Submit. The switch still works (it inserts the card),
+            // but the hint must not promise an interstitial "after this
+            // question" that vertical will never render there.
+            hint={layout === 'vertical' ? em.behavior.revealVerticalHint : em.behavior.revealHint}
+          >
             <Switch
               checked={revealAfter}
               onCheckedChange={onRevealAfterChange}

--- a/apps/web/app/admin/forms/[id]/edit/_components/type-gallery.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/type-gallery.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { BuilderMessages } from './builder-messages';
+import { cn } from '@/lib/cn';
+import type { BuilderMessages, GalleryItemId } from './builder-messages';
 import { GALLERY, GALLERY_GROUPS, type GalleryGroup, type GalleryItem } from './question-types';
 
 /**
@@ -15,11 +16,18 @@ export function TypeGallery({
   onClose,
   onPick,
   m,
+  disabled,
 }: {
   open: boolean;
   onClose: () => void;
   onPick: (item: GalleryItem) => void;
   m: BuilderMessages;
+  /**
+   * Tiles that can't be picked right now, with the REASON shown in the tile
+   * (e.g. vertical layout already has its one reveal). A greyed tile that says
+   * why beats a vanished tile the author hunts for.
+   */
+  disabled?: Partial<Record<GalleryItemId, string>>;
 }) {
   const [query, setQuery] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
@@ -124,21 +132,34 @@ export function TypeGallery({
                   <div className="grid gap-2.5 sm:grid-cols-3">
                     {items.map((it) => {
                       const label = m.gallery.items[it.id];
+                      const reason = disabled?.[it.id];
                       return (
                         <button
                           key={it.id}
                           type="button"
+                          disabled={!!reason}
+                          title={reason}
+                          data-testid={`gallery-item-${it.id}`}
                           onClick={() => onPick(it)}
-                          className="group flex items-center gap-3 rounded-xl border border-border bg-background p-3 text-left transition-colors hover:border-primary/60 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          className={cn(
+                            'group flex items-center gap-3 rounded-xl border border-border bg-background p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                            reason
+                              ? 'cursor-not-allowed opacity-55'
+                              : 'hover:border-primary/60 hover:bg-muted/50',
+                          )}
                         >
-                          <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/15 group-hover:text-foreground">
+                          <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-enabled:group-hover:bg-primary/15 group-enabled:group-hover:text-foreground">
                             <i aria-hidden className={`pi ${it.icon}`} style={{ fontSize: 16 }} />
                           </span>
                           <span className="min-w-0">
                             <span className="block truncate text-sm font-semibold text-foreground">
                               {label.title}
                             </span>
-                            <span className="block truncate text-xs text-muted-foreground">{label.desc}</span>
+                            {/* The reason REPLACES the description while off:
+                                the tile explains itself instead of tempting. */}
+                            <span className="block text-xs text-muted-foreground">
+                              {reason ?? label.desc}
+                            </span>
                           </span>
                         </button>
                       );

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -10,12 +10,14 @@ import type {
   FormBranding,
   FormOutcome,
   FormEnding,
+  FormLayout,
 } from '@quill/engine';
 import {
   normalizeConfig,
   renameStepKey as engineRenameStepKey,
   createEmptyStep,
   migrateRevealToStep,
+  resolveFormLayout,
 } from '@quill/engine';
 import type { FormTracking } from '@quill/types';
 import { formConfigSchema } from '@quill/types';
@@ -407,10 +409,17 @@ export function FormEditor({
   // flow round-trips it (normalizeConfig passes unknown top-level keys through).
   const setTracking = (tracking: FormTracking | undefined) =>
     mutate((c) => ({ ...c, tracking }) as FormConfig);
+  // Layout is switchable at any time: the config is identical either way, the
+  // renderers just present it differently — nothing is lost by toggling.
+  // 'slides' is stored as ABSENT so a slides form keeps the exact config shape
+  // every pre-layout form has.
+  const setLayout = (next: FormLayout) =>
+    mutate((c) => ({ ...c, layout: next === 'slides' ? undefined : next }));
 
   const selectedStep = selected != null ? config.steps[selected] : undefined;
   const scoringEnabled = config.scoring?.enabled !== false;
   const hasQuestions = config.steps.length > 0;
+  const layout = resolveFormLayout(config);
 
   const tabs: { id: Tab; label: string; icon: string }[] = [
     { id: 'build', label: bm.shell.tabBuild, icon: 'pi-th-large' },
@@ -583,6 +592,7 @@ export function FormEditor({
                       index={selected}
                       total={config.steps.length}
                       device={device}
+                      layout={layout}
                       onUpdate={(patch) => patchStep(selected, patch)}
                       m={bm}
                     />
@@ -624,6 +634,7 @@ export function FormEditor({
                     step={selectedStep}
                     index={selected}
                     steps={config.steps}
+                    layout={layout}
                     scoringEnabled={scoringEnabled}
                     onUpdate={(patch) => patchStep(selected, patch)}
                     onDelete={() => deleteStep(selected)}
@@ -672,7 +683,45 @@ export function FormEditor({
           </div>
         ) : (
           <div className="flex h-full flex-col gap-4 overflow-y-auto px-4 py-6 sm:px-8">
-            <CoverPanel config={config} onCoverChange={patchCover} onBrandingChange={patchBranding} m={m} />
+            {/* Layout picker first: it changes what several controls below mean
+                (cover CTA, per-question reveals), so it reads before them. */}
+            <section className="rounded-lg border border-border bg-card p-4">
+              <p className="text-sm font-semibold text-foreground">{m.layout.title}</p>
+              <p className="mb-3 mt-0.5 text-xs text-muted-foreground">{m.layout.subtitle}</p>
+              <div className="grid max-w-[520px] grid-cols-2 gap-2" role="radiogroup" aria-label={m.layout.title}>
+                {(
+                  [
+                    { id: 'slides' as const, label: m.layout.slides, hint: m.layout.slidesHint },
+                    { id: 'vertical' as const, label: m.layout.vertical, hint: m.layout.verticalHint },
+                  ]
+                ).map((opt) => (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    role="radio"
+                    aria-checked={layout === opt.id}
+                    data-testid={`design-layout-${opt.id}`}
+                    onClick={() => setLayout(opt.id)}
+                    className={cn(
+                      'flex flex-col gap-1 rounded-md border p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                      layout === opt.id
+                        ? 'border-primary bg-primary/10 text-foreground'
+                        : 'border-border text-muted-foreground hover:border-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <span className="text-sm font-medium">{opt.label}</span>
+                    <span className="text-xs text-muted-foreground">{opt.hint}</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+            <CoverPanel
+              config={config}
+              layout={layout}
+              onCoverChange={patchCover}
+              onBrandingChange={patchBranding}
+              m={m}
+            />
             <FlowPanel partialNote={bm.partial.designNote} m={m} />
             <EndingPanel
               config={config}

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -559,7 +559,17 @@ export function FormEditor({
           </button>
           <LinkActions
             publicPath={publicPath}
-            labels={{ copyLink: bm.shell.copyLink, copied: bm.shell.copied, openForm: bm.shell.openForm }}
+            formName={name}
+            labels={{
+              copyLink: bm.shell.copyLink,
+              copied: bm.shell.copied,
+              openForm: bm.shell.openForm,
+              embed: bm.shell.embed,
+              embedTitle: bm.shell.embedTitle,
+              embedIntro: bm.shell.embedIntro,
+              embedCopy: bm.shell.embedCopy,
+              embedCopied: bm.shell.embedCopied,
+            }}
           />
           <PublishButton
             formId={id}

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -24,6 +24,9 @@ import { formConfigSchema } from '@quill/types';
 import { saveFormAction } from '@/app/admin/actions';
 import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
+import { Switch } from '@/components/ui/switch';
+import { InlineField } from './_components/fields';
+import { anchorRevealsLast } from './_components/logic-util';
 import { QuestionSpine } from './_components/question-spine';
 import { CanvasQuestion } from './_components/canvas-question';
 import { QuestionSettings } from './_components/question-settings';
@@ -125,7 +128,16 @@ export function FormEditor({
   // authored under the old form-level reveal (Design-tab copy + a draggable
   // position marker) is folded into that shape the moment it opens, so the two
   // ways to author one screen never coexist on screen.
-  const [config, setConfig] = useState<FormConfig>(() => migrateRevealToStep(initialConfig));
+  const [config, setConfig] = useState<FormConfig>(() => {
+    const migrated = migrateRevealToStep(initialConfig);
+    // Vertical: a reveal card mid-list promises an interstitial the one-page
+    // form never plays there — fold it to the end on open, same idiom as the
+    // reveal migration above (identity-preserving when nothing moves, so an
+    // already-anchored form does not start dirty).
+    if (resolveFormLayout(migrated) !== 'vertical') return migrated;
+    const anchored = anchorRevealsLast(migrated.steps);
+    return anchored === migrated.steps ? migrated : { ...migrated, steps: anchored };
+  });
   // Deep-linkable tabs: `?tab=connect` selects the tab on load…
   const [tab, setTabState] = useState<Tab>(() => parseTab(searchParams.get('tab')));
   // …and switching syncs the URL shallowly (no navigation, no RSC refetch).
@@ -305,9 +317,17 @@ export function FormEditor({
   function addFromGallery(item: GalleryItem) {
     mutate((c) => {
       const step = stepFromGalleryItem(item, new Set(c.steps.map((s) => s.key)));
-      const steps = [...c.steps, step];
-      setSelected(steps.length - 1);
-      return { ...c, steps };
+      // Vertical: reveals are anchored last, so a new QUESTION lands before
+      // them — appending blindly would file it after the end-reveal, i.e.
+      // "after the results screen", a position that does not exist.
+      const appended = [...c.steps, step];
+      const steps = resolveFormLayout(c) === 'vertical' ? anchorRevealsLast(appended) : appended;
+      setSelected(steps.findIndex((s) => s.key === step.key));
+      return {
+        ...c,
+        steps,
+        partialSubmitAfterStep: reanchorAfterReorder(c.partialSubmitAfterStep, appended, steps),
+      };
     });
     setGalleryOpen(false);
     setTab('build');
@@ -331,25 +351,26 @@ export function FormEditor({
     });
   }
   function reorderSteps(from: number, to: number) {
-    mutate((c) => {
-      const steps = [...c.steps];
-      const [moved] = steps.splice(from, 1);
-      if (!moved) return c;
-      steps.splice(to, 0, moved);
+    // Compute the final order OUTSIDE the updater so selection can follow the
+    // selected step BY KEY — on vertical the anchor pass may move more than the
+    // dragged card (a reveal dropped mid-list snaps back to the end).
+    const before = config.steps;
+    const arr = [...before];
+    const [moved] = arr.splice(from, 1);
+    if (!moved) return;
+    arr.splice(to, 0, moved);
+    const after = layout === 'vertical' ? anchorRevealsLast(arr) : arr;
+    const selectedKey = selected != null ? before[selected]?.key : undefined;
+    mutate((c) => ({
+      ...c,
+      steps: after,
       // Keep the partial-submit marker attached to the step it fires AFTER.
-      return {
-        ...c,
-        steps,
-        partialSubmitAfterStep: reanchorAfterReorder(c.partialSubmitAfterStep, c.steps, steps),
-      };
-    });
-    setSelected((sel) => {
-      if (sel == null) return null;
-      if (sel === from) return to;
-      if (from < sel && to >= sel) return sel - 1;
-      if (from > sel && to <= sel) return sel + 1;
-      return sel;
-    });
+      partialSubmitAfterStep: reanchorAfterReorder(c.partialSubmitAfterStep, c.steps, after),
+    }));
+    if (selectedKey != null) {
+      const next = after.findIndex((s) => s.key === selectedKey);
+      setSelected(next >= 0 ? next : null);
+    }
   }
   function applyTemplate(tid: TemplateId) {
     const cfg = TEMPLATES[tid];
@@ -412,9 +433,44 @@ export function FormEditor({
   // Layout is switchable at any time: the config is identical either way, the
   // renderers just present it differently — nothing is lost by toggling.
   // 'slides' is stored as ABSENT so a slides form keeps the exact config shape
-  // every pre-layout form has.
+  // every pre-layout form has. Switching TO vertical folds any mid-list reveal
+  // to the end, where that layout actually plays it.
   const setLayout = (next: FormLayout) =>
-    mutate((c) => ({ ...c, layout: next === 'slides' ? undefined : next }));
+    mutate((c) => ({
+      ...c,
+      layout: next === 'slides' ? undefined : next,
+      steps: next === 'vertical' ? anchorRevealsLast(c.steps) : c.steps,
+      partialSubmitAfterStep:
+        next === 'vertical'
+          ? reanchorAfterReorder(c.partialSubmitAfterStep, c.steps, anchorRevealsLast(c.steps))
+          : c.partialSubmitAfterStep,
+    }));
+  /**
+   * The vertical layout's ONE reveal, controlled from Design: ON appends a
+   * reveal card at the end (edit its copy by selecting it), OFF removes every
+   * reveal card. Per-question "reveal after" switches don't exist on vertical —
+   * position is meaningless when the reveal always plays after Submit.
+   */
+  const hasReveal = config.steps.some((s) => s.type === 'reveal');
+  function setEndReveal(on: boolean) {
+    const keepLen = config.steps.filter((s) => s.type !== 'reveal').length;
+    mutate((c) => {
+      const has = c.steps.some((s) => s.type === 'reveal');
+      if (on === has) return c;
+      if (on) {
+        const step = createEmptyStep('reveal', new Set(c.steps.map((s) => s.key)));
+        return { ...c, steps: [...c.steps, step] }; // appended last — the marker never shifts
+      }
+      const keep = c.steps.filter((s) => s.type !== 'reveal');
+      // Re-anchor the partial marker by the key it pointed at (a reveal can't
+      // be the anchor's own step — it captures no answer — but positions shift).
+      const anchorKey = c.partialSubmitAfterStep != null ? c.steps[c.partialSubmitAfterStep - 1]?.key : undefined;
+      const idx = anchorKey ? keep.findIndex((s) => s.key === anchorKey) : -1;
+      return { ...c, steps: keep, partialSubmitAfterStep: idx >= 0 ? idx + 1 : undefined };
+    });
+    // Removing cards can strand the selection past the end of the list.
+    if (!on) setSelected((sel) => (sel == null ? sel : keepLen === 0 ? null : Math.min(sel, keepLen - 1)));
+  }
 
   const selectedStep = selected != null ? config.steps[selected] : undefined;
   const scoringEnabled = config.scoring?.enabled !== false;
@@ -714,6 +770,20 @@ export function FormEditor({
                   </button>
                 ))}
               </div>
+              {/* Vertical's one reveal is a FORM-level fact (it always plays
+                  after Submit), so its switch lives here — not on a question. */}
+              {layout === 'vertical' ? (
+                <div className="mt-4 max-w-[520px] border-t border-border pt-3">
+                  <InlineField label={m.layout.endReveal} hint={m.layout.endRevealHint}>
+                    <Switch
+                      checked={hasReveal}
+                      onCheckedChange={setEndReveal}
+                      data-testid="design-end-reveal"
+                      aria-label={m.layout.endReveal}
+                    />
+                  </InlineField>
+                </div>
+              ) : null}
             </section>
             <CoverPanel
               config={config}
@@ -733,7 +803,15 @@ export function FormEditor({
         )}
       </div>
 
-      <TypeGallery open={galleryOpen} onClose={() => setGalleryOpen(false)} onPick={addFromGallery} m={bm} />
+      <TypeGallery
+        open={galleryOpen}
+        onClose={() => setGalleryOpen(false)}
+        onPick={addFromGallery}
+        m={bm}
+        // Vertical: one reveal, always at the end — a second tile pick would
+        // create a card the renderer ignores, so it's offered exactly once.
+        disabled={layout === 'vertical' && hasReveal ? { reveal: bm.gallery.revealVerticalTaken } : undefined}
+      />
       <DevicePreviewModal open={previewOpen} onClose={() => setPreviewOpen(false)} publicPath={publicPath} m={m.preview} />
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -28,7 +28,7 @@ import { Switch } from '@/components/ui/switch';
 import { InlineField } from './_components/fields';
 import { anchorRevealsLast } from './_components/logic-util';
 import { QuestionSpine } from './_components/question-spine';
-import { CanvasQuestion } from './_components/canvas-question';
+import { CanvasQuestion, CanvasPage } from './_components/canvas-question';
 import { QuestionSettings } from './_components/question-settings';
 import { invalidateQuestionHubspotCache } from './_components/question-hubspot';
 import { renameQuestionMappingAction } from './_components/question-hubspot-actions';
@@ -641,17 +641,31 @@ export function FormEditor({
                 </div>
                 <div className="flex-1 px-4 py-6 sm:px-8">
                   {selectedStep && selected != null ? (
-                    <CanvasQuestion
-                      key={`${selected}-${focusCanvas}`}
-                      config={config}
-                      step={selectedStep}
-                      index={selected}
-                      total={config.steps.length}
-                      device={device}
-                      layout={layout}
-                      onUpdate={(patch) => patchStep(selected, patch)}
-                      m={bm}
-                    />
+                    layout === 'vertical' ? (
+                      // The one-page canvas IS the page: every question stacked
+                      // and editable, one Submit — no remount on selection, so
+                      // switching questions scrolls instead of swapping cards.
+                      <CanvasPage
+                        config={config}
+                        selected={selected}
+                        device={device}
+                        focusSignal={focusCanvas}
+                        onSelect={setSelected}
+                        onUpdateStep={patchStep}
+                        m={bm}
+                      />
+                    ) : (
+                      <CanvasQuestion
+                        key={`${selected}-${focusCanvas}`}
+                        config={config}
+                        step={selectedStep}
+                        index={selected}
+                        total={config.steps.length}
+                        device={device}
+                        onUpdate={(patch) => patchStep(selected, patch)}
+                        m={bm}
+                      />
+                    )
                   ) : (
                     <p className="py-16 text-center text-sm text-muted-foreground">{bm.settings.empty}</p>
                   )}

--- a/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
@@ -1,20 +1,36 @@
 'use client';
 
 import { useState } from 'react';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
 
 /**
- * Compact copy-link + open-in-new-tab controls for the editor header. The
- * public URL is resolved client-side from the real origin (the `publicPath`
- * prop is a server-stable path). A 2s "Copied" flash confirms the copy.
+ * Compact copy-link + embed + open-in-new-tab controls for the editor header.
+ * The public URL is resolved client-side from the real origin (the `publicPath`
+ * prop is a server-stable path). A 2s "Copied" flash confirms each copy.
  */
 export function LinkActions({
   publicPath,
+  formName,
   labels,
 }: {
   publicPath: string;
-  labels: { copyLink: string; copied: string; openForm: string };
+  /** The form's name — becomes the embed iframe's accessible title. */
+  formName: string;
+  labels: {
+    copyLink: string;
+    copied: string;
+    openForm: string;
+    embed: string;
+    embedTitle: string;
+    embedIntro: string;
+    embedCopy: string;
+    embedCopied: string;
+  };
 }) {
   const [copied, setCopied] = useState(false);
+  const [embedOpen, setEmbedOpen] = useState(false);
+  const [snippetCopied, setSnippetCopied] = useState(false);
 
   const copy = async () => {
     try {
@@ -23,6 +39,31 @@ export function LinkActions({
       setTimeout(() => setCopied(false), 2000);
     } catch {
       /* clipboard blocked — no-op */
+    }
+  };
+
+  /**
+   * The paste-into-your-site snippet: the form at `?embed=1` (content-height
+   * mode) inside a `data-dapta-forms` iframe, plus `embed.js`, which listens
+   * for the page's height reports and sizes the iframe to match. Built lazily
+   * so it always carries the CURRENT origin (localhost in dev, the real host
+   * in production).
+   */
+  const buildSnippet = () =>
+    [
+      `<iframe data-dapta-forms src="${window.location.origin}${publicPath}?embed=1"`,
+      `        title="${formName.replace(/"/g, '&quot;')}" loading="lazy"`,
+      `        style="width:100%;border:0;min-height:480px;"></iframe>`,
+      `<script src="${window.location.origin}/embed.js" async></script>`,
+    ].join('\n');
+
+  const copySnippet = async () => {
+    try {
+      await navigator.clipboard.writeText(buildSnippet());
+      setSnippetCopied(true);
+      setTimeout(() => setSnippetCopied(false), 2000);
+    } catch {
+      /* clipboard blocked — the snippet stays selectable in the code block */
     }
   };
 
@@ -42,6 +83,17 @@ export function LinkActions({
         <i aria-hidden className={`pi ${copied ? 'pi-check' : 'pi-link'}`} style={{ fontSize: 13 }} />
         <span className="hidden lg:inline">{copied ? labels.copied : labels.copyLink}</span>
       </button>
+      <button
+        type="button"
+        onClick={() => setEmbedOpen(true)}
+        className={btn}
+        aria-label={labels.embed}
+        title={labels.embed}
+        data-testid="editor-embed"
+      >
+        <i aria-hidden className="pi pi-code" style={{ fontSize: 13 }} />
+        <span className="hidden lg:inline">{labels.embed}</span>
+      </button>
       <a
         href={publicPath}
         target="_blank"
@@ -54,6 +106,24 @@ export function LinkActions({
         <i aria-hidden className="pi pi-external-link" style={{ fontSize: 13 }} />
         <span className="hidden lg:inline">{labels.openForm}</span>
       </a>
+
+      <Modal open={embedOpen} onClose={() => setEmbedOpen(false)} title={labels.embedTitle} labelId="embed-form-title">
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">{labels.embedIntro}</p>
+          <pre
+            data-testid="embed-snippet"
+            className="overflow-x-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs leading-relaxed text-foreground"
+          >
+            {embedOpen ? buildSnippet() : ''}
+          </pre>
+          <div className="flex justify-end">
+            <Button onClick={() => void copySnippet()} data-testid="embed-copy">
+              <i aria-hidden className={`pi ${snippetCopied ? 'pi-check' : 'pi-copy'}`} style={{ fontSize: 12 }} />{' '}
+              {snippetCopied ? labels.embedCopied : labels.embedCopy}
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/apps/web/app/admin/forms/create-form.tsx
+++ b/apps/web/app/admin/forms/create-form.tsx
@@ -15,6 +15,12 @@ interface Labels {
   cancel: string;
   /** Inline error when the name is left blank (V5-A8). */
   nameRequired: string;
+  /** Layout picker: slides (one question per screen) vs one vertical page. */
+  layoutLabel: string;
+  layoutSlides: string;
+  layoutSlidesDesc: string;
+  layoutVertical: string;
+  layoutVerticalDesc: string;
 }
 
 function SubmitButton({ label }: { label: string }) {
@@ -49,12 +55,14 @@ export function CreateForm({
 }) {
   const [open, setOpen] = useState(false);
   const [nameError, setNameError] = useState(false);
+  const [layout, setLayout] = useState<'slides' | 'vertical'>('slides');
 
   // Every open starts clean and every dismissal clears the error, so a Cancel
   // (or ESC, or overlay click) can't leave a stale "name required" on the next,
   // untouched dialog (V4-11). Cancel previously called only setOpen(false).
   const openDialog = () => {
     setNameError(false);
+    setLayout('slides');
     setOpen(true);
   };
   const closeDialog = () => {
@@ -127,6 +135,64 @@ export function CreateForm({
               </span>
             ) : null}
           </label>
+
+          {/* Layout picker: two visual cards. Rides the form as a hidden input
+              so the server action reads one flat FormData — no client fetch. */}
+          <fieldset className="flex flex-col gap-1.5">
+            <legend className="mb-1.5 text-sm font-medium">{labels.layoutLabel}</legend>
+            <input type="hidden" name="layout" value={layout} />
+            <div className="grid grid-cols-2 gap-2">
+              {(
+                [
+                  {
+                    id: 'slides' as const,
+                    label: labels.layoutSlides,
+                    desc: labels.layoutSlidesDesc,
+                    sketch: (
+                      // One tall card = one question per screen.
+                      <span aria-hidden className="flex h-10 items-center justify-center gap-1">
+                        <span className="h-8 w-6 rounded-sm border border-current opacity-90" />
+                        <span className="h-8 w-1.5 rounded-sm border border-current opacity-40" />
+                      </span>
+                    ),
+                  },
+                  {
+                    id: 'vertical' as const,
+                    label: labels.layoutVertical,
+                    desc: labels.layoutVerticalDesc,
+                    sketch: (
+                      // Stacked rows = every question on one page.
+                      <span aria-hidden className="flex h-10 flex-col items-center justify-center gap-1">
+                        <span className="h-1.5 w-9 rounded-sm border border-current opacity-90" />
+                        <span className="h-1.5 w-9 rounded-sm border border-current opacity-70" />
+                        <span className="h-1.5 w-9 rounded-sm border border-current opacity-50" />
+                      </span>
+                    ),
+                  },
+                ]
+              ).map((opt) => (
+                <button
+                  key={opt.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={layout === opt.id}
+                  data-testid={`create-form-layout-${opt.id}`}
+                  onClick={() => setLayout(opt.id)}
+                  className={cn(
+                    'flex flex-col items-center gap-1 rounded-md border p-3 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    layout === opt.id
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-border text-muted-foreground hover:border-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {opt.sketch}
+                  <span className="text-sm font-medium">{opt.label}</span>
+                  <span className="text-xs text-muted-foreground">{opt.desc}</span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
           <div className="flex items-center justify-end gap-2">
             <Button type="button" variant="ghost" onClick={closeDialog}>
               {labels.cancel}

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -32,6 +32,11 @@ export default async function FormsList() {
     namePlaceholder: m.namePlaceholder,
     nameRequired: m.nameRequired,
     cancel: m.cancel,
+    layoutLabel: m.layoutLabel,
+    layoutSlides: m.layoutSlides,
+    layoutSlidesDesc: m.layoutSlidesDesc,
+    layoutVertical: m.layoutVertical,
+    layoutVerticalDesc: m.layoutVerticalDesc,
   };
   const rowLabels = {
     menu: m.actions,

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -41,6 +41,11 @@ export default async function AdminHome() {
     namePlaceholder: messages.forms.namePlaceholder,
     nameRequired: messages.forms.nameRequired,
     cancel: messages.forms.cancel,
+    layoutLabel: messages.forms.layoutLabel,
+    layoutSlides: messages.forms.layoutSlides,
+    layoutSlidesDesc: messages.forms.layoutSlidesDesc,
+    layoutVertical: messages.forms.layoutVertical,
+    layoutVerticalDesc: messages.forms.layoutVerticalDesc,
   };
 
   return (

--- a/apps/web/components/public/embed-height-reporter.tsx
+++ b/apps/web/components/public/embed-height-reporter.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Mounted ONLY on `?embed=1` renders of the public form: posts the document's
+ * content height to the parent window whenever it changes, so the host page's
+ * `embed.js` can size the iframe and the form never shows an inner scrollbar.
+ *
+ * Security posture: the message carries a single number — never answers, keys
+ * or identifiers — which is why `targetOrigin: '*'` is acceptable here (the
+ * embedding site is by definition unknown to us). The parent matches frames by
+ * `event.source`, so the number can only ever size the frame it came from.
+ */
+export function EmbedHeightReporter() {
+  useEffect(() => {
+    if (window.parent === window) return; // not embedded — nothing to report to
+
+    let raf = 0;
+    const post = () => {
+      raf = 0;
+      const height = Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight,
+      );
+      window.parent.postMessage({ type: 'dapta-forms:resize', height }, '*');
+    };
+    // Coalesce bursts (typing shows/hides questions) into one report per frame.
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(post);
+    };
+
+    const ro = new ResizeObserver(schedule);
+    ro.observe(document.documentElement);
+    ro.observe(document.body);
+    window.addEventListener('load', schedule);
+    schedule();
+
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('load', schedule);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -19,6 +19,21 @@ interface StepInputProps {
   dropdownEmpty: string;
   /** Active locale — drives the phone picker's default country + copy. */
   locale?: string;
+  /**
+   * Focus the (first) text input on mount. Default `true` — the slides layout
+   * shows one question per screen, so focusing it is always right. The vertical
+   * layout renders every question at once and passes `false`: multiple
+   * autofocused inputs would fight, and the winner would scroll the page.
+   */
+  autoFocus?: boolean;
+  /**
+   * A NON-INTERACTION answer write (today: the slider seeding its default on
+   * mount so an untouched optional slider still submits a value). Falls back to
+   * `onChange` when absent — the slides layout treats both the same. The
+   * vertical layout passes a silent setter here: a mount-time seed must never
+   * fire the `start`/`step_complete` funnel events a real interaction fires.
+   */
+  onSeed?: (value: AnswerValue) => void;
 }
 
 /** The current multi-select answer as a string[] (defensive against scalars). */
@@ -39,6 +54,8 @@ export function StepInput({
   dropdownPlaceholder,
   dropdownEmpty,
   locale = 'en',
+  autoFocus = true,
+  onSeed,
 }: StepInputProps) {
   switch (step.type) {
     case 'name': {
@@ -60,7 +77,7 @@ export function StepInput({
               onChange={(e) => onFieldChange(firstField, e.target.value)}
               placeholder={firstLabel}
               aria-label={firstLabel}
-              autoFocus
+              autoFocus={autoFocus}
             />
           )}
           {secondField && (
@@ -100,7 +117,7 @@ export function StepInput({
           onChange={(e) => onChange(e.target.value)}
           placeholder={step.placeholder ?? ''}
           aria-label={step.question ?? step.key}
-          autoFocus
+          autoFocus={autoFocus}
         />
       );
 
@@ -113,7 +130,7 @@ export function StepInput({
           placeholder={step.placeholder ?? ''}
           aria-label={step.question ?? step.key}
           rows={4}
-          autoFocus
+          autoFocus={autoFocus}
         />
       );
 
@@ -202,7 +219,7 @@ export function StepInput({
       );
 
     case 'slider':
-      return <SliderInput step={step} value={value} onChange={onChange} />;
+      return <SliderInput step={step} value={value} onChange={onChange} onSeed={onSeed} />;
 
     case 'message':
       return step.helper ? <p className="pf-message__body">{step.helper}</p> : null;
@@ -216,10 +233,13 @@ function SliderInput({
   step,
   value,
   onChange,
+  onSeed,
 }: {
   step: FormStep;
   value: AnswerValue;
   onChange: (value: AnswerValue) => void;
+  /** Mount-time default seeding — see {@link StepInputProps.onSeed}. */
+  onSeed?: (value: AnswerValue) => void;
 }) {
   const { min, max } = sliderBounds(step);
   const stepSize = step.step ?? 1;
@@ -233,9 +253,11 @@ function SliderInput({
     ref.current?.style.setProperty('--pf-progress', `${pct}%`);
   }, [pct]);
 
-  // Seed the default answer so an untouched (optional) slider still submits a value.
+  // Seed the default answer so an untouched (optional) slider still submits a
+  // value. Routed through `onSeed` when provided: this is NOT an interaction,
+  // and the vertical layout must not count it as one (start/step_complete).
   useEffect(() => {
-    if (value == null || value === '') onChange(current);
+    if (value == null || value === '') (onSeed ?? onChange)(current);
   }, []);
 
   return (

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -262,7 +262,8 @@ export const adminApi = {
   // Forms
   listForms: () => req<FormSummary[]>('GET', '/v1/forms'),
   getForm: (id: string) => req<FormDetail>('GET', `/v1/forms/${id}`),
-  createForm: (b: { name: string; slug?: string }) => req<FormDetail>('POST', '/v1/forms', b),
+  createForm: (b: { name: string; slug?: string; config?: unknown }) =>
+    req<FormDetail>('POST', '/v1/forms', b),
   updateForm: (id: string, b: { name?: string; slug?: string; config?: unknown }) =>
     req<FormDetail>('PUT', `/v1/forms/${id}`, b),
   duplicateForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/duplicate`),

--- a/apps/web/public/embed.js
+++ b/apps/web/public/embed.js
@@ -1,0 +1,40 @@
+/**
+ * Dapta Forms embed helper — auto-resizes embedded form iframes.
+ *
+ * Drop next to any iframe carrying the `data-dapta-forms` attribute:
+ *
+ *   <iframe data-dapta-forms src="https://your-host/acct/handle/slug?embed=1"
+ *           title="My form" loading="lazy"
+ *           style="width:100%;border:0;min-height:480px;"></iframe>
+ *   <script src="https://your-host/embed.js" async></script>
+ *
+ * The embedded page (opened with ?embed=1) posts its content height whenever
+ * it changes; this script sets the matching iframe's height so the form never
+ * shows an inner scrollbar. Frames are matched by `event.source`, never by
+ * URL, so several forms can share one page and a message can only ever size
+ * the frame it came from. Only a number crosses the boundary — no answers, no
+ * identifiers — and the listener ignores anything that isn't that message.
+ */
+(function () {
+  'use strict';
+
+  var MAX_HEIGHT = 20000; // sanity cap — a runaway report can't blow up the host page
+
+  window.addEventListener('message', function (event) {
+    var data = event && event.data;
+    if (!data || data.type !== 'dapta-forms:resize' || typeof data.height !== 'number') return;
+    if (!isFinite(data.height) || data.height <= 0) return;
+
+    var frames = document.querySelectorAll('iframe[data-dapta-forms]');
+    for (var i = 0; i < frames.length; i++) {
+      var frame = frames[i];
+      try {
+        if (event.source === frame.contentWindow) {
+          frame.style.height = Math.min(Math.ceil(data.height), MAX_HEIGHT) + 'px';
+        }
+      } catch (_) {
+        /* cross-origin contentWindow access can throw — skip that frame */
+      }
+    }
+  });
+})();

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -30,6 +30,8 @@ import {
   sanitizeStepKey,
   resolveQuestion,
   resolveEnding,
+  resolveFormLayout,
+  FORM_LAYOUTS,
   type FormConfig,
   type FormStep,
   type FormOutcome,
@@ -1636,5 +1638,29 @@ describe('scheduler step (V6)', () => {
     };
     expect(runtimeSteps(cfg, { pick: 'a' }).map((s) => s.key)).toEqual(['pick']);
     expect(runtimeSteps(cfg, { pick: 'b' }).map((s) => s.key)).toEqual(['pick', 'later']);
+  });
+});
+
+describe('resolveFormLayout (vertical layout — back-compat default)', () => {
+  it('defaults to slides when the field is absent (every legacy config)', () => {
+    expect(resolveFormLayout({ version: 1, steps: [] } as FormConfig)).toBe('slides');
+  });
+
+  it('defaults to slides for a null/undefined config', () => {
+    expect(resolveFormLayout(null)).toBe('slides');
+    expect(resolveFormLayout(undefined)).toBe('slides');
+  });
+
+  it('returns the configured layout when set', () => {
+    expect(resolveFormLayout({ version: 1, steps: [], layout: 'vertical' } as FormConfig)).toBe(
+      'vertical',
+    );
+    expect(resolveFormLayout({ version: 1, steps: [], layout: 'slides' } as FormConfig)).toBe(
+      'slides',
+    );
+  });
+
+  it('FORM_LAYOUTS lists exactly the two supported layouts', () => {
+    expect(FORM_LAYOUTS).toEqual(['slides', 'vertical']);
   });
 });

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -351,10 +351,23 @@ export interface FormEnding {
   redirectDelayMs?: number;
 }
 
+/**
+ * How the public form presents its steps (additive — absent = `'slides'`, so
+ * every form published before this field existed renders exactly as it did):
+ *  - `'slides'`   — one question per screen, walked step by step (the original).
+ *  - `'vertical'` — every visible question on one page, answered in any order
+ *    and submitted once. Skip-logic still applies live: `runtimeSteps` is
+ *    recomputed on every answer, so questions show/hide as the respondent types.
+ */
+export const FORM_LAYOUTS = ['slides', 'vertical'] as const;
+export type FormLayout = (typeof FORM_LAYOUTS)[number];
+
 export interface FormConfig {
   version: 1;
   branding?: FormBranding | null;
   cover?: FormCover | null;
+  /** Presentation layout for the public form. Absent = `'slides'` (back-compat). */
+  layout?: FormLayout;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];
@@ -385,6 +398,15 @@ export type AnswerValue =
   | null
   | undefined;
 export type Answers = Record<string, AnswerValue>;
+
+/**
+ * The layout the public form renders with. Pure resolver shared by the
+ * renderer and the builder so both always agree — and the single place the
+ * `absent = 'slides'` back-compat default lives.
+ */
+export function resolveFormLayout(config: Pick<FormConfig, 'layout'> | null | undefined): FormLayout {
+  return config?.layout ?? 'slides';
+}
 
 /** Normalize an answer to the set of string tokens it represents (for matching). */
 function tokens(value: AnswerValue): string[] {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -499,8 +499,6 @@ export interface FormsMessages {
         terminalHint: string;
         reveal: string;
         revealHint: string;
-        /** Vertical layout: the reveal only plays after Submit, never mid-page. */
-        revealVerticalHint: string;
         /** Hidden-question toggle — filled via a URL parameter (V4-13). */
         hidden: string;
         hiddenHint: string;
@@ -544,6 +542,9 @@ export interface FormsMessages {
         verticalHint: string;
         /** Shown in the cover section when vertical: no Start gate, CTA unused. */
         coverCtaNote: string;
+        /** Vertical's ONE reveal (form-level): shown once, after Submit. */
+        endReveal: string;
+        endRevealHint: string;
       };
       cover: {
         title: string;
@@ -1310,8 +1311,6 @@ export const en: FormsMessages = {
         reveal: 'Show reveal screen after',
         revealHint:
           'Adds a reveal card right after this question. Turning it off removes that card. Edit its copy by selecting the card.',
-        revealVerticalHint:
-          'On a one-page form the reveal never plays mid-page — it shows once, after Submit, before the result.',
         hidden: 'Hidden question',
         hiddenHint: 'Not shown to respondents — its answer is filled from a matching URL parameter (?key=value).',
         fieldKey: 'Field key',
@@ -1348,6 +1347,9 @@ export const en: FormsMessages = {
           'Every question on a single page with one Submit. Logic still applies live — questions show and hide as answers change.',
         coverCtaNote:
           'On a one-page form the cover renders as a header above the questions — there is no Start button, so its text is not used.',
+        endReveal: 'Reveal screen before results',
+        endRevealHint:
+          'Plays once, after Submit and before the result. Edit its copy by selecting the card at the end of the question list.',
       },
       cover: {
         title: 'Cover screen',
@@ -2109,8 +2111,6 @@ export const es: FormsMessages = {
         reveal: 'Mostrar pantalla de revelación después',
         revealHint:
           'Añade una tarjeta de revelación justo después de esta pregunta. Al apagarlo se elimina esa tarjeta. Edita su texto seleccionando la tarjeta.',
-        revealVerticalHint:
-          'En un formulario de una página la revelación nunca se muestra a mitad de página — aparece una vez, después de Enviar y antes del resultado.',
         hidden: 'Pregunta oculta',
         hiddenHint: 'No se muestra a los respondientes — su respuesta se rellena desde un parámetro de URL coincidente (?clave=valor).',
         fieldKey: 'Clave del campo',
@@ -2147,6 +2147,9 @@ export const es: FormsMessages = {
           'Todas las preguntas en una sola página con un solo Enviar. La lógica sigue aplicando en vivo — las preguntas aparecen y se ocultan según las respuestas.',
         coverCtaNote:
           'En un formulario de una página la portada se muestra como encabezado sobre las preguntas — no hay botón de inicio, así que su texto no se usa.',
+        endReveal: 'Pantalla de revelación antes del resultado',
+        endRevealHint:
+          'Se muestra una vez, después de Enviar y antes del resultado. Edita su texto seleccionando la tarjeta al final de la lista de preguntas.',
       },
       cover: {
         title: 'Portada',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -34,6 +34,10 @@ export interface FormsMessages {
     ctaQuestion: string;
     ctaAction: string;
     progressLabel: string; // {current} {total}
+    /** Vertical layout: the answered-question counter. // {answered} {total} */
+    verticalProgress: string;
+    /** Vertical layout: inline error summary shown next to the Submit button. */
+    verticalErrors: string;
     revealHeadline: string;
     revealSubtitle: string;
     noSteps: string;
@@ -257,6 +261,12 @@ export interface FormsMessages {
       namePlaceholder: string;
       /** V5 — inline blank-name error (replaces the browser's native bubble). */
       nameRequired: string;
+      /** Layout picker in the create dialog (slides vs vertical page). */
+      layoutLabel: string;
+      layoutSlides: string;
+      layoutSlidesDesc: string;
+      layoutVertical: string;
+      layoutVerticalDesc: string;
       cancel: string;
       emptyTitle: string;
       emptyBody: string;
@@ -489,6 +499,8 @@ export interface FormsMessages {
         terminalHint: string;
         reveal: string;
         revealHint: string;
+        /** Vertical layout: the reveal only plays after Submit, never mid-page. */
+        revealVerticalHint: string;
         /** Hidden-question toggle — filled via a URL parameter (V4-13). */
         hidden: string;
         hiddenHint: string;
@@ -521,6 +533,17 @@ export interface FormsMessages {
         hint: string;
         none: string;
         afterStep: string; // {n}
+      };
+      /** Form layout picker (Design tab): slides vs one-page vertical. */
+      layout: {
+        title: string;
+        subtitle: string;
+        slides: string;
+        slidesHint: string;
+        vertical: string;
+        verticalHint: string;
+        /** Shown in the cover section when vertical: no Start gate, CTA unused. */
+        coverCtaNote: string;
       };
       cover: {
         title: string;
@@ -572,6 +595,8 @@ export interface FormsMessages {
         title: string;
         empty: string;
         coverTitle: string;
+        /** Vertical page preview: the single Submit at the end of the page. */
+        verticalSubmit: string;
         step: string;
         of: string;
         device: string;
@@ -865,6 +890,8 @@ export const en: FormsMessages = {
     ctaQuestion: 'Want your own form?',
     ctaAction: 'Get Dapta Forms — free',
     progressLabel: 'Step {current} of {total}',
+    verticalProgress: '{answered} of {total} answered',
+    verticalErrors: 'Check the highlighted questions above.',
     revealHeadline: 'Reviewing your answers…',
     revealSubtitle: 'One moment while we match you with the best next step.',
     noSteps: 'This form has no steps yet.',
@@ -1068,6 +1095,11 @@ export const en: FormsMessages = {
       nameLabel: 'Form name',
       namePlaceholder: 'e.g. Lead qualification quiz',
       nameRequired: 'Give your form a name.',
+      layoutLabel: 'Layout',
+      layoutSlides: 'Slides',
+      layoutSlidesDesc: 'One question per screen, step by step.',
+      layoutVertical: 'One page',
+      layoutVerticalDesc: 'All questions on a single page, one Submit.',
       cancel: 'Cancel',
       emptyTitle: 'No forms yet',
       emptyBody: 'Create your first form to start collecting responses.',
@@ -1278,6 +1310,8 @@ export const en: FormsMessages = {
         reveal: 'Show reveal screen after',
         revealHint:
           'Adds a reveal card right after this question. Turning it off removes that card. Edit its copy by selecting the card.',
+        revealVerticalHint:
+          'On a one-page form the reveal never plays mid-page — it shows once, after Submit, before the result.',
         hidden: 'Hidden question',
         hiddenHint: 'Not shown to respondents — its answer is filled from a matching URL parameter (?key=value).',
         fieldKey: 'Field key',
@@ -1303,6 +1337,17 @@ export const en: FormsMessages = {
         hint: 'Save a partial submission once a question is completed, even if the respondent never finishes.',
         none: 'Off — only save completed submissions',
         afterStep: 'After question {n}',
+      },
+      layout: {
+        title: 'Layout',
+        subtitle: 'How respondents move through the form.',
+        slides: 'Slides',
+        slidesHint: 'One question per screen, step by step.',
+        vertical: 'One page',
+        verticalHint:
+          'Every question on a single page with one Submit. Logic still applies live — questions show and hide as answers change.',
+        coverCtaNote:
+          'On a one-page form the cover renders as a header above the questions — there is no Start button, so its text is not used.',
       },
       cover: {
         title: 'Cover screen',
@@ -1354,6 +1399,7 @@ export const en: FormsMessages = {
         title: 'Live preview',
         empty: 'Select a step to preview it.',
         coverTitle: 'Cover',
+        verticalSubmit: 'Submit',
         step: 'Step',
         of: 'of',
         device: 'Device preview',
@@ -1642,6 +1688,8 @@ export const es: FormsMessages = {
     ctaQuestion: '¿Quieres tu propio formulario?',
     ctaAction: 'Consigue Dapta Forms — gratis',
     progressLabel: 'Paso {current} de {total}',
+    verticalProgress: '{answered} de {total} respondidas',
+    verticalErrors: 'Revisa las preguntas marcadas arriba.',
     revealHeadline: 'Revisando tus respuestas…',
     revealSubtitle: 'Un momento mientras encontramos el mejor siguiente paso para ti.',
     noSteps: 'Este formulario aún no tiene pasos.',
@@ -1846,6 +1894,11 @@ export const es: FormsMessages = {
       nameLabel: 'Nombre del formulario',
       namePlaceholder: 'p. ej. Cuestionario de calificación de leads',
       nameRequired: 'Ponle un nombre a tu formulario.',
+      layoutLabel: 'Diseño',
+      layoutSlides: 'Diapositivas',
+      layoutSlidesDesc: 'Una pregunta por pantalla, paso a paso.',
+      layoutVertical: 'Una página',
+      layoutVerticalDesc: 'Todas las preguntas en una sola página, un solo Enviar.',
       cancel: 'Cancelar',
       emptyTitle: 'Aún no hay formularios',
       emptyBody: 'Crea tu primer formulario para empezar a recibir respuestas.',
@@ -2056,6 +2109,8 @@ export const es: FormsMessages = {
         reveal: 'Mostrar pantalla de revelación después',
         revealHint:
           'Añade una tarjeta de revelación justo después de esta pregunta. Al apagarlo se elimina esa tarjeta. Edita su texto seleccionando la tarjeta.',
+        revealVerticalHint:
+          'En un formulario de una página la revelación nunca se muestra a mitad de página — aparece una vez, después de Enviar y antes del resultado.',
         hidden: 'Pregunta oculta',
         hiddenHint: 'No se muestra a los respondientes — su respuesta se rellena desde un parámetro de URL coincidente (?clave=valor).',
         fieldKey: 'Clave del campo',
@@ -2081,6 +2136,17 @@ export const es: FormsMessages = {
         hint: 'Guarda un envío parcial al completar una pregunta, aunque la persona no termine.',
         none: 'Desactivado — solo guardar envíos completos',
         afterStep: 'Tras la pregunta {n}',
+      },
+      layout: {
+        title: 'Diseño',
+        subtitle: 'Cómo avanzan los respondientes por el formulario.',
+        slides: 'Diapositivas',
+        slidesHint: 'Una pregunta por pantalla, paso a paso.',
+        vertical: 'Una página',
+        verticalHint:
+          'Todas las preguntas en una sola página con un solo Enviar. La lógica sigue aplicando en vivo — las preguntas aparecen y se ocultan según las respuestas.',
+        coverCtaNote:
+          'En un formulario de una página la portada se muestra como encabezado sobre las preguntas — no hay botón de inicio, así que su texto no se usa.',
       },
       cover: {
         title: 'Portada',
@@ -2132,6 +2198,7 @@ export const es: FormsMessages = {
         title: 'Vista previa en vivo',
         empty: 'Selecciona un paso para previsualizarlo.',
         coverTitle: 'Portada',
+        verticalSubmit: 'Enviar',
         step: 'Paso',
         of: 'de',
         device: 'Vista por dispositivo',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,7 +5,13 @@
  * from the same schema (never trust the client; validate on both sides).
  */
 import { z } from 'zod';
-import { CONDITION_OPS, FORM_FIELD_TYPES, isSafeHttpUrl, isSafeImageUrl } from '@quill/engine';
+import {
+  CONDITION_OPS,
+  FORM_FIELD_TYPES,
+  FORM_LAYOUTS,
+  isSafeHttpUrl,
+  isSafeImageUrl,
+} from '@quill/engine';
 
 /** A URL rendered into `<img src>` — reject script protocols (XSS defense-in-depth). */
 const safeImageUrl = z
@@ -596,6 +602,11 @@ export const formConfigSchema = z.object({
   version: z.literal(1),
   branding: formBrandingSchema.nullable().optional(),
   cover: formCoverSchema.nullable().optional(),
+  /**
+   * Presentation layout for the public form (ADDITIVE — absent on every legacy
+   * config, which then renders as `'slides'`, exactly as it always has).
+   */
+  layout: z.enum(FORM_LAYOUTS).optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),


### PR DESCRIPTION
## What

Two features, one branch (they share plumbing on purpose):

1. **Vertical one-page layout** — creating or editing a form now offers two layouts: **Slides** (the original one-question-per-screen walk) and **One page** (every question on a single page, one Submit). Same engine, same logic, same submit contract.
2. **Embed on any site** — every published form can be dropped into a customer's page with a copy-paste iframe snippet that auto-sizes to its content.

## How it works

### Layout (additive config)
- `config.layout: 'slides' | 'vertical'` — **absent means slides**, resolved in one place (`resolveFormLayout`), so every published form keeps rendering exactly as before (invariant #4).
- The vertical renderer walks the same pure engine: `runtimeSteps(config, answers)` is recomputed on every answer, so **skip-logic, goto jumps, dynamic question variants and branch closing all apply live on the page**. Zero server/API/DB changes — the engine re-validates identically on submit.

### Vertical-specific behavior
- Cover renders as a **hero header** (no Start gate; its CTA text is unused and the editor says so).
- **One reveal, always at the end**: reveal cards are anchored last on every mutation (open, layout switch, reorder — a reveal dragged mid-list snaps back — and new questions insert before it). The per-question "reveal after" switch isn't offered on vertical; its replacement is a single **"Reveal screen before results"** switch in Design. The gallery's reveal tile disables itself once one exists and explains why.
- A **terminal** step with an answer hides everything after it (no auto-submit; a required question hidden by the cut never blocks Submit).
- **Schedulers embed inline** and lazy-mount near the viewport.
- Validation is inline on blur + a submit-time sweep that scrolls to the first invalid question.
- The **Build canvas is the page itself**: every question stacked and editable in place (shared `QuestionEditableBody`, so slides and vertical can't drift), one Submit at the end, and selecting a question smooth-scrolls to it.

### Funnel metrics stay comparable across layouts
- `step_view` fires when a question **enters the viewport** (index 0 on load matches a cover-less slides form, so Starts is apples-to-apples).
- `step_complete` fires when a question first holds a valid answer; `partial_submit` when the threshold answer becomes valid.
- A slider's mount-time default seeding goes through a silent `onSeed` channel: it never fires `start`/`step_complete`, never ticks the progress counter, never trips a terminal cut.
- Drop-off attribution already keys by `stepKey` (V5-D3), so `analytics.service.ts` needed no changes.

### Embeds
- `?embed=1` renders the form in content-height mode (viewport-height rules relaxed — a `dvh` rule inside an auto-sized iframe is a feedback loop; slides keeps a 480px floor).
- `EmbedHeightReporter` (embedded renders only) posts the document height on every content change. **Only a number crosses the boundary** — no answers, no identifiers — which is why `targetOrigin: '*'` is acceptable.
- `/embed.js` (static, dependency-free) sizes `data-dapta-forms` iframes, matching frames by `event.source` — never by URL — with a sanity cap.
- New **Embed** button in the editor header → dialog with the snippet, built client-side so it always carries the real origin.

## Verification (headless E2E against the dev server, plus the suite)

- **Public vertical, 20/20**: live `showWhen` (question appears/disappears with the answer), live goto pruning (and un-pruning), dynamic question variants, blur + submit validation with scroll-to-error, reveal after Submit, thank-you.
- **Event stream, exact order in DB**: `view → step_view (viewport) → start (first interaction) → step_complete × N → partial_submit → submit`; completed submission with correct score; partial persisted.
- **Gap sweep, 11/11**: name/phone/dropdown/multi-select answer and count correctly, dropdown never auto-advances, terminal cut + counter shrink + hidden-required never blocks, scheduler lazy path.
- **Editor, 10/10 + editing persistence**: one-page canvas, spine selection scrolls, in-canvas edits reach the draft (verified in SQLite); real mouse DnD: a dragged question moves, a dragged reveal snaps back to the end.
- **Embeds, 7/7 from a genuinely different origin**: vertical iframe grows 480px → content, height re-syncs when logic reveals a question, slides walk advances inside the iframe with no height loop.
- **Slides regression**: cover → start → answer → advance; single-card canvas, per-question reveal switch and gallery tile unchanged.
- `pnpm lint / typecheck / test / build` green (engine 170 tests incl. new layout + anchor helpers).

## Notes for review
- Changeset included (`vertical-form-layout`): minor for `@quill/engine`, `@quill/types`, `@quill/shared`.
- `fix/editor-topbar-and-cover-toggles` (cards/option-layout work) is still open and touches `form-logic.ts` / `types` / the editor — whichever lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)