### PR TITLE
feat: score-gated conditions, per-question HubSpot panel, public form title, booking-time answers sync

### DIFF
--- a/.changeset/score-conditions-title-booking-sync.md
+++ b/.changeset/score-conditions-title-booking-sync.md
@@ -1,0 +1,14 @@
+---
+'@quill/engine': minor
+'@quill/types': minor
+'@quill/shared': minor
+'@quill/db': patch
+'@quill/destinations': patch
+---
+
+Score-sourced visibility conditions: a show/hide rule can reference the reserved
+`@score` source (the running score over the steps before the one being decided),
+offered in the builder as "Score so far" with numeric operators. Adds the public
+form title (`config.title`, additive) resolved everywhere through the new
+`publicTitle()` helper, surfaces it in the profile listing, and corrects the
+destination port's idempotency-key documentation.

--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -73,14 +73,17 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 /** Point the seeded form at ONE enabled HubSpot destination with bookingSync. */
-async function setHubspotDestination(bookingSyncConfig?: Record<string, string>) {
+async function setHubspotDestination(
+  bookingSyncConfig?: Record<string, string>,
+  extra: Record<string, unknown> = {},
+) {
   const account = await getAccountByCode(db, 'acme');
   const forms = await listForms(db, account!.id);
   const form = forms.find((f) => f.slug === 'lead-qualifier')!;
   const full = await db.get<{ config: string }>(sql`SELECT config FROM form WHERE id = ${form.id}`);
   const config = JSON.parse(full!.config);
   config.destinations = [
-    { type: 'hubspot', enabled: true, settings: {}, bookingSync: bookingSyncConfig },
+    { type: 'hubspot', enabled: true, settings: {}, bookingSync: bookingSyncConfig, ...extra },
   ];
   await updateForm(db, account!.id, form.id, { config });
   return { accountId: account!.id, formId: form.id };
@@ -269,8 +272,14 @@ describe('booking_sync delivery', () => {
     expect(rows[0]!.nextAttemptAt).toBeGreaterThan(rows[0]!.createdAt);
   });
 
-  it('no bookingSync config on the destination → skipped (permanent config gap)', async () => {
+  it('no bookingSync config and nothing else to write → skipped (permanent config gap)', async () => {
     await setHubspotDestination(undefined);
+    // The submission HAS an email, so the submit path already synced the
+    // answers — at booking time there is genuinely nothing left to write.
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-nocfg',
+      data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+    });
     await svc.booking('acme', 'lead-qualifier', {
       sessionId: 'sess-nocfg',
       provider: 'hubspot_meetings',
@@ -283,6 +292,129 @@ describe('booking_sync delivery', () => {
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('skipped');
+    expect(rows[0]!.lastError).toContain('nothing to write');
     expect(calls).toHaveLength(0);
+  });
+
+  it('scheduler-collected email: the quiz answers sync at booking, keyed on the invitee', async () => {
+    // The form asks for NO email — the scheduler collects it. The submit-time
+    // destination was a no-op, so booking is where the answers reach the CRM.
+    await setHubspotDestination(BOOKING_SYNC_CONFIG, {
+      fieldMappings: { role: 'contact_role' },
+      valueMaps: { role: { founder: 'Founder / CEO' } },
+      staticProperties: { bz_optin: 'Form submitted Producto' },
+      outcomeProperty: 'lead_tier',
+      settings: { note: false },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-sched',
+      data: { role: 'founder', team_size: 20 }, // no email anywhere
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-sched',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const startIso = '2026-08-02T10:00:00Z';
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: startIso } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'Invitee@Corp.IO' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '77' }] }),
+    });
+    await newWorker().drainOnce();
+
+    const rows = await listOutbox(db, { kind: 'booking_sync' });
+    expect(rows[0]!.status).toBe('done');
+
+    // TWO upserts, both keyed on the invitee: the mapped answers, then the
+    // booking properties.
+    const hubspot = calls.filter((c) => c.url === HUBSPOT_UPSERT_URL);
+    expect(hubspot).toHaveLength(2);
+    const inputs = hubspot.map(
+      (c) => (c.body as { inputs: Array<Record<string, unknown>> }).inputs[0]!,
+    );
+    for (const input of inputs) expect(input.id).toBe('invitee@corp.io');
+
+    const answerProps = inputs[0]!.properties as Record<string, string>;
+    expect(answerProps.email).toBe('invitee@corp.io');
+    expect(answerProps.contact_role).toBe('Founder / CEO'); // value map applied
+    expect(answerProps.bz_optin).toBe('Form submitted Producto');
+    expect(inputs[1]!.properties).toEqual({
+      sales_stage: 'demo_booked',
+      hours_booking: String(Date.parse(startIso)),
+      sales_date_booked: String(Date.UTC(2026, 7, 2)),
+    });
+  });
+
+  it('a submission that already carries an email never re-syncs the answers', async () => {
+    await setHubspotDestination(BOOKING_SYNC_CONFIG, {
+      fieldMappings: { role: 'contact_role' },
+      settings: { note: false },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-hasmail',
+      data: { role: 'founder', team_size: 20, email: 'own@corp.io' },
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-hasmail',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'invitee@corp.io' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '5' }] }),
+    });
+    await newWorker().drainOnce();
+
+    const rows = await listOutbox(db, { kind: 'booking_sync' });
+    expect(rows[0]!.status).toBe('done');
+
+    // ONE upsert only — the booking properties. The submit path owns the
+    // answers for a form that asks its own email question.
+    const hubspot = calls.filter((c) => c.url === HUBSPOT_UPSERT_URL);
+    expect(hubspot).toHaveLength(1);
+    const props = (hubspot[0]!.body as { inputs: Array<{ properties: Record<string, string> }> })
+      .inputs[0]!.properties;
+    expect(props.contact_role).toBeUndefined();
+  });
+
+  it('answers sync alone completes the row when no bookingSync properties exist', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { role: 'contact_role' },
+      settings: { note: false },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-onlyanswers',
+      data: { role: 'founder', team_size: 20 },
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-onlyanswers',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'solo@corp.io' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '8' }] }),
+    });
+    await newWorker().drainOnce();
+
+    const rows = await listOutbox(db, { kind: 'booking_sync' });
+    expect(rows[0]!.status).toBe('done'); // not skipped — the answers went out
+    const hubspot = calls.filter((c) => c.url === HUBSPOT_UPSERT_URL);
+    expect(hubspot).toHaveLength(1);
+    const props = (hubspot[0]!.body as { inputs: Array<{ properties: Record<string, string> }> })
+      .inputs[0]!.properties;
+    expect(props.contact_role).toBe('founder'); // no value map on this destination
   });
 });

--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -329,8 +329,9 @@ describe('booking_sync delivery', () => {
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done');
 
-    // TWO upserts, both keyed on the invitee: the mapped answers, then the
-    // booking properties.
+    // TWO upserts, both keyed on the invitee — BOOKING PROPERTIES FIRST. The
+    // order is the retry-safety: the answers sync ends in a Note (no idempotent
+    // create), so it must be the LAST write of the whole delivery.
     const hubspot = calls.filter((c) => c.url === HUBSPOT_UPSERT_URL);
     expect(hubspot).toHaveLength(2);
     const inputs = hubspot.map(
@@ -338,15 +339,52 @@ describe('booking_sync delivery', () => {
     );
     for (const input of inputs) expect(input.id).toBe('invitee@corp.io');
 
-    const answerProps = inputs[0]!.properties as Record<string, string>;
-    expect(answerProps.email).toBe('invitee@corp.io');
-    expect(answerProps.contact_role).toBe('Founder / CEO'); // value map applied
-    expect(answerProps.bz_optin).toBe('Form submitted Producto');
-    expect(inputs[1]!.properties).toEqual({
+    expect(inputs[0]!.properties).toEqual({
       sales_stage: 'demo_booked',
       hours_booking: String(Date.parse(startIso)),
       sales_date_booked: String(Date.UTC(2026, 7, 2)),
     });
+    const answerProps = inputs[1]!.properties as Record<string, string>;
+    expect(answerProps.email).toBe('invitee@corp.io');
+    expect(answerProps.contact_role).toBe('Founder / CEO'); // value map applied
+    expect(answerProps.bz_optin).toBe('Form submitted Producto');
+  });
+
+  it('a free-text answer that merely LOOKS like an email does not suppress the answers sync', async () => {
+    // The gate follows the ADAPTER's email semantics (mapping to `email` /
+    // an `email` answer) — not the loose booking-key heuristic. A company
+    // field like "ceo@acme.io's startup" must not strand the answers.
+    await setHubspotDestination(BOOKING_SYNC_CONFIG, {
+      fieldMappings: { role: 'contact_role' },
+      settings: { note: false },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-lookalike',
+      data: { role: 'founder', team_size: 20, company: 'ceo@acme.io' },
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-lookalike',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'real@corp.io' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '3' }] }),
+    });
+    await newWorker().drainOnce();
+
+    const rows = await listOutbox(db, { kind: 'booking_sync' });
+    expect(rows[0]!.status).toBe('done');
+    const hubspot = calls.filter((c) => c.url === HUBSPOT_UPSERT_URL);
+    expect(hubspot).toHaveLength(2); // booking props + the answers sync
+    const answers = (hubspot[1]!.body as { inputs: Array<{ id: string; properties: Record<string, string> }> })
+      .inputs[0]!;
+    expect(answers.id).toBe('real@corp.io'); // keyed on the INVITEE, not the lookalike
+    expect(answers.properties.contact_role).toBe('founder');
   });
 
   it('a submission that already carries an email never re-syncs the answers', async () => {

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -6,8 +6,11 @@ import {
   type FormDestination,
   type HubspotDestination,
 } from '@quill/types';
+import { resolveOutcome, type FormConfig } from '@quill/engine';
+import { createDestination } from '@quill/destinations';
 import type { ServerEnv } from '@quill/config/env';
 import { OutboxSkipError } from './email-effects';
+import { extractUtm } from './destination-effects';
 import type { BookingSyncPayload } from './booking-effects';
 import { DB, ENV } from './tokens';
 
@@ -67,12 +70,11 @@ export class BookingSyncEffects {
     if (!destination) {
       throw new OutboxSkipError('booking sync: no enabled HubSpot destination on the form');
     }
+    // No early skip on absent bookingSync properties: even without them, a
+    // booking may still carry the answers sync below. The "nothing to write"
+    // decision is made at the end, once both halves are known.
     const sync = destination.bookingSync;
     const hasStage = Boolean(sync?.stageProperty?.trim() && sync?.stageValue?.trim());
-    const hasTimeProps = Boolean(sync?.dateProperty?.trim() || sync?.hoursProperty?.trim());
-    if (!sync || (!hasStage && !hasTimeProps)) {
-      throw new OutboxSkipError('booking sync: destination has no bookingSync properties configured');
-    }
 
     // --- Calendly enrichment (event start + invitee email) -------------------
     let startMs = payload.startTime;
@@ -107,7 +109,8 @@ export class BookingSyncEffects {
     }
 
     // --- Respondent email: invitee first, else the session's submission ------
-    const email = inviteeEmail ?? (await this.emailFromSubmission(payload.formId, payload.sessionId));
+    const submissionEmail = await this.emailFromSubmission(payload.formId, payload.sessionId);
+    const email = inviteeEmail ?? submissionEmail;
     if (!email) {
       throw new OutboxSkipError(
         'booking sync: no respondent email resolvable (no Calendly invitee, none in the submission)',
@@ -116,17 +119,12 @@ export class BookingSyncEffects {
 
     // --- Build the configured booking properties ------------------------------
     const properties: Record<string, string> = {};
-    if (hasStage) properties[sync.stageProperty!.trim()] = sync.stageValue!.trim();
-    if (startMs != null && Number.isFinite(startMs)) {
+    if (hasStage && sync) properties[sync.stageProperty!.trim()] = sync.stageValue!.trim();
+    if (sync && startMs != null && Number.isFinite(startMs)) {
       if (sync.hoursProperty?.trim()) properties[sync.hoursProperty.trim()] = String(startMs);
       if (sync.dateProperty?.trim()) {
         properties[sync.dateProperty.trim()] = String(utcMidnightMs(startMs));
       }
-    }
-    if (Object.keys(properties).length === 0) {
-      throw new OutboxSkipError(
-        'booking sync: nothing to write (no meeting start time resolvable and no stage configured)',
-      );
     }
 
     // --- Upsert the contact ----------------------------------------------------
@@ -146,11 +144,114 @@ export class BookingSyncEffects {
       );
       throw new OutboxSkipError('HUBSPOT_PRIVATE_APP_TOKEN not set — booking sync logged property keys only');
     }
+
+    // --- Full answers sync, keyed on the invitee (V7) --------------------------
+    // A form whose scheduler collects the email (no email QUESTION of its own)
+    // reaches submit time with nothing for the HubSpot destination to key on, so
+    // that delivery resolved as a permanent no-op and the quiz answers never
+    // synced. The Calendly invitee address closes the gap: run the SAME mapped
+    // delivery the submit path would have run, with the invitee email injected.
+    // Gated on the submission having no email of its own, so a form WITH an
+    // email question — whose submit-time delivery already ran, Note included —
+    // never double-writes.
+    const syncedAnswers =
+      !submissionEmail && inviteeEmail
+        ? await this.syncAnswersAtBooking(payload, form, destination, hubspotToken, inviteeEmail)
+        : false;
+
+    if (Object.keys(properties).length === 0) {
+      if (syncedAnswers) {
+        this.log.log(
+          `booking sync delivered (booking ${payload.bookingEventId}): answers synced; ` +
+            'no booking properties configured',
+        );
+        return;
+      }
+      throw new OutboxSkipError(
+        'booking sync: nothing to write (no meeting start time resolvable and no stage configured)',
+      );
+    }
+
     await this.upsertContact(hubspotToken, email, properties);
     this.log.log(
       `booking sync delivered (booking ${payload.bookingEventId}): contact updated ` +
-        `[${Object.keys(properties).join(', ')}]`,
+        `[${Object.keys(properties).join(', ')}]${syncedAnswers ? ' + submission answers' : ''}`,
     );
+  }
+
+  /**
+   * Deliver the submission answers through the standard HubSpot adapter — field
+   * mappings, value maps, score/outcome/static properties, Note — keyed on the
+   * Calendly invitee's email. Reuses the exact adapter the submit path uses so
+   * the two flows can never drift on mapping semantics. Retryable adapter
+   * failures propagate (the outbox retries the whole row; every write here is
+   * an idempotent upsert). Returns false when there is no submission to sync.
+   */
+  private async syncAnswersAtBooking(
+    payload: BookingSyncPayload,
+    form: { name: string; config: unknown },
+    destination: HubspotDestination,
+    token: string,
+    inviteeEmail: string,
+  ): Promise<boolean> {
+    const row = await this.db.get<{ id: string; data: unknown; score: number }>(
+      sql`SELECT id, data, score FROM submission
+          WHERE form_id = ${payload.formId} AND session_id = ${payload.sessionId} LIMIT 1`,
+    );
+    if (!row) {
+      this.log.warn('booking sync: no submission for the session — booking properties only');
+      return false;
+    }
+    const data = parseJsonColumn<Record<string, unknown>>(row.data, {});
+    const score = Number(row.score) || 0;
+
+    // Outcome label recomputed exactly as submit time does (engine, stored config).
+    const parsed = formConfigSchema.safeParse(form.config);
+    const outcomeLabel = parsed.success
+      ? (resolveOutcome(
+          parsed.data as unknown as FormConfig,
+          score,
+          data as Parameters<typeof resolveOutcome>[2],
+        )?.label ?? null)
+      : null;
+
+    // Through the factory — the same construction seam the submit path uses
+    // (invariant #7); the token is injected here and never persisted.
+    const adapter = createDestination(
+      {
+        type: 'hubspot',
+        hubspot: {
+          token,
+          fieldMappings: destination.fieldMappings ?? {},
+          utmMappings: destination.utmMappings ?? {},
+          scoreProperty: destination.scoreProperty ?? undefined,
+          dateProperty: destination.dateProperty ?? undefined,
+          note: destination.settings?.note,
+          valueMaps: destination.valueMaps,
+          outcomeProperty: destination.outcomeProperty ?? undefined,
+          staticProperties: destination.staticProperties,
+          inferCompanyFromEmail: destination.inferCompanyFromEmail,
+        },
+      },
+      this.fetchImpl,
+    );
+    const result = await adapter.deliver({
+      idempotencyKey: `booking:${payload.bookingEventId}:hubspot`,
+      submissionId: row.id,
+      formId: payload.formId,
+      formName: form.name,
+      accountId: payload.accountId,
+      sessionId: payload.sessionId,
+      score,
+      outcomeLabel,
+      phase: 'complete',
+      submittedAt: Date.now(),
+      // The invitee email rides as the `email` answer the adapter keys on; a
+      // stored value would win, but this path only runs when none exists.
+      data: { ...data, email: inviteeEmail },
+      utm: extractUtm(data),
+    });
+    return result.delivered;
   }
 
   /**

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -108,8 +108,11 @@ export class BookingSyncEffects {
       }
     }
 
+    // --- The session's submission (one read serves three consumers below) ----
+    const submission = await this.loadSubmission(payload.formId, payload.sessionId);
+
     // --- Respondent email: invitee first, else the session's submission ------
-    const submissionEmail = await this.emailFromSubmission(payload.formId, payload.sessionId);
+    const submissionEmail = submission ? looseEmailFromData(submission.data) : null;
     const email = inviteeEmail ?? submissionEmail;
     if (!email) {
       throw new OutboxSkipError(
@@ -127,7 +130,6 @@ export class BookingSyncEffects {
       }
     }
 
-    // --- Upsert the contact ----------------------------------------------------
     // Per-account HubSpot token (connected → decrypted), else the env fallback.
     const hubspotToken = await resolveProviderToken(
       this.db,
@@ -145,38 +147,71 @@ export class BookingSyncEffects {
       throw new OutboxSkipError('HUBSPOT_PRIVATE_APP_TOKEN not set — booking sync logged property keys only');
     }
 
+    // --- Booking properties FIRST — write order is the retry-safety here -------
+    // The answers sync below ends in a Note engagement, which HubSpot's API
+    // offers no idempotent create for. Everything BEFORE the Note must therefore
+    // be a retry-safe upsert, and NOTHING may run after it: with the booking
+    // upsert first and the Note last, no retryable failure can fire once a Note
+    // exists, so the outbox retrying this row can never duplicate one.
+    const wroteBooking = Object.keys(properties).length > 0;
+    if (wroteBooking) await this.upsertContact(hubspotToken, email, properties);
+
     // --- Full answers sync, keyed on the invitee (V7) --------------------------
     // A form whose scheduler collects the email (no email QUESTION of its own)
     // reaches submit time with nothing for the HubSpot destination to key on, so
     // that delivery resolved as a permanent no-op and the quiz answers never
     // synced. The Calendly invitee address closes the gap: run the SAME mapped
     // delivery the submit path would have run, with the invitee email injected.
-    // Gated on the submission having no email of its own, so a form WITH an
-    // email question — whose submit-time delivery already ran, Note included —
-    // never double-writes.
+    // Gated on the ADAPTER's own email resolution (a mapping to `email`, or an
+    // `email` answer): when THAT delivery already ran at submit time — Note
+    // included — this path must never double-write. The looser email heuristic
+    // above stays only as the booking-properties key fallback it always was.
+    const adapterEmail = submission ? adapterResolvableEmail(destination, submission.data) : null;
     const syncedAnswers =
-      !submissionEmail && inviteeEmail
-        ? await this.syncAnswersAtBooking(payload, form, destination, hubspotToken, inviteeEmail)
+      !adapterEmail && inviteeEmail && submission
+        ? await this.syncAnswersAtBooking(payload, form, destination, hubspotToken, inviteeEmail, submission)
         : false;
 
-    if (Object.keys(properties).length === 0) {
-      if (syncedAnswers) {
-        this.log.log(
-          `booking sync delivered (booking ${payload.bookingEventId}): answers synced; ` +
-            'no booking properties configured',
-        );
-        return;
-      }
+    if (!wroteBooking && !syncedAnswers) {
       throw new OutboxSkipError(
         'booking sync: nothing to write (no meeting start time resolvable and no stage configured)',
       );
     }
-
-    await this.upsertContact(hubspotToken, email, properties);
     this.log.log(
-      `booking sync delivered (booking ${payload.bookingEventId}): contact updated ` +
-        `[${Object.keys(properties).join(', ')}]${syncedAnswers ? ' + submission answers' : ''}`,
+      `booking sync delivered (booking ${payload.bookingEventId}): ` +
+        `${wroteBooking ? `contact updated [${Object.keys(properties).join(', ')}]` : 'no booking properties configured'}` +
+        `${syncedAnswers ? ' + submission answers' : ''}`,
     );
+  }
+
+  /**
+   * The session's stored submission, parsed once for the three consumers in
+   * `deliver` (email gate, booking-key fallback, answers sync). Null when the
+   * session never persisted one (e.g. a booking with no partial save yet).
+   */
+  private async loadSubmission(formId: string, sessionId: string): Promise<SubmissionRow | null> {
+    const row = await this.db.get<{
+      id: string;
+      data: unknown;
+      score: number;
+      completed_at: number | null;
+      partial_at: number | null;
+      started_at: number;
+    }>(
+      sql`SELECT id, data, score, completed_at, partial_at, started_at FROM submission
+          WHERE form_id = ${formId} AND session_id = ${sessionId} LIMIT 1`,
+    );
+    if (!row) return null;
+    return {
+      id: String(row.id),
+      data: parseJsonColumn<Record<string, unknown>>(row.data, {}),
+      score: Number(row.score) || 0,
+      completedAt: row.completed_at == null ? null : Number(row.completed_at),
+      // The moment the submission reached its CURRENT phase — what the port's
+      // `submittedAt` means. Never the delivery clock: outbox retries/backoff
+      // can run hours later, and the date property + Note would lie.
+      submittedAt: Number(row.completed_at ?? row.partial_at ?? row.started_at) || Date.now(),
+    };
   }
 
   /**
@@ -184,8 +219,9 @@ export class BookingSyncEffects {
    * mappings, value maps, score/outcome/static properties, Note — keyed on the
    * Calendly invitee's email. Reuses the exact adapter the submit path uses so
    * the two flows can never drift on mapping semantics. Retryable adapter
-   * failures propagate (the outbox retries the whole row; every write here is
-   * an idempotent upsert). Returns false when there is no submission to sync.
+   * failures propagate and the outbox retries the whole row — safe because the
+   * contact write is an idempotent upsert and the Note is the LAST side effect
+   * of the whole delivery (see the write-order comment in `deliver`).
    */
   private async syncAnswersAtBooking(
     payload: BookingSyncPayload,
@@ -193,17 +229,9 @@ export class BookingSyncEffects {
     destination: HubspotDestination,
     token: string,
     inviteeEmail: string,
+    submission: SubmissionRow,
   ): Promise<boolean> {
-    const row = await this.db.get<{ id: string; data: unknown; score: number }>(
-      sql`SELECT id, data, score FROM submission
-          WHERE form_id = ${payload.formId} AND session_id = ${payload.sessionId} LIMIT 1`,
-    );
-    if (!row) {
-      this.log.warn('booking sync: no submission for the session — booking properties only');
-      return false;
-    }
-    const data = parseJsonColumn<Record<string, unknown>>(row.data, {});
-    const score = Number(row.score) || 0;
+    const { data, score } = submission;
 
     // Outcome label recomputed exactly as submit time does (engine, stored config).
     const parsed = formConfigSchema.safeParse(form.config);
@@ -237,15 +265,20 @@ export class BookingSyncEffects {
     );
     const result = await adapter.deliver({
       idempotencyKey: `booking:${payload.bookingEventId}:hubspot`,
-      submissionId: row.id,
+      submissionId: submission.id,
       formId: payload.formId,
       formName: form.name,
       accountId: payload.accountId,
       sessionId: payload.sessionId,
       score,
       outcomeLabel,
-      phase: 'complete',
-      submittedAt: Date.now(),
+      // Honest phase: a mid-form scheduler books BEFORE the final submit, and
+      // the adapter's complete-only extras (Note, score/outcome/static props)
+      // must not fire off a partial answer set. Known limit: answers given
+      // AFTER the scheduler still reach HubSpot only if the form collects an
+      // email — the submit-time delivery keys on that, not on this booking.
+      phase: submission.completedAt != null ? 'complete' : 'partial',
+      submittedAt: submission.submittedAt,
       // The invitee email rides as the `email` answer the adapter keys on; a
       // stored value would win, but this path only runs when none exists.
       data: { ...data, email: inviteeEmail },
@@ -279,22 +312,6 @@ export class BookingSyncEffects {
     return (await res.json()) as CalendlyResource;
   }
 
-  /** Best-effort respondent email from the session's stored submission answers. */
-  private async emailFromSubmission(formId: string, sessionId: string): Promise<string | null> {
-    const row = await this.db.get<{ data: unknown }>(
-      sql`SELECT data FROM submission WHERE form_id = ${formId} AND session_id = ${sessionId} LIMIT 1`,
-    );
-    if (!row) return null;
-    const data = parseJsonColumn<Record<string, unknown>>(row.data, {});
-    for (const [key, value] of Object.entries(data)) {
-      if (typeof value !== 'string') continue;
-      if (/@/.test(value) && (key.toLowerCase().includes('email') || /@[^@]+\.[^@]+$/.test(value))) {
-        return value.trim().toLowerCase();
-      }
-    }
-    return null;
-  }
-
   /**
    * Minimal focused HubSpot client: upsert one contact keyed by email (the
    * same `batch/upsert` wire the pilot used). Deliberately NOT the destinations
@@ -322,6 +339,51 @@ export class BookingSyncEffects {
       );
     }
   }
+}
+
+/** The session's submission, parsed and phase-stamped (see `loadSubmission`). */
+interface SubmissionRow {
+  id: string;
+  data: Record<string, unknown>;
+  score: number;
+  completedAt: number | null;
+  submittedAt: number;
+}
+
+/**
+ * Best-effort respondent email from the stored answers — the BOOKING-KEY
+ * fallback only. Deliberately loose (any email-shaped string in any answer):
+ * for stamping date/hours on a contact, a probably-right key beats no key.
+ */
+function looseEmailFromData(data: Record<string, unknown>): string | null {
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value !== 'string') continue;
+    if (/@/.test(value) && (key.toLowerCase().includes('email') || /@[^@]+\.[^@]+$/.test(value))) {
+      return value.trim().toLowerCase();
+    }
+  }
+  return null;
+}
+
+/**
+ * The email the SUBMIT-TIME adapter would have keyed on — a field mapping to
+ * the `email` contact property, else a literal `email` answer (mirrors
+ * `HubspotDestination.resolveEmail`). This, not the loose heuristic above, is
+ * the answers-sync gate: the question is "did the submit delivery already run
+ * with a key?", and only the adapter's own semantics can answer it.
+ */
+function adapterResolvableEmail(
+  destination: HubspotDestination,
+  data: Record<string, unknown>,
+): string | null {
+  for (const [stepKey, property] of Object.entries(destination.fieldMappings ?? {})) {
+    const value = data[stepKey];
+    if (property?.trim() === 'email' && typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  const direct = data.email;
+  return typeof direct === 'string' && direct.trim() ? direct.trim() : null;
 }
 
 /** UTC-midnight epoch-ms of the calendar day containing `epochMs` (UTC). */

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -229,7 +229,7 @@ function extractDestinations(config: unknown): FormDestination[] {
  * that is the primary source. Flat top-level `utm_*` answer keys are accepted as
  * a robustness fallback only; they never override a nested value.
  */
-function extractUtm(data: Record<string, unknown>): Record<string, string> {
+export function extractUtm(data: Record<string, unknown>): Record<string, string> {
   const out: Record<string, string> = {};
   const add = (key: string, value: unknown) => {
     if (key in out) return; // first writer wins — nested is written first

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -76,7 +76,7 @@ export class SubmissionService {
       headline: profile.headline ?? null,
       bio: profile.bio ?? null,
       links: profile.links ?? [],
-      forms: forms.map((f) => ({ slug: f.slug, name: f.name })),
+      forms: forms.map((f) => ({ slug: f.slug, name: f.title ?? f.name })),
       branding: profile.branding ?? null,
     };
   }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/opengraph-image.tsx
@@ -1,3 +1,4 @@
+import { publicTitle } from '@quill/engine';
 import { ImageResponse } from 'next/og';
 import { readableOn, DEFAULT_ACCENT, DEFAULT_CANVAS, DEFAULT_CANVAS_FOREGROUND } from '@quill/shared';
 import { getPublicForm } from '@/lib/api';
@@ -35,7 +36,8 @@ export default async function OgImage({
   // The author's exact color — the card shows the brand, not a corrected version.
   const accent = branding.primaryColor?.trim() || DEFAULT_ACCENT;
 
-  const headline = form?.config.cover?.headline || form?.name || 'Form';
+  const headline =
+    form?.config.cover?.headline || (form ? publicTitle(form.config, form.name) : null) || 'Form';
   const sub = form?.config.cover?.subheadline ?? '';
   const eyebrow = form?.config.cover?.eyebrow ?? form?.config.cover?.badge ?? '';
 

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { getPublicForm } from '@/lib/api';
 import { publicLocale } from '@/lib/locale';
 import { getMessages, t } from '@quill/shared';
 import { MadeWithBadge } from '@/components/made-with-badge';
-import { resolveFormLayout } from '@quill/engine';
+import { resolveFormLayout, publicTitle } from '@quill/engine';
 import { resolveTracking } from '@/components/tracking/resolve-tracking';
 import { TrackingScripts } from '@/components/tracking/tracking-scripts';
 import { EmbedHeightReporter } from '@/components/public/embed-height-reporter';
@@ -25,8 +25,10 @@ export async function generateMetadata({
   const form = await getPublicForm(accountCode, slug);
   if (!form) return {};
   const locale = await publicLocale();
+  // The author-set public title wins over the private dashboard name.
+  const title = publicTitle(form.config, form.name);
   const description =
-    form.config.cover?.subheadline ?? t(getMessages(locale).growth.seoForm, { name: form.name });
+    form.config.cover?.subheadline ?? t(getMessages(locale).growth.seoForm, { name: title });
 
   // An author-supplied card wins outright; otherwise the sibling
   // `opengraph-image` route renders one from the form's own branding, and Next
@@ -35,14 +37,14 @@ export async function generateMetadata({
   const images = custom ? [{ url: custom }] : undefined;
 
   return {
-    title: form.name,
+    title,
     description,
-    openGraph: { title: form.name, description, type: 'website', ...(images ? { images } : {}) },
+    openGraph: { title, description, type: 'website', ...(images ? { images } : {}) },
     twitter: {
       // A generated 1200×630 card deserves the large format; only a form with
       // neither would fall back to the small one, and there is no such form.
       card: 'summary_large_image',
-      title: form.name,
+      title,
       description,
       ...(images ? { images } : {}),
     },
@@ -87,7 +89,7 @@ export default async function PublicFormPage({
         <Renderer
           accountCode={accountCode}
           slug={slug}
-          name={form.name}
+          name={publicTitle(form.config, form.name)}
           config={form.config}
           locale={locale}
         />

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -277,6 +277,8 @@ export interface BuilderMessages {
     condBetween: string;
     condAnd: string;
     condBlank: string;
+    /** Name for the reserved running-score condition source. */
+    condScore: string;
     condMissingField: string;
     /** V5-QA — this step's rules mean it can never be shown. */
     neverAppears: string;
@@ -576,6 +578,7 @@ const en: BuilderMessages = {
     condBetween: 'is between',
     condAnd: 'and',
     condBlank: '(not set)',
+    condScore: 'Score so far',
     condMissingField: 'question deleted',
     neverAppears: 'These rules mean this question never appears.',
     outcomeKicker: 'Ending',
@@ -872,6 +875,7 @@ const es: BuilderMessages = {
     condBetween: 'está entre',
     condAnd: 'y',
     condBlank: '(sin definir)',
+    condScore: 'Puntaje hasta aquí',
     condMissingField: 'pregunta eliminada',
     neverAppears: 'Con estas reglas, esta pregunta nunca aparece.',
     outcomeKicker: 'Final',

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -50,6 +50,7 @@ export function DesignPanel({
   publicPath,
   locale,
   layout,
+  onTitleChange,
   onLayoutChange,
   hasReveal,
   onEndRevealChange,
@@ -65,6 +66,8 @@ export function DesignPanel({
   /** Slides or one page — the first decision, because it changes what several
    *  controls below even mean. */
   layout: FormLayout;
+  /** Set/clear the PUBLIC title (empty = fall back to the dashboard name). */
+  onTitleChange: (title: string) => void;
   onLayoutChange: (next: FormLayout) => void;
   /** Vertical's single end-of-form reveal (a form-level fact, not a question). */
   hasReveal: boolean;
@@ -111,6 +114,18 @@ export function DesignPanel({
     <div className="grid h-full min-h-0 gap-4 px-4 py-6 sm:px-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,46%)] lg:overflow-hidden">
       {/* ── Controls ───────────────────────────────────────────────────── */}
       <div className="flex min-w-0 flex-col gap-4 lg:overflow-y-auto lg:pr-1">
+        <PanelSection title={d.publicTitle} subtitle={d.publicTitleHint}>
+          <div className="max-w-[520px]">
+            <TextField
+              aria-label={d.publicTitle}
+              value={config.title ?? ''}
+              placeholder={name}
+              maxLength={200}
+              onChange={(e) => onTitleChange(e.target.value)}
+            />
+          </div>
+        </PanelSection>
+
         <PanelSection title={m.layout.title} subtitle={m.layout.subtitle}>
           <div className="grid max-w-[520px] grid-cols-2 gap-2" role="radiogroup" aria-label={m.layout.title}>
             {[

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -6,8 +6,7 @@ import {
   DEFAULT_FORM_FONT,
   FORM_BACKGROUND_STYLES,
   isSafeImageUrl,
-  resolveDesign,
-} from '@quill/engine';
+  resolveDesign, publicTitle } from '@quill/engine';
 import {
   AA_CONTRAST,
   DEFAULT_ACCENT,
@@ -517,7 +516,7 @@ export function DesignPanel({
             config={config}
             selected={vertical ? 'cover' : screen}
             layout={layout}
-            name={name}
+            name={publicTitle(config, name)}
             locale={locale}
             m={m.preview}
           />
@@ -768,7 +767,8 @@ function SharePreview({
 }) {
   const branding = config.branding ?? {};
   const image = branding.ogImage?.trim() || null;
-  const headline = config.cover?.headline ?? name;
+  // Same resolution as the real card: cover headline, else the PUBLIC title.
+  const headline = config.cover?.headline ?? publicTitle(config, name);
   const ground = branding.background?.trim() || DEFAULT_CANVAS;
   // The author's exact color, like everywhere else — the share card must show
   // the card that will actually be generated, not a corrected version of it.

--- a/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Answers, FormConfig, FormLayout } from '@quill/engine';
-import { runtimeSteps } from '@quill/engine';
+import { runtimeSteps, publicTitle } from '@quill/engine';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
 import { LivePreview } from './live-preview';
@@ -141,7 +141,7 @@ export function DevicePreviewModal({
               config={config}
               selected={vertical ? 'cover' : index}
               layout={layout}
-              name={name}
+              name={publicTitle(config, name)}
               locale={locale}
               m={m}
             />

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-conditions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-conditions.tsx
@@ -5,7 +5,9 @@ import {
   conditionsContradict,
   conditionsNarrow,
   conditionNeverHolds,
+  isScoreCondition,
   operatorsForFieldType,
+  SCORE_FIELD,
   type ConditionOp,
   type FormStep,
   type StepCondition,
@@ -32,16 +34,24 @@ export function LogicConditions({
   step,
   index,
   steps,
+  scoringEnabled = true,
   onUpdate,
   m,
 }: {
   step: FormStep;
   index: number;
   steps: FormStep[];
+  /** Form-level scoring switch — off means every score gate would read 0. */
+  scoringEnabled?: boolean;
   onUpdate: (patch: Partial<FormStep>) => void;
   m: LogicMessages;
 }) {
   const prior = steps.slice(0, index);
+
+  // The running score is only worth offering when something ahead can move it;
+  // with no scoring question above, every gate would read a constant 0.
+  const scoreSource =
+    scoringEnabled && prior.some((s) => scoresPoints(s)) ? SCORE_FIELD : null;
 
   if (prior.length === 0) {
     return <p className="text-xs text-muted-foreground">{m.noPriorFields}</p>;
@@ -80,6 +90,7 @@ export function LogicConditions({
         noneLabel={m.none}
         cond={step.showWhen ?? null}
         prior={prior}
+        scoreSource={scoreSource}
         onChange={(showWhen) => onUpdate({ showWhen: showWhen ?? undefined })}
         m={m}
       />
@@ -89,6 +100,7 @@ export function LogicConditions({
         noneLabel={m.hideNone}
         cond={step.hideWhen ?? null}
         prior={prior}
+        scoreSource={scoreSource}
         onChange={(hideWhen) => onUpdate({ hideWhen: hideWhen ?? undefined })}
         m={m}
       />
@@ -148,6 +160,16 @@ function opLabel(op: ConditionOp, m: LogicMessages): string {
   }
 }
 
+/**
+ * Does this step move the score? Mirrors the engine's `stepScore`: only choice
+ * and slider types score, and lead-capture / opted-out steps never do.
+ */
+function scoresPoints(step: FormStep): boolean {
+  if (step.flowGroup === 'lead_capture') return false;
+  if (step.scoringEnabled === false) return false;
+  return step.type === 'dropdown' || step.type === 'multiple_choice' || step.type === 'slider';
+}
+
 /** One condition row: field select (none = rule off) + operator/value picker. */
 function ConditionEditor({
   testid,
@@ -155,6 +177,7 @@ function ConditionEditor({
   noneLabel,
   cond,
   prior,
+  scoreSource,
   onChange,
   m,
 }: {
@@ -163,12 +186,19 @@ function ConditionEditor({
   noneLabel: string;
   cond: StepCondition | null;
   prior: FormStep[];
+  /** `SCORE_FIELD` when the running score is offerable here, else null. */
+  scoreSource: typeof SCORE_FIELD | null;
   onChange: (next: StepCondition | null) => void;
   m: LogicMessages;
 }) {
   const NONE = '';
-  const source = cond ? prior.find((s) => s.key === cond.field) : undefined;
-  const ops: ConditionOp[] = source ? operatorsForFieldType(source.type) : ['in'];
+  const onScore = cond ? isScoreCondition(cond) : false;
+  const source = cond && !onScore ? prior.find((s) => s.key === cond.field) : undefined;
+  const ops: ConditionOp[] = onScore
+    ? operatorsForFieldType(SCORE_FIELD)
+    : source
+      ? operatorsForFieldType(source.type)
+      : ['in'];
   // Numeric sources (slider) expose the comparison operators; everything else
   // keeps the single `in` ("matches any of") behavior with no operator UI.
   const numeric = ops[0] !== 'in';
@@ -180,10 +210,15 @@ function ConditionEditor({
       onChange(null);
       return;
     }
+    // Keep the operands when re-picking the same source.
+    if (cond && cond.field === key) return;
+    if (key === SCORE_FIELD) {
+      // Numeric by definition — seed the first comparison op, operand next.
+      onChange({ field: SCORE_FIELD, values: [], op: operatorsForFieldType(SCORE_FIELD)[0] });
+      return;
+    }
     const next = prior.find((s) => s.key === key);
     if (!next) return;
-    // Keep the operands when re-picking the same field.
-    if (cond && cond.field === key) return;
     const nextOps = operatorsForFieldType(next.type);
     if (nextOps[0] !== 'in') {
       // Numeric source: seed the first comparison op (operand typed next).
@@ -224,12 +259,14 @@ function ConditionEditor({
         className="h-8 py-1 text-xs"
       >
         <option value={NONE}>{noneLabel}</option>
+        {scoreSource ? <option value={SCORE_FIELD}>{m.scoreField}</option> : null}
         {prior.map((s, i) => (
           <option key={s.key} value={s.key}>
             {s.question?.trim() || `${i + 1} · ${s.key}`}
           </option>
         ))}
       </SelectField>
+      {onScore ? <p className="text-[11px] leading-relaxed text-muted-foreground">{m.scoreHint}</p> : null}
 
       {cond ? (
         numeric ? (

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-conditions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-conditions.tsx
@@ -52,6 +52,13 @@ export function LogicConditions({
   // with no scoring question above, every gate would read a constant 0.
   const scoreSource =
     scoringEnabled && prior.some((s) => scoresPoints(s)) ? SCORE_FIELD : null;
+  // A rule ALREADY on the score while nothing above can move it: the gate reads
+  // a constant 0, so a show rule hides the question from everyone — silently,
+  // since the rule itself is perfectly well-formed. Name it.
+  const scoreDead =
+    !scoreSource &&
+    ((step.showWhen && isScoreCondition(step.showWhen)) ||
+      (step.hideWhen && isScoreCondition(step.hideWhen)));
 
   if (prior.length === 0) {
     return <p className="text-xs text-muted-foreground">{m.noPriorFields}</p>;
@@ -120,6 +127,15 @@ export function LogicConditions({
           className="rounded-md border border-destructive/50 bg-destructive/10 px-2.5 py-2 text-xs font-medium text-destructive"
         >
           {brokenCopy}
+        </p>
+      ) : null}
+      {scoreDead ? (
+        <p
+          role="alert"
+          data-testid="logic-score-dead"
+          className="rounded-md border border-destructive/50 bg-destructive/10 px-2.5 py-2 text-xs font-medium text-destructive"
+        >
+          {m.scoreDead}
         </p>
       ) : null}
       {hideBroken ? (
@@ -259,7 +275,7 @@ function ConditionEditor({
         className="h-8 py-1 text-xs"
       >
         <option value={NONE}>{noneLabel}</option>
-        {scoreSource ? <option value={SCORE_FIELD}>{m.scoreField}</option> : null}
+        {scoreSource || onScore ? <option value={SCORE_FIELD}>{m.scoreField}</option> : null}
         {prior.map((s, i) => (
           <option key={s.key} value={s.key}>
             {s.question?.trim() || `${i + 1} · ${s.key}`}

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
@@ -332,6 +332,7 @@ function ConditionLine({
     opBetween: m.map.condBetween,
     and: m.map.condAnd,
     blank: m.map.condBlank,
+    score: m.map.condScore,
   });
   const show = kind === 'show';
   return (

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-util.spec.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-util.spec.ts
@@ -26,3 +26,34 @@ describe('anchorRevealsLast (vertical layout — reveals always at the end)', ()
     expect(anchorRevealsLast(steps)).toBe(steps);
   });
 });
+
+describe('describeCondition — the reserved score source', () => {
+  const labels = {
+    fallbackQuestion: (i: number) => `Question ${i + 1}`,
+    opIn: 'is any of',
+    opEq: 'equals',
+    opGt: 'is greater than',
+    opLt: 'is less than',
+    opBetween: 'is between',
+    and: 'and',
+    blank: '(not set)',
+    score: 'Score so far',
+  };
+  const steps = [q('role'), q('company')];
+
+  it('names the score source and never marks it dangling', async () => {
+    const { describeCondition } = await import('./logic-util');
+    const d = describeCondition({ field: '@score', op: 'gt', value: 5 }, steps, labels);
+    expect(d.field).toBe('Score so far');
+    expect(d.operator).toBe('is greater than');
+    expect(d.operand).toBe('5');
+    expect(d.dangling).toBe(false);
+  });
+
+  it('a missing STEP field still dangles (score handling must not mask it)', async () => {
+    const { describeCondition } = await import('./logic-util');
+    const d = describeCondition({ field: 'ghost', values: ['x'] }, steps, labels);
+    expect(d.field).toBe('ghost');
+    expect(d.dangling).toBe(true);
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-util.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-util.ts
@@ -4,7 +4,7 @@
  * the declarative `showWhen`/`hideWhen` conditions still work (honored by the
  * engine, drawn on the map) and count toward a question's rule total.
  */
-import type { FormStep } from '@quill/engine';
+import { SCORE_FIELD, type FormStep } from '@quill/engine';
 
 /** How many logic rules a question carries (goto jumps + show/hide conditions). */
 export function ruleCount(step: FormStep): number {
@@ -65,28 +65,36 @@ export function describeCondition(
     and: string;
     /** Shown in place of an operand the author has not filled in yet. */
     blank: string;
+    /** Name for the reserved running-score source. */
+    score: string;
   },
 ): DescribedCondition {
-  const sourceIndex = steps.findIndex((s) => s.key === cond.field);
+  // The running score is a reserved source, not a question — resolving it
+  // against `steps` would find nothing and mark a valid rule as dangling.
+  const onScore = cond.field === SCORE_FIELD;
+  const sourceIndex = onScore ? -1 : steps.findIndex((s) => s.key === cond.field);
   const source = sourceIndex >= 0 ? steps[sourceIndex] : undefined;
-  const field = source
-    ? source.question?.trim() || labels.fallbackQuestion(sourceIndex)
-    : cond.field;
+  const field = onScore
+    ? labels.score
+    : source
+      ? source.question?.trim() || labels.fallbackQuestion(sourceIndex)
+      : cond.field;
+  const dangling = !onScore && !source;
 
   const num = (n: number | undefined): string => (n == null ? labels.blank : String(n));
   switch (cond.op) {
     case 'eq':
-      return { field, operator: labels.opEq, operand: num(cond.value), dangling: !source };
+      return { field, operator: labels.opEq, operand: num(cond.value), dangling };
     case 'gt':
-      return { field, operator: labels.opGt, operand: num(cond.value), dangling: !source };
+      return { field, operator: labels.opGt, operand: num(cond.value), dangling };
     case 'lt':
-      return { field, operator: labels.opLt, operand: num(cond.value), dangling: !source };
+      return { field, operator: labels.opLt, operand: num(cond.value), dangling };
     case 'between':
       return {
         field,
         operator: labels.opBetween,
         operand: `${num(cond.min)} ${labels.and} ${num(cond.max)}`,
-        dangling: !source,
+        dangling,
       };
     default: {
       // `in` (or an absent op, which the engine treats as `in`).
@@ -94,7 +102,7 @@ export function describeCondition(
       const operand = values.length
         ? values.map((v) => (source ? optionLabel(source, v) : v)).join(', ')
         : labels.blank;
-      return { field, operator: labels.opIn, operand, dangling: !source };
+      return { field, operator: labels.opIn, operand, dangling };
     }
   }
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -652,8 +652,9 @@ export function QuestionSettings({
 
       </AdvancedSettings>
 
-      {/* HubSpot — map this answer to a contact property. Message/reveal/scheduler
-          steps collect no answer, so there is nothing to map. Restored here after
+      {/* HubSpot — map this answer to a contact property. Message/reveal steps
+          collect no answer, so there is nothing to map (a scheduler DOES answer
+          — the booked slot — so it keeps the section). Restored here after
           d0ecffe dropped the render while collapsing the advanced settings; it
           stays OUTSIDE AdvancedSettings so the mapping is visible at a glance. */}
       {!isInputlessType(step.type) ? (

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -23,6 +23,7 @@ import { SliderScoringEditor } from './slider-scoring-editor';
 import { maxScoreForSteps } from './scoring-util';
 import { LogicRules } from './logic-rules';
 import { LogicConditions } from './logic-conditions';
+import { QuestionHubspotSection } from './question-hubspot';
 import { QuestionVariants } from './question-variants';
 import { SchedulerPanel } from './scheduler-panel';
 import { tokenOptionsBefore } from './token-textarea';
@@ -63,6 +64,7 @@ function currentItemId(step: FormStep): string {
  * the "doesn't affect the score" hint instead of scoring.
  */
 export function QuestionSettings({
+  formId,
   step,
   index,
   steps,
@@ -77,7 +79,9 @@ export function QuestionSettings({
   onRevealAfterChange,
   onRenameKey,
   publicUrl,
+  onOpenConnect,
 }: {
+  formId: string;
   step: FormStep;
   index: number;
   steps: FormStep[];
@@ -97,6 +101,8 @@ export function QuestionSettings({
   onRenameKey: (nextKey: string) => void;
   /** The form's real public URL, for the prefill example. */
   publicUrl?: string | null;
+  /** Switch the editor to the Connect tab (the mapping's other home). */
+  onOpenConnect: () => void;
 }) {
   const contact = isContactType(step.type);
   // Form-wide "highest possible" total (same math as Results). Drives the
@@ -499,7 +505,14 @@ export function QuestionSettings({
           <i aria-hidden className="pi pi-eye text-secondary" style={{ fontSize: 11 }} />
           {em.logic.title}
         </p>
-        <LogicConditions step={step} index={index} steps={steps} onUpdate={onUpdate} m={em.logic} />
+        <LogicConditions
+          step={step}
+          index={index}
+          steps={steps}
+          scoringEnabled={scoringEnabled}
+          onUpdate={onUpdate}
+          m={em.logic}
+        />
         {/* Personal-email branch needs an earlier email answer — impossible on
             the first question, so hide it there. A reveal is skipped or played
             by the plain conditions above; a second, narrower visibility rule on
@@ -638,6 +651,20 @@ export function QuestionSettings({
       ) : null}
 
       </AdvancedSettings>
+
+      {/* HubSpot — map this answer to a contact property. Message/reveal/scheduler
+          steps collect no answer, so there is nothing to map. Restored here after
+          d0ecffe dropped the render while collapsing the advanced settings; it
+          stays OUTSIDE AdvancedSettings so the mapping is visible at a glance. */}
+      {!isInputlessType(step.type) ? (
+        <QuestionHubspotSection
+          formId={formId}
+          stepKey={step.key}
+          locale={locale}
+          onOpenConnect={onOpenConnect}
+          m={bm.hubspot}
+        />
+      ) : null}
       {dialog}
     </div>
   );

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -382,6 +382,9 @@ export function FormEditor({
     setStatus('saving');
   }
 
+  // Public title (V7): what the tab/OG/cover show. Empty clears back to `name`.
+  const setTitle = (title: string) =>
+    mutate((c) => ({ ...c, title: title.trim() ? title : null }));
   const patchCover = (patch: Partial<FormCover>) =>
     mutate((c) => ({ ...c, cover: { ...c.cover, ...patch } }));
   const patchBranding = (patch: Partial<FormBranding>) =>
@@ -720,6 +723,8 @@ export function FormEditor({
               <aside className="min-h-0 overflow-y-auto border-t border-border lg:border-t-0">
                 {selectedStep && selected != null ? (
                   <QuestionSettings
+                    formId={id}
+                    onOpenConnect={() => setTab('connect')}
                     publicUrl={publicPath}
                     step={selectedStep}
                     index={selected}
@@ -776,6 +781,7 @@ export function FormEditor({
             publicPath={publicPath}
             locale={locale}
             layout={layout}
+            onTitleChange={setTitle}
             onLayoutChange={setLayout}
             hasReveal={hasReveal}
             onEndRevealChange={setEndReveal}

--- a/packages/db/src/members.spec.ts
+++ b/packages/db/src/members.spec.ts
@@ -123,3 +123,32 @@ describe('removeMember', () => {
     expect(res.ok).toBe(true);
   });
 });
+
+describe('listPublishedFormsForAccount — public title extraction', () => {
+  it('surfaces config.title when set and null otherwise, on both dialects', async () => {
+    const { listPublishedFormsForAccount } = await import('./members');
+    const { insertAccountWithShortCode } = await import('./short-links');
+    const externalId = `x-${randomUUID()}`;
+    await insertAccountWithShortCode(db, { name: 'Titled Co', externalId });
+    const account = await db.get<{ id: string; code: string }>(
+      sql`SELECT id, code FROM account WHERE external_id = ${externalId} LIMIT 1`,
+    );
+    const mk = async (slug: string, config: unknown) => {
+      await db.run(
+        sql`INSERT INTO form (id, account_id, name, slug, config, created_at, updated_at)
+            VALUES (${randomUUID()}, ${account!.id}, ${'Internal ' + slug}, ${slug},
+                    ${JSON.stringify(config)}, ${Date.now()}, ${Date.now()})`,
+      );
+    };
+    await mk('with-title', { version: 1, title: '  Público  ', steps: [] });
+    await mk('no-title', { version: 1, steps: [] });
+    await mk('empty-title', { version: 1, title: '   ', steps: [] });
+
+    const rows = await listPublishedFormsForAccount(db, account!.code);
+    const bySlug = Object.fromEntries(rows.map((r) => [r.slug, r]));
+    expect(bySlug['with-title']!.title).toBe('Público'); // trimmed
+    expect(bySlug['with-title']!.name).toBe('Internal with-title');
+    expect(bySlug['no-title']!.title).toBeNull();
+    expect(bySlug['empty-title']!.title).toBeNull(); // whitespace = unset
+  });
+});

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -367,7 +367,10 @@ export async function findMembership(
 /** One published form as the public profile lists it. */
 export interface ProfileFormRow {
   slug: string;
+  /** The private dashboard label — the fallback when no public title is set. */
   name: string;
+  /** The author's public title, when the form has one. */
+  title: string | null;
 }
 
 /** A member's stored public page + the identity fields it renders alongside. */
@@ -427,10 +430,17 @@ export async function listPublishedFormsForAccount(
 ): Promise<ProfileFormRow[]> {
   const account = await getAccountByCode(db, accountCode);
   if (!account) return [];
+  // `config` rides along so the listing can show the PUBLIC title. The column is
+  // jsonb on Postgres and TEXT on SQLite, so the extraction happens here in JS
+  // rather than in dialect-specific SQL.
   const rows = await db.all<Record<string, unknown>>(
-    sql`SELECT slug, name FROM form WHERE account_id = ${account.id} ORDER BY created_at ASC`,
+    sql`SELECT slug, name, config FROM form WHERE account_id = ${account.id} ORDER BY created_at ASC`,
   );
-  return rows.map((r) => ({ slug: String(r.slug), name: String(r.name) }));
+  return rows.map((r) => {
+    const config = parseJsonColumn<{ title?: unknown }>(r.config, {});
+    const title = typeof config.title === 'string' && config.title.trim() ? config.title.trim() : null;
+    return { slug: String(r.slug), name: String(r.name), title };
+  });
 }
 
 /** Replace a member's public page (account-scoped). NULL removes it entirely. */

--- a/packages/destinations/src/destination.port.ts
+++ b/packages/destinations/src/destination.port.ts
@@ -25,10 +25,13 @@ export type DestinationType = 'webhook' | 'hubspot';
  */
 export interface DestinationContext {
   /**
-   * Stable, event-specific de-duplication key
-   * (`submission:<id>:<phase>:<destinationType>`). A retried delivery reuses the
-   * same key; distinct events get distinct keys. Webhooks forward it as a header
-   * and HubSpot uses it to guard the note engagement.
+   * Stable, event-specific de-duplication key. Submission deliveries use
+   * `submission:<id>:<phase>:<destinationType>:<index>`; the booking-time
+   * answers sync uses `booking:<bookingEventId>:hubspot`. A retried delivery
+   * reuses the same key; distinct events get distinct keys. Webhooks forward it
+   * as a header so the RECEIVER can dedupe. NOTE: the HubSpot adapter does not
+   * read it — its Note create is not idempotent, which is why every caller must
+   * make the Note the LAST side effect of a delivery (nothing retryable after).
    */
   idempotencyKey: string;
   /** The persisted submission id (the domain anchor). */

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -28,6 +28,7 @@ import {
   conditionsContradict,
   conditionsNarrow,
   conditionNeverHolds,
+  SCORE_FIELD,
   sliderHasNoTravel,
   overlappingSliderRanges,
   sliderBounds,
@@ -1850,5 +1851,114 @@ describe('emailSourceFor', () => {
   it('prefers the question over the scheduler — it does not depend on anyone booking', () => {
     const config = cfg(step({ key: 'book', type: 'scheduler' }), step({ key: 'email', type: 'email' }));
     expect(emailSourceFor(config)).toEqual({ kind: 'question', key: 'email' });
+  });
+});
+
+describe('score-sourced conditions (SCORE_FIELD)', () => {
+  /** q1 (+8 when 'hi') → gate → q3 (+1). The gate reads the score BEFORE itself. */
+  const cfg = {
+    version: 1,
+    steps: [
+      {
+        key: 'q1',
+        type: 'multiple_choice',
+        options: [
+          { label: 'hi', value: 'hi', points: 8 },
+          { label: 'lo', value: 'lo', points: 1 },
+        ],
+      },
+      { key: 'gate', type: 'message', showWhen: { field: SCORE_FIELD, op: 'gt', value: 5 } },
+      { key: 'q3', type: 'multiple_choice', options: [{ label: 'y', value: 'y', points: 1 }] },
+    ],
+  } as unknown as FormConfig;
+
+  it('shows the gated step once the running score passes the bound', () => {
+    expect(visibleSteps(cfg, { q1: 'hi' }).map((s) => s.key)).toEqual(['q1', 'gate', 'q3']);
+  });
+
+  it('hides it when the running score is below the bound', () => {
+    expect(visibleSteps(cfg, { q1: 'lo' }).map((s) => s.key)).toEqual(['q1', 'q3']);
+  });
+
+  it('unanswered upstream means a zero running score', () => {
+    expect(visibleSteps(cfg, {}).map((s) => s.key)).toEqual(['q1', 'q3']);
+  });
+
+  it('terminates — the score and the visibility do not recurse', () => {
+    expect(computeScore(cfg, { q1: 'hi', q3: 'y' })).toBe(9);
+    expect(computeScore(cfg, { q1: 'lo', q3: 'y' })).toBe(2);
+  });
+
+  it('a gated step keeps its OWN points; they just count from the next step on', () => {
+    const scored = {
+      version: 1,
+      steps: [
+        { key: 'q1', type: 'multiple_choice', options: [{ label: 'a', value: 'a', points: 6 }] },
+        {
+          key: 'bonus',
+          type: 'multiple_choice',
+          showWhen: { field: SCORE_FIELD, op: 'gt', value: 5 },
+          options: [{ label: 'b', value: 'b', points: 10 }],
+        },
+      ],
+    } as unknown as FormConfig;
+    // The gate saw 6 (q1 only) and admitted `bonus`; the TOTAL still counts both.
+    expect(visibleSteps(scored, { q1: 'a', bonus: 'b' }).map((s) => s.key)).toEqual(['q1', 'bonus']);
+    expect(computeScore(scored, { q1: 'a', bonus: 'b' })).toBe(16);
+  });
+
+  it('a step cannot gate on a score its own answer produced', () => {
+    const selfish = {
+      version: 1,
+      steps: [
+        {
+          key: 'only',
+          type: 'multiple_choice',
+          showWhen: { field: SCORE_FIELD, op: 'gt', value: 5 },
+          options: [{ label: 'a', value: 'a', points: 10 }],
+        },
+      ],
+    } as unknown as FormConfig;
+    // Its own 10 points are not in the prefix, so the gate sees 0 and hides it.
+    expect(visibleSteps(selfish, { only: 'a' })).toEqual([]);
+    expect(computeScore(selfish, { only: 'a' })).toBe(0);
+  });
+
+  it('hideWhen reads the running score too', () => {
+    const hidden = {
+      version: 1,
+      steps: [
+        { key: 'q1', type: 'multiple_choice', options: [{ label: 'a', value: 'a', points: 9 }] },
+        { key: 'consolation', type: 'message', hideWhen: { field: SCORE_FIELD, op: 'gt', value: 5 } },
+      ],
+    } as unknown as FormConfig;
+    expect(visibleSteps(hidden, { q1: 'a' }).map((s) => s.key)).toEqual(['q1']);
+    expect(visibleSteps(hidden, {}).map((s) => s.key)).toEqual(['q1', 'consolation']);
+  });
+
+  it('scoring turned off leaves every score gate reading zero', () => {
+    const off = { ...cfg, scoring: { enabled: false } } as unknown as FormConfig;
+    expect(visibleSteps(off, { q1: 'hi' }).map((s) => s.key)).toEqual(['q1', 'q3']);
+  });
+
+  it('offers the numeric operators, never `in`', () => {
+    expect(operatorsForFieldType(SCORE_FIELD)).toEqual(['gt', 'lt', 'eq', 'between']);
+  });
+
+  it('flags an `in` rule on the score as broken rather than silently dead', () => {
+    expect(conditionNeverHolds({ field: SCORE_FIELD, values: ['5'] })).toBe('missing_operand');
+    expect(conditionNeverHolds({ field: SCORE_FIELD, op: 'gt', value: 5 })).toBeNull();
+  });
+
+  it('`between` bounds the running score inclusively', () => {
+    const band = {
+      version: 1,
+      steps: [
+        { key: 'q1', type: 'slider', min: 0, max: 10, sliderScoring: [{ min: 0, max: 10, points: 3 }] },
+        { key: 'mid', type: 'message', showWhen: { field: SCORE_FIELD, op: 'between', min: 3, max: 5 } },
+      ],
+    } as unknown as FormConfig;
+    expect(visibleSteps(band, { q1: 4 }).map((s) => s.key)).toEqual(['q1', 'mid']);
+    expect(visibleSteps(band, {}).map((s) => s.key)).toEqual(['q1']);
   });
 });

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -461,8 +461,27 @@ export interface FormEnding {
 export const FORM_LAYOUTS = ['slides', 'vertical'] as const;
 export type FormLayout = (typeof FORM_LAYOUTS)[number];
 
+/**
+ * The title to show the PUBLIC — `config.title` when the author set one, else
+ * the form's internal name. One resolver so the tab, the OG/Twitter cards, the
+ * generated share image, the cover heading and the profile listing can never
+ * disagree about what a form is called.
+ */
+export function publicTitle(config: { title?: string | null } | null | undefined, name: string): string {
+  const t = config?.title?.trim();
+  return t ? t : name;
+}
+
 export interface FormConfig {
   version: 1;
+  /**
+   * The form's PUBLIC title — the browser tab, the share cards, and the cover
+   * heading. Separate from `form.name`, which stays the private label the author
+   * picked at creation and only ever shows inside the dashboard. Absent falls
+   * back to `name`, so every form authored before this field keeps its exact
+   * current title. See {@link publicTitle}.
+   */
+  title?: string | null;
   branding?: FormBranding | null;
   cover?: FormCover | null;
   /** Presentation layout for the public form. Absent = `'slides'` (back-compat). */
@@ -530,6 +549,29 @@ function numericAnswer(value: AnswerValue): number | null {
 }
 
 /**
+ * The reserved condition source meaning "the running score at this point in the
+ * form" — the total over the steps ALREADY on the runtime path, before the step
+ * being decided.
+ *
+ * Why a prefix and not the final score: a step's visibility cannot depend on a
+ * total that includes the step itself, or `computeScore -> runtimeSteps ->
+ * visibleSteps -> conditionHolds -> computeScore` never terminates. A prefix is
+ * both non-circular and what the respondent actually experiences — by the time
+ * they reach step N they have answered 1..N-1, and N is still unanswered, so it
+ * could not have contributed anyway. No step's points are ever discarded: they
+ * simply count from the next step onward.
+ *
+ * `@` is outside the step-key grammar (`sanitizeStepKey` keeps `[a-z0-9_]`), so
+ * this token can never collide with a real key.
+ */
+export const SCORE_FIELD = '@score';
+
+/** Is this condition sourced from the running score rather than an answer? */
+export function isScoreCondition(cond: Pick<StepCondition, 'field'>): boolean {
+  return cond.field === SCORE_FIELD;
+}
+
+/**
  * Does the current answer to `cond.field` satisfy the condition? The operator
  * (`cond.op`, default `in` for back-compat) selects the comparison:
  *  - `in`   — the answer's tokens intersect `values` (the legacy choice match).
@@ -537,14 +579,19 @@ function numericAnswer(value: AnswerValue): number | null {
  *  - `between` — the numeric answer lies within `[min, max]` inclusive.
  * A numeric op whose operand is missing, or whose answer isn't numeric, never
  * holds (the step stays in its default visibility).
+ *
+ * `scoreSoFar` is the running score (see `SCORE_FIELD`). It is only read when
+ * the condition names that reserved source; an `in` op against it never holds,
+ * because a score is a number and has no tokens to intersect.
  */
-function conditionHolds(cond: StepCondition, answers: Answers): boolean {
+function conditionHolds(cond: StepCondition, answers: Answers, scoreSoFar = 0): boolean {
   const op = cond.op ?? 'in';
   if (op === 'in') {
+    if (isScoreCondition(cond)) return false;
     const got = new Set(tokens(answers[cond.field]));
     return (cond.values ?? []).some((v) => got.has(v));
   }
-  const n = numericAnswer(answers[cond.field]);
+  const n = isScoreCondition(cond) ? scoreSoFar : numericAnswer(answers[cond.field]);
   if (n == null) return false;
   switch (op) {
     case 'eq':
@@ -565,21 +612,36 @@ function conditionHolds(cond: StepCondition, answers: Answers): boolean {
  * when it is not `hidden`, its `showWhen` holds (or is absent) AND its `hideWhen`
  * does not hold — and, for a personal-email-only branch step, only when the
  * email is personal.
+ *
+ * This is a FORWARD walk, not a filter, because a condition may read the running
+ * score (`SCORE_FIELD`): each step is decided against the total over the steps
+ * already admitted ahead of it. That ordering is what keeps the score and the
+ * visibility from depending on each other — see `SCORE_FIELD`.
+ *
+ * The running score here is the pre-`goto` prefix. A forward jump is applied
+ * afterwards (`runtimeSteps`), so a step that a branch skips can still have
+ * contributed to a gate upstream of the jump — but only if it carries a STALE
+ * answer, since a step the respondent never saw is unanswered and scores 0.
  */
 export function visibleSteps(config: FormConfig, answers: Answers): FormStep[] {
-  return config.steps.filter((step) => {
+  const scored = config.scoring?.enabled !== false;
+  const out: FormStep[] = [];
+  let scoreSoFar = 0;
+  for (const step of config.steps) {
     // A hidden step is never rendered as a question — it is skipped in the walk
     // (and therefore never scored). Its answer can still be seeded (e.g. from a
     // URL parameter) and rides along into the submission via the answers map.
-    if (step.hidden) return false;
-    if (step.showWhen && !conditionHolds(step.showWhen, answers)) return false;
-    if (step.hideWhen && conditionHolds(step.hideWhen, answers)) return false;
+    if (step.hidden) continue;
+    if (step.showWhen && !conditionHolds(step.showWhen, answers, scoreSoFar)) continue;
+    if (step.hideWhen && conditionHolds(step.hideWhen, answers, scoreSoFar)) continue;
     if (step.showForPersonalEmailOnly) {
       const emailKey = findEmailKey(config);
-      if (!emailKey || !isPersonalEmail(answers[emailKey])) return false;
+      if (!emailKey || !isPersonalEmail(answers[emailKey])) continue;
     }
-    return true;
-  });
+    out.push(step);
+    if (scored) scoreSoFar += stepScore(step, answers);
+  }
+  return out;
 }
 
 /** The first `email`-typed step's key (the branch pivot for personal-email logic). */
@@ -628,7 +690,10 @@ export function emailSourceFor(config: FormConfig): EmailSource {
  * comparison set; every other type keeps the legacy "matches any of" (`in`).
  * Shared so the editor and the engine can never drift on which op is valid where.
  */
-export function operatorsForFieldType(type: FormFieldType): ConditionOp[] {
+export function operatorsForFieldType(type: FormFieldType | typeof SCORE_FIELD): ConditionOp[] {
+  // The running score is a number, so it gets the comparison set and never `in`
+  // — a score has no tokens for a set-membership test to intersect.
+  if (type === SCORE_FIELD) return ['gt', 'lt', 'eq', 'between'];
   return type === 'slider' ? ['eq', 'gt', 'lt', 'between'] : ['in'];
 }
 
@@ -734,6 +799,10 @@ export function conditionNeverHolds(
       if (cond.min == null || cond.max == null) return 'missing_operand';
       return cond.min > cond.max ? 'empty_interval' : null;
     default:
+      // `in` against the running score can never hold — a number has no tokens.
+      // The builder only offers numeric ops for it, so this catches a config
+      // written by hand or migrated from an answer source.
+      if (isScoreCondition(cond)) return 'missing_operand';
       return (cond.values ?? []).length === 0 ? 'no_values' : null;
   }
 }
@@ -1234,6 +1303,23 @@ function sliderPoints(step: FormStep, value: AnswerValue): number {
  * up (V4-17). No builder path writes `step.points`; it is ignored now, matching
  * `maxStepPoints` and `scoringSteps`.
  */
+/**
+ * One step's contribution to the score, ignoring visibility (the caller decides
+ * that). Shared by `computeScore` and the running-score prefix in
+ * `visibleSteps`, so a gate and the final total can never disagree about what a
+ * step is worth. Lead-capture fields, per-question opt-outs, unanswered steps,
+ * and every non-scoring type all contribute 0.
+ */
+function stepScore(step: FormStep, answers: Answers): number {
+  if (step.flowGroup === 'lead_capture') return 0;
+  if (step.scoringEnabled === false) return 0; // per-question opt-out (V5-B2)
+  const value = answers[step.key];
+  if (value == null || value === '') return 0;
+  if (step.type === 'dropdown' || step.type === 'multiple_choice') return optionPoints(step, value);
+  if (step.type === 'slider') return sliderPoints(step, value);
+  return 0;
+}
+
 export function computeScore(config: FormConfig, answers: Answers): number {
   if (config.scoring && config.scoring.enabled === false) return 0;
   // The runtime PATH (visibility + forward goto jumps) — a step jumped over by a
@@ -1241,13 +1327,8 @@ export function computeScore(config: FormConfig, answers: Answers): number {
   const visible = new Set(runtimeSteps(config, answers).map((s) => s.key));
   let score = 0;
   for (const step of config.steps) {
-    if (step.flowGroup === 'lead_capture') continue;
-    if (step.scoringEnabled === false) continue; // per-question opt-out (V5-B2)
     if (!visible.has(step.key)) continue;
-    const value = answers[step.key];
-    if (value == null || value === '') continue;
-    if (step.type === 'dropdown' || step.type === 'multiple_choice') score += optionPoints(step, value);
-    else if (step.type === 'slider') score += sliderPoints(step, value);
+    score += stepScore(step, answers);
   }
   return score;
 }

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -541,6 +541,7 @@ export interface FormsMessages {
         noPriorFields: string;
         scoreField: string;
         scoreHint: string;
+        scoreDead: string;
         hint: string;
         hideNone: string;
         personalEmailOnly: string;
@@ -1639,6 +1640,8 @@ export const en: FormsMessages = {
         noPriorFields: 'Add a step before this one to branch on its answer.',
         scoreField: 'Score so far',
         scoreHint: 'The points collected by the questions above this one. This question\u2019s own answer is not counted \u2014 it has not been given yet.',
+        scoreDead:
+          'This rule reads the score, but no question above this one can add points \u2014 the score is always 0 here, so it can never change what respondents see. Clear it, or move a scored question above.',
         hint: 'Show or hide this question based on an earlier answer.',
         hideNone: 'Never hidden',
         personalEmailOnly: 'Personal email only',
@@ -2689,6 +2692,8 @@ export const es: FormsMessages = {
         noPriorFields: 'Añade un paso antes de este para ramificar por su respuesta.',
         scoreField: 'Puntaje hasta aquí',
         scoreHint: 'Los puntos que suman las preguntas anteriores a esta. La respuesta de esta pregunta no cuenta: todavía no la dieron.',
+        scoreDead:
+          'Esta regla lee el puntaje, pero ninguna pregunta anterior a esta suma puntos: aquí el puntaje siempre es 0 y la regla nunca cambia lo que se muestra. Bórrala, o mueve una pregunta con puntos arriba.',
         hint: 'Muestra u oculta esta pregunta según una respuesta anterior.',
         hideNone: 'Nunca se oculta',
         personalEmailOnly: 'Solo correo personal',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -539,6 +539,8 @@ export interface FormsMessages {
         valuesHint: string;
         clear: string;
         noPriorFields: string;
+        scoreField: string;
+        scoreHint: string;
         hint: string;
         hideNone: string;
         personalEmailOnly: string;
@@ -751,6 +753,8 @@ export interface FormsMessages {
       };
       /** The Design tab: everything about how the form looks. */
       design: {
+        publicTitle: string;
+        publicTitleHint: string;
         presetsTitle: string;
         presetsSubtitle: string;
         presetsCustom: string;
@@ -1633,6 +1637,8 @@ export const en: FormsMessages = {
         valuesHint: 'Comma-separated values from that field’s options.',
         clear: 'Clear',
         noPriorFields: 'Add a step before this one to branch on its answer.',
+        scoreField: 'Score so far',
+        scoreHint: 'The points collected by the questions above this one. This question\u2019s own answer is not counted \u2014 it has not been given yet.',
         hint: 'Show or hide this question based on an earlier answer.',
         hideNone: 'Never hidden',
         personalEmailOnly: 'Personal email only',
@@ -1802,6 +1808,9 @@ export const en: FormsMessages = {
         next: 'Next screen',
       },
       design: {
+        publicTitle: 'Form title',
+        publicTitleHint:
+          'What visitors see — the browser tab, share previews, and the cover heading. Leave empty to use the form\u2019s internal name.',
         presetsTitle: 'Theme',
         presetsSubtitle: 'A starting point you can edit. Pick one, then change anything below.',
         presetsCustom: 'Custom',
@@ -2678,6 +2687,8 @@ export const es: FormsMessages = {
         valuesHint: 'Valores separados por comas de las opciones de ese campo.',
         clear: 'Limpiar',
         noPriorFields: 'Añade un paso antes de este para ramificar por su respuesta.',
+        scoreField: 'Puntaje hasta aquí',
+        scoreHint: 'Los puntos que suman las preguntas anteriores a esta. La respuesta de esta pregunta no cuenta: todavía no la dieron.',
         hint: 'Muestra u oculta esta pregunta según una respuesta anterior.',
         hideNone: 'Nunca se oculta',
         personalEmailOnly: 'Solo correo personal',
@@ -2847,6 +2858,9 @@ export const es: FormsMessages = {
         next: 'Pantalla siguiente',
       },
       design: {
+        publicTitle: 'Título del formulario',
+        publicTitleHint:
+          'Lo que ven los visitantes: la pestaña del navegador, las vistas previas al compartir y el encabezado de portada. Déjalo vacío para usar el nombre interno del formulario.',
         presetsTitle: 'Tema',
         presetsSubtitle: 'Un punto de partida editable. Elige uno y luego cambia lo que quieras.',
         presetsCustom: 'Personalizado',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -800,6 +800,13 @@ export interface PublicProfile {
 
 export const formConfigSchema = z.object({
   version: z.literal(1),
+  /**
+   * PUBLIC title (ADDITIVE). Separate from `form.name`, the private label in the
+   * dashboard. Absent — every legacy config — falls back to the name, so no
+   * published form changes. Deliberately NOT under `branding`: the brand kit
+   * snapshots that object across forms, and a title is per-form by definition.
+   */
+  title: z.string().max(200).nullable().optional(),
   branding: formBrandingSchema.nullable().optional(),
   cover: formCoverSchema.nullable().optional(),
   /**


### PR DESCRIPTION
## What this ships

Four builder/runtime features Josue asked for, plus the fixes from a full `forms-reviewer` pass.

### 1. Score-gated visibility conditions (`@score`)

A show/hide condition can now reference the reserved **`@score`** source — the running score over the steps *before* the one being decided. Evaluating against that prefix (a forward walk in `visibleSteps`, sharing `stepScore` with `computeScore`) is what keeps score and visibility from recursing into each other, and it matches what the respondent experiences: their own unanswered question never counts, and **no step's points are ever discarded** — a gated step's points simply count from the next step onward.

- Builder offers **"Score so far" / "Puntaje hasta aquí"** as a condition source (numeric operators only), only when an earlier step can move the score.
- The logic map names score conditions; `conditionNeverHolds` flags an `in` rule against the score instead of letting it die silently.
- A stale `@score` rule (scoring later disabled / scored questions removed) stays visible with an explicit warning rather than silently gating on a constant 0.
- `@` is outside the step-key grammar, so the token can never collide with a real key. Legacy configs are untouched — the filter→walk rewrite is observationally identical when no condition uses `@score`.

### 2. Per-question HubSpot mapping restored (regression fix)

`d0ecffe` dropped the `QuestionHubspotSection` render while collapsing the advanced settings and never re-homed it — the component, its server action, and the editor's cache invalidation stayed behind as dead code. Wired back in, **outside** AdvancedSettings so the mapping is visible at a glance.

### 3. Public form title, separate from the dashboard name

`config.title` (additive, zod-capped at 200). What visitors see — browser tab, OG/Twitter cards, generated share image, cover heading, public profile listing — all resolved through one engine helper, `publicTitle(config, name)`, so the surfaces can never disagree. Absent falls back to the internal name: every existing form keeps its exact current title. Deliberately **not** under `config.branding` (the brand kit snapshots that object across forms). Authored from a new field at the top of the Design tab; all three builder previews resolve it too.

### 4. Booking-time answers sync, keyed on the Calendly invitee

A form whose scheduler collects the email (no email question of its own) reached submit time with nothing for the HubSpot destination to key on — the delivery no-op'd and the quiz answers never reached the CRM. `booking_sync` now closes the gap: when the submission has no adapter-resolvable email and Calendly reports the invitee's, it runs the **same factory-built destination the submit path uses** (field mappings, value maps, score/outcome/static properties, Note), keyed on the invitee, then writes the booking properties.

**Write order is the retry-safety**: idempotent upserts first, the Note last — HubSpot has no idempotent Note create, so nothing retryable may run after one exists (the port doc's note-guard claim was false and has been corrected). Phase derives from `completed_at` and `submittedAt` is the submission's own timestamp, never the delivery clock.

Known limit (documented in code): with a mid-form scheduler, answers given *after* booking reach HubSpot only if the form collects an email — the submit-time delivery keys on that.

## Review

Ran the repo's `forms-reviewer` agent before opening this. Both blockers fixed (Note duplication on retry; missing changeset), all four should-fixes addressed, nits included. Explicitly verified by the reviewer: engine purity, i18n en/es parity, account scoping, no PII in logs, config v1 additivity, DCO + conventional commits.

## Tests

- 720 tests green across the monorepo (SQLite); lint, typecheck, full build clean.
- 12 new engine tests for `@score` (prefix semantics, no-recursion, gated-step-keeps-points, hideWhen, between, scoring-off).
- 4 new API tests for the booking-time sync (order, gate, lookalike-email, answers-only completion).
- Verified end-to-end in the browser against a worktree dev server: score gate branches both ways on the public renderer; title propagates to `<title>`/OG/Twitter after publish.
- Postgres parity job runs in CI (docker unavailable locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)