### PR TITLE
feat(web): import dropdown/choice options from a spreadsheet paste

### DIFF
--- a/.changeset/options-import.md
+++ b/.changeset/options-import.md
@@ -1,0 +1,5 @@
+---
+'@quill/shared': minor
+---
+
+Builder: dropdown and multiple-choice questions can now import their options from a spreadsheet paste — one or two columns (option + optional score), TSV/CSV/semicolon or one-per-line, with automatic header detection (EN/ES), per-row validation that never blocks the rest of the paste, duplicate de-duplication, and replace/append modes.

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { useState } from 'react';
 import type { FormOption, FormOptionLayout } from '@quill/engine';
 import { slugify } from '@quill/engine';
 import { Button } from '@/components/ui/button';
 import { HelpTip } from '@/components/ui/help-tip';
 import { TextField, NumberField } from './fields';
 import { IconPicker } from './icon-picker';
+import { OptionsImportModal } from './options-import-modal';
 import { SortableList, SortableRow } from './sortable';
 import type { EditorMessages } from './messages';
 
@@ -42,6 +44,7 @@ export function OptionsEditor({
   m: EditorMessages['options'];
 }) {
   const ids = options.map((_, i) => `opt-${i}`);
+  const [importOpen, setImportOpen] = useState(false);
 
   function update(index: number, patch: Partial<FormOption>) {
     onChange(options.map((o, i) => (i === index ? { ...o, ...patch } : o)));
@@ -165,11 +168,27 @@ export function OptionsEditor({
           {m.pointsHint}
         </p>
       ) : null}
-      <div>
+      <div className="flex flex-wrap gap-2">
         <Button variant="outline" size="sm" onClick={add}>
           <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
         </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="options-import-open"
+          onClick={() => setImportOpen(true)}
+        >
+          <i aria-hidden className="pi pi-file-import" style={{ fontSize: 11 }} /> {m.importer.open}
+        </Button>
       </div>
+      <OptionsImportModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        options={options}
+        onApply={onChange}
+        scoringEnabled={showPoints}
+        m={m.importer}
+      />
     </div>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-import-modal.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-import-modal.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { FormOption } from '@quill/engine';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { parseOptionsPaste, buildImportedOptions, type ImportRow } from './options-import';
+import type { EditorMessages } from './messages';
+
+/**
+ * "Import options from a spreadsheet" — the modal behind the button in
+ * {@link OptionsEditor}. A big paste box with a LIVE preview underneath:
+ * every keystroke re-parses (the parser is pure and cheap), each row shows
+ * its fate (ok / duplicate / invalid score), and the CTA always states
+ * exactly how many options it will import. Errors never block the paste —
+ * an author fixes two cells in the preview's terms, not by re-copying 200.
+ */
+export function OptionsImportModal({
+  open,
+  onClose,
+  options,
+  onApply,
+  scoringEnabled,
+  m,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** The question's current options (append de-dupes against them). */
+  options: FormOption[];
+  onApply: (next: FormOption[]) => void;
+  /** The question is scored — used for the "no scores in paste" note. */
+  scoringEnabled: boolean;
+  m: EditorMessages['options']['importer'];
+}) {
+  const [text, setText] = useState('');
+  const [mode, setMode] = useState<'replace' | 'append'>('replace');
+
+  const parsed = useMemo(
+    () =>
+      parseOptionsPaste(text, {
+        existingLabels: mode === 'append' ? options.map((o) => o.label) : [],
+      }),
+    [text, mode, options],
+  );
+
+  const importable = parsed.importable;
+  const anyScore = importable.some((r) => r.points != null);
+  const replaceLosesIcons = mode === 'replace' && options.some((o) => o.icon);
+
+  const summary: string[] = [];
+  if (parsed.rows.length > 0) {
+    summary.push(interpolate2(m.summaryValid, importable.length));
+    if (anyScore)
+      summary.push(interpolate2(m.summaryWithScore, importable.filter((r) => r.points != null).length));
+    if (parsed.skippedHeader) summary.push(m.summaryHeaderSkipped);
+    if (parsed.extraColumns) summary.push(m.summaryExtraColumns);
+    if (parsed.truncated)
+      summary.push(
+        interpolate2(m.summaryTruncated, parsed.rows.filter((r) => r.status === 'ok').length - importable.length),
+      );
+  }
+
+  function statusLabel(r: ImportRow): { text: string; tone: 'ok' | 'warn' | 'bad' } {
+    if (r.status === 'duplicate') return { text: m.statusDuplicate, tone: 'warn' };
+    if (r.status === 'invalidPoints') return { text: m.statusInvalid, tone: 'bad' };
+    if (r.rounded) return { text: interpolate2(m.statusRounded, r.points ?? 0), tone: 'ok' };
+    return { text: m.statusOk, tone: 'ok' };
+  }
+
+  function apply() {
+    onApply(buildImportedOptions(importable, options, mode));
+    setText('');
+    onClose();
+  }
+
+  const toneClass = {
+    ok: 'bg-primary/10 text-primary',
+    warn: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+    bad: 'bg-destructive/10 text-destructive',
+  } as const;
+
+  return (
+    <Modal open={open} onClose={onClose} title={m.title} labelId="options-import-title">
+      <div className="flex flex-col gap-3">
+        <p className="text-xs text-muted-foreground">{m.intro}</p>
+        <textarea
+          data-testid="options-import-paste"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={m.placeholder}
+          spellCheck={false}
+          rows={6}
+          className="w-full resize-y rounded-md border border-border bg-background px-3 py-2 font-mono text-xs leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div
+            className="inline-flex overflow-hidden rounded-md border border-border"
+            role="group"
+            aria-label={m.title}
+          >
+            {(['replace', 'append'] as const).map((mo) => (
+              <button
+                key={mo}
+                type="button"
+                data-testid={`options-import-mode-${mo}`}
+                onClick={() => setMode(mo)}
+                className={
+                  'px-3 py-1.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ' +
+                  (mode === mo
+                    ? 'bg-primary/15 font-semibold text-foreground'
+                    : 'bg-card text-muted-foreground hover:text-foreground')
+                }
+              >
+                {mo === 'replace' ? m.modeReplace : m.modeAppend}
+              </button>
+            ))}
+          </div>
+          {summary.length > 0 ? (
+            <p data-testid="options-import-summary" className="text-xs tabular-nums text-muted-foreground" aria-live="polite">
+              {summary.join(' · ')}
+            </p>
+          ) : null}
+        </div>
+
+        {parsed.rows.length > 0 ? (
+          <div className="max-h-56 overflow-y-auto rounded-md border border-border">
+            <table className="w-full border-collapse text-xs" data-testid="options-import-preview">
+              <thead className="sticky top-0 bg-card">
+                <tr className="border-b border-border text-left text-[10px] uppercase tracking-wide text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">{m.colOption}</th>
+                  <th className="w-16 px-3 py-2 font-medium">{m.colScore}</th>
+                  <th className="w-28 px-3 py-2 font-medium">{m.colStatus}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {parsed.rows.map((r) => {
+                  const st = statusLabel(r);
+                  return (
+                    <tr key={`${r.line}-${r.label}`} className="border-b border-border last:border-b-0">
+                      <td className="px-3 py-1.5">{r.label}</td>
+                      <td className="px-3 py-1.5 font-mono tabular-nums">{r.points ?? '—'}</td>
+                      <td className="px-3 py-1.5">
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${toneClass[st.tone]}`}>
+                          {st.text}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
+        {replaceLosesIcons ? (
+          <p className="text-xs text-amber-600 dark:text-amber-400" data-testid="options-import-icons-note">
+            {m.replaceIconsNote}
+          </p>
+        ) : null}
+        {scoringEnabled && parsed.rows.length > 0 && !anyScore ? (
+          <p className="text-xs text-muted-foreground" data-testid="options-import-noscores-note">
+            {m.noScoresNote}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            {m.cancel}
+          </Button>
+          <Button
+            size="sm"
+            data-testid="options-import-apply"
+            disabled={importable.length === 0}
+            onClick={apply}
+          >
+            {interpolate2(m.submit, importable.length)}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/** `{n}` interpolation for the importer strings (engine interpolate expects answers). */
+function interpolate2(template: string, n: number): string {
+  return template.replace('{n}', String(n));
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-import.spec.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-import.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { parseOptionsPaste, buildImportedOptions, OPTIONS_IMPORT_CAP } from './options-import';
+
+describe('parseOptionsPaste — delimiter detection', () => {
+  it('parses a Sheets copy (TSV) with two columns', () => {
+    const r = parseOptionsPaste('SaaS B2B\t10\nE-commerce\t8');
+    expect(r.delimiter).toBe('\t');
+    expect(r.rows).toEqual([
+      { line: 1, label: 'SaaS B2B', points: 10, status: 'ok', rounded: false },
+      { line: 2, label: 'E-commerce', points: 8, status: 'ok', rounded: false },
+    ]);
+  });
+
+  it('parses CSV and semicolon exports', () => {
+    expect(parseOptionsPaste('A,1\nB,2').delimiter).toBe(',');
+    expect(parseOptionsPaste('A;1\nB;2').delimiter).toBe(';');
+  });
+
+  it('treats a plain list (no delimiter) as label-only rows', () => {
+    const r = parseOptionsPaste('One\nTwo\nThree');
+    expect(r.delimiter).toBeNull();
+    expect(r.rows.map((x) => x.points)).toEqual([null, null, null]);
+  });
+
+  it('a stray comma inside ONE label does not turn the paste two-column', () => {
+    // 1 of 3 lines has a comma → below the 80% consistency bar.
+    const r = parseOptionsPaste('Health, wellness\nFinance\nEducation');
+    expect(r.delimiter).toBeNull();
+    expect(r.rows[0]!.label).toBe('Health, wellness');
+  });
+});
+
+describe('parseOptionsPaste — header detection', () => {
+  it('skips an EN header row', () => {
+    const r = parseOptionsPaste('Option\tScore\nSaaS\t10');
+    expect(r.skippedHeader).toBe(true);
+    expect(r.rows).toHaveLength(1);
+  });
+
+  it('skips an ES header row', () => {
+    const r = parseOptionsPaste('Opción\tPuntos\nSalud\t7');
+    expect(r.skippedHeader).toBe(true);
+    expect(r.rows[0]!.label).toBe('Salud');
+  });
+
+  it('skips an unknown header when the score column is numeric below', () => {
+    const r = parseOptionsPaste('Industria\tCalificación\nSaaS\t10');
+    expect(r.skippedHeader).toBe(true);
+  });
+
+  it('keeps row 1 when nothing marks it as a header', () => {
+    const r = parseOptionsPaste('SaaS\t10\nSalud\t7');
+    expect(r.skippedHeader).toBe(false);
+    expect(r.rows).toHaveLength(2);
+  });
+
+  it('never treats a single-line paste as a header', () => {
+    const r = parseOptionsPaste('Option\t5');
+    expect(r.skippedHeader).toBe(false);
+    expect(r.rows).toHaveLength(1);
+  });
+});
+
+describe('parseOptionsPaste — per-row tolerance', () => {
+  it('marks a non-numeric score as invalidPoints without failing the rest', () => {
+    const r = parseOptionsPaste('A\t1\nB\tN/A\nC\t3');
+    expect(r.rows.map((x) => x.status)).toEqual(['ok', 'invalidPoints', 'ok']);
+    expect(r.importable.map((x) => x.label)).toEqual(['A', 'C']);
+  });
+
+  it('rounds decimal scores and flags them', () => {
+    const r = parseOptionsPaste('A\t7.4\nB\t7,6');
+    expect(r.rows[0]).toMatchObject({ points: 7, rounded: true });
+    expect(r.rows[1]).toMatchObject({ points: 8, rounded: true });
+  });
+
+  it('de-dupes by normalized label — first wins, case-insensitive', () => {
+    const r = parseOptionsPaste('SaaS\t10\nsaas\t9\n SaaS \t8');
+    expect(r.rows.map((x) => x.status)).toEqual(['ok', 'duplicate', 'duplicate']);
+  });
+
+  it('de-dupes against existing options (append mode)', () => {
+    const r = parseOptionsPaste('Kept\t1\nNew\t2', { existingLabels: ['kept'] });
+    expect(r.rows.map((x) => x.status)).toEqual(['duplicate', 'ok']);
+  });
+
+  it('ignores empty lines and empty labels, keeps source line numbers', () => {
+    const r = parseOptionsPaste('A\t1\n\n\t9\nB\t2');
+    expect(r.rows.map((x) => [x.line, x.label])).toEqual([
+      [1, 'A'],
+      [4, 'B'],
+    ]);
+  });
+
+  it('flags extra columns and ignores them', () => {
+    const r = parseOptionsPaste('A,1,note\nB,2,note');
+    expect(r.extraColumns).toBe(true);
+    expect(r.rows[0]).toMatchObject({ label: 'A', points: 1 });
+  });
+
+  it('truncates at the cap, counting existing options against it', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `Opt ${i}`).join('\n');
+    const r = parseOptionsPaste(lines, { cap: 25, existingLabels: ['x', 'y'] });
+    expect(r.importable).toHaveLength(23);
+    expect(r.truncated).toBe(true);
+    expect(OPTIONS_IMPORT_CAP).toBe(200);
+  });
+});
+
+describe('buildImportedOptions', () => {
+  const rows = parseOptionsPaste('SaaS B2B\t10\nE-commerce\t8\nSin score').importable;
+
+  it('replace: clean slate, slugged values, points only where present', () => {
+    const out = buildImportedOptions(rows, [{ label: 'Old', value: 'old', icon: '⭐' }], 'replace');
+    expect(out).toEqual([
+      { label: 'SaaS B2B', value: 'saas_b2b', points: 10 },
+      { label: 'E-commerce', value: 'e_commerce', points: 8 },
+      { label: 'Sin score', value: 'sin_score' },
+    ]);
+  });
+
+  it('append: keeps existing options (icons included) and de-collides values', () => {
+    const existing = [{ label: 'SaaS old', value: 'saas_b2b', icon: '⭐' }];
+    const out = buildImportedOptions(rows, existing, 'append');
+    expect(out[0]).toEqual(existing[0]); // untouched, icon survives
+    expect(out[1]!.value).toBe('saas_b2b-2'); // collision suffixed
+  });
+
+  it('never emits a comma inside a value (variant-key separator)', () => {
+    const r = parseOptionsPaste('Salud; bienestar y más\t5\nOtra\t1');
+    const out = buildImportedOptions(r.importable, [], 'replace');
+    for (const o of out) expect(o.value.includes(',')).toBe(false);
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-import.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-import.ts
@@ -1,0 +1,192 @@
+/**
+ * Spreadsheet-paste → options parser (pure, unit-tested — no React, no I/O).
+ *
+ * Authors keep long option lists (industries, countries, products) in a
+ * spreadsheet, usually with the qualification score in the next column.
+ * Copying 1–2 columns out of Google Sheets/Excel puts TSV on the clipboard;
+ * exports and hand-written lists arrive as CSV/semicolon or one-per-line.
+ * This module turns any of those into `FormOption[]` rows, being tolerant
+ * per row (a bad score marks THAT row, never fails the paste) so an author
+ * can fix two cells instead of re-copying two hundred.
+ */
+import type { FormOption } from '@quill/engine';
+import { slugify } from '@quill/engine';
+
+/** Hard cap on options per question — same ceiling the editor enforces. */
+export const OPTIONS_IMPORT_CAP = 200;
+
+/** Header tokens (col 1) that mark row 1 as a header, EN + ES. */
+const HEADER_WORDS = /^(option|opci[oó]n|label|etiqueta|choice|answer|respuesta|item)$/i;
+
+export type ImportRowStatus = 'ok' | 'duplicate' | 'invalidPoints';
+
+export interface ImportRow {
+  /** 1-based line number in the pasted text (for the preview + error messages). */
+  line: number;
+  label: string;
+  /** Parsed integer score, or null when the row carried none. */
+  points: number | null;
+  status: ImportRowStatus;
+  /** True when a decimal score was rounded to the integer the schema stores. */
+  rounded: boolean;
+}
+
+export interface ImportParseResult {
+  rows: ImportRow[];
+  /** Rows that will actually import (status ok, within the cap). */
+  importable: ImportRow[];
+  delimiter: '\t' | ';' | ',' | null;
+  skippedHeader: boolean;
+  /** Some line had more than two columns (extras are ignored). */
+  extraColumns: boolean;
+  /** The cap cut valid rows off the end. */
+  truncated: boolean;
+}
+
+/**
+ * Pick the column delimiter. A tab wins on a SINGLE occurrence: tabs never
+ * appear inside a hand-typed label — their presence means the clipboard came
+ * from a spreadsheet, where a row with an empty score cell may carry no tab at
+ * all. `;`/`,` DO occur inside prose labels ("Health, wellness"), so those
+ * need 80% of lines to agree before the paste is treated as two-column.
+ * Null = single column (labels only, no scores).
+ */
+function detectDelimiter(lines: string[]): '\t' | ';' | ',' | null {
+  if (lines.some((l) => l.includes('\t'))) return '\t';
+  const need = Math.max(1, Math.ceil(lines.length * 0.8));
+  for (const d of [';', ','] as const) {
+    if (lines.filter((l) => l.includes(d)).length >= need) return d;
+  }
+  return null;
+}
+
+/** Parse a score cell to an integer; null = empty, NaN = invalid. */
+function parseScore(raw: string): number {
+  // A decimal comma only survives here on tab/semicolon pastes (on a comma
+  // paste it was already a column split) — normalize it to a dot.
+  return Number(raw.replace(',', '.'));
+}
+
+/**
+ * Row 1 is a header when its first cell is a known header word, or when the
+ * sheet clearly has a score column (some later row parses numeric there) but
+ * row 1's second cell does not. A single-line paste is never a header.
+ */
+function isHeader(cols: string[], hasNumericBelow: boolean): boolean {
+  const first = (cols[0] ?? '').trim();
+  if (HEADER_WORDS.test(first)) return true;
+  const second = (cols[1] ?? '').trim();
+  if (second !== '' && Number.isNaN(parseScore(second)) && hasNumericBelow) return true;
+  return false;
+}
+
+/**
+ * Parse pasted spreadsheet text into preview rows. `existingLabels` (append
+ * mode) count toward de-duplication — the paste can never re-add an option
+ * the question already has. Every anomaly is a per-row status or a flag on
+ * the result; parsing itself never throws.
+ */
+export function parseOptionsPaste(
+  text: string,
+  opts: { existingLabels?: string[]; cap?: number } = {},
+): ImportParseResult {
+  const cap = opts.cap ?? OPTIONS_IMPORT_CAP;
+  const allLines = text.split(/\r?\n/);
+  const lines: { n: number; text: string }[] = [];
+  allLines.forEach((l, i) => {
+    if (l.trim() !== '') lines.push({ n: i + 1, text: l });
+  });
+
+  const result: ImportParseResult = {
+    rows: [],
+    importable: [],
+    delimiter: null,
+    skippedHeader: false,
+    extraColumns: false,
+    truncated: false,
+  };
+  if (lines.length === 0) return result;
+
+  const delimiter = detectDelimiter(lines.map((l) => l.text));
+  result.delimiter = delimiter;
+  const split = (l: string) => (delimiter ? l.split(delimiter) : [l]);
+
+  let startAt = 0;
+  if (delimiter && lines.length > 1) {
+    const numericBelow = lines
+      .slice(1)
+      .some((l) => {
+        const c = split(l.text)[1]?.trim() ?? '';
+        return c !== '' && !Number.isNaN(parseScore(c));
+      });
+    if (isHeader(split(lines[0]!.text), numericBelow)) {
+      startAt = 1;
+      result.skippedHeader = true;
+    }
+  }
+
+  const seen = new Set(
+    (opts.existingLabels ?? []).map((l) => l.trim().toLowerCase()).filter(Boolean),
+  );
+
+  for (let i = startAt; i < lines.length; i++) {
+    const cols = split(lines[i]!.text);
+    if (cols.length > 2) result.extraColumns = true;
+    const label = (cols[0] ?? '').trim().slice(0, 200);
+    if (!label) continue; // a delimiter-only line ("\t") carries nothing
+
+    const row: ImportRow = { line: lines[i]!.n, label, points: null, status: 'ok', rounded: false };
+
+    const key = label.toLowerCase();
+    if (seen.has(key)) row.status = 'duplicate';
+    else seen.add(key);
+
+    const rawScore = (cols[1] ?? '').trim();
+    if (rawScore !== '') {
+      const num = parseScore(rawScore);
+      if (Number.isNaN(num)) {
+        // A duplicate row keeps its (more actionable) duplicate status.
+        if (row.status === 'ok') row.status = 'invalidPoints';
+      } else {
+        row.points = Math.round(num);
+        row.rounded = num !== row.points;
+      }
+    }
+
+    result.rows.push(row);
+  }
+
+  // Cap so that existing + imported never exceeds the per-question ceiling.
+  const ok = result.rows.filter((r) => r.status === 'ok');
+  const allowed = Math.max(0, cap - (opts.existingLabels ?? []).length);
+  result.importable = ok.slice(0, allowed);
+  result.truncated = ok.length > result.importable.length;
+  return result;
+}
+
+/**
+ * Materialize the importable rows into `FormOption[]`. Values are slugified
+ * labels, suffixed `-2`, `-3`… on collision (against BOTH the kept existing
+ * options and earlier imported rows), and never contain a comma — a comma in
+ * an option value is the separator in dynamic-question variant keys.
+ * `append` keeps the current options (icons included); `replace` starts clean.
+ */
+export function buildImportedOptions(
+  importable: ImportRow[],
+  existing: FormOption[],
+  mode: 'replace' | 'append',
+): FormOption[] {
+  const base = mode === 'append' ? [...existing] : [];
+  const taken = new Set(base.map((o) => o.value));
+  const out = [...base];
+  importable.forEach((r, i) => {
+    const root = slugify(r.label, `option_${i + 1}`).replace(/,/g, '');
+    let value = root;
+    for (let k = 2; taken.has(value); k++) value = `${root}-${k}`;
+    taken.add(value);
+    const option: FormOption = { label: r.label, value };
+    if (r.points != null) option.points = r.points;
+    out.push(option);
+  });
+  return out;
+}

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -424,6 +424,40 @@ export interface FormsMessages {
         valueHelp: string;
         /** V5 — what the visible label is. */
         labelHelp: string;
+        /** Spreadsheet-paste import (option + optional score columns). */
+        importer: {
+          /** The "Import options" button beside "Add option". */
+          open: string;
+          title: string;
+          /** One-line how-to above the textarea. */
+          intro: string;
+          placeholder: string;
+          modeReplace: string;
+          modeAppend: string;
+          colOption: string;
+          colScore: string;
+          colStatus: string;
+          statusOk: string;
+          statusDuplicate: string;
+          statusInvalid: string;
+          /** {n} — decimal rounded to this integer. */
+          statusRounded: string;
+          /** {n} valid rows summary chip. */
+          summaryValid: string;
+          /** {n} rows carrying a score. */
+          summaryWithScore: string;
+          summaryHeaderSkipped: string;
+          summaryExtraColumns: string;
+          /** {n} rows cut by the per-question cap. */
+          summaryTruncated: string;
+          /** CTA — {n} interpolated. */
+          submit: string;
+          /** Replace would drop icons the current options carry. */
+          replaceIconsNote: string;
+          /** Paste has no score column but the question is scored. */
+          noScoresNote: string;
+          cancel: string;
+        };
       };
       sliderScoring: {
         title: string;
@@ -1423,6 +1457,31 @@ export const en: FormsMessages = {
         labelHelp: 'What respondents read on the option. Safe to reword at any time.',
         valueHelp:
           'What gets stored in the response and sent to HubSpot or a webhook. Keep it stable — changing it breaks past answers and any mapping that points at it.',
+        importer: {
+          open: 'Import options',
+          title: 'Import options from a spreadsheet',
+          intro:
+            'Copy one or two columns from your sheet and paste them here. Column 1 is the option, column 2 (optional) is its score. A header row is detected automatically.',
+          placeholder: 'SaaS B2B\t10\nE-commerce\t8\nHealthcare\t7',
+          modeReplace: 'Replace options',
+          modeAppend: 'Add to the end',
+          colOption: 'Option',
+          colScore: 'Score',
+          colStatus: 'Status',
+          statusOk: 'ok',
+          statusDuplicate: 'duplicate',
+          statusInvalid: 'invalid score',
+          statusRounded: 'rounded to {n}',
+          summaryValid: '{n} valid',
+          summaryWithScore: '{n} with score',
+          summaryHeaderSkipped: 'header skipped',
+          summaryExtraColumns: 'extra columns ignored',
+          summaryTruncated: '{n} over the limit',
+          submit: 'Import {n} options',
+          replaceIconsNote: 'Replacing removes the icons your current options carry.',
+          noScoresNote: 'No scores in this paste — this question keeps its current points.',
+          cancel: 'Cancel',
+        },
       },
       sliderScoring: {
         title: 'Slider scoring',
@@ -2352,6 +2411,31 @@ export const es: FormsMessages = {
         labelHelp: 'Lo que leen los respondientes en la opción. Puedes reescribirlo cuando quieras.',
         valueHelp:
           'Lo que se guarda en la respuesta y se envía a HubSpot o al webhook. Mantenlo estable — cambiarlo rompe las respuestas anteriores y cualquier mapeo que lo use.',
+        importer: {
+          open: 'Importar opciones',
+          title: 'Importar opciones desde una hoja de cálculo',
+          intro:
+            'Copia una o dos columnas de tu hoja y pégalas aquí. La columna 1 es la opción y la columna 2 (opcional) su puntaje. La fila de encabezado se detecta sola.',
+          placeholder: 'SaaS B2B\t10\nE-commerce\t8\nSalud\t7',
+          modeReplace: 'Reemplazar opciones',
+          modeAppend: 'Agregar al final',
+          colOption: 'Opción',
+          colScore: 'Puntaje',
+          colStatus: 'Estado',
+          statusOk: 'ok',
+          statusDuplicate: 'duplicada',
+          statusInvalid: 'puntaje inválido',
+          statusRounded: 'redondeado a {n}',
+          summaryValid: '{n} válidas',
+          summaryWithScore: '{n} con puntaje',
+          summaryHeaderSkipped: 'encabezado omitido',
+          summaryExtraColumns: 'columnas extra ignoradas',
+          summaryTruncated: '{n} sobre el límite',
+          submit: 'Importar {n} opciones',
+          replaceIconsNote: 'Reemplazar elimina los íconos de las opciones actuales.',
+          noScoresNote: 'Este pegado no trae puntajes — la pregunta conserva sus puntos actuales.',
+          cancel: 'Cancelar',
+        },
         icon: 'Ícono',
         iconHelp:
           'Un emoji, una o dos letras, o una imagen. Los emoji y las letras se muestran en un círculo; las imágenes reciben una caja donde entran completas, así un logo ancho no se recorta. Las imágenes solo están disponibles en el diseño de tarjetas.',


### PR DESCRIPTION
## What

**Import options from a spreadsheet** — a paste modal for dropdown and multiple-choice questions that turns 1–2 copied columns (option + optional score) into options in one step. Nobody mainstream imports option + score together (Typeform/SurveyMonkey/Jotform only bulk-add plain text) — for a lead-scoring-first product this feeds the score column straight into qualification.

## How it works

- **"Import options"** button beside "Add option" in the options editor → modal with a paste box and a **live preview**: every keystroke re-parses; each row shows its fate (ok / duplicate / invalid score / rounded), and the CTA always states exactly what it will do ("Import 4 options").
- **Formats:** TSV (a single tab anywhere marks a spreadsheet copy — a row with an empty score cell still parses), CSV/semicolon (80% of lines must agree, so a comma inside one label never splits the paste), or one label per line.
- **Header detection** (EN/ES: option/opción/label/etiqueta/… or non-numeric score cell with numeric rows below). Never on single-line pastes.
- **Per-row tolerance:** a bad score ("N/A") marks that row and excludes it — the other 199 import fine. Decimals round to the schema's integer with a per-row note. Duplicates de-dupe by normalized label (first wins; existing options count in append mode).
- **Replace / append:** append keeps current options (icons included) and suffixes colliding values `-2`, `-3`…; replace warns when current options carry icons.
- **Bounds:** 200-option cap (counting existing), labels capped at the schema's 200 chars, values slugified and never contain a comma (the dynamic-variant separator).

## Zero contract changes

Imports write the existing `{ label, value, points? }` option shape — no engine, schema, or API changes. The parser is a pure module in the editor (`options-import.ts`) with 19 unit tests.

## Verification

- `pnpm test` all green (web 106 incl. 19 new parser tests, engine 217, api 153, db 62, shared 40, destinations 51, notifications 34); typecheck + lint pass
- Live E2E (headless Chrome on :3300): button renders → paste with header+dup+decimal+N/A shows correct per-row statuses and summary ("4 valid · 4 with score · header skipped") → apply replaces options with points [10, 8, 7, 5] → autosaved draft verified in DB after reload → append mode imports only the non-duplicate row and persists
- i18n EN+ES parity compiler-enforced; read-only repo reviewer pass: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)