### PR TITLE
fix(web): read the API host at runtime so one image serves every environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,17 @@
 # TRUST_PROXY_HOPS=1
 
 # --- Web app --------------------------------------------------------------
-# Where the web app reaches the API from the server (RSC fetch). Default:
-# http://localhost:4000. If you move the api with API_PORT, match it here.
+# Where the web app reaches the API from the SERVER (RSC fetch, server actions).
+# Read at runtime, so one built image can serve several environments — and it may
+# point at an internal address, since these calls never leave the server. Takes
+# precedence over NEXT_PUBLIC_API_URL. Default: fall back to that, then
+# http://localhost:4000.
+# API_URL=http://localhost:4000
+#
+# Where the BROWSER reaches the API. Next inlines every NEXT_PUBLIC_* at build
+# time — into the server bundle too — so this value is frozen into the image and
+# must be publicly reachable. Set API_URL as well when one image is promoted
+# across environments; otherwise every environment inherits the build's host.
 # NEXT_PUBLIC_API_URL=http://localhost:4000
 #
 # Product name shown in the UI (titles, headings). Default: "Forms".

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -13,9 +13,10 @@ import type {
   MemberProfile,
   SubmissionsPage,
 } from '@quill/types';
+import { serverApiUrl } from './api-url';
 import { getSession, clearSession, authProvider, getWorkspace } from './auth-session';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const API_URL = serverApiUrl;
 
 /** An API error that carries the HTTP status + error code. */
 export class ApiError extends Error {

--- a/apps/web/lib/api-url.ts
+++ b/apps/web/lib/api-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Where server-side code reaches the Forms API.
+ *
+ * `NEXT_PUBLIC_*` is inlined at BUILD time into **every** bundle — the server
+ * chunks too, not only the browser ones. A production `next build` leaves zero
+ * `process.env.NEXT_PUBLIC_API_URL` reads behind, so the runtime ConfigMap value
+ * can never win. That means one image built once cannot carry a per-environment
+ * API host in `NEXT_PUBLIC_API_URL`: whatever host the build saw is frozen into
+ * the server code of every environment that image is promoted to.
+ *
+ * `API_URL` has no `NEXT_PUBLIC_` prefix, so Next leaves it as a genuine runtime
+ * `process.env` read and the per-environment ConfigMap wins — the same way
+ * `AUTH_PROVIDER` and `IAM_BASE_URL` already work. It may point at the public
+ * host or at the cluster-internal Service; server-to-server calls do not need
+ * to leave the cluster.
+ *
+ * The `NEXT_PUBLIC_API_URL` fallback is deliberate: a fork, a `pnpm dev`, or a
+ * Vercel deploy that only sets the public var keeps working with no change.
+ */
+export const serverApiUrl =
+  process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -5,8 +5,9 @@
  */
 import { cache } from 'react';
 import type { PublicForm, PublicProfile } from '@quill/types';
+import { serverApiUrl } from './api-url';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const API_URL = serverApiUrl;
 
 async function getJson<T>(path: string): Promise<T | null> {
   const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -4,8 +4,9 @@ import { redirect } from 'next/navigation';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { SESSION_COOKIE, WORKSPACE_COOKIE } from './session';
 import { signValue, unsignValue } from './signed-value';
+import { serverApiUrl } from './api-url';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const API_URL = serverApiUrl;
 
 /**
  * Web session lifecycle (per AUTH-WEB-CONTRACT §1–4). The web owns the session;

--- a/apps/web/lib/booking-embed.ts
+++ b/apps/web/lib/booking-embed.ts
@@ -13,6 +13,7 @@
  * origin-allowlisted, shape-checked, and URI/date fields validated before use.
  */
 import type { BookingCallbackInput, BookingProvider } from '@quill/types';
+import { serverApiUrl } from './api-url';
 import type { CalendlyWidgetPrefill } from './booking-prefill';
 
 export const CALENDLY_SCRIPT_SRC = 'https://assets.calendly.com/assets/external/widget.js';
@@ -228,9 +229,11 @@ export function attachBookingMessageListener(
   return () => window.removeEventListener('message', listener);
 }
 
-// Same base-URL resolution as apps/web/lib/api.ts — NEXT_PUBLIC_* is inlined
-// client-side and readable server-side, so this helper works from either.
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+// Same base-URL resolution as apps/web/lib/api.ts. This module runs from BOTH
+// sides, and each gets the right answer: on the server `API_URL` resolves from
+// the per-environment runtime env, and in the browser it is absent so the
+// inlined public host is used — which is the only one a browser could reach.
+const API_URL = serverApiUrl;
 
 /**
  * Report a booked meeting to the public API (`bookingCallbackSchema` payload)


### PR DESCRIPTION
## What this fixes

`forms.dapta.ai` has been reading and writing the **dev** database since 2026-07-14.

Proof, no login needed — both are public, server-rendered pages:

| request | result |
|---|---|
| `forms-api.dapta.dev/v1/public/forms/4ayta3/customer-feedback` | **200** — `"name": "test de prod"` |
| `forms-api.dapta.ai/v1/public/forms/4ayta3/customer-feedback` | **404** — `NOT_FOUND` |
| `forms.dapta.ai/4ayta3/alec/customer-feedback` | **200** — renders it |

The prd web app serves a form the prd API says does not exist. That form was created *through the prd UI*, and it lives in dev.

## Root cause

`NEXT_PUBLIC_*` is inlined at build time into **every** bundle — server chunks included, not just the browser ones. A production `next build` leaves **zero** `process.env.NEXT_PUBLIC_API_URL` reads behind, so the per-environment ConfigMap can never win.

The pipeline builds one image with `--build-arg NEXT_PUBLIC_API_URL="https://forms-api.dapta.dev"` and promotes it to prd by tree tag, so prd inherited the dev host inside its server code. Introduced by `d17dac2` in `dapta-forms-deploy`, which replaced a per-env `$API_URL` with the literal.

Two in-repo comments claim the opposite — `apps/web/Dockerfile` ("inlining only covers client bundles") and `ci-cd.yml` ("no client component reads NEXT_PUBLIC_API_URL"). Both are false. This PR replaces the first; the second needs a companion PR on the deploy repo.

### Why it looked like the environments were separated

`auth.provider.workos.ts` JIT-creates an account for any `account_id` claim it has not seen. dev and prd authenticate through different IAM environments, so a prd login minted a **ghost account inside dev** (`4ayta3`) instead of failing. Two accounts in one database read as two databases. The real prd account has been unreachable from `forms.dapta.ai` since 14 Jul.

## The change

Server-side callers now resolve `API_URL` — no `NEXT_PUBLIC_` prefix, so Next leaves it a genuine runtime read, exactly like `AUTH_PROVIDER` and `IAM_BASE_URL` already are.

`NEXT_PUBLIC_API_URL` stays the fallback: a fork, a `pnpm dev`, or a Vercel deploy that only sets the public var is unaffected. `API_URL` may also point at the cluster-internal Service, since these calls never leave the server.

New `apps/web/lib/api-url.ts`, consumed by `admin-api.ts`, `api.ts`, `auth-session.ts`, `booking-embed.ts`.

`booking-embed.ts` runs on both sides and each gets the right answer: the server reads the runtime env, the browser has no `API_URL` and keeps the inlined public host — the only address a browser could reach.

**Build-once/promote-by-tree is preserved.** No pipeline change; prd promotion stays a ~14s no-build operation.

## Verification

Production build with a sentinel host:

```
SERVER bundle   process.env.API_URL          → 12   ✅ runtime
                sentinel (as ?? fallback)    → 12
CLIENT bundle   process.env.API_URL          →  0   ✅ never exposed
                sentinel (the public host)   →  2   ✅ correct
```

Compiled shape: `process.env.API_URL ?? "https://SENTINEL-BAKED.example" ?? "http://localhost:4000"`.

Gate: `pnpm lint`, `pnpm typecheck`, `pnpm test` (16/16 tasks, 113 web tests) all green.

## Merging this is not enough

1. **This PR** → `develop` → `main`.
2. **Companion PR on `apps-configs-flux2`**: add `API_URL` to `dev/lab/forms-web/configmap.yaml` and `prd/lab/forms-web/configmap.yaml`. Without it `API_URL` is empty, the fallback takes over, and nothing changes.
3. **Dispatch the prd deploy** — merging `main` ships nothing:
   `gh workflow run ci-cd.yml --repo Dapta-Tech/dapta-forms-deploy -f environment=prd`

Steps 1 and 2 are order-independent; either alone leaves today's behaviour untouched.

### Done when

```bash
curl -s -o /dev/null -w "%{http_code}\n" https://forms.dapta.ai/hhmnkg/josue/demo-api-completo
```

Currently **200**. It must become **404** — prd no longer answering with dev data.

Expect prd to start showing the real prd account (the forms stranded since 14 Jul), and the ghost account's `test de prod` / `nueva` to disappear from prd. They are not deleted — they stay in dev and remain visible on `forms.dapta.dev`.

## Known remaining gap (out of scope)

`form-editor.tsx` and `integrations-editor.tsx` are client components that keep the baked host for their unload beacon. That path sends no `Authorization` header, so it cannot write cross-environment — it fails closed and drops a pending edit. The proper fix is a same-origin `/api` proxy, already noted as "Future" in `apps/web/Dockerfile`; it should not ride a launch-week hotfix.