### PR TITLE
fix(web): show the promo banner on forms with no cover screen

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -69,9 +69,17 @@ export function FormRenderer({
 }) {
   const m = getMessages(locale).renderer;
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
-  const cover = config.cover && config.cover.enabled !== false ? config.cover : null;
+  // The cover SCREEN: null when switched off, which is what gates the `cover`
+  // phase, the Start CTA and the back-to-cover step.
+  const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
+  // The banner is page CHROME, not part of the cover screen — `bannerScope:
+  // 'form'` exists precisely to pin it above the steps. Reading it off the
+  // gated value above made it unreachable whenever the cover was switched off,
+  // even though `showBanner` handles that case, and it disagreed with the
+  // builder preview (which reads `config.cover` directly).
+  const chrome = config.cover ?? null;
 
-  const [phase, setPhase] = useState<Phase>(cover ? 'cover' : 'steps');
+  const [phase, setPhase] = useState<Phase>(coverScreen ? 'cover' : 'steps');
   const [answers, setAnswers] = useState<Answers>({});
   const [index, setIndex] = useState(0);
   const [animKey, setAnimKey] = useState(0);
@@ -285,7 +293,7 @@ export function FormRenderer({
         // the start signal ("started answering"). The metric already counts
         // `step_complete` sessions; this keeps the event stream itself
         // consistent across form shapes. Cover forms emit it from `start()`.
-        if (!cover && !startSent.current) {
+        if (!coverScreen && !startSent.current) {
           startSent.current = true;
           track('start');
         }
@@ -416,7 +424,7 @@ export function FormRenderer({
     if (phase === 'steps' && index > 0) {
       setAnimKey((k) => k + 1);
       setIndex((i) => i - 1);
-    } else if (phase === 'steps' && index === 0 && cover) {
+    } else if (phase === 'steps' && index === 0 && coverScreen) {
       setPhase('cover');
     }
   }
@@ -464,7 +472,7 @@ export function FormRenderer({
         answers={answersRef.current}
         m={m}
         accountCode={accountCode}
-        cover={cover}
+        cover={chrome}
         design={design}
       />
     );
@@ -472,7 +480,7 @@ export function FormRenderer({
 
   if (phase === 'booking' && booking?.outcome.booking) {
     return (
-      <PhaseShell className="pf pf--booking-page" design={design} cover={cover}>
+      <PhaseShell className="pf pf--booking-page" design={design} cover={chrome}>
         <BookingScreen
           booking={booking.outcome.booking}
           answers={answersRef.current}
@@ -491,7 +499,7 @@ export function FormRenderer({
         design={design}
         role="status"
         aria-live="polite"
-        cover={cover}
+        cover={chrome}
       >
         <RevealScreen
           reveal={config.reveal}
@@ -510,7 +518,7 @@ export function FormRenderer({
         design={design}
         role="status"
         aria-live="polite"
-        cover={cover}
+        cover={chrome}
       >
         <div className="pf-reveal__inner">
           <div className="pf-reveal__spinner" aria-hidden="true" />
@@ -520,16 +528,18 @@ export function FormRenderer({
     );
   }
 
-  if (phase === 'cover' && cover) {
-    const logo = cover.logo ?? config.branding?.logo ?? null;
-    const logos = showClientLogos(cover) ? (cover.clientLogos ?? config.branding?.clientLogos ?? []) : [];
+  if (phase === 'cover' && coverScreen) {
+    const logo = coverScreen.logo ?? config.branding?.logo ?? null;
+    const logos = showClientLogos(coverScreen)
+      ? (coverScreen.clientLogos ?? config.branding?.clientLogos ?? [])
+      : [];
     return (
       <PhaseShell
         className="pf pf--cover"
         design={design}
         onKeyDown={(e) => e.key === 'Enter' && start()}
         tabIndex={-1}
-        cover={cover}
+        cover={chrome}
         isCover
       >
         <header className="pf__cover-header">
@@ -537,18 +547,18 @@ export function FormRenderer({
         </header>
         <div className="pf__cover-main">
           <div className="pf__cover-content pf-animate">
-            {cover.eyebrow || cover.badge ? (
-              <p className="pf__badge">{cover.eyebrow ?? cover.badge}</p>
+            {coverScreen.eyebrow || coverScreen.badge ? (
+              <p className="pf__badge">{coverScreen.eyebrow ?? coverScreen.badge}</p>
             ) : null}
-            <h1 className="pf__title">{cover.headline ?? name}</h1>
-            {cover.subheadline ? <p className="pf__subheadline">{cover.subheadline}</p> : null}
-            {cover.trustBadge ? <p className="pf__trust">{cover.trustBadge}</p> : null}
+            <h1 className="pf__title">{coverScreen.headline ?? name}</h1>
+            {coverScreen.subheadline ? <p className="pf__subheadline">{coverScreen.subheadline}</p> : null}
+            {coverScreen.trustBadge ? <p className="pf__trust">{coverScreen.trustBadge}</p> : null}
           </div>
           <ClientLogosMarquee logos={logos} label={m.trustedBy} />
         </div>
         <div className="pf__cover-footer">
           <button type="button" className="pf__btn" onClick={start}>
-            {cover.ctaText ?? m.start}
+            {coverScreen.ctaText ?? m.start}
           </button>
         </div>
       </PhaseShell>
@@ -577,7 +587,7 @@ export function FormRenderer({
         design={design}
         role="status"
         aria-live="polite"
-        cover={cover}
+        cover={chrome}
       >
         <RevealScreen
           reveal={step.reveal ?? { enabled: true }}
@@ -613,12 +623,12 @@ export function FormRenderer({
     const booking = step.scheduler
       ? schedulerToBooking(step.scheduler, schedPrefill.customAnswers)
       : null;
-    const schedLogo = cover?.logo ?? config.branding?.logo ?? null;
+    const schedLogo = coverScreen?.logo ?? config.branding?.logo ?? null;
     return (
-      <PhaseShell className="pf" design={design} cover={cover}>
+      <PhaseShell className="pf" design={design} cover={chrome}>
         <header className="pf__topbar">
           <div className="pf__topbar-inner">
-            {index > 0 || cover ? (
+            {index > 0 || coverScreen ? (
               <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
                 ←
               </button>
@@ -674,13 +684,13 @@ export function FormRenderer({
   // multi-select choice (pick several, then Continue) — shows the button.
   const autoAdvances = step.type === 'dropdown' || (step.type === 'multiple_choice' && !isMultiSelect(step));
   const showContinue = !autoAdvances;
-  const logo = cover?.logo ?? config.branding?.logo ?? null;
+  const logo = coverScreen?.logo ?? config.branding?.logo ?? null;
 
   return (
-    <PhaseShell className="pf" design={design} onKeyDown={onKeyDown} cover={cover}>
+    <PhaseShell className="pf" design={design} onKeyDown={onKeyDown} cover={chrome}>
       <header className="pf__topbar">
         <div className="pf__topbar-inner">
-          {index > 0 || cover ? (
+          {index > 0 || coverScreen ? (
             <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
               ←
             </button>

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -36,6 +36,7 @@ import {
   revealAfterKey,
   nameFields,
   isSafeHttpUrl,
+  showBanner,
   type Answers,
   type AnswerValue,
   type FormStep,
@@ -159,7 +160,12 @@ export function VerticalFormRenderer({
 }) {
   const m = getMessages(locale).renderer;
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
-  const cover = config.cover && config.cover.enabled !== false ? config.cover : null;
+  // The cover HERO: null when switched off, which is what gates the hero block.
+  const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
+  // The banner is page CHROME, independent of the hero — see the note in
+  // `form-renderer.tsx`. `showBanner` already handles a disabled cover; reading
+  // it off the gated value above is what made it unreachable.
+  const chrome = config.cover ?? null;
 
   const [phase, setPhase] = useState<Phase>('form');
   const [answers, setAnswers] = useState<Answers>({});
@@ -498,7 +504,7 @@ export function VerticalFormRenderer({
         answers={answersRef.current}
         m={m}
         accountCode={accountCode}
-        cover={cover}
+        cover={chrome}
         design={design}
       />
     );
@@ -506,7 +512,7 @@ export function VerticalFormRenderer({
 
   if (phase === 'booking' && booking?.outcome.booking) {
     return (
-      <PhaseShell className="pf pf--booking-page" design={design} cover={cover}>
+      <PhaseShell className="pf pf--booking-page" design={design} cover={chrome}>
         <BookingScreen
           booking={booking.outcome.booking}
           answers={answersRef.current}
@@ -525,7 +531,7 @@ export function VerticalFormRenderer({
         design={design}
         role="status"
         aria-live="polite"
-        cover={cover}
+        cover={chrome}
       >
         <RevealScreen
           reveal={pendingReveal ?? { enabled: true }}
@@ -544,7 +550,7 @@ export function VerticalFormRenderer({
         design={design}
         role="status"
         aria-live="polite"
-        cover={cover}
+        cover={chrome}
       >
         <div className="pf-reveal__inner">
           <div className="pf-reveal__spinner" aria-hidden="true" />
@@ -554,8 +560,8 @@ export function VerticalFormRenderer({
     );
   }
 
-  const logo = cover?.logo ?? config.branding?.logo ?? null;
-  const logos = cover?.clientLogos ?? config.branding?.clientLogos ?? [];
+  const logo = coverScreen?.logo ?? config.branding?.logo ?? null;
+  const logos = coverScreen?.clientLogos ?? config.branding?.clientLogos ?? [];
   const total = answerable.length;
 
   return (
@@ -566,10 +572,15 @@ export function VerticalFormRenderer({
       {/* Banner + progress share ONE sticky group so they never fight for the
           viewport top; the banner's own sticky is neutralized on this layout. */}
       <div className="pf-v__sticky">
-        {/* The one page is simultaneously the cover and the form, so both
-            banner scopes show it here (showBanner(cover, true) === has text);
-            the post-submit phases defer to the scope via the shared shell. */}
-        {cover?.bannerText ? <div className="pf__banner">{cover.bannerText}</div> : null}
+        {/* This page is simultaneously the cover and the form, so a
+            'cover'-scoped banner belongs here — but only when the hero is
+            actually rendered. With the cover switched off there is no cover on
+            the page, so 'cover' scope has nothing to attach to and only 'form'
+            shows, exactly as in the slides layout. The post-submit phases defer
+            to the scope via the shared shell. */}
+        {showBanner(chrome, coverScreen != null) ? (
+          <div className="pf__banner">{chrome?.bannerText}</div>
+        ) : null}
         {total > 0 ? (
           <div className="pf-v__progressbar">
             <div className="pf-progress" aria-hidden="true">
@@ -593,14 +604,14 @@ export function VerticalFormRenderer({
             <FormLogo src={logo} name={name} />
           </header>
 
-          {cover ? (
+          {coverScreen ? (
             <section className="pf-v__hero pf-animate">
-              {cover.eyebrow || cover.badge ? (
-                <p className="pf__badge">{cover.eyebrow ?? cover.badge}</p>
+              {coverScreen.eyebrow || coverScreen.badge ? (
+                <p className="pf__badge">{coverScreen.eyebrow ?? coverScreen.badge}</p>
               ) : null}
-              <h1 className="pf__title">{cover.headline ?? name}</h1>
-              {cover.subheadline ? <p className="pf__subheadline">{cover.subheadline}</p> : null}
-              {cover.trustBadge ? <p className="pf__trust">{cover.trustBadge}</p> : null}
+              <h1 className="pf__title">{coverScreen.headline ?? name}</h1>
+              {coverScreen.subheadline ? <p className="pf__subheadline">{coverScreen.subheadline}</p> : null}
+              {coverScreen.trustBadge ? <p className="pf__trust">{coverScreen.trustBadge}</p> : null}
               <ClientLogosMarquee logos={logos} label={m.trustedBy} />
             </section>
           ) : null}

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -771,6 +771,18 @@ describe('cover presentation toggles', () => {
     expect(showBanner(scoped, false)).toBe(true);
   });
 
+  it('showBanner ignores cover.enabled — a banner is page chrome, not the cover screen', () => {
+    // The renderers used to pass a value already nulled by `enabled === false`,
+    // which made `bannerScope: 'form'` unreachable on exactly the forms that
+    // need it: the ones with no cover screen. `showBanner` decides this, and it
+    // decides it from the SCOPE, so a disabled cover still shows a 'form' banner.
+    const off = { enabled: false, bannerText: 'Limited spots', bannerScope: 'form' as const };
+    expect(showBanner(off, false)).toBe(true);
+    // ...and a 'cover'-scoped banner still has nowhere to show without a cover.
+    const offCoverScoped = { enabled: false, bannerText: 'Limited spots', bannerScope: 'cover' as const };
+    expect(showBanner(offCoverScoped, false)).toBe(false);
+  });
+
   it('showClientLogos hides the marquee only on an explicit false', () => {
     expect(showClientLogos(undefined)).toBe(true);
     expect(showClientLogos(null)).toBe(true);


### PR DESCRIPTION
## The bug

`cover.bannerScope: 'form'` exists to pin the promo banner above every screen in the flow. It never worked on a form with the cover switched off — the one shape that needs it most. Both public renderers derived their banner source from a value that had already been nulled:

```js
const cover = config.cover && config.cover.enabled !== false ? config.cover : null;
```

`showBanner` handles a disabled cover correctly — it decides from the SCOPE — but it never got the chance. So setting a banner on a cover-less form saved fine, rendered in the builder preview (`live-preview.tsx` reads `config.cover` directly), and then showed nothing on the live page. **The preview and the real form disagreed**, which is what made this expensive to spot.

Found while building the Dapta booking quiz, where all four forms run cover-less by design.

## The fix

Split the two concepts that the single `cover` local was carrying:

| | what it is | drives |
|---|---|---|
| `coverScreen` | the cover SCREEN, still gated by `enabled` | the `cover` phase, Start CTA, back-to-cover, the hero block, cover logo/copy |
| `chrome` | `config.cover`, ungated | passed to `PhaseShell` purely as the banner source — matching what the builder preview already does |

Everything else is a mechanical rename. No conditional changed shape, only which of the two values it reads.

### Second bug, in the vertical layout

It skipped `showBanner` entirely and hardcoded `isCover: true`, reasoning that its one page is simultaneously the cover and the form. That only holds while the hero renders. It now passes `coverScreen != null`, so a `'cover'`-scoped banner no longer appears on a cover-less vertical form — and the two layouts agree on all four combinations.

## Verification

Against the dev server, both layouts, every combination of `cover.enabled` x `bannerScope`:

```
slides   enabled=false scope=form   banner=1  cover_ui=0   <- was 0, the bug
slides   enabled=false scope=cover  banner=0  cover_ui=0
slides   enabled=true  scope=form   banner=1  cover_ui=1
slides   enabled=true  scope=cover  banner=1  cover_ui=1
vertical enabled=false scope=form   banner=1  cover_ui=0   <- was 0
vertical enabled=false scope=cover  banner=0  cover_ui=0   <- was 1, the second bug
vertical enabled=true  scope=form   banner=1  cover_ui=1
vertical enabled=true  scope=cover  banner=1  cover_ui=1
```

No console errors. `pnpm test`, `typecheck`, `lint` and `build` all green.

## Scope

- **No engine change.** `showBanner` was already correct; the bug was at the call site. The added test pins that contract so a caller cannot reintroduce it.
- **No schema or config change.** Every stored config keeps parsing and rendering exactly as before, except the case that was broken — so no changeset.
- No i18n (no new strings), no migrations, no API change.

## Risk

Concentrated in one place: if a `cover` usage that belongs to the cover SCREEN had been routed to `chrome`, a form with the cover switched off would start rendering the cover. The table above pins `cover_ui=0` for all four `enabled=false` rows in both layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)