### PR TITLE
release(forms): isolate the server API by environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,17 @@
 # TRUST_PROXY_HOPS=1
 
 # --- Web app --------------------------------------------------------------
-# Where the web app reaches the API from the server (RSC fetch). Default:
-# http://localhost:4000. If you move the api with API_PORT, match it here.
+# Where the web app reaches the API from the SERVER (RSC fetch, server actions).
+# Read at runtime, so one built image can serve several environments — and it may
+# point at an internal address, since these calls never leave the server. Takes
+# precedence over NEXT_PUBLIC_API_URL. Default: fall back to that, then
+# http://localhost:4000.
+# API_URL=http://localhost:4000
+#
+# Where the BROWSER reaches the API. Next inlines every NEXT_PUBLIC_* at build
+# time — into the server bundle too — so this value is frozen into the image and
+# must be publicly reachable. Set API_URL as well when one image is promoted
+# across environments; otherwise every environment inherits the build's host.
 # NEXT_PUBLIC_API_URL=http://localhost:4000
 #
 # Product name shown in the UI (titles, headings). Default: "Forms".

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -13,9 +13,10 @@ import type {
   MemberProfile,
   SubmissionsPage,
 } from '@quill/types';
+import { serverApiUrl } from './api-url';
 import { getSession, clearSession, authProvider, getWorkspace } from './auth-session';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const API_URL = serverApiUrl;
 
 /** An API error that carries the HTTP status + error code. */
 export class ApiError extends Error {

--- a/apps/web/lib/api-url.ts
+++ b/apps/web/lib/api-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Where server-side code reaches the Forms API.
+ *
+ * `NEXT_PUBLIC_*` is inlined at BUILD time into **every** bundle — the server
+ * chunks too, not only the browser ones. A production `next build` leaves zero
+ * `process.env.NEXT_PUBLIC_API_URL` reads behind, so the runtime ConfigMap value
+ * can never win. That means one image built once cannot carry a per-environment
+ * API host in `NEXT_PUBLIC_API_URL`: whatever host the build saw is frozen into
+ * the server code of every environment that image is promoted to.
+ *
+ * `API_URL` has no `NEXT_PUBLIC_` prefix, so Next leaves it as a genuine runtime
+ * `process.env` read and the per-environment ConfigMap wins — the same way
+ * `AUTH_PROVIDER` and `IAM_BASE_URL` already work. It may point at the public
+ * host or at the cluster-internal Service; server-to-server calls do not need
+ * to leave the cluster.
+ *
+ * The `NEXT_PUBLIC_API_URL` fallback is deliberate: a fork, a `pnpm dev`, or a
+ * Vercel deploy that only sets the public var keeps working with no change.
+ */
+export const serverApiUrl =
+  process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -5,8 +5,9 @@
  */
 import { cache } from 'react';
 import type { PublicForm, PublicProfile } from '@quill/types';
+import { serverApiUrl } from './api-url';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const API_URL = serverApiUrl;
 
 async function getJson<T>(path: string): Promise<T | null> {
   const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -4,8 +4,9 @@ import { redirect } from 'next/navigation';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { SESSION_COOKIE, WORKSPACE_COOKIE } from './session';
 import { signValue, unsignValue } from './signed-value';
+import { serverApiUrl } from './api-url';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const API_URL = serverApiUrl;
 
 /**
  * Web session lifecycle (per AUTH-WEB-CONTRACT §1–4). The web owns the session;

--- a/apps/web/lib/booking-embed.ts
+++ b/apps/web/lib/booking-embed.ts
@@ -13,6 +13,7 @@
  * origin-allowlisted, shape-checked, and URI/date fields validated before use.
  */
 import type { BookingCallbackInput, BookingProvider } from '@quill/types';
+import { serverApiUrl } from './api-url';
 import type { CalendlyWidgetPrefill } from './booking-prefill';
 
 export const CALENDLY_SCRIPT_SRC = 'https://assets.calendly.com/assets/external/widget.js';
@@ -228,9 +229,11 @@ export function attachBookingMessageListener(
   return () => window.removeEventListener('message', listener);
 }
 
-// Same base-URL resolution as apps/web/lib/api.ts — NEXT_PUBLIC_* is inlined
-// client-side and readable server-side, so this helper works from either.
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+// Same base-URL resolution as apps/web/lib/api.ts. This module runs from BOTH
+// sides, and each gets the right answer: on the server `API_URL` resolves from
+// the per-environment runtime env, and in the browser it is absent so the
+// inlined public host is used — which is the only one a browser could reach.
+const API_URL = serverApiUrl;
 
 /**
  * Report a booked meeting to the public API (`bookingCallbackSchema` payload)


### PR DESCRIPTION
## Production hotfix

This is the exact reviewed runtime-API fix from develop PR #51, cherry-picked onto the current production branch so the release contains no unrelated Forms features.

## Effective diff

- 6 files
- 44 insertions / 8 deletions
- server callers prefer the runtime API_URL
- NEXT_PUBLIC_API_URL remains a compatibility fallback

## Safety

- The source change was merged into develop before this release cut.
- The source PR passed DCO, Conventional Commits, SQLite build/test, PostgreSQL tests, and the publish gate.
- Local verification passed 115 web tests, lint, typecheck, and a production Next.js build.
- Companion GitOps release is Dapta-Tech/apps-configs-flux2#1542.
- No unrelated develop changes are included.

## Gate

Waits for Felipe review and merge. After both release PRs merge, validate dev and manually dispatch the production promotion.