### PR TITLE
release(email): use plural Forms sender

### DIFF
--- a/packages/notifications/src/adapters/http.spec.ts
+++ b/packages/notifications/src/adapters/http.spec.ts
@@ -47,7 +47,7 @@ describe('HttpEmailProvider — transactional-v1', () => {
         profile: 'transactional-v1',
         clientId: CLIENT_ID,
         signingSecret: SECRET,
-        fromEmail: 'form@notifications-dapta.ai',
+        fromEmail: 'forms@notifications-dapta.ai',
         fromName: 'Dapta Forms',
       },
       impl,
@@ -101,7 +101,7 @@ describe('HttpEmailProvider — transactional-v1', () => {
   it('requires a tenant account context on the signed wire', async () => {
     const { impl } = stubFetch();
     const provider = new HttpEmailProvider(
-      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'form@notifications-dapta.ai' },
+      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'forms@notifications-dapta.ai' },
       impl,
     );
     expect(provider.requiresAccountContext).toBe(true);
@@ -111,7 +111,7 @@ describe('HttpEmailProvider — transactional-v1', () => {
   it('throws on a non-2xx so the outbox retries (never a silent drop)', async () => {
     const { impl } = stubFetch(500, {});
     const provider = new HttpEmailProvider(
-      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'form@notifications-dapta.ai' },
+      { endpoint: ENDPOINT, profile: 'transactional-v1', clientId: CLIENT_ID, signingSecret: SECRET, fromEmail: 'forms@notifications-dapta.ai' },
       impl,
     );
     await expect(

--- a/packages/notifications/src/factory.spec.ts
+++ b/packages/notifications/src/factory.spec.ts
@@ -26,7 +26,7 @@ describe('createEmailProvider — env gating', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const provider = createEmailProvider({
       provider: 'http',
-      fromEmail: 'form@notifications-dapta.ai',
+      fromEmail: 'forms@notifications-dapta.ai',
       http: { endpoint: 'https://email.example.com/api/internal/email/send', profile: 'transactional-v1' },
     });
     expect(provider).toBeInstanceOf(LogOnlyEmailProvider);
@@ -37,7 +37,7 @@ describe('createEmailProvider — env gating', () => {
   it('builds the signed HTTP provider when endpoint + clientId + secret are all set', () => {
     const provider = createEmailProvider({
       provider: 'http',
-      fromEmail: 'form@notifications-dapta.ai',
+      fromEmail: 'forms@notifications-dapta.ai',
       fromName: 'Dapta Forms',
       http: {
         endpoint: 'https://email.example.com/api/internal/email/send',


### PR DESCRIPTION
## Production release

This is the exact reviewed test alignment from develop PR #42, cherry-picked onto the current production branch so the release contains no unrelated Forms work.

- replace the former singular form@ examples with forms@notifications-dapta.ai
- no runtime logic changes
- prevents future regression of the sender identity

## Effective diff

- 2 test files
- 5 insertions / 5 deletions

## Verification

The source patch passed:

- 34 notification tests
- notification lint
- notification typecheck
- full repository CI and DCO

The release cherry-pick is patch-equivalent to the reviewed source commit.