### PR TITLE
feat: make funnel metrics accurate across layouts

### DIFF
--- a/.changeset/metrics-accuracy.md
+++ b/.changeset/metrics-accuracy.md
@@ -1,0 +1,7 @@
+---
+'@quill/db': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+Metrics accuracy: Starts now count sessions that started answering (`start` OR `step_complete`) instead of "saw the first question", which degenerated into Views on cover-less and vertical forms; a Bookings card joins the Analytics dashboard (unique booked sessions, cohort-anchored); the vertical layout's drop-off funnel counts answers (`step_complete`) instead of views, since every question is visible on load there; and the builder's question spine nudges authors to set a partial-capture point after their email question when none is configured.

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -144,14 +144,18 @@ describe('P0 metric-definition fixes', () => {
   const ev = (sessionId: string, type: string, stepIndex: number | null, at: number) =>
     recordFormEvent(db, { formId, sessionId, type, stepIndex, now: at });
 
-  it('Starts come from step_view idx 0, so a cover-less session (no `start` event) counts', async () => {
-    // A cover-less form never emits the cover-CTA `start` event; the old code
-    // counted `start` and reported 0 starts. These 3 sessions reach Q1 with NO
-    // `start` event and MUST count.
-    for (const s of ['nocover-1', 'nocover-2', 'nocover-3']) await ev(s, 'step_view', 0, NOW);
+  it('Starts count sessions that STARTED ANSWERING (start OR step_complete)', async () => {
+    // A cover-less form never emits the cover-CTA `start` event — but its
+    // respondents DO answer questions. These 3 sessions each completed Q1 with
+    // NO `start` event and MUST count. A 4th session merely SAW Q1 (step_view
+    // idx 0, the previous definition) and must NOT count — on a cover-less
+    // form the first question renders on mount, so counting sight made
+    // Starts ≈ Views.
+    for (const s of ['nocover-1', 'nocover-2', 'nocover-3']) await ev(s, 'step_complete', 0, NOW);
+    await ev('looker', 'step_view', 0, NOW);
 
     const a = (await svc.funnel(accountId, formId, {}))!;
-    expect(a.starts).toBe(11); // 8 baseline + 3 cover-less (would stay 8 under old `start`-event count)
+    expect(a.starts).toBe(11); // 8 baseline `start` + 3 answered (NOT the looker)
     expect(a.completionRate).toBe(27.3); // 3 completed / 11 starts — non-zero, the P0 fix
     // Prove the added sessions truly have no `start` event backing them.
     const startEvents = await db.get<{ n: number | string }>(
@@ -210,13 +214,13 @@ describe('P0 metric-definition fixes', () => {
     // window (each has a 'view'), but only one ever recorded reaching Q1.
     const T = NOW + 3_000_000;
     await ev('clamp-a', 'view', null, T);
-    await ev('clamp-a', 'step_view', 0, T); // clamp-a's start beacon landed
+    await ev('clamp-a', 'step_complete', 0, T); // clamp-a's start beacon landed
     await ev('clamp-b', 'view', null, T); // clamp-b's start beacon was lost
     await insertSubmission({ session: 'clamp-a', data: {}, score: 0, startedAt: T - 5_000, completedAt: T });
     await insertSubmission({ session: 'clamp-b', data: {}, score: 0, startedAt: T - 5_000, completedAt: T });
 
     const a = (await svc.funnel(accountId, formId, { from: T - 1, to: T + 1 }))!;
-    expect(a.starts).toBe(1); // only clamp-a has a step_view idx0 row
+    expect(a.starts).toBe(1); // only clamp-a has a start signal (step_complete)
     expect(a.submissions).toBe(2); // both are in-cohort (both have a 'view') and both completed
     expect(a.completionRate).toBe(100); // raw ratio would be 200%
     expect(a.trends.every((p) => p.completionRate == null || p.completionRate <= 100)).toBe(true);
@@ -331,7 +335,7 @@ describe('P0 metric-definition fixes', () => {
     // it in the SAME day.
     const midnight = Math.floor((NOW + 20 * DAY) / DAY) * DAY;
     await ev('midnight1', 'view', null, midnight - 5_000); // 5s before midnight
-    await ev('midnight1', 'step_view', 0, midnight + 5_000); // 5s after midnight
+    await ev('midnight1', 'step_complete', 0, midnight + 5_000); // 5s after midnight
     await insertSubmission({
       session: 'midnight1',
       data: {},

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,10 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { resolveFormLayout } from '@quill/engine';
 import type { Db } from '@quill/db';
 import {
   uniqueViewCount,
   startCount,
   stepViewCounts,
+  stepCompleteCounts,
   partialCount,
+  bookingCount,
   completedSubmissions,
   dailyViewSessions,
   dailyStartSessions,
@@ -155,13 +158,21 @@ export class AnalyticsService {
     if (!form) return null;
     const config = form.config as FormConfig;
     const steps = config.steps ?? [];
+    // Vertical shows every question on one page, so "viewed step X" fires for
+    // most of the form on load and the per-step funnel flattens into Views.
+    // There the honest per-question signal is "answered" (step_complete);
+    // slides keeps "reached the step" (step_view).
+    const dropoffMode = resolveFormLayout(config) === 'vertical' ? 'answered' : 'viewed';
 
-    const [views, starts, stepViews, partialSubmits, completed, dailyViews, dailyStarts] =
+    const [views, starts, stepViews, partialSubmits, bookings, completed, dailyViews, dailyStarts] =
       await Promise.all([
         uniqueViewCount(this.db, formId, range),
         startCount(this.db, formId, range),
-        stepViewCounts(this.db, formId, range),
+        dropoffMode === 'answered'
+          ? stepCompleteCounts(this.db, formId, range)
+          : stepViewCounts(this.db, formId, range),
         partialCount(this.db, formId, range),
+        bookingCount(this.db, formId, range),
         completedSubmissions(this.db, formId, range),
         dailyViewSessions(this.db, formId, range),
         dailyStartSessions(this.db, formId, range),
@@ -234,6 +245,8 @@ export class AnalyticsService {
       completionRate,
       timeToComplete,
       partialSubmits,
+      bookings,
+      dropoffMode,
       dropoff,
       trends,
       range: { from: range.from ?? null, to: range.to ?? null },

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -81,6 +81,7 @@ export function FormRenderer({
   const utmRef = useRef<Record<string, string>>({});
   const redirected = useRef(false); // a deferred redirect fires exactly once
   const viewTracked = useRef(false);
+  const startSent = useRef(false); // one `start` per session, whichever path emits it
   const partialSent = useRef(false);
   const advancing = useRef(false);
   const submitAfterReveal = useRef(false);
@@ -277,6 +278,14 @@ export function FormRenderer({
         const completedIdx = nextSteps.findIndex((s) => s.key === completed.key);
         const isLast = completedIdx >= 0 ? completedIdx >= nextSteps.length - 1 : index >= nextSteps.length - 1;
 
+        // A cover-less form has no Start CTA, so the first completed answer IS
+        // the start signal ("started answering"). The metric already counts
+        // `step_complete` sessions; this keeps the event stream itself
+        // consistent across form shapes. Cover forms emit it from `start()`.
+        if (!cover && !startSent.current) {
+          startSent.current = true;
+          track('start');
+        }
         track('step_complete', index, completed.key);
 
         // Partial submit once past the configured lead-capture threshold.
@@ -391,6 +400,7 @@ export function FormRenderer({
   }
 
   function start() {
+    startSent.current = true;
     track('start');
     lastStepViewKey.current = null;
     setPhase('steps');

--- a/apps/web/app/admin/forms/[id]/analytics/page.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/page.tsx
@@ -135,7 +135,7 @@ async function AnalyticsData({
     throw e;
   }
 
-  const hasActivity = a.views + a.starts + a.submissions + a.partialSubmits > 0;
+  const hasActivity = a.views + a.starts + a.submissions + a.partialSubmits + a.bookings > 0;
   if (!hasActivity) {
     // A filtered range with no activity is NOT the same as a form nobody has
     // ever opened — telling an owner with 500 responses "once people open your
@@ -167,13 +167,20 @@ async function AnalyticsData({
       value: a.timeToComplete == null ? '—' : formatDuration(a.timeToComplete, m.seconds),
     },
     { label: m.metricPartials, value: String(a.partialSubmits) },
+    // Only when the form actually converts through a meeting: an eternal "0"
+    // on every plain form would read as a broken metric, not an absent feature.
+    ...(a.bookings > 0 ? [{ label: m.metricBookings, value: String(a.bookings) }] : []),
   ];
 
   const maxViews = Math.max(1, ...a.dropoff.map((r) => r.views));
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+      <div
+        className={`grid grid-cols-2 gap-3 sm:grid-cols-3 ${
+          cards.length === 7 ? 'lg:grid-cols-7' : 'lg:grid-cols-6'
+        }`}
+      >
         {cards.map((c) => (
           <div key={c.label} className="rounded-lg border border-border bg-card p-4">
             <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{c.label}</div>
@@ -203,13 +210,17 @@ async function AnalyticsData({
 
       <section>
         <h2 className="text-lg font-semibold">{m.dropoffTitle}</h2>
-        <p className="mb-3 text-sm text-muted-foreground">{m.dropoffSubtitle}</p>
+        <p className="mb-3 text-sm text-muted-foreground">
+          {a.dropoffMode === 'answered' ? m.dropoffSubtitleAnswered : m.dropoffSubtitle}
+        </p>
         <div className="overflow-hidden rounded-lg border border-border bg-card">
           <table className="w-full border-collapse text-sm">
             <thead>
               <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
                 <th className="px-4 py-3 font-medium">{m.colStep}</th>
-                <th className="w-[45%] px-4 py-3 font-medium">{m.colViews}</th>
+                <th className="w-[45%] px-4 py-3 font-medium">
+                  {a.dropoffMode === 'answered' ? m.colAnswered : m.colViews}
+                </th>
                 <th className="px-4 py-3 text-right font-medium">{m.colDropoff}</th>
               </tr>
             </thead>

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -68,6 +68,10 @@ export interface BuilderMessages {
     tipCapture: string;
     /** Popover: how a partial is stored/upgraded. */
     tipStored: string;
+    /** Lead-capture nudge: email question present but no threshold set. */
+    suggestEmail: string;
+    /** The nudge's one-click action label. */
+    suggestEmailAction: string;
     /** Popover: privacy nudge about collecting unfinished answers. */
     tipNotify: string;
     /** Popover: where partials appear in the admin. */
@@ -364,6 +368,9 @@ const en: BuilderMessages = {
       'Captures respondents’ answers once they reach this point, even if they never finish the form.',
     tipStored:
       'Each partial is stored as a submission and upgraded in place if the respondent completes the form.',
+    suggestEmail:
+      'This form asks for an email, but answers are only saved at the end. Capture the lead as soon as they share their email — even if they never finish.',
+    suggestEmailAction: 'Capture after the email question',
     tipNotify: 'Consider letting respondents know their answers may be collected before they submit.',
     tipWhere: 'View them in Submissions with the “Partial” filter.',
     tipAfterLast: 'After the last question it never fires — the final submit already captures everything.',
@@ -637,6 +644,9 @@ const es: BuilderMessages = {
       'Captura las respuestas cuando la persona llega a este punto, aunque nunca termine el formulario.',
     tipStored:
       'Cada parcial se guarda como un envío y se actualiza en su lugar si la persona completa el formulario.',
+    suggestEmail:
+      'Este formulario pide un email, pero las respuestas solo se guardan al final. Captura el lead en cuanto comparta su email — aunque nunca termine.',
+    suggestEmailAction: 'Capturar tras la pregunta de email',
     tipNotify: 'Considera avisar a tus respondientes de que sus respuestas pueden recopilarse antes de enviar.',
     tipWhere: 'Míralos en Envíos con el filtro «Parciales».',
     tipAfterLast: 'Después de la última pregunta nunca se activa — el envío final ya lo captura todo.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-spine.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-spine.tsx
@@ -240,6 +240,33 @@ export function QuestionSpine({
           {m.partial.add}
         </button>
       ) : null}
+
+      {(() => {
+        // Lead-capture nudge: the form asks for an email but has no partial
+        // threshold, so a respondent who answers everything and abandons at the
+        // end (e.g. a required scheduler) leaves NOTHING behind. Suggest the
+        // fix with a one-click "capture after the email question". Only when
+        // the email question is not the last step — after the last question a
+        // threshold never fires (the final submit already captures it all).
+        const emailIdx = steps.findIndex((s) => s.type === 'email' && !s.hidden);
+        if (partialIdx != null || emailIdx < 0 || emailIdx >= steps.length - 1) return null;
+        return (
+          <div
+            data-testid="partial-point-suggest"
+            className="rounded-xl border border-secondary/40 bg-secondary/[0.06] p-3 text-xs text-muted-foreground"
+          >
+            <p>{m.partial.suggestEmail}</p>
+            <button
+              type="button"
+              data-testid="partial-point-suggest-apply"
+              onClick={() => onPartialChange(emailIdx + 1)}
+              className="mt-2 rounded-md border border-secondary/60 px-2.5 py-1 font-medium text-secondary transition-colors hover:bg-secondary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {m.partial.suggestEmailAction}
+            </button>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/db/src/analytics.spec.ts
+++ b/packages/db/src/analytics.spec.ts
@@ -20,7 +20,9 @@ import {
   uniqueViewCount,
   startCount,
   stepViewCounts,
+  stepCompleteCounts,
   partialCount,
+  bookingCount,
   completedSubmissions,
   dailyViewSessions,
   dailyStartSessions,
@@ -53,6 +55,14 @@ async function ev(
     sql`INSERT INTO form_event (id, form_id, session_id, type, step_index, step_key, created_at)
         VALUES (${randomUUID()}, ${formId}, ${sessionId}, ${type},
                 ${opts.stepIndex ?? null}, ${opts.stepKey ?? null}, ${createdAt})`,
+  );
+}
+
+/** Insert one booking-event row (provider callback) for a session. */
+async function booking(sessionId: string, createdAt: number): Promise<void> {
+  await db.run(
+    sql`INSERT INTO booking_event (id, form_id, session_id, provider, created_at)
+        VALUES (${randomUUID()}, ${formId}, ${sessionId}, ${'calendly'}, ${createdAt})`,
   );
 }
 
@@ -89,6 +99,7 @@ beforeEach(async () => {
 afterEach(async () => {
   // Leave a shared Postgres database clean (memory SQLite just evaporates).
   await db.run(sql`DELETE FROM form_event WHERE form_id = ${formId}`);
+  await db.run(sql`DELETE FROM booking_event WHERE form_id = ${formId}`);
   await db.run(sql`DELETE FROM submission WHERE form_id = ${formId}`);
   await db.run(sql`DELETE FROM form WHERE id = ${formId}`);
   await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
@@ -105,12 +116,40 @@ describe('unique counting (COUNT DISTINCT session_id)', () => {
     expect(await uniqueViewCount(db, formId)).toBe(2);
   });
 
-  it('counts a Start only for sessions that reached step_view index 0', async () => {
+  it('counts a Start only for sessions that started answering (start OR step_complete)', async () => {
+    // s1: cover form — clicked the Start CTA (start event), no answer yet.
     await ev('s1', 'view', D1 + 10);
-    await ev('s1', 'step_view', D1 + 20, { stepIndex: 0 });
-    await ev('s1', 'step_view', D1 + 30, { stepIndex: 0 }); // reload → still one
-    await ev('s2', 'view', D1 + 40); // viewed but never reached the first question
-    expect(await startCount(db, formId)).toBe(1);
+    await ev('s1', 'start', D1 + 20);
+    await ev('s1', 'start', D1 + 30); // double-fire → still one session
+    // s2: cover-less form — answered the first question (no start event).
+    await ev('s2', 'view', D1 + 40);
+    await ev('s2', 'step_view', D1 + 50, { stepIndex: 0 });
+    await ev('s2', 'step_complete', D1 + 60, { stepIndex: 0, stepKey: 'q1' });
+    // s3: only SAW the first question (cover-less mount) and left. Under the
+    // old step_view-idx-0 definition this counted as a Start, making
+    // Starts ≈ Views on cover-less forms. It must NOT count.
+    await ev('s3', 'view', D1 + 70);
+    await ev('s3', 'step_view', D1 + 80, { stepIndex: 0 });
+    expect(await startCount(db, formId)).toBe(2);
+  });
+});
+
+describe('booking count (distinct sessions, cohort-anchor windowed)', () => {
+  it('de-dupes provider double-callbacks and windows by the session anchor', async () => {
+    // s1: full funnel inside the window; Calendly fires the callback twice.
+    await ev('s1', 'view', D1 + 100);
+    await booking('s1', D1 + 500);
+    await booking('s1', D1 + 501); // duplicate callback → still one session
+    // s2: anchored the day BEFORE the window; its booking lands inside it.
+    // Cohort anchoring must attribute the booking to the anchor day (excluded).
+    await ev('s2', 'view', D0 + 100);
+    await booking('s2', D1 + 600);
+    // s3: no funnel events at all (beacons lost) — falls back to the booking's
+    // own created_at, inside the window.
+    await booking('s3', D1 + 700);
+
+    expect(await bookingCount(db, formId, WINDOW)).toBe(2); // s1 + s3
+    expect(await bookingCount(db, formId)).toBe(3); // unbounded sees all
   });
 });
 
@@ -142,10 +181,10 @@ describe('integer day bucketing (anchor / 86400000)', () => {
   });
 
   it('daily Starts follow the same anchor day even when the start event lands next day', async () => {
-    // First-seen at the end of day 20000; the actual step_view crosses into
+    // First-seen at the end of day 20000; the actual answer crosses into
     // 20001. The start must bucket into 20000 (the anchor day), not 20001.
     await ev('s', 'view', D2 - 1000);
-    await ev('s', 'step_view', D2 + 1000, { stepIndex: 0 });
+    await ev('s', 'step_complete', D2 + 1000, { stepIndex: 0, stepKey: 'q1' });
     const byDay = new Map(
       (await dailyStartSessions(db, formId)).map((r) => [r.day, r.n]),
     );
@@ -214,5 +253,17 @@ describe('step-view attribution — by authored key vs legacy index', () => {
     expect(counts.byKey.get('q_email')).toBe(1);
     expect(counts.byIndex.get(2)).toBe(1);
     expect(counts.byKey.has('__none__')).toBe(false);
+  });
+
+  it('counts step COMPLETIONS separately (the vertical funnel body)', async () => {
+    // Both sessions SAW q1; only one answered it. The answered funnel must say
+    // 1 while the viewed funnel says 2 — this split is the whole point of the
+    // vertical drop-off mode.
+    await ev('s_a', 'step_view', D1 + 100, { stepIndex: 0, stepKey: 'q1' });
+    await ev('s_a', 'step_complete', D1 + 150, { stepIndex: 0, stepKey: 'q1' });
+    await ev('s_b', 'step_view', D1 + 200, { stepIndex: 0, stepKey: 'q1' });
+
+    expect((await stepCompleteCounts(db, formId)).byKey.get('q1')).toBe(1);
+    expect((await stepViewCounts(db, formId)).byKey.get('q1')).toBe(2);
   });
 });

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -79,17 +79,22 @@ export async function uniqueViewCount(db: Db, formId: string, range?: DateRange)
 }
 
 /**
- * "Starts" = unique sessions that reached the first question (`step_view` with
- * `step_index = 0`). This is the signal that fires for EVERY form: the legacy
- * `start` event is only emitted by the cover CTA, so a cover-less form never
- * produced one and reported 0 starts (and 0% completion) despite real answers.
- * `step_view` idx 0 is captured whether or not a cover exists. Windowed by the
+ * "Starts" = unique sessions that STARTED ANSWERING: they clicked the cover CTA
+ * (`start`) or completed at least one question (`step_complete`). The previous
+ * definition — `step_view` with `step_index = 0` — degenerated on forms without
+ * a cover (and on the vertical layout, where the first question is visible on
+ * load): the first question renders on mount, so Starts ≈ Views and the metric
+ * carried no signal. Counting explicit intent instead fixes that for BOTH kinds
+ * of form, retroactively: historical sessions already carry `step_complete`
+ * rows, and cover sessions already carry `start`, so no cutover or backfill is
+ * needed. A session that only looked at question 1 and left now counts as a
+ * View (and as drop-off on that question), not as a Start. Windowed by the
  * session's cohort anchor (V5-D1) — see {@link cohortSessionIds}.
  */
 export async function startCount(db: Db, formId: string, range?: DateRange): Promise<number> {
   const row = await db.get<{ n: number | string | null }>(
     sql`SELECT COUNT(DISTINCT session_id) AS n FROM form_event
-        WHERE form_id = ${formId} AND type = 'step_view' AND step_index = 0
+        WHERE form_id = ${formId} AND type IN ('start', 'step_complete')
         AND session_id IN ${cohortSessionIds(formId, range)}`,
   );
   return Number(row?.n ?? 0);
@@ -121,16 +126,40 @@ export async function stepViewCounts(
   formId: string,
   range?: DateRange,
 ): Promise<StepViewCounts> {
+  return stepEventCounts(db, formId, 'step_view', range);
+}
+
+/**
+ * Unique-session step COMPLETIONS ("answered"), same dual keying as
+ * {@link stepViewCounts}. This is the honest funnel body for the VERTICAL
+ * layout: every question is on one page, so "viewed" fires for most of the
+ * form the moment it loads and the per-step drop-off flattens into Views.
+ * What actually varies per question there is whether it got answered.
+ */
+export async function stepCompleteCounts(
+  db: Db,
+  formId: string,
+  range?: DateRange,
+): Promise<StepViewCounts> {
+  return stepEventCounts(db, formId, 'step_complete', range);
+}
+
+async function stepEventCounts(
+  db: Db,
+  formId: string,
+  type: 'step_view' | 'step_complete',
+  range?: DateRange,
+): Promise<StepViewCounts> {
   const [keyRows, indexRows] = await Promise.all([
     db.all<{ step_key: string; n: number | string }>(
       sql`SELECT step_key, COUNT(DISTINCT session_id) AS n FROM form_event
-          WHERE form_id = ${formId} AND type = 'step_view' AND step_key IS NOT NULL
+          WHERE form_id = ${formId} AND type = ${type} AND step_key IS NOT NULL
           AND session_id IN ${cohortSessionIds(formId, range)}
           GROUP BY step_key`,
     ),
     db.all<{ step_index: number | string | null; n: number | string }>(
       sql`SELECT step_index, COUNT(DISTINCT session_id) AS n FROM form_event
-          WHERE form_id = ${formId} AND type = 'step_view' AND step_key IS NULL
+          WHERE form_id = ${formId} AND type = ${type} AND step_key IS NULL
           AND step_index IS NOT NULL
           AND session_id IN ${cohortSessionIds(formId, range)}
           GROUP BY step_index`,
@@ -167,6 +196,27 @@ export async function partialCount(db: Db, formId: string, range?: DateRange): P
     sql`SELECT COUNT(*) AS n FROM submission s
         WHERE s.form_id = ${formId} AND s.completed_at IS NULL AND s.partial_at IS NOT NULL
         ${andRange(submissionAnchor(), range)}`,
+  );
+  return Number(row?.n ?? 0);
+}
+
+/**
+ * Unique sessions that booked a meeting (scheduler step / booking outcome) —
+ * DISTINCT session_id so a provider double-callback can never count twice.
+ * Windowed by the session's cohort anchor like every other funnel metric
+ * (V5-D1): the session's earliest `form_event`, falling back to the booking's
+ * own `created_at` for a session whose top-of-funnel beacons were all lost.
+ */
+export async function bookingCount(db: Db, formId: string, range?: DateRange): Promise<number> {
+  const anchor = sql`COALESCE(
+    (SELECT MIN(fe.created_at) FROM form_event fe
+     WHERE fe.form_id = b.form_id AND fe.session_id = b.session_id),
+    b.created_at
+  )`;
+  const row = await db.get<{ n: number | string | null }>(
+    sql`SELECT COUNT(DISTINCT b.session_id) AS n FROM booking_event b
+        WHERE b.form_id = ${formId}
+        ${andRange(anchor, range)}`,
   );
   return Number(row?.n ?? 0);
 }
@@ -278,14 +328,15 @@ export async function dailyViewSessions(
   return rows.map((r) => ({ day: Number(r.day), n: Number(r.n) }));
 }
 
-/** Per-day unique sessions that reached the first question (trend for Starts). */
+/** Per-day unique sessions that started answering (trend for Starts — same
+ *  `start`/`step_complete` definition as {@link startCount}). */
 export async function dailyStartSessions(
   db: Db,
   formId: string,
   range?: DateRange,
 ): Promise<{ day: number; n: number }[]> {
   const rows = await db.all<{ day: number | string; n: number | string }>(
-    dailySessionsQuery(formId, sql`type = 'step_view' AND step_index = 0`, range),
+    dailySessionsQuery(formId, sql`type IN ('start', 'step_complete')`, range),
   );
   return rows.map((r) => ({ day: Number(r.day), n: Number(r.n) }));
 }

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -778,6 +778,7 @@ export interface FormsMessages {
       metricCompletionRate: string;
       metricTimeToComplete: string;
       metricPartials: string;
+      metricBookings: string;
       rangeToday: string;
       rangeWeek: string;
       rangeMonth: string;
@@ -796,7 +797,9 @@ export interface FormsMessages {
       dropoffSubtitle: string;
       colStep: string;
       colViews: string;
+      colAnswered: string;
       colDropoff: string;
+      dropoffSubtitleAnswered: string;
       coverRow: string;
       landingRow: string;
       emptyRangeTitle: string;
@@ -1690,6 +1693,7 @@ export const en: FormsMessages = {
       metricCompletionRate: 'Completion rate',
       metricTimeToComplete: 'Time to complete',
       metricPartials: 'Partial submits',
+      metricBookings: 'Bookings',
       rangeToday: 'Today',
       rangeWeek: 'Last week',
       rangeMonth: 'Last month',
@@ -1707,7 +1711,9 @@ export const en: FormsMessages = {
       dropoffSubtitle: 'How many people reach each step, and how many leave.',
       colStep: 'Step',
       colViews: 'Views',
+      colAnswered: 'Answered',
       colDropoff: 'Drop-off',
+      dropoffSubtitleAnswered: 'How many people answer each question, and how many stop there.',
       coverRow: 'Cover / landing',
       landingRow: 'Form views',
       emptyRangeTitle: 'No activity in this range',
@@ -2603,6 +2609,7 @@ export const es: FormsMessages = {
       metricCompletionRate: 'Tasa de finalización',
       metricTimeToComplete: 'Tiempo para completar',
       metricPartials: 'Envíos parciales',
+      metricBookings: 'Reservas',
       rangeToday: 'Hoy',
       rangeWeek: 'Última semana',
       rangeMonth: 'Último mes',
@@ -2620,7 +2627,9 @@ export const es: FormsMessages = {
       dropoffSubtitle: 'Cuántas personas llegan a cada paso y cuántas se van.',
       colStep: 'Paso',
       colViews: 'Vistas',
+      colAnswered: 'Respondida',
       colDropoff: 'Abandono',
+      dropoffSubtitleAnswered: 'Cuántas personas responden cada pregunta y cuántas se detienen ahí.',
       coverRow: 'Portada / inicio',
       landingRow: 'Vistas del formulario',
       emptyRangeTitle: 'Sin actividad en este rango',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -919,6 +919,18 @@ export const analyticsResponseSchema = z.object({
   timeToComplete: z.number().int().nullable(),
   /** Partial-only submissions (partialAt set, completedAt null). */
   partialSubmits: z.number().int(),
+  /**
+   * Unique sessions that booked a meeting (scheduler step / booking outcome).
+   * For a form whose conversion is the meeting, this is the real bottom of the
+   * funnel — Submissions alone under-reports it.
+   */
+  bookings: z.number().int(),
+  /**
+   * What the drop-off funnel body counts per step: `viewed` (slides — reached
+   * the step) or `answered` (vertical — completed it; every question is
+   * visible on load there, so "viewed" would flatten into Views).
+   */
+  dropoffMode: z.enum(['viewed', 'answered']),
   /** Cover row + one row per configured step. */
   dropoff: z.array(dropoffRowSchema),
   /** Gap-filled per-day series for the Trends chart (oldest → newest). */


### PR DESCRIPTION
## What

Four metric-accuracy fixes, verified live (16/16 headless E2E checks on :3500) and unit-tested (all suites green).

### 1. Starts = started answering (`start` OR `step_complete`)
The old definition — `step_view` at index 0 — degenerated on cover-less forms and on the vertical layout: the first question renders on load, so **Starts ≈ Views** and the metric carried no signal. Starts now count sessions that clicked the cover CTA **or** completed at least one question. No backfill needed: historical sessions already carry `step_complete` rows, and cover sessions already carry `start`. Cover-less slides forms also emit `start` on the first completed answer now, keeping the event stream consistent (vertical already did).

### 2. Bookings card in Analytics
`booking_event` was recorded but invisible. For a form that converts through a meeting, booking IS the conversion. New `bookingCount`: unique booked sessions, cohort-anchored (V5-D1), de-duped against provider double-callbacks. The card renders only when the form has bookings, so plain forms keep their 6-card grid.

### 3. Vertical drop-off counts answers, not views
On a one-page form every question is "viewed" the moment the page loads — the viewed funnel flattened into Views. When `layout: 'vertical'`, the funnel body uses `step_complete` (answered) per step key. The response carries `dropoffMode: 'viewed' | 'answered'` and the dashboard labels the column honestly (Views / Answered, EN+ES).

### 4. Lead-capture nudge in the builder
The lost-lead scenario found in QA: a form asks for email, the respondent answers everything, abandons at the final (required) scheduler — and leaves **nothing** behind because no partial threshold was set. The question spine now shows a one-click suggestion ("Capture after the email question") when the form has an email step, no threshold, and the email question is not last (a threshold after the last question never fires).

## Verification
- `pnpm test` all green (engine 212, web 81, db 62, api 129, destinations 51); typecheck + lint + build pass
- New unit tests: startCount definition (looker ≠ starter), bookingCount (dedupe + cohort window + lost-beacon fallback), stepCompleteCounts vs stepViewCounts split
- Live E2E (headless Chrome): looker session → Starts 0; answering session → Starts 1; vertical `dropoffMode='answered'` with per-question answered counts; Bookings card shows 1 after a double-callback insert; nudge appears → one click sets the marker → nudge gone; no nudge when email is the last question
- Read-only repo reviewer pass: no invariant violations (portable SQL, additive schema, i18n parity, DCO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)