### PR TITLE
fix(web): stop clipping the advanced group, and prove it stays reachable

### DIFF
--- a/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
@@ -39,21 +39,37 @@ export function AdvancedSettings({
     <section
       data-testid="advanced-settings"
       data-open={open}
-      // `shrink-0` is load-bearing, not tidiness. `overflow-hidden` (which clips
-      // the children to the rounded corners) makes CSS resolve this box's
-      // `min-height: auto` to 0 — and as a flex child of the settings column,
-      // which routinely overflows, the browser then compressed the whole group
-      // to 2px. It read as "Advanced settings is missing and the panel won't
-      // scroll"; there was simply nothing left to scroll to. Every sibling
-      // survives because they are `overflow: visible` and keep their min-content
-      // floor. The column is a scroll container, so nothing in it should shrink.
-      className="mt-2 shrink-0 overflow-hidden rounded-md border border-border"
+      // NO `overflow-hidden` here, deliberately, and the reason is worth the
+      // paragraph. It was originally set to clip the children to the rounded
+      // corners. But any `overflow` other than `visible` makes CSS resolve this
+      // box's `min-height: auto` to **0**, which removes its min-content floor —
+      // and as a flex child of the settings column, which routinely overflows,
+      // the browser then compressed the whole group to 2px. Open or closed.
+      //
+      // The failure mode was the worst kind: the content still existed, laid out
+      // at its full 840px, silently clipped inside a 2px box. The column's
+      // scrollHeight never grew, so there was nothing to scroll to either. It
+      // read exactly as reported — "I can expand it, but I cannot scroll to the
+      // options, they hide behind the screen."
+      //
+      // `shrink-0` alone also fixes it, and is kept as a second line of defence,
+      // but removing the clip is what makes the bug impossible rather than
+      // merely counteracted: with `overflow: visible` this box cannot be squashed
+      // no matter what the flex algorithm wants, and anything unexpected would
+      // overflow VISIBLY instead of vanishing. The corners are rounded on the
+      // button itself instead.
+      className="mt-2 shrink-0 rounded-md border border-border"
     >
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        className="flex w-full flex-wrap items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        // Rounds itself rather than relying on the parent to clip it: the header
+        // is the only thing whose background reaches the corners. Closed, it is
+        // the whole box; open, only the top two.
+        className={`flex w-full flex-wrap items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          open ? 'rounded-t-md' : 'rounded-md'
+        }`}
       >
         <i
           aria-hidden

--- a/qa/e2e/advanced-settings-reachable.spec.ts
+++ b/qa/e2e/advanced-settings-reachable.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * The Advanced settings group must stay REACHABLE, at every viewport height.
+ *
+ * This is a layout regression test, and it exists because the bug it guards
+ * against is invisible to every other kind of test. The group carried
+ * `overflow-hidden` (to clip its children to the rounded corners). Any
+ * `overflow` other than `visible` makes CSS resolve `min-height: auto` to 0,
+ * which strips the box's min-content floor — and as a flex child of the
+ * settings column, which routinely overflows, the browser compressed the entire
+ * group to **2px**, open or closed.
+ *
+ * Nothing threw. The DOM was correct, every unit test passed, the children were
+ * laid out at their full height — silently clipped inside a 2px box, with the
+ * column's scrollHeight never growing, so there was nothing to scroll to
+ * either. It reached us as "I can expand it, but I cannot scroll to the
+ * options, they hide behind the screen."
+ *
+ * Only a real browser measuring real boxes can catch that, which is why this
+ * lives in the Playwright suite rather than beside the component.
+ */
+
+/** The QA API. Overridable so this can also be pointed at a dev instance. */
+const API = process.env.QA_API_URL ?? 'http://localhost:4400';
+
+async function createForm(
+  request: APIRequestContext,
+  name: string,
+): Promise<{ id: string }> {
+  const res = await request.post(`${API}/v1/forms`, {
+    data: {
+      name,
+      config: {
+        version: 1,
+        steps: [
+          {
+            // The type the bug was reported on: a choice question carries
+            // options AND a Logic section, so its panel is one of the tallest,
+            // which is exactly when the group used to be squashed away.
+            key: 'role',
+            type: 'multiple_choice',
+            question: 'What best describes you?',
+            required: true,
+            options: [
+              { label: 'Founder', value: 'founder' },
+              { label: 'Team lead', value: 'lead' },
+              { label: 'Individual', value: 'individual' },
+            ],
+          },
+        ],
+      },
+    },
+  });
+  expect(res.ok(), `POST /v1/forms failed: ${res.status()}`).toBeTruthy();
+  return { id: (await res.json()).id };
+}
+
+// Short viewports are where a squashed flex child hurts most, so the shortest
+// one here is deliberately smaller than any laptop we expect someone to use.
+for (const height of [900, 720, 560]) {
+  test(`advanced settings expands and every row is reachable at 1440x${height}`, async ({
+    page,
+    request,
+  }) => {
+    await page.setViewportSize({ width: 1440, height });
+    const form = await createForm(request, `qa-advanced-reach-${height}-${Date.now()}`);
+    await page.goto(`/admin/forms/${form.id}/edit`);
+
+    const advanced = page.locator('[data-testid="advanced-settings"]');
+    await expect(advanced).toBeVisible();
+
+    // Collapsed, the header alone must still occupy real height — this is the
+    // exact assertion that fails at 2px.
+    const collapsed = await advanced.boundingBox();
+    expect(collapsed!.height, 'collapsed header has real height').toBeGreaterThan(24);
+
+    await advanced.locator('button').first().click();
+    await expect(advanced).toHaveAttribute('data-open', 'true');
+
+    // Expanded, the box must be as tall as what it contains: nothing may be
+    // clipped INSIDE it, which is how the content used to disappear.
+    const hidden = await advanced.evaluate((el) => {
+      const body = el.querySelector(':scope > div');
+      if (!body) return -1;
+      return Math.max(0, Math.round(body.scrollHeight - el.getBoundingClientRect().height));
+    });
+    expect(hidden, 'no rows clipped inside the group').toBe(0);
+
+    // And it must be possible to actually get to the last row by scrolling, the
+    // way a person would.
+    const panel = page.locator('div.flex.h-full.flex-col.gap-5.overflow-y-auto');
+    await panel.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    const lastRowVisible = await advanced.evaluate((el, vh) => {
+      const rows = [...(el.querySelector(':scope > div')?.children ?? [])];
+      const last = rows[rows.length - 1];
+      if (!last) return false;
+      const r = last.getBoundingClientRect();
+      return r.top >= 0 && r.bottom <= vh + 1;
+    }, height);
+    expect(lastRowVisible, 'the last advanced row can be scrolled into view').toBe(true);
+  });
+}


### PR DESCRIPTION
`shrink-0` (shipped in #45) counteracted the symptom. This removes the cause, and adds the browser-level test that would have caught it in the first place.

## What actually happens

Any `overflow` other than `visible` makes CSS resolve a box's `min-height: auto` to **0**, which strips its min-content floor. The advanced group carried `overflow-hidden` purely to clip children to its rounded corners — so as a flex child of the settings column, which routinely overflows, the browser squashed it to 2px. Open or closed.

Measured in a real browser, expanded, at 1440x800:

| | height | clipped inside | panel scroll |
|---|---|---|---|
| `overflow-hidden` + `shrink:1` (before #45) | **2px** | **838px** | 112px |
| `overflow-hidden` + `shrink:0` (#45) | 883px | 0px | 993px |
| **no overflow** + `shrink:1` (this PR) | 883px | 0px | 993px |

The third row is the point. With the clip gone the box **cannot be squashed at all**, so correctness no longer depends on one utility class surviving a future edit. `shrink-0` stays as a second line of defence. The rounded corners move onto the header button — the only child whose background reaches them.

## Why this was worth a structural fix

The failure mode was the worst kind. Nothing threw, every unit test passed, and the children were laid out at their full 840px — silently clipped inside a 2px box. The column's `scrollHeight` never grew, so there was nothing to scroll to either.

It reached us as *"I can expand it, but I cannot scroll to the options, they hide behind the screen."* That is precisely what 838px of invisible content with no scrollbar feels like.

## The regression test

Only a real browser measuring real boxes can catch this, so it is a Playwright spec rather than a unit test. It asserts three things at three viewport heights (900 / 720 / 560), on a `multiple_choice` question — the type this was reported on, and one of the tallest panels, since it carries both options and a Logic section:

1. the collapsed header has real height (this is the assertion that reads `2`)
2. nothing is clipped **inside** the group once expanded
3. the last row can actually be scrolled into view

Verified to **fail** against the clipped version (`Expected: > 24, Received: 2`, all three heights) and pass against this one.

## Verified

- Chromium and WebKit, at 900 / 800 / 720 / 640 / 560 — nothing hidden, last row reachable in every combination
- Re-checked with `flex-shrink` forcibly set back to `1` at runtime: still correct, which is the whole point of removing the clip

## Test plan

- [x] `pnpm typecheck` 16/16
- [x] `pnpm lint` 16/16, zero warnings
- [x] New Playwright spec passes (3/3) and fails against the broken version (3/3)
- [x] No new strings, no schema change, no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
