### PR TITLE
fix(web): seamless client-logos marquee and unclipped app-switcher menu

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -881,6 +881,7 @@
   color: var(--muted-foreground);
 }
 .pf-logos__viewport {
+  position: relative; /* anchors the hidden measuring row */
   overflow: hidden;
   width: 100%;
   mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
@@ -891,12 +892,23 @@
   width: max-content;
   animation: pf-logos-marquee 24s linear infinite;
 }
+/* Invisible single-copy row the component measures to size the real track. */
+.pf-logos__track--measure {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+  animation: none;
+}
 @media (prefers-reduced-motion: reduce) {
   .pf-logos__track {
     animation: none;
     flex-wrap: wrap;
     justify-content: center;
     width: 100%;
+  }
+  /* Static fallback shows each logo once — the loop copies disappear. */
+  .pf-logos__chip--dup {
+    display: none;
   }
 }
 .pf-logos__chip {

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -180,7 +180,7 @@ export function AdminShell({
         {PRODUCT_NAME.charAt(0)}
       </span>
       {!railCollapsed ? <span className="text-sm font-semibold text-foreground">{PRODUCT_NAME}</span> : null}
-      <AppSwitcher messages={messages.switcher} collapsed={railCollapsed} />
+      <AppSwitcher messages={messages.switcher} />
       {/* The rail toggle is a desktop pref; hidden on the editor route where the
           rail is force-collapsed for canvas. */}
       {!studio ? (

--- a/apps/web/components/app-switcher.tsx
+++ b/apps/web/components/app-switcher.tsx
@@ -39,16 +39,17 @@ function suiteHref(base: string): string {
   }
 }
 
-export function AppSwitcher({
-  messages: m,
-  collapsed = false,
-}: {
-  messages: SwitcherMessages;
-  collapsed?: boolean;
-}) {
+export function AppSwitcher({ messages: m }: { messages: SwitcherMessages }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // Viewport coordinates for the menu. It renders position:fixed because the
+  // desktop rail is a scroll container (md:overflow-y-auto) — an absolute menu
+  // inside it gets CLIPPED at the rail's edge, which with the rail collapsed
+  // (64px) hid the whole menu behind the main content. Fixed positioning
+  // escapes the clip regardless of the rail state.
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 
   // No sibling product configured → the switcher would only show "current"; hide it.
   const hasSuite = PLATFORM_URL.length > 0 || CALENDARS_URL.length > 0;
@@ -61,11 +62,16 @@ export function AppSwitcher({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false);
     };
+    // The menu is position:fixed — anchored to viewport coordinates captured on
+    // open — so any scroll would leave it floating detached. Close instead.
+    const onScroll = () => setOpen(false);
     document.addEventListener('mousedown', onDown);
     document.addEventListener('keydown', onKey);
+    document.addEventListener('scroll', onScroll, true);
     return () => {
       document.removeEventListener('mousedown', onDown);
       document.removeEventListener('keydown', onKey);
+      document.removeEventListener('scroll', onScroll, true);
     };
   }, [open]);
 
@@ -83,20 +89,30 @@ export function AppSwitcher({
         aria-expanded={open}
         aria-label={m.trigger}
         title={m.trigger}
-        onClick={() => setOpen((o) => !o)}
+        ref={triggerRef}
+        onClick={() => {
+          const rect = triggerRef.current?.getBoundingClientRect();
+          // Clamp so the 240px panel never leaves the viewport on narrow screens.
+          if (rect) {
+            setPos({
+              top: rect.bottom + 8,
+              left: Math.max(8, Math.min(rect.left, window.innerWidth - 248)),
+            });
+          }
+          setOpen((o) => !o);
+        }}
         className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.98]"
       >
         <i aria-hidden className="pi pi-th-large" style={{ fontSize: 18 }} />
       </button>
 
-      {open ? (
+      {open && pos ? (
         <div
           ref={menuRef}
           role="menu"
           aria-label={m.menuLabel}
-          className={`absolute z-50 mt-2 w-60 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg ${
-            collapsed ? 'left-0' : 'left-0'
-          }`}
+          style={{ top: pos.top, left: pos.left }}
+          className="fixed z-50 w-60 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
         >
           <p className="px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {m.eyebrow}

--- a/apps/web/components/public/client-logos-marquee.tsx
+++ b/apps/web/components/public/client-logos-marquee.tsx
@@ -1,17 +1,20 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { FormClientLogo } from '@quill/engine';
 
-function LogoChip({ logo }: { logo: FormClientLogo }) {
+function LogoChip({ logo, dup }: { logo: FormClientLogo; dup?: boolean }) {
   const [failed, setFailed] = useState(false);
   const showText = !logo.src || failed;
   return (
-    <div className="pf-logos__chip">
+    <div
+      className={dup ? 'pf-logos__chip pf-logos__chip--dup' : 'pf-logos__chip'}
+      aria-hidden={dup || undefined}
+    >
       {!showText && logo.src ? (
         <img
           src={logo.src}
-          alt={logo.name}
+          alt={dup ? '' : logo.name}
           className="pf-logos__img"
           onError={() => setFailed(true)}
         />
@@ -24,8 +27,19 @@ function LogoChip({ logo }: { logo: FormClientLogo }) {
 
 /**
  * Optional "trusted by" marquee on the cover. Config-driven logos (image or text
- * fallback); duplicated once for a seamless loop. Falls back to a static wrapped
- * row when the viewer prefers reduced motion (handled in CSS).
+ * fallback).
+ *
+ * The CSS loop translates the track by -50%, which is only seamless when each
+ * HALF of the track is at least as wide as the viewport. With two or three
+ * logos a single copy is far narrower than the 620px viewport, so the old
+ * duplicate-once version scrolled a giant empty gap through the mask on every
+ * cycle — it looked like the carousel "ended" and restarted. The set is now
+ * repeated as many times as the measured widths require (a hidden one-set row
+ * provides the copy width; re-measured on resize).
+ *
+ * Every chip beyond the first set is a visual duplicate: aria-hidden here, and
+ * hidden entirely by the reduced-motion CSS so the static wrapped fallback
+ * shows each logo exactly once.
  */
 export function ClientLogosMarquee({
   logos,
@@ -34,16 +48,47 @@ export function ClientLogosMarquee({
   logos: FormClientLogo[];
   label: string;
 }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  // Copies of the set per half-track. SSR renders 1 — exactly the old
+  // duplicate-once layout — and the effect corrects it after hydration.
+  const [setsPerHalf, setSetsPerHalf] = useState(1);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const measure = measureRef.current;
+    if (!viewport || !measure) return;
+    const update = () => {
+      const vw = viewport.offsetWidth;
+      const oneSet = measure.scrollWidth;
+      if (vw > 0 && oneSet > 0) setSetsPerHalf(Math.max(1, Math.ceil(vw / oneSet)));
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(viewport);
+    ro.observe(measure);
+    return () => ro.disconnect();
+  }, [logos]);
+
   if (!logos.length) return null;
-  const items = [...logos, ...logos];
+
+  const totalSets = setsPerHalf * 2;
   return (
     <div className="pf-logos">
       {label ? <p className="pf-logos__label">{label}</p> : null}
-      <div className="pf-logos__viewport">
-        <div className="pf-logos__track">
-          {items.map((logo, i) => (
-            <LogoChip key={`${logo.name}-${i}`} logo={logo} />
+      <div ref={viewportRef} className="pf-logos__viewport">
+        {/* Hidden single-set row, purely for measuring one copy's width. */}
+        <div ref={measureRef} className="pf-logos__track pf-logos__track--measure" aria-hidden>
+          {logos.map((logo, i) => (
+            <LogoChip key={`m-${logo.name}-${i}`} logo={logo} dup />
           ))}
+        </div>
+        <div className="pf-logos__track">
+          {Array.from({ length: totalSets }, (_, s) =>
+            logos.map((logo, i) => (
+              <LogoChip key={`${s}-${logo.name}-${i}`} logo={logo} dup={s > 0} />
+            )),
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Bug 1 — "Trusted by" marquee looked like it ended and restarted

The CSS loop translates the track by **-50%**, which is only seamless when each half of the track is at least as wide as the viewport (620px). The component duplicated the logo set exactly once — with 2-3 logos a copy is ~200-300px, so every cycle scrolled a giant empty gap through the mask.

**Fix:** the component now measures a hidden one-set row and repeats the set as many times as the widths require (`ceil(viewport / oneSetWidth)` per half; re-measured on resize via ResizeObserver). The animation itself was always infinite — only the duplication count was wrong.

- Copies beyond the first set are `aria-hidden` (screen readers hear each logo once).
- The `prefers-reduced-motion` static fallback hides the copies entirely, so the wrapped row shows each logo exactly once (before, it showed everything twice).
- SSR renders the old duplicate-once layout and the client corrects it after hydration — no layout shift for wide sets.

**Verified (Playwright, 2 text logos):** half-track 794px ≥ viewport 620px → seamless; 16 chips = 8 sets; 14 duplicates aria-hidden.

## Bug 2 — app-switcher menu hidden when the rail is collapsed

The desktop sidebar is a scroll container (`md:overflow-y-auto`), so the switcher's absolutely-positioned menu was **clipped at the rail's edge** — with the rail collapsed to 64px, the whole 240px panel disappeared behind the main content.

**Fix:** the menu renders `position: fixed` at the trigger's viewport coordinates (clamped so it never leaves the viewport; closes on scroll so it can't float detached). Escapes the clip in both rail states with no z-index gymnastics against the main column. Also removes the dead `collapsed ? 'left-0' : 'left-0'` branch and the now-unused `collapsed` prop.

**Verified (Playwright, collapsed rail):** menu opens fully visible over the content — 240px wide at x=13.5, all 3 suite items present.

## Notes

- `apps/web` only — no package behavior change, so no changeset.
- Full web test suite green (113 tests), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)