### PR TITLE
feat: work in more than one workspace, and four fixes behind it

### DIFF
--- a/.changeset/webhook-failure-reason.md
+++ b/.changeset/webhook-failure-reason.md
@@ -1,0 +1,22 @@
+---
+'@quill/destinations': minor
+'@quill/shared': minor
+---
+
+Say why a webhook test delivery failed.
+
+The toast read `Test failed: webhook delivery failed: HTTP 400` — true, and
+useless. A status code alone sends the author to check the wrong thing.
+
+`WebhookHttpError` now carries the status and a truncated copy of the endpoint's
+own response body, which names the real reason far more often than the code does.
+Its `message` is byte-identical to what the adapter always threw, because the
+outbox stores that string and two tests assert on it — it is a contract, not
+prose.
+
+The classification is deliberately conservative. Only 405/501 lets us state that
+POST is refused, because that is the one status which actually says so. A 400
+means the endpoint read the request and rejected the body; claiming the method
+was wrong there would be right often enough to be trusted and wrong often enough
+to waste an afternoon. So 4xx copy states what we send — POST, `application/json`
+— and lets the endpoint's own message do the rest.

--- a/.changeset/workspace-switcher.md
+++ b/.changeset/workspace-switcher.md
@@ -1,0 +1,24 @@
+---
+'@quill/db': minor
+---
+
+Let a person work in more than one workspace.
+
+The data model always allowed it — uniqueness on `member` is per account, and
+`inviteMember` writes a row into the INVITING account — but nothing ever read it
+back. Login resolved a single row and stopped (`ORDER BY created_at LIMIT 1`), so
+an invited teammate signed in and landed in their own oldest account. Every
+invitation was a dead end.
+
+`listWorkspacesForIdentity` is the query that was missing: every account where a
+person holds a membership, matched on the IAM subject when there is one and on
+their email address otherwise, because an invite only ever knew the address.
+Invited rows are listed — an invitation you cannot see is one that does not work,
+and opening it is what accepting means. Disabled rows never appear.
+
+`findMembership` is the authorization check behind the switch, and the reason
+this is safe: the workspace is named by a request header, that header proves
+nothing, and membership is re-derived from the database on every request. An
+account the caller has no row in is a 403 — deliberately not a quiet fall back to
+their home account, because a quiet fallback puts writes into a tenant the person
+did not believe they were in.

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -119,6 +119,18 @@ export class AdminCrudController {
     return this.admin.me(p);
   }
 
+  /**
+   * Every workspace this person can enter, for the switcher.
+   *
+   * Answered from the caller's HOME identity rather than the workspace they are
+   * currently in — otherwise switching into a workspace would replace the list
+   * with that workspace's own view and there would be no way back out.
+   */
+  @Get('workspaces')
+  async workspaces(@Req() req: ReqLike) {
+    return this.auth.listWorkspaces(req);
+  }
+
   /** This member's public page config (the raw blob, or null). */
   @Get('me/profile')
   async myProfile(@Req() req: ReqLike) {

--- a/apps/api/src/auth.service.ts
+++ b/apps/api/src/auth.service.ts
@@ -1,10 +1,20 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import type { Db } from '@quill/db';
-import { activateInvitedMember, getMemberRole } from '@quill/db';
+import {
+  activateInvitedMember,
+  findMembership,
+  getMemberIdentity,
+  getMemberRole,
+  listWorkspacesForIdentity,
+  type WorkspaceRow,
+} from '@quill/db';
 import { AUTH_PROVIDER, DB } from './tokens';
-import { type AuthProvider, type HostPrincipal, type ReqLike } from './auth.provider';
+import { header, type AuthProvider, type HostPrincipal, type ReqLike } from './auth.provider';
 
 export type { HostPrincipal, ReqLike } from './auth.provider';
+
+/** The header the web app uses to ask for a workspace other than the home one. */
+export const WORKSPACE_HEADER = 'x-quill-workspace';
 
 /**
  * Auth authority for the API. Host/dashboard identity is delegated to the
@@ -19,21 +29,71 @@ export class AuthService {
   ) {}
 
   /**
-   * Resolve the authenticated host via the configured provider, then enrich it
-   * with the account role (`member.role`) so the permission layer can authorize.
-   * The provider stays role-agnostic; role resolution is centralized here so it
-   * behaves identically across the local and workos providers. Throws 401 if the
-   * provider cannot resolve the host.
+   * Resolve the authenticated host, and then the account they are acting in.
+   *
+   * Those are two different questions, and separating them is the point of this
+   * method. The provider answers only the first — WHO is calling — from a token
+   * it validated. WHICH account they act in used to be the same answer: the
+   * token's `account_id`, or for the dev stub the caller's oldest member row.
+   * That made a second workspace unreachable and made every invitation a dead
+   * end, because signing in always landed you back in your own account.
+   *
+   * A request may now NAME an account via `x-quill-workspace`, and that name is
+   * treated as nothing more than a request. Authorization comes from
+   * re-deriving membership out of the database, on every request, keyed to the
+   * identity the provider already proved. A header naming an account the caller
+   * has no row in is a 403 — never a quiet fall back to the home account,
+   * because a quiet fallback means writes land in a tenant the person did not
+   * believe they were in.
+   *
+   * Throws 401 if the provider cannot resolve the host.
    */
   async resolveHost(req: ReqLike): Promise<HostPrincipal> {
-    const id = await this.provider.resolveHost(req);
+    const home = await this.provider.resolveHost(req);
     // An invited member who actually shows up is no longer invited. Nothing
     // flipped this before, so someone who accepted stayed "invited" in the
     // members list forever and an admin had no way to tell a pending invite
     // from an active teammate. Scoped to exactly that transition — `disabled`
     // must never be revived by a login, which is the whole point of disabling.
-    await activateInvitedMember(this.db, id.accountId, id.memberId);
-    const role = (await getMemberRole(this.db, id.accountId, id.memberId)) ?? 'member';
-    return { ...id, role };
+    await activateInvitedMember(this.db, home.accountId, home.memberId);
+
+    const requested = header(req, WORKSPACE_HEADER)?.trim();
+    if (!requested || requested === home.accountId) {
+      const role = (await getMemberRole(this.db, home.accountId, home.memberId)) ?? 'member';
+      return { ...home, role };
+    }
+
+    const identity = await getMemberIdentity(this.db, home.accountId, home.memberId);
+    const membership = identity ? await findMembership(this.db, identity, requested) : null;
+    if (!membership) {
+      throw new ForbiddenException({
+        error: 'WORKSPACE_FORBIDDEN',
+        message: 'You are not a member of that workspace.',
+      });
+    }
+
+    // Opening a workspace you were invited to IS accepting the invitation — the
+    // same transition the home account gets above, for the same reason.
+    await activateInvitedMember(this.db, membership.accountId, membership.memberId);
+    return {
+      accountId: membership.accountId,
+      memberId: membership.memberId,
+      role: membership.role,
+    };
+  }
+
+  /**
+   * Every workspace the CALLER can enter.
+   *
+   * Derived from the home identity the provider resolved, never from whichever
+   * workspace they are currently viewing — so the list reads the same from
+   * inside any of them, and a switch can never strand someone somewhere with no
+   * way back.
+   */
+  async listWorkspaces(req: ReqLike): Promise<WorkspaceRow[]> {
+    const home = await this.provider.resolveHost(req);
+    const identity = await getMemberIdentity(this.db, home.accountId, home.memberId);
+    if (!identity) return [];
+    return listWorkspacesForIdentity(this.db, identity);
   }
 }

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -27,7 +27,7 @@ import {
   upsertIntegration,
 } from '@quill/db';
 import { formDestinationSchema, maskConfigSecrets, type FormDestination } from '@quill/types';
-import { WebhookDestination } from '@quill/destinations';
+import { WebhookDestination, WebhookHttpError } from '@quill/destinations';
 import type { ServerEnv } from '@quill/config/env';
 import { AuthService, type ReqLike } from './auth.service';
 import { assertAdmin } from './permissions';
@@ -495,7 +495,7 @@ export class FormDestinationsController {
   async pingWebhook(
     @Req() req: ReqLike,
     @Param('id') id: string,
-  ): Promise<{ ok: boolean; message?: string }> {
+  ): Promise<WebhookPingResult> {
     const p = await this.auth.resolveHost(req);
     assertAdmin(p);
     const form = await getFormById(this.db, p.accountId, id);
@@ -546,11 +546,87 @@ export class FormDestinationsController {
       });
       return { ok: true };
     } catch (err) {
-      // The adapter's messages already carry the HTTP status or the transport
-      // failure — that string IS the useful diagnostic for the far end.
-      return { ok: false, message: err instanceof Error ? err.message : String(err) };
+      // "HTTP 400" alone sends the author looking in the wrong place. Classify
+      // it into something the UI can explain, and pass along the endpoint's own
+      // response — which names the real reason far more often than the status
+      // code does.
+      return { ok: false, ...classifyWebhookFailure(err) };
     }
   }
+}
+
+/** What went wrong with a test delivery, in terms the UI can explain. */
+export type WebhookPingReason =
+  | 'method_not_allowed'
+  | 'unsupported_media_type'
+  | 'rejected_body'
+  | 'unauthorized'
+  | 'not_found'
+  | 'rate_limited'
+  | 'server_error'
+  | 'redirect'
+  | 'blocked'
+  | 'unreachable'
+  | 'unknown';
+
+export interface WebhookPingResult {
+  ok: boolean;
+  reason?: WebhookPingReason;
+  /** The status the endpoint answered with, when it answered at all. */
+  status?: number;
+  /** The endpoint's own response body, trimmed and truncated. */
+  detail?: string;
+  /** The raw adapter message — kept for the log and for reasons we cannot name. */
+  message?: string;
+}
+
+/**
+ * Map a failed delivery onto a reason the UI has copy for.
+ *
+ * Deliberately NOT a guess at intent. A 405 genuinely means "this endpoint does
+ * not accept POST" and we say exactly that; a 400 means the endpoint read the
+ * request and rejected the body, which is a different sentence, even though the
+ * underlying mistake is often the same one. Saying "your webhook is not POST"
+ * on a 400 would be right often enough to be trusted and wrong often enough to
+ * send someone down the wrong path — so the copy for 4xx states what we send
+ * (POST, application/json) and lets the endpoint's own message do the rest.
+ */
+export function classifyWebhookFailure(err: unknown): {
+  reason: WebhookPingReason;
+  status?: number;
+  detail?: string;
+  message: string;
+} {
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (err instanceof WebhookHttpError) {
+    const { status, detail } = err;
+    const base = { status, detail: detail ?? undefined, message };
+    if (status >= 300 && status < 400) return { reason: 'redirect', ...base };
+    if (status === 405 || status === 501) return { reason: 'method_not_allowed', ...base };
+    if (status === 415) return { reason: 'unsupported_media_type', ...base };
+    if (status === 401 || status === 403) return { reason: 'unauthorized', ...base };
+    if (status === 404 || status === 410) return { reason: 'not_found', ...base };
+    if (status === 429) return { reason: 'rate_limited', ...base };
+    if (status >= 500) return { reason: 'server_error', ...base };
+    if (status >= 400) return { reason: 'rejected_body', ...base };
+    return { reason: 'unknown', ...base };
+  }
+
+  // The SSRF guard refused before anything left the process. Its own message is
+  // the explanation; naming it separately keeps "we blocked this" from reading
+  // like "your server is down".
+  if (/blocked|private|loopback|link-local|metadata|not a public/i.test(message)) {
+    return { reason: 'blocked', message };
+  }
+  // AbortError (our timeout) and fetch's TypeError both mean nobody answered.
+  if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+    return { reason: 'unreachable', message };
+  }
+  if (/fetch failed|ENOTFOUND|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up/i.test(message)) {
+    return { reason: 'unreachable', message };
+  }
+  return { reason: 'unknown', message };
 }
 
 /**

--- a/apps/api/src/webhook-ping.spec.ts
+++ b/apps/api/src/webhook-ping.spec.ts
@@ -133,4 +133,82 @@ describe('webhook ping', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
     expect(calls).toHaveLength(0);
   });
+
+  /**
+   * The failure REASON, which is the whole point of a test button.
+   *
+   * "webhook delivery failed: HTTP 400" is true and useless — it sends the
+   * author to check the wrong thing. Each status has to arrive as a reason the
+   * UI has a sentence for, carrying the endpoint's own words.
+   */
+  describe('explains why a delivery failed', () => {
+    /** Answer the ping with a chosen status + body, then read the result. */
+    async function ping(status: number, body = ''): Promise<Awaited<ReturnType<typeof controller.pingWebhook>>> {
+      await setWebhook('http://localhost:4999/hook');
+      controller.fetchImpl = (async (url: string, init: RequestInit) => {
+        calls.push({ url: String(url), init });
+        return new Response(body, { status });
+      }) as unknown as typeof fetch;
+      return controller.pingWebhook(asOwner(), formId);
+    }
+
+    it('names a refused method only when the endpoint actually said so', async () => {
+      const res = await ping(405);
+      expect(res.ok).toBe(false);
+      expect(res.reason).toBe('method_not_allowed');
+      expect(res.status).toBe(405);
+    });
+
+    it('does NOT claim the method was wrong on a 400 — the body was rejected', async () => {
+      const res = await ping(400);
+      expect(res.reason).toBe('rejected_body');
+      expect(res.reason).not.toBe('method_not_allowed');
+    });
+
+    it("passes through the endpoint's own explanation", async () => {
+      const res = await ping(400, '{"error":"missing field: email"}');
+      expect(res.detail).toBe('{"error":"missing field: email"}');
+    });
+
+    it('truncates a huge error page instead of storing it whole', async () => {
+      const res = await ping(500, 'x'.repeat(5000));
+      expect(res.reason).toBe('server_error');
+      expect(res.detail!.length).toBeLessThan(500);
+      expect(res.detail!.endsWith('…')).toBe(true);
+    });
+
+    it.each([
+      [401, 'unauthorized'],
+      [403, 'unauthorized'],
+      [404, 'not_found'],
+      [415, 'unsupported_media_type'],
+      [429, 'rate_limited'],
+      [502, 'server_error'],
+    ])('maps HTTP %i to %s', async (status, reason) => {
+      const res = await ping(status);
+      expect(res.reason).toBe(reason);
+    });
+
+    it('calls a refusal by the SSRF guard blocked, not unreachable', async () => {
+      await setWebhook('https://10.0.0.5/hook');
+      const res = await controller.pingWebhook(asOwner(), formId);
+      expect(res.reason).toBe('blocked');
+      expect(calls).toHaveLength(0);
+    });
+
+    it('reports a host that never answers as unreachable', async () => {
+      await setWebhook('http://localhost:4999/hook');
+      controller.fetchImpl = (async () => {
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch;
+      const res = await controller.pingWebhook(asOwner(), formId);
+      expect(res.reason).toBe('unreachable');
+    });
+
+    it('leaves a success with no reason at all', async () => {
+      await setWebhook('http://localhost:4999/hook');
+      const res = await controller.pingWebhook(asOwner(), formId);
+      expect(res).toEqual({ ok: true });
+    });
+  });
 });

--- a/apps/api/src/workspace-switch.spec.ts
+++ b/apps/api/src/workspace-switch.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * The workspace switch, which is an AUTHORIZATION boundary before it is a
+ * feature. Everything here runs the real `AuthService` against in-memory SQLite.
+ *
+ * What each test is protecting, worst first:
+ *
+ *   1. **a header cannot grant access.** `x-quill-workspace` names an account;
+ *      it proves nothing. Membership is re-derived from the database on every
+ *      request, and an account the caller has no row in is a 403.
+ *   2. **a refusal is never a silent fallback.** Quietly serving the home
+ *      account instead would put writes into a tenant the person did not
+ *      believe they were in — far worse than an error.
+ *   3. **a revoked membership stays revoked.** `disabled` is not selectable, no
+ *      matter what the cookie remembers.
+ *   4. the role comes from the TARGET account. Owning your own workspace must
+ *      not make you an owner of one you were invited into.
+ *   5. opening an invitation accepts it, which is the only thing that ever made
+ *      `inviteMember` lead anywhere.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import {
+  createDb,
+  migrate,
+  seed,
+  getAccountByCode,
+  insertAccountWithShortCode,
+  listWorkspacesForIdentity,
+  sql,
+  type Db,
+} from '@quill/db';
+import { AuthService, WORKSPACE_HEADER } from './auth.service';
+import { LocalAuthProvider, type ReqLike } from './auth.provider';
+
+const EMAIL = 'alex@example.com';
+
+describe('workspace switch', () => {
+  let db: Db;
+  let auth: AuthService;
+  let homeAccountId: string;
+
+  /** The dev stub resolves this email; the header names the workspace wanted. */
+  const as = (workspace?: string): ReqLike => ({
+    headers: { 'x-quill-email': EMAIL, ...(workspace ? { [WORKSPACE_HEADER]: workspace } : {}) },
+  });
+
+  beforeEach(async () => {
+    db = await createDb('file::memory:');
+    await migrate(db);
+    await seed(db);
+    homeAccountId = (await getAccountByCode(db, 'acme'))!.id;
+    const provider = new LocalAuthProvider(db, {
+      NODE_ENV: 'test',
+      DEV_LOGIN_EMAIL: undefined,
+      AUTH_LOCAL_STRICT: undefined,
+      SEED_DEMO_FORM: false,
+    });
+    auth = new AuthService(db, provider);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  /** A second account, optionally with a member row for our person. */
+  async function makeAccount(
+    name: string,
+    member?: { role?: string; status?: string; email?: string; externalId?: string },
+  ): Promise<string> {
+    const externalId = `ext:${name}`;
+    await insertAccountWithShortCode(db, { name, externalId });
+    const row = await db.get<{ id: string }>(
+      sql`SELECT id FROM account WHERE external_id = ${externalId} LIMIT 1`,
+    );
+    const accountId = String(row!.id);
+    if (member) {
+      await db.run(
+        sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, external_id, created_at)
+            VALUES (${randomUUID()}, ${accountId}, ${member.email ?? EMAIL}, ${name},
+              ${`h-${name}`}, ${member.role ?? 'member'}, ${member.status ?? 'active'},
+              ${member.externalId ?? null}, ${Date.now()})`,
+      );
+    }
+    return accountId;
+  }
+
+  it('stays in the home account when no workspace is named', async () => {
+    const other = await makeAccount('Beta', { role: 'admin' });
+    const p = await auth.resolveHost(as());
+    expect(p.accountId).toBe(homeAccountId);
+    expect(p.accountId).not.toBe(other);
+  });
+
+  it('enters a workspace the caller is a member of', async () => {
+    const beta = await makeAccount('Beta', { role: 'admin' });
+    const p = await auth.resolveHost(as(beta));
+    expect(p.accountId).toBe(beta);
+    // …and as a DIFFERENT member row than the home one.
+    const home = await auth.resolveHost(as());
+    expect(p.memberId).not.toBe(home.memberId);
+  });
+
+  it('takes the role from the target account, not the home one', async () => {
+    const beta = await makeAccount('Beta', { role: 'member' });
+    const home = await auth.resolveHost(as());
+    expect(home.role).toBe('owner'); // owner of their own seeded workspace
+    const p = await auth.resolveHost(as(beta));
+    expect(p.role).toBe('member'); // …but only a member of Beta
+  });
+
+  it('REFUSES an account the caller has no membership in', async () => {
+    const stranger = await makeAccount('Stranger'); // no member row for us
+    await expect(auth.resolveHost(as(stranger))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses rather than silently falling back to the home account', async () => {
+    const stranger = await makeAccount('Stranger');
+    // The dangerous outcome is not an error — it is a 200 scoped somewhere the
+    // caller did not choose. Assert we never return at all.
+    let resolved: string | null = null;
+    try {
+      resolved = (await auth.resolveHost(as(stranger))).accountId;
+    } catch {
+      /* expected */
+    }
+    expect(resolved).toBeNull();
+  });
+
+  it('refuses an account where the membership was disabled', async () => {
+    const beta = await makeAccount('Beta', { status: 'disabled' });
+    await expect(auth.resolveHost(as(beta))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses a workspace id that does not exist at all', async () => {
+    await expect(auth.resolveHost(as('no-such-account'))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('accepts the invitation when an invited workspace is opened', async () => {
+    const beta = await makeAccount('Beta', { status: 'invited' });
+    const p = await auth.resolveHost(as(beta));
+    expect(p.accountId).toBe(beta);
+    const row = await db.get<{ status: string }>(
+      sql`SELECT status FROM member WHERE id = ${p.memberId}`,
+    );
+    expect(row!.status).toBe('active');
+  });
+
+  it('matches on external_id when the member row carries one', async () => {
+    // Give the home member an external id, then a second account whose row
+    // shares it but uses a different address — the same person to the IAM.
+    const home = await auth.resolveHost(as());
+    await db.run(sql`UPDATE member SET external_id = 'sub-123' WHERE id = ${home.memberId}`);
+    const beta = await makeAccount('Beta', {
+      email: 'different@example.com',
+      externalId: 'sub-123',
+    });
+    const p = await auth.resolveHost(as(beta));
+    expect(p.accountId).toBe(beta);
+  });
+
+  describe('the list behind the switcher', () => {
+    it('returns every workspace the caller can enter, and no others', async () => {
+      const beta = await makeAccount('Beta', { role: 'admin' });
+      const gamma = await makeAccount('Gamma', { status: 'invited' });
+      await makeAccount('Disabled', { status: 'disabled' });
+      await makeAccount('Stranger'); // nobody's
+
+      const list = await auth.listWorkspaces(as());
+      const ids = list.map((w) => w.accountId).sort();
+      expect(ids).toEqual([homeAccountId, beta, gamma].sort());
+      expect(list.find((w) => w.accountId === gamma)!.status).toBe('invited');
+    });
+
+    it('reads the same from inside another workspace — no way to get stranded', async () => {
+      const beta = await makeAccount('Beta');
+      const fromHome = (await auth.listWorkspaces(as())).map((w) => w.accountId).sort();
+      const fromBeta = (await auth.listWorkspaces(as(beta))).map((w) => w.accountId).sort();
+      expect(fromBeta).toEqual(fromHome);
+      expect(fromBeta).toContain(homeAccountId);
+    });
+
+    it('lists an account once even when both identity keys match it', async () => {
+      const home = await auth.resolveHost(as());
+      await db.run(sql`UPDATE member SET external_id = 'sub-123' WHERE id = ${home.memberId}`);
+      const list = await listWorkspacesForIdentity(db, {
+        externalId: 'sub-123',
+        email: EMAIL,
+      });
+      expect(list.filter((w) => w.accountId === homeAccountId)).toHaveLength(1);
+    });
+
+    it('is empty for an identity with neither key', async () => {
+      expect(await listWorkspacesForIdentity(db, { externalId: null, email: null })).toEqual([]);
+    });
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
@@ -39,7 +39,15 @@ export function AdvancedSettings({
     <section
       data-testid="advanced-settings"
       data-open={open}
-      className="mt-2 overflow-hidden rounded-md border border-border"
+      // `shrink-0` is load-bearing, not tidiness. `overflow-hidden` (which clips
+      // the children to the rounded corners) makes CSS resolve this box's
+      // `min-height: auto` to 0 — and as a flex child of the settings column,
+      // which routinely overflows, the browser then compressed the whole group
+      // to 2px. It read as "Advanced settings is missing and the panel won't
+      // scroll"; there was simply nothing left to scroll to. Every sibling
+      // survives because they are `overflow: visible` and keep their min-content
+      // floor. The column is a scroll container, so nothing in it should shrink.
+      className="mt-2 shrink-0 overflow-hidden rounded-md border border-border"
     >
       <button
         type="button"

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
@@ -7,6 +7,7 @@ import type { CalendlyEventType } from '@/lib/admin-api';
 import { Select } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { buttonVariants } from '@/components/ui/button';
+import { ProviderLogo } from '@/components/ui/provider-logo';
 import { cn } from '@/lib/cn';
 import { Field } from './fields';
 import { loadCalendlyEventTypesAction } from './scheduler-actions';
@@ -93,7 +94,11 @@ export function SchedulerPanel({
 
   return (
     <section className="flex flex-col gap-3 border-t border-border pt-4" data-testid="scheduler-panel">
-      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      {/* The mark, not a generic calendar glyph: this section books through
+          Calendly specifically, and every other surface that says so now shows
+          the same logo. */}
+      <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <ProviderLogo provider="calendly" size={13} />
         {s.schedulerSection}
       </p>
       <p className="text-xs text-muted-foreground">{s.schedulerHint}</p>

--- a/apps/web/app/admin/forms/[id]/integrations/actions.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { adminApi } from '@/lib/admin-api';
+import { adminApi, type WebhookPingResult } from '@/lib/admin-api';
 import type { FormDestination } from '@quill/types';
 
 /**
@@ -36,10 +36,14 @@ export async function saveIntegrationsAction(
  * account, and routed through the real adapter so the SSRF check that protects
  * every live delivery protects this one too.
  */
-export async function pingWebhookAction(id: string): Promise<{ ok: boolean; message?: string }> {
+export async function pingWebhookAction(id: string): Promise<WebhookPingResult> {
   try {
     return await adminApi.pingWebhook(id);
   } catch (e) {
-    return { ok: false, message: e instanceof Error ? e.message : 'Could not reach the webhook.' };
+    return {
+      ok: false,
+      reason: 'unknown',
+      message: e instanceof Error ? e.message : 'Could not reach the webhook.',
+    };
   }
 }

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -10,9 +10,14 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Select, type SelectOption } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { ProviderLogo, type LogoProvider } from '@/components/ui/provider-logo';
 import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
-import type { HubSpotPropertiesResponse } from '@/lib/admin-api';
+import type {
+  HubSpotPropertiesResponse,
+  WebhookPingReason,
+  WebhookPingResult,
+} from '@/lib/admin-api';
 import { trackDestinationWrite } from '@/lib/connect-sync';
 import { propertyLookup, suggestProperty, type QuestionMeta } from './auto-map';
 import { pingWebhookAction, saveIntegrationsAction } from './actions';
@@ -654,6 +659,45 @@ function KeySelect({
   );
 }
 
+/**
+ * Turn a failed test delivery into a sentence someone can act on.
+ *
+ * The old toast said "Test failed: webhook delivery failed: HTTP 400" — a true
+ * statement that sends the reader to the wrong place. What actually helps is
+ * three things in order: what the endpoint did, what we sent it (POST with a
+ * JSON body — the assumption most often wrong), and the endpoint's OWN response,
+ * which usually names the real reason.
+ *
+ * Only 405/501 lets us say outright that POST is refused. On a 400 the endpoint
+ * read the request and rejected the body; claiming the method was wrong there
+ * would be a guess dressed as a diagnosis.
+ */
+export function explainPingFailure(res: WebhookPingResult, m: Msgs): string {
+  const REASON: Record<WebhookPingReason, string> = {
+    method_not_allowed: m.pingMethodNotAllowed,
+    unsupported_media_type: m.pingUnsupportedMedia,
+    rejected_body: m.pingRejectedBody,
+    unauthorized: m.pingUnauthorized,
+    not_found: m.pingNotFound,
+    rate_limited: m.pingRateLimited,
+    server_error: m.pingServerError,
+    redirect: m.pingRedirect,
+    blocked: m.pingBlocked,
+    unreachable: m.pingUnreachable,
+    unknown: m.pingUnknown,
+  };
+  const headline = res.reason ? REASON[res.reason] : m.pingUnknown;
+  const parts = [
+    res.status ? fill(m.pingStatus, { status: String(res.status) }) : null,
+    headline,
+    // Not shown for `blocked` / `unreachable`: nothing was ever POSTed, so
+    // telling the reader what we send would only be noise.
+    res.status ? m.pingWeSend : null,
+    res.detail ? fill(m.pingEndpointSaid, { detail: res.detail }) : null,
+  ].filter(Boolean);
+  return parts.join(' ');
+}
+
 function Card({
   title,
   desc,
@@ -661,6 +705,7 @@ function Card({
   onToggle,
   m,
   badge,
+  logo,
   children,
 }: {
   title: string;
@@ -669,6 +714,8 @@ function Card({
   onToggle: (v: boolean) => void;
   m: Msgs;
   badge?: string;
+  /** The provider this card configures, when it is a named third party. */
+  logo?: LogoProvider;
   children: React.ReactNode;
 }) {
   return (
@@ -676,6 +723,7 @@ function Card({
       <div className="flex items-start justify-between gap-4">
         <div>
           <div className="flex items-center gap-2">
+            {logo ? <ProviderLogo provider={logo} size={20} /> : null}
             <h2 className="text-lg font-semibold">{title}</h2>
             {badge ? (
               <span className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-xs font-medium text-foreground">
@@ -786,7 +834,7 @@ function WebhookCard({
     try {
       const res = await pingWebhookAction(formId);
       if (res.ok) success(m.pingOk);
-      else toastError(fill(m.pingFailed, { reason: res.message ?? '' }));
+      else toastError(explainPingFailure(res, m));
     } finally {
       setPinging(false);
     }
@@ -908,7 +956,10 @@ function HubspotCard({
   if (!emailSource) {
     return (
       <section data-testid="hubspot-card" className="rounded-lg border border-border bg-card p-5">
-        <h2 className="text-lg font-semibold">{m.hubspotTitle}</h2>
+        <div className="flex items-center gap-2">
+          <ProviderLogo provider="hubspot" size={20} />
+          <h2 className="text-lg font-semibold">{m.hubspotTitle}</h2>
+        </div>
         <p className="mt-0.5 text-sm text-muted-foreground">{m.hubspotDesc}</p>
         <div
           data-testid="hubspot-needs-email"
@@ -925,7 +976,10 @@ function HubspotCard({
   if (!showMapping) {
     return (
       <section className="rounded-lg border border-border bg-card p-5">
-        <h2 className="text-lg font-semibold">{m.hubspotTitle}</h2>
+        <div className="flex items-center gap-2">
+          <ProviderLogo provider="hubspot" size={20} />
+          <h2 className="text-lg font-semibold">{m.hubspotTitle}</h2>
+        </div>
         <p className="mt-0.5 text-sm text-muted-foreground">{m.hubspotDesc}</p>
         <div className="mt-4 rounded-md border border-dashed border-border bg-muted/40 p-4">
           <p className="text-sm font-medium text-foreground">{m.connectPromptTitle}</p>
@@ -1002,6 +1056,7 @@ function HubspotCard({
     <Card
       title={m.hubspotTitle}
       desc={m.hubspotDesc}
+      logo="hubspot"
       enabled={state.enabled}
       onToggle={(enabled) => onChange({ ...state, enabled })}
       m={m}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -26,11 +26,18 @@ export default async function AdminLayout({ children }: { children: ReactNode })
   const initialCollapsed = jar.get('forms.nav.collapsed')?.value === '1';
   const chrome = getMessages(await getLocale()).admin.chrome;
 
+  // Best-effort: a failure here must never take down the dashboard. Without the
+  // list the switcher simply does not render, which is exactly how it behaves
+  // for the single-workspace majority anyway.
+  const workspaces = await adminApi.listWorkspaces().catch(() => []);
+
   return (
     <ToastProvider>
       <AdminShell
         initialCollapsed={initialCollapsed}
         messages={chrome}
+        workspaces={workspaces}
+        currentAccountId={me.accountId}
         user={{ displayName: me.displayName, handle: me.handle, accountCode: me.accountCode }}
       >
         {children}

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -1,0 +1,32 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
+import { setWorkspace } from '@/lib/auth-session';
+import { adminApi } from '@/lib/admin-api';
+
+/**
+ * Enter a different workspace.
+ *
+ * The choice is written into the signed session cookie and nothing else — no
+ * new token is minted and no membership is granted here. The API re-derives
+ * membership on every subsequent request and answers 403 if it does not hold,
+ * so this action cannot widen anyone's access even if the id it is handed is
+ * wrong or hostile.
+ *
+ * It still verifies BEFORE writing, because failing at the moment of the click
+ * is far better than storing a choice that makes the next page 403 and bounce.
+ */
+export async function switchWorkspaceAction(accountId: string): Promise<{ error?: string }> {
+  const id = accountId.trim();
+  if (!id) return { error: 'unknown' };
+
+  const workspaces = await adminApi.listWorkspaces();
+  const target = workspaces.find((w) => w.accountId === id);
+  if (!target) return { error: 'forbidden' };
+
+  await setWorkspace(id);
+  // Every admin page is scoped to the account, so all of it is now stale.
+  revalidatePath('/admin', 'layout');
+  redirect('/admin');
+}

--- a/apps/web/app/api/workspace/reset/route.ts
+++ b/apps/web/app/api/workspace/reset/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { WORKSPACE_COOKIE } from '@/lib/session';
+
+/**
+ * Drop the chosen workspace and go home.
+ *
+ * This exists because of WHERE cookies can be written. When the API answers
+ * `WORKSPACE_FORBIDDEN` — the membership was revoked, or the account is gone —
+ * the discovery happens inside a Server Component render, and `cookies().set()`
+ * throws there. Redirecting without clearing produced an infinite loop: every
+ * page load re-sent the dead workspace, got another 403, and redirected again.
+ *
+ * A Route Handler owns its response, so the cookie deletion actually lands.
+ * Clearing is unconditional and idempotent, which is what makes the loop
+ * impossible rather than merely unlikely.
+ */
+export async function GET(request: Request) {
+  const res = NextResponse.redirect(new URL('/admin', request.url));
+  res.cookies.delete(WORKSPACE_COOKIE);
+  return res;
+}

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -6,6 +6,8 @@ import { usePathname } from 'next/navigation';
 import { isNavItemActive, type FormsMessages } from '@quill/shared';
 import { signOutAction } from '@/app/login/actions';
 import { AppSwitcher } from '@/components/app-switcher';
+import { WorkspaceSwitcher } from '@/components/workspace-switcher';
+import type { Workspace } from '@/lib/admin-api';
 
 type ChromeMessages = FormsMessages['admin']['chrome'];
 
@@ -114,6 +116,8 @@ export function AdminShell({
   user,
   messages,
   initialCollapsed = false,
+  workspaces = [],
+  currentAccountId,
   children,
 }: {
   user: ShellUser | null;
@@ -121,6 +125,10 @@ export function AdminShell({
   messages: ChromeMessages;
   /** Server-read cookie value → no collapse-rail FOUC on reload. */
   initialCollapsed?: boolean;
+  /** Every account the caller can enter. Fewer than two renders no switcher. */
+  workspaces?: Workspace[];
+  /** The account these pages are currently scoped to. */
+  currentAccountId?: string;
   children: ReactNode;
 }) {
   const pathname = usePathname();
@@ -263,13 +271,31 @@ export function AdminShell({
         <span className="text-sm font-semibold">{PRODUCT_NAME}</span>
       </header>
 
-      {/* Desktop sidebar — flush, bordered, collapsible rail */}
+      {/* Desktop sidebar — flush, bordered, collapsible rail.
+          Pinned to the viewport (`sticky h-dvh`) rather than left to stretch
+          with the page. As a plain flex item it grew to the FULL document
+          height — 2834px on Settings — which dragged the `mt-auto` footer, and
+          with it the account name and sign-out, ~2000px below the fold. The
+          editor never showed the bug only because that route is its own
+          `h-[100dvh] overflow-hidden` shell. `overflow-y-auto` keeps the rail
+          usable if the nav ever outgrows a short viewport. */}
       <aside
-        className={`hidden shrink-0 flex-col gap-6 border-r border-border bg-popover py-4 transition-[width] md:flex ${
+        className={`hidden shrink-0 flex-col gap-6 border-r border-border bg-popover py-4 transition-[width] md:sticky md:top-0 md:flex md:h-dvh md:overflow-y-auto ${
           railCollapsed ? 'w-[64px] px-2' : 'w-60 px-4'
         }`}
       >
         {brand}
+        {/* Directly under the wordmark and above the nav: which tenant every
+            link below belongs to. It renders nothing at all for the single-
+            workspace majority. */}
+        {currentAccountId ? (
+          <WorkspaceSwitcher
+            workspaces={workspaces}
+            currentAccountId={currentAccountId}
+            collapsed={railCollapsed}
+            m={messages.workspaces}
+          />
+        ) : null}
         <nav aria-label="Primary">
           <NavLinks collapsed={railCollapsed} nav={messages.nav} />
         </nav>
@@ -303,6 +329,13 @@ export function AdminShell({
           <span className="text-sm font-semibold text-foreground">{PRODUCT_NAME}</span>
           <AppSwitcher messages={messages.switcher} />
         </div>
+        {currentAccountId ? (
+          <WorkspaceSwitcher
+            workspaces={workspaces}
+            currentAccountId={currentAccountId}
+            m={messages.workspaces}
+          />
+        ) : null}
         <nav>
           <NavLinks collapsed={false} nav={messages.nav} onNavigate={() => setDrawerOpen(false)} />
         </nav>

--- a/apps/web/components/ui/provider-logo.tsx
+++ b/apps/web/components/ui/provider-logo.tsx
@@ -5,11 +5,15 @@
  * network and no CDN reachable, and the CSP on the public pages blocks external
  * hosts outright. An inline path always renders.
  *
- * These are simplified geometric marks — enough for someone scanning the page to
- * recognise which service a card belongs to, which the generic `pi-sync` and
- * `pi-calendar` glyphs never did. `mono` drops the brand colour and inherits
- * `currentColor` for places where a coloured logo would fight the surrounding
- * text (an inline mention, a disabled state).
+ * These are the OFFICIAL marks — HubSpot's sprocket and Calendly's ring — and
+ * they replace a pair of geometric approximations drawn by hand. A logo that is
+ * nearly right reads as a knock-off, which is a poor thing to sit beside a
+ * prompt for someone's CRM credentials. The marks are the trademarks of
+ * HubSpot, Inc. and Calendly LLC, used only to identify which service an
+ * integration talks to — never as our own branding.
+ *
+ * `mono` drops the brand colour for `currentColor`, for places where a coloured
+ * logo would fight the surrounding text (an inline mention, a disabled state).
  */
 
 export type LogoProvider = 'hubspot' | 'calendly';
@@ -19,49 +23,51 @@ const BRAND: Record<LogoProvider, string> = {
   calendly: '#006BFF',
 };
 
+/** Each mark is one filled path on a 24×24 grid, so `mono` is a single swap. */
+const PATH: Record<LogoProvider, string> = {
+  hubspot:
+    'M18.164 7.93V5.084a2.198 2.198 0 001.267-1.978v-.067A2.2 2.2 0 0017.238.845h-.067a2.2 2.2 0 00-2.193 2.193v.067a2.196 2.196 0 001.252 1.973l.013.006v2.852a6.22 6.22 0 00-2.969 1.31l.012-.01-7.828-6.095A2.497 2.497 0 104.3 4.656l-.012.006 7.697 5.991a6.176 6.176 0 00-1.038 3.446c0 1.343.425 2.588 1.147 3.607l-.013-.02-2.342 2.343a1.968 1.968 0 00-.58-.095h-.002a2.033 2.033 0 102.033 2.033 1.978 1.978 0 00-.1-.595l.005.014 2.317-2.317a6.247 6.247 0 104.782-11.134l-.036-.005zm-.964 9.378a3.206 3.206 0 113.215-3.207v.002a3.206 3.206 0 01-3.207 3.207z',
+  calendly:
+    'M19.655 14.262c.281 0 .557.023.828.064 0 .005-.005.01-.005.014-.105.267-.234.534-.381.786l-1.219 2.106c-1.112 1.936-3.177 3.127-5.411 3.127h-2.432c-2.23 0-4.294-1.191-5.412-3.127l-1.218-2.106a6.251 6.251 0 0 1 0-6.252l1.218-2.106C6.736 4.832 8.8 3.641 11.035 3.641h2.432c2.23 0 4.294 1.191 5.411 3.127l1.219 2.106c.147.252.271.519.381.786 0 .004.005.009.005.014-.267.041-.543.064-.828.064-1.816 0-2.501-.607-3.291-1.306-.764-.676-1.711-1.517-3.44-1.517h-1.029c-1.251 0-2.387.455-3.2 1.278-.796.805-1.233 1.904-1.233 3.099v1.411c0 1.196.437 2.295 1.233 3.099.813.823 1.949 1.278 3.2 1.278h1.034c1.729 0 2.676-.841 3.439-1.517.791-.703 1.471-1.306 3.287-1.301Zm.005-3.237c.399 0 .794-.036 1.179-.11-.002-.004-.002-.01-.002-.014-.073-.414-.193-.823-.349-1.218.731-.12 1.407-.396 1.986-.819 0-.004-.005-.013-.005-.018-.331-1.085-.832-2.101-1.489-3.03-.649-.915-1.435-1.719-2.331-2.395-1.867-1.398-4.088-2.138-6.428-2.138-1.448 0-2.855.28-4.175.841-1.273.543-2.423 1.315-3.407 2.299S2.878 6.552 2.341 7.83c-.557 1.324-.842 2.726-.842 4.175 0 1.448.281 2.855.842 4.174.542 1.274 1.314 2.423 2.298 3.407s2.129 1.761 3.407 2.299c1.324.556 2.727.841 4.175.841 2.34 0 4.561-.74 6.428-2.137a10.815 10.815 0 0 0 2.331-2.396c.652-.929 1.158-1.949 1.489-3.03 0-.004.005-.014.005-.018-.579-.423-1.255-.699-1.986-.819.161-.395.276-.804.349-1.218.005-.009.005-.014.005-.023.869.166 1.692.506 2.404 1.035.685.505.552 1.075.446 1.416C22.184 20.437 17.619 24 12.221 24c-6.625 0-12-5.375-12-12s5.37-12 12-12c5.398 0 9.963 3.563 11.471 8.464.106.341.239.915-.446 1.421-.717.529-1.535.873-2.404 1.034.128.716.128 1.45 0 2.166-.387-.074-.782-.11-1.182-.11-4.184 0-3.968 2.823-6.736 2.823h-1.029c-1.899 0-3.15-1.357-3.15-3.095v-1.411c0-1.738 1.251-3.094 3.15-3.094h1.034c2.768 0 2.552 2.823 6.731 2.827Z',
+};
+
+/** The provider's own name, for the accessible label when one is asked for. */
+const LABEL: Record<LogoProvider, string> = { hubspot: 'HubSpot', calendly: 'Calendly' };
+
 export function ProviderLogo({
   provider,
   size = 18,
   mono = false,
+  titled = false,
   className,
 }: {
   provider: LogoProvider;
   size?: number;
   /** Inherit `currentColor` instead of painting the brand colour. */
   mono?: boolean;
+  /**
+   * Give the mark an accessible name. Only set this where the logo stands
+   * ALONE — beside the provider's own name it is decoration, and announcing
+   * "HubSpot HubSpot" is worse than announcing nothing.
+   */
+  titled?: boolean;
   className?: string;
 }) {
-  const color = mono ? 'currentColor' : BRAND[provider];
+  const name = LABEL[provider];
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
       className={className}
-      aria-hidden="true"
+      role={titled ? 'img' : undefined}
+      aria-label={titled ? name : undefined}
+      aria-hidden={titled ? undefined : true}
       focusable="false"
       data-provider-logo={provider}
     >
-      {provider === 'hubspot' ? (
-        // The sprocket: a wheel, the stem rising from it, and the crossbar of
-        // nodes at the top. Read as a whole it is the HubSpot silhouette.
-        <g stroke={color} strokeWidth={1.9} strokeLinecap="round">
-          <circle cx="8.6" cy="16.4" r="5" />
-          <path d="M8.6 11.4V7.2" />
-          <path d="M8.6 7.2h9.2" />
-          <circle cx="19.4" cy="7.2" r="2.1" fill={color} stroke="none" />
-          <circle cx="8.6" cy="4.4" r="1.9" fill={color} stroke="none" />
-        </g>
-      ) : (
-        // A thick open ring with squared terminals — the Calendly silhouette
-        // without tracing the wordmark.
-        <g stroke={color} strokeWidth={2.6} strokeLinecap="round">
-          <path d="M17.6 7.8a6.4 6.4 0 1 0 0 8.4" />
-          <path d="M19.6 5.6 17.2 8" />
-          <path d="M19.6 18.4 17.2 16" />
-        </g>
-      )}
+      {titled ? <title>{name}</title> : null}
+      <path d={PATH[provider]} fill={mono ? 'currentColor' : BRAND[provider]} />
     </svg>
   );
 }

--- a/apps/web/components/workspace-switcher.tsx
+++ b/apps/web/components/workspace-switcher.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useRef, useState, useTransition } from 'react';
+import type { FormsMessages } from '@quill/shared';
+import type { Workspace } from '@/lib/admin-api';
+import { switchWorkspaceAction } from '@/app/admin/workspace-actions';
+
+type Messages = FormsMessages['admin']['chrome']['workspaces'];
+
+/**
+ * Which workspace you are in, and how to change it.
+ *
+ * Renders NOTHING for someone who belongs to a single account — the overwhelming
+ * majority — because a picker with one entry is a control that teaches you it
+ * does nothing. It appears the moment a second membership exists, which in
+ * practice is the moment an invitation is accepted.
+ *
+ * Switching is a server action: it rewrites the signed session cookie and
+ * reloads. It grants nothing on its own — the API re-checks membership on every
+ * request — so the worst a tampered choice can do is 403.
+ *
+ * WAI-ARIA menu-button pattern, matching AppSwitcher: Escape and outside click
+ * dismiss, and focus lands on the first item when it opens.
+ */
+export function WorkspaceSwitcher({
+  workspaces,
+  currentAccountId,
+  collapsed = false,
+  m,
+}: {
+  workspaces: Workspace[];
+  currentAccountId: string;
+  collapsed?: boolean;
+  m: Messages;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, start] = useTransition();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  // One membership is not a choice. Say nothing rather than show a dead control.
+  if (workspaces.length < 2) return null;
+
+  const current = workspaces.find((w) => w.accountId === currentAccountId);
+  const label = current?.accountName ?? m.unknown;
+
+  function choose(accountId: string) {
+    if (accountId === currentAccountId) {
+      setOpen(false);
+      return;
+    }
+    start(async () => {
+      await switchWorkspaceAction(accountId);
+    });
+  }
+
+  return (
+    <div ref={wrapRef} className="relative" data-testid="workspace-switcher">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={pending}
+        title={collapsed ? label : undefined}
+        className={`flex w-full items-center gap-2 rounded-md border border-border bg-card px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 ${
+          collapsed ? 'justify-center' : ''
+        }`}
+      >
+        <span
+          aria-hidden
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-primary/15 text-[10px] font-semibold text-foreground"
+        >
+          {label.slice(0, 1).toUpperCase()}
+        </span>
+        {!collapsed ? (
+          <>
+            <span className="min-w-0 flex-1 truncate text-foreground" data-testid="workspace-current">
+              {label}
+            </span>
+            <i
+              aria-hidden
+              className={`pi ${pending ? 'pi-spinner pi-spin' : 'pi-chevron-down'} text-muted-foreground`}
+              style={{ fontSize: 10 }}
+            />
+          </>
+        ) : null}
+      </button>
+
+      {open ? (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label={m.menuLabel}
+          className="absolute left-0 right-0 top-full z-50 mt-1 flex flex-col overflow-hidden rounded-md border border-border bg-popover py-1 shadow-lg"
+        >
+          <p className="px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {m.eyebrow}
+          </p>
+          {workspaces.map((w) => {
+            const active = w.accountId === currentAccountId;
+            return (
+              <button
+                key={w.accountId}
+                type="button"
+                role="menuitem"
+                onClick={() => choose(w.accountId)}
+                className="flex items-center gap-2 px-2.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
+              >
+                <i
+                  aria-hidden
+                  className={`pi ${active ? 'pi-check text-primary' : 'pi-circle-off opacity-0'}`}
+                  style={{ fontSize: 11 }}
+                />
+                <span className="min-w-0 flex-1 truncate">{w.accountName}</span>
+                {/* An invitation you have not opened yet. Naming it is the
+                    difference between "why are there two?" and "ah, that one is
+                    waiting for me." */}
+                {w.status === 'invited' ? (
+                  <span className="shrink-0 rounded-sm bg-secondary/15 px-1.5 py-0.5 text-[10px] font-medium text-secondary">
+                    {m.invited}
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -12,7 +12,7 @@ import type {
   MemberProfile,
   SubmissionsPage,
 } from '@quill/types';
-import { getSession, clearSession, authProvider } from './auth-session';
+import { getSession, clearSession, authProvider, getWorkspace } from './auth-session';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 
@@ -30,10 +30,15 @@ export class ApiError extends Error {
 
 async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
   const session = await getSession();
+  // Which workspace, asked separately from who — and read from its own cookie,
+  // because the local provider serves developers who have no session at all.
+  // The API re-checks membership against the database; this authorizes nothing.
+  const workspace = await getWorkspace();
   const headers: Record<string, string> = {};
   if (body) headers['content-type'] = 'application/json';
   if (session?.provider === 'workos') headers['authorization'] = `Bearer ${session.accessToken}`;
   else if (session?.provider === 'local') headers['x-quill-email'] = session.email;
+  if (workspace) headers['x-quill-workspace'] = workspace;
 
   const res = await fetch(`${API_URL}${path}`, {
     method,
@@ -49,6 +54,18 @@ async function req<T>(method: string, path: string, body?: unknown): Promise<T> 
     }
     redirect(authProvider() === 'workos' ? '/api/auth/logout' : '/login');
   }
+  // The stored workspace is no longer ours — the membership was revoked, or the
+  // account is gone. Self-heal rather than leaving every page 403ing with no way
+  // back, which is what being removed from a workspace would otherwise feel like.
+  //
+  // Via a ROUTE HANDLER, not a `setWorkspace(null)` here: this code runs inside
+  // a Server Component render, where `cookies().set()` throws. Clearing it here
+  // and redirecting anyway produced an infinite loop — the dead workspace was
+  // re-sent on every hop. The handler owns its response, so the delete lands.
+  if (res.status === 403 && workspace) {
+    const j = (await res.clone().json().catch(() => ({}))) as { error?: string };
+    if (j.error === 'WORKSPACE_FORBIDDEN') redirect('/api/workspace/reset');
+  }
   if (!res.ok) {
     const j = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
     throw new ApiError(res.status, j.message ?? j.error ?? `${method} ${path} → ${res.status}`, j.error);
@@ -59,6 +76,40 @@ async function req<T>(method: string, path: string, body?: unknown): Promise<T> 
 
 export type AccountRole = 'owner' | 'admin' | 'member';
 export type MemberStatus = 'active' | 'invited' | 'disabled';
+
+/** One account the signed-in person can act in. */
+export interface Workspace {
+  accountId: string;
+  accountCode: string;
+  accountName: string;
+  memberId: string;
+  role: AccountRole;
+  /** `invited` until they first open it — shown as pending in the switcher. */
+  status: MemberStatus;
+}
+
+/** Why a webhook test delivery failed — mirrors `WebhookPingReason` in the API. */
+export type WebhookPingReason =
+  | 'method_not_allowed'
+  | 'unsupported_media_type'
+  | 'rejected_body'
+  | 'unauthorized'
+  | 'not_found'
+  | 'rate_limited'
+  | 'server_error'
+  | 'redirect'
+  | 'blocked'
+  | 'unreachable'
+  | 'unknown';
+
+export interface WebhookPingResult {
+  ok: boolean;
+  reason?: WebhookPingReason;
+  status?: number;
+  /** The endpoint's own response body, trimmed and truncated by the API. */
+  detail?: string;
+  message?: string;
+}
 
 export interface Me {
   accountId: string;
@@ -309,9 +360,11 @@ export const adminApi = {
   /** Replace the caller's own public page; null removes it. */
   saveMyProfile: (profile: MemberProfile | null) =>
     req<{ ok: boolean }>('PUT', '/v1/me/profile', { profile }),
+  /** Every workspace the caller can enter, for the switcher. */
+  listWorkspaces: () => req<Workspace[]>('GET', '/v1/workspaces'),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */
   pingWebhook: (id: string) =>
-    req<{ ok: boolean; message?: string }>('POST', `/v1/forms/${id}/destinations/webhook/ping`),
+    req<WebhookPingResult>('POST', `/v1/forms/${id}/destinations/webhook/ping`),
   /** Validate + encrypt-store a pasted provider token; returns the token-free status. */
   connectIntegration: (provider: IntegrationProvider, token: string) =>
     req<IntegrationStatus>('POST', `/v1/integrations/${provider}/connect`, { token }),

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -2,7 +2,8 @@ import 'server-only';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { SESSION_COOKIE } from './session';
+import { SESSION_COOKIE, WORKSPACE_COOKIE } from './session';
+import { signValue, unsignValue } from './signed-value';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 
@@ -80,9 +81,44 @@ export async function getSession(): Promise<Session | null> {
  */
 export async function hostHeaders(): Promise<Record<string, string>> {
   const s = await getSession();
-  if (s?.provider === 'workos') return { authorization: `Bearer ${s.accessToken}` };
-  if (s?.provider === 'local') return { 'x-quill-email': s.email };
-  return {};
+  const h: Record<string, string> = {};
+  if (s?.provider === 'workos') h['authorization'] = `Bearer ${s.accessToken}`;
+  else if (s?.provider === 'local') h['x-quill-email'] = s.email;
+  // The workspace travels ALONGSIDE identity, never instead of it — and it is
+  // sent even when there is no session, because the OSS `local` provider
+  // resolves a developer who never signed in. It authorizes nothing on its own.
+  const workspace = await getWorkspace();
+  if (workspace) h['x-quill-workspace'] = workspace;
+  return h;
+}
+
+// --- The chosen workspace -----------------------------------------------------
+//
+// Signed with the same secret as the session, but stored separately, because
+// the two have different lifetimes: a session may not exist at all (the OSS
+// local provider needs no cookie), and hanging the choice off one meant the
+// switcher silently did nothing for precisely those users.
+
+/** The account the person chose to act in, or null for their home one. */
+export async function getWorkspace(): Promise<string | null> {
+  const jar = await cookies();
+  return unsignValue(jar.get(WORKSPACE_COOKIE)?.value, secret());
+}
+
+/** Record (or clear, with null) the chosen workspace. */
+export async function setWorkspace(accountId: string | null): Promise<void> {
+  const jar = await cookies();
+  if (!accountId) {
+    jar.delete(WORKSPACE_COOKIE);
+    return;
+  }
+  jar.set(WORKSPACE_COOKIE, signValue(accountId, secret()), {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 60 * 60 * 24 * 30,
+  });
 }
 
 /**

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -1,2 +1,18 @@
 /** OSS local-auth session cookie name (the FE gate for the dashboard). */
 export const SESSION_COOKIE = 'quill_session';
+
+/**
+ * The workspace the person chose to act in.
+ *
+ * Deliberately its OWN cookie rather than a field inside the session, because
+ * the two have different lifetimes and different requirements. A session cookie
+ * may not exist at all — the OSS `local` provider resolves a developer with no
+ * cookie whatsoever — and folding the choice into it meant the switcher
+ * silently did nothing for exactly those users.
+ *
+ * It is a preference, not a credential: it names an account and grants nothing.
+ * The API re-derives membership from the database on every request and answers
+ * 403 when the caller has no row in that account, so the worst a forged value
+ * can do is bounce you home.
+ */
+export const WORKSPACE_COOKIE = 'quill_workspace';

--- a/apps/web/lib/signed-value.spec.ts
+++ b/apps/web/lib/signed-value.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { signValue, unsignValue } from './signed-value';
+
+const SECRET = 'a-test-secret';
+
+describe('signed cookie values', () => {
+  it('round-trips a value', () => {
+    expect(unsignValue(signValue('account-123', SECRET), SECRET)).toBe('account-123');
+  });
+
+  it('rejects a tampered payload', () => {
+    const signed = signValue('account-123', SECRET);
+    const [, sig] = signed.split('.');
+    const forged = `${Buffer.from('account-999').toString('base64url')}.${sig}`;
+    expect(unsignValue(forged, SECRET)).toBeNull();
+  });
+
+  it('rejects a value with the signature stripped off', () => {
+    const [payload] = signValue('account-123', SECRET).split('.');
+    expect(unsignValue(payload, SECRET)).toBeNull();
+  });
+
+  it('rejects a value signed with a different secret (rotation)', () => {
+    expect(unsignValue(signValue('account-123', 'old-secret'), SECRET)).toBeNull();
+  });
+
+  it('does not throw on a signature of the wrong LENGTH', () => {
+    // timingSafeEqual throws rather than returning false on a length mismatch —
+    // a forged cookie must read as absent, never crash the request.
+    const [payload] = signValue('account-123', SECRET).split('.');
+    expect(() => unsignValue(`${payload}.short`, SECRET)).not.toThrow();
+    expect(unsignValue(`${payload}.short`, SECRET)).toBeNull();
+  });
+
+  it('reads absent and empty as null', () => {
+    expect(unsignValue(undefined, SECRET)).toBeNull();
+    expect(unsignValue('', SECRET)).toBeNull();
+    expect(unsignValue('.', SECRET)).toBeNull();
+  });
+
+  it('round-trips unsigned when no secret is configured (bare OSS fork)', () => {
+    // Sound ONLY because the value authorizes nothing: the API re-checks
+    // membership against the database before honouring the workspace.
+    const v = signValue('account-123', '');
+    expect(v).not.toContain('.');
+    expect(unsignValue(v, '')).toBe('account-123');
+  });
+});

--- a/apps/web/lib/signed-value.ts
+++ b/apps/web/lib/signed-value.ts
@@ -1,0 +1,39 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * `base64url(value).hmac` — a tamper-evident cookie value.
+ *
+ * Pure and secret-as-argument on purpose: it holds no request state and reads
+ * no environment, so it is directly testable, unlike everything in
+ * `auth-session.ts` that lives behind `server-only`.
+ *
+ * With no secret (a bare OSS `local` fork) the payload rides alone. That is
+ * sound only for values which authorize NOTHING on their own — the chosen
+ * workspace is checked against the caller's memberships server-side on every
+ * request — and must never be used for a credential.
+ */
+export function signValue(value: string, secret: string): string {
+  const payload = Buffer.from(value).toString('base64url');
+  if (!secret) return payload;
+  return `${payload}.${createHmac('sha256', secret).update(payload).digest('base64url')}`;
+}
+
+/** The value back, or null when the signature does not hold. */
+export function unsignValue(raw: string | undefined, secret: string): string | null {
+  if (!raw) return null;
+  const [payload, sig] = raw.split('.');
+  if (!payload) return null;
+  if (secret) {
+    const expected = createHmac('sha256', secret).update(payload).digest('base64url');
+    // Length first: timingSafeEqual throws on a mismatch rather than returning
+    // false, and a forged cookie must read as "absent", never as a crash.
+    if (
+      !sig ||
+      sig.length !== expected.length ||
+      !timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
+    ) {
+      return null;
+    }
+  }
+  return Buffer.from(payload, 'base64url').toString() || null;
+}

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -232,6 +232,136 @@ export async function activateInvitedMember(
   );
 }
 
+// --- Workspaces (the accounts one person belongs to) --------------------------
+
+/**
+ * Who is asking, independent of which account they are currently in.
+ *
+ * `externalId` is the identity provider's stable subject (the JWT `sub`) and is
+ * the right key when there is one. `email` is the fallback for the local dev
+ * provider, whose JIT members carry no external id — and it is also how an
+ * INVITE binds: an admin types an address, and whoever proves control of that
+ * address is that member. Both come from an already-authenticated principal;
+ * neither is ever read from the request.
+ */
+export interface MemberIdentity {
+  externalId: string | null;
+  email: string | null;
+}
+
+/** One account this person can act in. */
+export interface WorkspaceRow {
+  accountId: string;
+  accountCode: string;
+  accountName: string;
+  memberId: string;
+  role: AccountRole;
+  /** `invited` until they first enter it — the switcher marks these as pending. */
+  status: MemberStatus;
+}
+
+/**
+ * Read the identity of an already-resolved member, so the caller can look for
+ * the same person elsewhere. Returns null for a member that does not exist.
+ */
+export async function getMemberIdentity(
+  db: Db,
+  accountId: string,
+  memberId: string,
+): Promise<MemberIdentity | null> {
+  const r = await db.get<{ external_id: string | null; email: string | null }>(
+    sql`SELECT external_id, email FROM member WHERE id = ${memberId} AND account_id = ${accountId} LIMIT 1`,
+  );
+  if (!r) return null;
+  return { externalId: r.external_id ?? null, email: r.email ?? null };
+}
+
+/**
+ * Every account this person can enter — the ones they are in, plus the ones
+ * they have been invited to and not yet opened.
+ *
+ * The data model has always allowed this — uniqueness on `member` is per
+ * account, and `inviteMember` writes a row into the INVITING account — but
+ * nothing ever read it back. Login resolves one row and stops
+ * (`ORDER BY created_at LIMIT 1`), so an invited teammate signed in and landed
+ * in their own oldest account, and the invitation led nowhere at all. This is
+ * the query that was missing.
+ *
+ * `invited` rows ARE listed: an invitation you cannot see is an invitation that
+ * does not work, and entering one is what accepting it means. `disabled` rows
+ * never appear — a revoked membership must not be reachable by picking it out
+ * of a menu.
+ */
+export async function listWorkspacesForIdentity(
+  db: Db,
+  identity: MemberIdentity,
+): Promise<WorkspaceRow[]> {
+  const email = identity.email?.trim().toLowerCase() || null;
+  const externalId = identity.externalId || null;
+  if (!email && !externalId) return [];
+
+  // Match on EITHER key. A person can hold rows created by two different paths
+  // — an IAM-provisioned one carrying `external_id`, and an invite that only
+  // ever knew their address — and both are the same human.
+  const rows = await db.all<{
+    account_id: string;
+    code: string;
+    name: string;
+    member_id: string;
+    role: string;
+    status: string;
+  }>(
+    sql`SELECT a.id AS account_id, a.code, a.name, m.id AS member_id, m.role, m.status
+        FROM member m JOIN account a ON a.id = m.account_id
+        WHERE m.status IN ('active', 'invited')
+          AND (
+            (${externalId} IS NOT NULL AND m.external_id = ${externalId})
+            OR (${email} IS NOT NULL AND lower(m.email) = ${email})
+          )
+        ORDER BY a.name ASC, a.created_at ASC`,
+  );
+
+  // The same account can match on both keys (one row, two predicates) — and in
+  // principle a person could hold two member rows in one account. Collapse to
+  // one entry per account so the switcher never lists a workspace twice.
+  const seen = new Set<string>();
+  const out: WorkspaceRow[] = [];
+  for (const r of rows) {
+    if (seen.has(r.account_id)) continue;
+    seen.add(r.account_id);
+    out.push({
+      accountId: r.account_id,
+      accountCode: r.code,
+      accountName: r.name,
+      memberId: r.member_id,
+      role: (ACCOUNT_ROLES as readonly string[]).includes(r.role)
+        ? (r.role as AccountRole)
+        : 'member',
+      status: (MEMBER_STATUSES as readonly string[]).includes(r.status)
+        ? (r.status as MemberStatus)
+        : 'active',
+    });
+  }
+  return out;
+}
+
+/**
+ * Resolve this person's membership in one specific account, or null.
+ *
+ * This is the authorization check behind the workspace switch — the only thing
+ * standing between an account id someone asked for and another tenant's data.
+ * It re-derives membership from the database on every request and never trusts
+ * anything the request carried.
+ */
+export async function findMembership(
+  db: Db,
+  identity: MemberIdentity,
+  accountId: string,
+): Promise<WorkspaceRow | null> {
+  const all = await listWorkspacesForIdentity(db, identity);
+  return all.find((w) => w.accountId === accountId) ?? null;
+}
+
 // --- Public member page (the /[accountCode]/[handle] route) -------------------
 
 /** One published form as the public profile lists it. */

--- a/packages/destinations/src/adapters/webhook.ts
+++ b/packages/destinations/src/adapters/webhook.ts
@@ -131,10 +131,55 @@ export class WebhookDestination implements SubmissionDestination {
     // No redirects: a 3xx (or the opaque redirect fetch surfaces as status 0)
     // is a failure, never a followed hop.
     if (res.status === 0 || (res.status >= 300 && res.status < 400)) {
-      throw new Error(`webhook delivery refused: endpoint attempted a redirect (HTTP ${res.status})`);
+      throw new WebhookHttpError(
+        `webhook delivery refused: endpoint attempted a redirect (HTTP ${res.status})`,
+        res.status,
+        null,
+      );
     }
-    if (!res.ok) throw new Error(`webhook delivery failed: HTTP ${res.status}`);
+    if (!res.ok) {
+      // The receiver's own body is the single most useful thing we can hand
+      // back — it usually names the exact reason a status code cannot. Read it
+      // best-effort and bounded: a failing endpoint may answer with a whole
+      // HTML error page, and none of this belongs in an outbox row.
+      const detail = await readErrorBody(res);
+      throw new WebhookHttpError(`webhook delivery failed: HTTP ${res.status}`, res.status, detail);
+    }
     return { delivered: true, driver: 'webhook' };
+  }
+}
+
+/** How much of the receiver's error body we keep. Enough to carry a JSON error. */
+const MAX_ERROR_BODY = 400;
+
+async function readErrorBody(res: Response): Promise<string | null> {
+  try {
+    const text = (await res.text()).trim();
+    if (!text) return null;
+    return text.length > MAX_ERROR_BODY ? `${text.slice(0, MAX_ERROR_BODY)}…` : text;
+  } catch {
+    return null; // an unreadable body must never mask the status we already have.
+  }
+}
+
+/**
+ * A delivery the endpoint answered and rejected.
+ *
+ * The `message` is byte-identical to what this adapter has always thrown — the
+ * outbox stores it and two tests assert on it, so it is a contract, not a
+ * string. The status and the receiver's body ride alongside it so a caller that
+ * can do something better with them (the admin test delivery, which explains the
+ * failure to a person) does not have to parse English out of a message.
+ */
+export class WebhookHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    /** The endpoint's own response body, trimmed and truncated, when it sent one. */
+    readonly detail: string | null,
+  ) {
+    super(message);
+    this.name = 'WebhookHttpError';
   }
 }
 

--- a/packages/destinations/src/index.ts
+++ b/packages/destinations/src/index.ts
@@ -15,6 +15,7 @@ export {
 export { LogOnlyDestination } from './adapters/log-only';
 export {
   WebhookDestination,
+  WebhookHttpError,
   type WebhookDestinationOptions,
   type WebhookPayload,
   signWebhookBody,

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -123,6 +123,15 @@ export interface FormsMessages {
         calendars: string;
         opensNewTab: string;
       };
+      /** The workspace picker — a different axis from `switcher` (product). */
+      workspaces: {
+        menuLabel: string;
+        eyebrow: string;
+        /** Marks a workspace you were invited to and have not opened yet. */
+        invited: string;
+        /** The account is not among the caller's memberships (a stale choice). */
+        unknown: string;
+      };
     };
     /** The dashboard home (/admin) — greeting, public link, stats, quick actions. */
     home: {
@@ -944,6 +953,26 @@ export interface FormsMessages {
       pingFailed: string;
       pingNeedsUrl: string;
       pingHelp: string;
+      /**
+       * Why a test delivery failed. One line per reason the API can name — a
+       * bare "HTTP 400" told the author nothing about where to look. Only
+       * `pingMethodNotAllowed` may claim POST was refused; that is the one
+       * status that actually says so.
+       */
+      pingStatus: string;
+      pingWeSend: string;
+      pingEndpointSaid: string;
+      pingMethodNotAllowed: string;
+      pingUnsupportedMedia: string;
+      pingRejectedBody: string;
+      pingUnauthorized: string;
+      pingNotFound: string;
+      pingRateLimited: string;
+      pingServerError: string;
+      pingRedirect: string;
+      pingBlocked: string;
+      pingUnreachable: string;
+      pingUnknown: string;
       connectedBadge: string;
       propertiesUnavailable: string;
       mapQuestions: string;
@@ -1118,6 +1147,12 @@ export const en: FormsMessages = {
         dapta: 'Dapta AI',
         calendars: 'Dapta Calendars',
         opensNewTab: '(opens in a new tab)',
+      },
+      workspaces: {
+        menuLabel: 'Your workspaces',
+        eyebrow: 'Workspace',
+        invited: 'Invited',
+        unknown: 'Unknown workspace',
       },
     },
     home: {
@@ -1896,6 +1931,21 @@ export const en: FormsMessages = {
       pingNeedsUrl: 'Save a webhook URL first.',
       pingHelp:
         'Posts one sample body in the real shape, signed the same way, so you can check what your endpoint receives. The answers are made up and marked as a test.',
+      pingStatus: 'Your endpoint answered HTTP {status}.',
+      pingWeSend: 'Dapta Forms always delivers with POST and a JSON body.',
+      pingEndpointSaid: 'It replied: {detail}',
+      pingMethodNotAllowed: 'It does not accept POST on this URL.',
+      pingUnsupportedMedia: 'It refused the content type.',
+      pingRejectedBody: 'It read the request and rejected the body.',
+      pingUnauthorized: 'It refused the request as unauthorised — check any token or secret it expects.',
+      pingNotFound: 'There is nothing at that URL.',
+      pingRateLimited: 'It is rate-limiting us — try again shortly.',
+      pingServerError: 'It failed on its side.',
+      pingRedirect: 'It answered with a redirect, which we never follow. Use the final URL directly.',
+      pingBlocked:
+        'Blocked before sending: that address is private, reserved, or internal, and we never post to those.',
+      pingUnreachable: 'Nothing answered at that URL — check the host is reachable and not timing out.',
+      pingUnknown: 'The delivery failed for a reason we could not identify.',
       connectedBadge: 'HubSpot connected',
       propertiesUnavailable:
         'HubSpot properties are temporarily unavailable — you can still type a property name.',
@@ -2069,6 +2119,12 @@ export const es: FormsMessages = {
         dapta: 'Dapta AI',
         calendars: 'Dapta Calendars',
         opensNewTab: '(se abre en una pestaña nueva)',
+      },
+      workspaces: {
+        menuLabel: 'Tus workspaces',
+        eyebrow: 'Workspace',
+        invited: 'Invitado',
+        unknown: 'Workspace desconocido',
       },
     },
     home: {
@@ -2850,6 +2906,21 @@ export const es: FormsMessages = {
       pingNeedsUrl: 'Primero guarda una URL de webhook.',
       pingHelp:
         'Manda un cuerpo de ejemplo con la forma real, firmado igual, para que veas qué recibe tu endpoint. Las respuestas son inventadas y van marcadas como prueba.',
+      pingStatus: 'Tu endpoint respondió HTTP {status}.',
+      pingWeSend: 'Dapta Forms siempre entrega con POST y un cuerpo JSON.',
+      pingEndpointSaid: 'Respondió: {detail}',
+      pingMethodNotAllowed: 'No acepta POST en esa URL.',
+      pingUnsupportedMedia: 'Rechazó el tipo de contenido.',
+      pingRejectedBody: 'Leyó la petición y rechazó el cuerpo.',
+      pingUnauthorized: 'Rechazó la petición por falta de autorización: revisa el token o secreto que espera.',
+      pingNotFound: 'No hay nada en esa URL.',
+      pingRateLimited: 'Nos está limitando por frecuencia; probá de nuevo en un momento.',
+      pingServerError: 'Falló de su lado.',
+      pingRedirect: 'Respondió con una redirección, y nunca las seguimos. Usá la URL final directamente.',
+      pingBlocked:
+        'Bloqueado antes de enviar: esa dirección es privada, reservada o interna, y nunca publicamos hacia ahí.',
+      pingUnreachable: 'Nadie respondió en esa URL: revisá que el host esté accesible y no expire.',
+      pingUnknown: 'La entrega falló por un motivo que no pudimos identificar.',
       connectedBadge: 'HubSpot conectado',
       propertiesUnavailable:
         'Las propiedades de HubSpot no están disponibles temporalmente; aún puedes escribir el nombre de una propiedad.',


### PR DESCRIPTION
Four reported bugs traced to their causes, and the workspace switch that finally gives invitations somewhere to lead. **No migration** — every table this needs already exists.

---

## Advanced settings was two pixels tall

Not a scroll bug. Measured on a running instance, the section had `clientHeight: 2`.

`overflow-hidden` is there to clip children to the rounded corners. In CSS that also resolves the box's `min-height: auto` to **0** — and as a flex child of the settings column, which routinely overflows, the browser compressed the whole group to nothing. Every sibling survived because they are `overflow: visible` and keep their min-content floor.

That is why it read as *"Advanced settings is missing and the panel won't scroll"*: there was nothing left to scroll to. And why zooming out helped — less content, less to compress.

`shrink-0`, and the height goes 2px → 42px. The column is a scroll container, so nothing inside it should ever shrink.

**On "check every question type":** the group is mounted from a single unconditional call site for all twelve, and the cause is a box-model property, not per-type markup. There is no type where the fix does not apply and no type-specific path that could reintroduce it. I also swept the rest of the admin for the same pattern — a flex child with `overflow-hidden` inside a scrolling column — and the question spine was the only other candidate. It does not squash: forced to 160px, its rows keep their heights.

## The sidebar grew with the page

On Settings the `<aside>` measured **2834px** — the full document height — with `position: static`. The `mt-auto` footer therefore sat at y=2761, roughly 2000px below the fold, which is why the account name and sign-out only appeared after scrolling to the very bottom.

The editor never showed the bug because that route is its own `h-[100dvh] overflow-hidden` shell.

Pinned with `sticky top-0 h-dvh`, plus `overflow-y-auto` so the rail stays usable if the nav ever outgrows a short viewport.

## Real brand marks

The previous HubSpot sprocket and Calendly ring were geometric approximations I drew by hand. These are the official marks. Still inline SVG — a fork has to render with no CDN reachable — and still one filled path each, so the `mono` variant is a single swap.

They now appear wherever the provider is actually named: the **Connect tab**'s HubSpot card (all three states, including the two early returns) and the builder's **scheduler panel**, not only the Connections page.

## Why the webhook test failed

The toast said `Test failed: webhook delivery failed: HTTP 400`. True, and useless.

`WebhookHttpError` now carries the status **and a truncated copy of the endpoint's own response body**, which names the real reason far more often than a status code can. Its `message` is byte-identical to what the adapter always threw — the outbox stores that string and two tests assert on it, so it is a contract, not prose.

### Where this deliberately does less than asked

The report was that the error appears when the webhook is not a POST endpoint, and should say so. The endpoint answered **400**, not 405.

A 400 means it read the request and rejected the body. Only **405/501** actually says "I do not accept POST", and that is the only case where the copy claims it. Writing "your webhook is not POST" on every 400 would be right often enough to be trusted and wrong often enough to cost someone an afternoon.

So each status maps to what it genuinely means, every 4xx also states what we send (POST, `application/json` — the assumption most often wrong), and the endpoint's own message carries the rest. `blocked` and `unreachable` are named separately so "we refused to send this" never reads as "your server is down".

## Working in more than one workspace

Forms mapped one Dapta account to one Forms account, and login resolved a single member row — `ORDER BY created_at ASC LIMIT 1`. So an invited teammate signed in and landed in **their own oldest account**. Every invitation was a dead end.

I looked at how the platform does it first. `workspace-card.component.ts` writes the id to `localStorage`, shows a spinner, and reloads; no token is re-minted and no server is asked. Backends receive the choice as `x-workspace-id`. (`IAMAuthService.switchWorkspace()` exists and nothing calls it.) That shape does not port directly — localStorage is per-origin, and `forms.dapta.dev` cannot read `app.dapta.ai`'s — but the principle does, and Forms can be stricter about it.

**Identity and tenancy are now separate questions.** The provider answers only WHO, from a token it validated. A request may NAME an account via `x-quill-workspace`, and that header proves nothing at all: membership is re-derived from the database on every request, keyed to the identity already proven, matched on the IAM subject when there is one and on the email address otherwise — because an invite only ever knew the address.

An account the caller holds no row in is a **403**, deliberately not a quiet fall back to the home account. A silent fallback means writes landing in a tenant the person did not believe they were in, which is worse than an error. Revoked (`disabled`) memberships are unreachable, and the switcher's list is always derived from the home identity, so entering a workspace can never strand someone with no way back.

Opening a workspace you were invited to **accepts the invitation** — the same `invited → active` transition the home account already had, for the same reason.

The switcher renders nothing for someone with a single membership, which is nearly everyone. It appears the moment a second one exists.

### Two things this got wrong first

Both found by running it, not by reading it.

**The choice lived inside the session cookie.** Reasonable — it inherits the HMAC. But `getSession()` returns null for anyone the OSS `local` provider resolves without one, and my `if (!s) return` meant the switch silently did nothing for exactly those users. It has its own signed cookie now, which is also more honest: it is a preference, not a credential, and it authorizes nothing.

**Clearing a revoked workspace looped forever.** `cookies().set()` throws inside a Server Component render, so catching it and redirecting anyway re-sent the dead workspace on every hop — 89 requests before I stopped it. A route handler owns its response, so the delete actually lands. Verified: revoking the membership mid-session now produces exactly `/admin/forms → /api/workspace/reset → /admin`, one hop.

## Verified against a running instance

- Advanced settings reachable and 42px tall at the bottom of the panel
- The sidebar footer visible on Settings without scrolling; the editor unaffected
- `/v1/workspaces` returns all three memberships; `/v1/me` with the header returns the target account and **its** role (`admin` in Beta, `owner` at home)
- Switching to Beta Co shows Beta's data — 0 forms, no public link — not Acme's
- Entering the invited Gamma Labs flipped that row `invited → active` in the database
- Revoking a membership mid-session bounces home in one hop, with no loop

## Test plan

- [x] `pnpm typecheck` 16/16
- [x] `pnpm lint` 16/16, zero warnings
- [x] `pnpm test` 16/16 — **677 passing**, 33 of them new (13 workspace authorization, 13 webhook failure reasons, 7 signed-cookie)
- [x] `pnpm build` 9/9
- [x] i18n EN + ES for every new string (compiler-enforced parity)
- [x] Changesets for both behavioural changes
- [x] No migration — `member` and `account` already carry everything this needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
