### PR TITLE
fix(web): make the form logo and the cover logo separately editable

### DIFF
--- a/.changeset/plain-donkeys-smile.md
+++ b/.changeset/plain-donkeys-smile.md
@@ -1,0 +1,11 @@
+---
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+Give a form two independently editable logos. `resolveFormLogos` resolves the
+form's own logo (`branding.logo`) and the cover screen's (`cover.logo`) as
+separate axes, where `null` means "show none" and an absent value inherits — so
+clearing a logo removes it instead of falling through to the other surface's,
+and a logo snapshotted from a workspace brand kit is finally visible and
+editable from the Design tab. Configs written before this render unchanged.

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -24,6 +24,7 @@ import {
   isMultiSelect,
   isSafeHttpUrl,
   showClientLogos,
+  resolveFormLogos,
   type Answers,
   type AnswerValue,
   type FormStep,
@@ -72,6 +73,11 @@ export function FormRenderer({
   // The cover SCREEN: null when switched off, which is what gates the `cover`
   // phase, the Start CTA and the back-to-cover step.
   const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
+  // Both logos, resolved once. Like the banner below, the LOGO is not part of
+  // the cover screen either: reading it off the gated value above meant that
+  // switching the cover off silently dropped the author's logo everywhere and
+  // fell back to whatever the brand kit had once snapshotted into the form.
+  const logos = resolveFormLogos(config);
   // The banner is page CHROME, not part of the cover screen — `bannerScope:
   // 'form'` exists precisely to pin it above the steps. Reading it off the
   // gated value above made it unreachable whenever the cover was switched off,
@@ -529,8 +535,7 @@ export function FormRenderer({
   }
 
   if (phase === 'cover' && coverScreen) {
-    const logo = coverScreen.logo ?? config.branding?.logo ?? null;
-    const logos = showClientLogos(coverScreen)
+    const clientLogos = showClientLogos(coverScreen)
       ? (coverScreen.clientLogos ?? config.branding?.clientLogos ?? [])
       : [];
     return (
@@ -543,7 +548,7 @@ export function FormRenderer({
         isCover
       >
         <header className="pf__cover-header">
-          <FormLogo src={logo} name={name} />
+          <FormLogo src={logos.cover} name={name} />
         </header>
         <div className="pf__cover-main">
           <div className="pf__cover-content pf-animate">
@@ -554,7 +559,7 @@ export function FormRenderer({
             {coverScreen.subheadline ? <p className="pf__subheadline">{coverScreen.subheadline}</p> : null}
             {coverScreen.trustBadge ? <p className="pf__trust">{coverScreen.trustBadge}</p> : null}
           </div>
-          <ClientLogosMarquee logos={logos} label={m.trustedBy} />
+          <ClientLogosMarquee logos={clientLogos} label={m.trustedBy} />
         </div>
         <div className="pf__cover-footer">
           <button type="button" className="pf__btn" onClick={start}>
@@ -623,7 +628,6 @@ export function FormRenderer({
     const booking = step.scheduler
       ? schedulerToBooking(step.scheduler, schedPrefill.customAnswers)
       : null;
-    const schedLogo = coverScreen?.logo ?? config.branding?.logo ?? null;
     return (
       <PhaseShell className="pf" design={design} cover={chrome}>
         <header className="pf__topbar">
@@ -635,7 +639,7 @@ export function FormRenderer({
             ) : (
               <span className="pf__back pf__back--placeholder" />
             )}
-            <FormLogo src={schedLogo} name={name} />
+            <FormLogo src={logos.form} name={name} />
             <span className="pf__back pf__back--placeholder" />
           </div>
           <FormProgress total={steps.length} currentIndex={index} locale={locale} style={design.design.progressStyle} />
@@ -684,8 +688,6 @@ export function FormRenderer({
   // multi-select choice (pick several, then Continue) — shows the button.
   const autoAdvances = step.type === 'dropdown' || (step.type === 'multiple_choice' && !isMultiSelect(step));
   const showContinue = !autoAdvances;
-  const logo = coverScreen?.logo ?? config.branding?.logo ?? null;
-
   return (
     <PhaseShell className="pf" design={design} onKeyDown={onKeyDown} cover={chrome}>
       <header className="pf__topbar">
@@ -697,7 +699,7 @@ export function FormRenderer({
           ) : (
             <span className="pf__back pf__back--placeholder" />
           )}
-          <FormLogo src={logo} name={name} />
+          <FormLogo src={logos.form} name={name} />
           <span className="pf__back pf__back--placeholder" />
         </div>
         <FormProgress total={steps.length} currentIndex={index} locale={locale} style={design.design.progressStyle} />

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -37,6 +37,7 @@ import {
   nameFields,
   isSafeHttpUrl,
   showBanner,
+  resolveFormLogos,
   type Answers,
   type AnswerValue,
   type FormStep,
@@ -560,8 +561,12 @@ export function VerticalFormRenderer({
     );
   }
 
-  const logo = coverScreen?.logo ?? config.branding?.logo ?? null;
-  const logos = coverScreen?.clientLogos ?? config.branding?.clientLogos ?? [];
+  // One page, one header — and the hero right under it IS the cover screen when
+  // one is on, so the header carries the cover's logo there and the form's own
+  // when the cover is off. Either can be cleared to nothing independently.
+  const logos = resolveFormLogos(config);
+  const headerLogo = coverScreen ? logos.cover : logos.form;
+  const clientLogos = coverScreen?.clientLogos ?? config.branding?.clientLogos ?? [];
   const total = answerable.length;
 
   return (
@@ -601,7 +606,7 @@ export function VerticalFormRenderer({
       <div className="pf__main">
         <div className="pf-v__page">
           <header className="pf-v__header">
-            <FormLogo src={logo} name={name} />
+            <FormLogo src={headerLogo} name={name} />
           </header>
 
           {coverScreen ? (
@@ -612,7 +617,7 @@ export function VerticalFormRenderer({
               <h1 className="pf__title">{coverScreen.headline ?? name}</h1>
               {coverScreen.subheadline ? <p className="pf__subheadline">{coverScreen.subheadline}</p> : null}
               {coverScreen.trustBadge ? <p className="pf__trust">{coverScreen.trustBadge}</p> : null}
-              <ClientLogosMarquee logos={logos} label={m.trustedBy} />
+              <ClientLogosMarquee logos={clientLogos} label={m.trustedBy} />
             </section>
           ) : null}
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -6,7 +6,10 @@ import {
   DEFAULT_FORM_FONT,
   FORM_BACKGROUND_STYLES,
   isSafeImageUrl,
-  resolveDesign, publicTitle } from '@quill/engine';
+  resolveDesign,
+  resolveFormLogos,
+  publicTitle,
+} from '@quill/engine';
 import {
   AA_CONTRAST,
   DEFAULT_ACCENT,
@@ -90,6 +93,11 @@ export function DesignPanel({
   const d = m.design;
   const branding = config.branding ?? {};
   const design = resolveDesign(branding);
+  const cover = config.cover ?? {};
+  // What each surface actually shows right now — the fields below are bound to
+  // this, not to the raw stored values, so the panel can never claim a form has
+  // no logo while one is rendering.
+  const logos = resolveFormLogos(config);
 
   // The colors every contrast readout is measured against. When the author has
   // not chosen a ground, that is the shared dark canvas the form actually
@@ -384,17 +392,48 @@ export function DesignPanel({
         </PanelSection>
 
         <PanelSection title={d.layoutTitle} subtitle={d.layoutSubtitle}>
-          <Field label={m.cover.logo} hint={m.cover.logoHint}>
+          {/* TWO logos, each with its own field and each clearable to nothing.
+              The form's logo shows the RESOLVED value, so a form carrying a logo
+              snapshotted from the workspace brand kit finally displays it here —
+              that value used to render on every screen while both this panel and
+              the brand-kit page showed an empty box, which made it impossible to
+              replace or remove. Emptying either field writes null, which the
+              resolver reads as "show nothing" rather than falling back. */}
+          <Field label={d.formLogo} hint={d.formLogoHint}>
             <TextField
-              value={config.cover?.logo ?? ''}
+              value={logos.form ?? ''}
               placeholder="https://…"
-              onChange={(e) => onCoverChange({ logo: e.target.value || null })}
+              data-testid="design-form-logo"
+              onChange={(e) => onBrandingChange({ logo: e.target.value || null })}
             />
           </Field>
-          {config.cover?.logo && !isSafeImageUrl(config.cover.logo) ? (
+          {logos.form && !isSafeImageUrl(logos.form) ? (
             <p className="text-xs text-destructive" role="alert">
               {m.cover.logoInvalid}
             </p>
+          ) : null}
+          {/* Offering a cover logo on a form with no cover screen would be a
+              control that changes nothing — the same rule the axes below follow. */}
+          {cover.enabled !== false ? (
+            <>
+              {/* Bound to the RESOLVED cover logo, like the field above. A form
+                  that inherits shows the URL it inherits rather than an empty
+                  box, so emptying this field is always the same promise: the
+                  cover shows no logo. */}
+              <Field label={m.cover.logo} hint={m.cover.logoHint}>
+                <TextField
+                  value={logos.cover ?? ''}
+                  placeholder="https://…"
+                  data-testid="design-cover-logo"
+                  onChange={(e) => onCoverChange({ logo: e.target.value || null })}
+                />
+              </Field>
+              {logos.cover && !isSafeImageUrl(logos.cover) ? (
+                <p className="text-xs text-destructive" role="alert">
+                  {m.cover.logoInvalid}
+                </p>
+              ) : null}
+            </>
           ) : null}
           {/* The one-page layout puts the logo in a hero, not a top bar, so
               neither size nor placement applies there. */}

--- a/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/live-preview.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import type { AnswerValue, Answers, FormConfig, FormLayout, FormStep } from '@quill/engine';
-import { resolveQuestion, showBanner, showClientLogos } from '@quill/engine';
+import { resolveFormLogos, resolveQuestion, showBanner, showClientLogos } from '@quill/engine';
 import { getMessages } from '@quill/shared';
 import { formDesignProps } from '@/lib/form-design';
 import { FormLogo } from '@/components/public/form-logo';
@@ -122,7 +122,11 @@ function VerticalBody({
   const r = getMessages(locale).renderer;
   const [answers, setAnswers] = useState<Answers>({});
   const cover = config.cover ?? {};
-  const logo = cover.logo ?? config.branding?.logo ?? null;
+  // Same rule as the published one-page layout: the hero IS the cover when one
+  // is on, so the single header shows the cover's logo there and the form's own
+  // when the cover is off.
+  const formLogos = resolveFormLogos(config);
+  const logo = cover.enabled !== false ? formLogos.cover : formLogos.form;
   const logos = showClientLogos(cover) ? (cover.clientLogos ?? config.branding?.clientLogos ?? []) : [];
   // A reveal is an interstitial the one-page layout plays after submit, not a
   // block on the page — same filter the renderer applies.
@@ -205,7 +209,7 @@ function VerticalBody({
 function CoverBody({ config, name, locale }: { config: FormConfig; name: string; locale: string }) {
   const r = getMessages(locale).renderer;
   const cover = config.cover ?? {};
-  const logo = cover.logo ?? config.branding?.logo ?? null;
+  const logo = resolveFormLogos(config).cover;
   const logos = showClientLogos(cover) ? (cover.clientLogos ?? config.branding?.clientLogos ?? []) : [];
 
   return (
@@ -254,7 +258,7 @@ function StepBody({
   const r = getMessages(locale).renderer;
   const design = formDesignProps(config.branding);
   const [answers, setAnswers] = useState<Answers>({});
-  const logo = config.cover?.logo ?? config.branding?.logo ?? null;
+  const logo = resolveFormLogos(config).form;
   const total = config.steps.length;
   // The same display resolution the public renderer applies, so a question that
   // interpolates an earlier answer previews the way it will read.

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -24,6 +24,7 @@ import {
   resolveOptionLayout,
   showBanner,
   showClientLogos,
+  resolveFormLogos,
   operatorsForFieldType,
   conditionsContradict,
   conditionsNarrow,
@@ -796,6 +797,76 @@ describe('cover presentation toggles', () => {
     const cover = { clientLogos: [{ name: 'Acme' }], showClientLogos: false };
     expect(showClientLogos(cover)).toBe(false);
     expect(cover.clientLogos).toHaveLength(1);
+  });
+});
+
+describe('resolveFormLogos', () => {
+  const WHITE = 'https://cdn.example.com/white.png';
+  const BLACK = 'https://cdn.example.com/black.png';
+
+  it('a config with neither field shows no logo anywhere', () => {
+    expect(resolveFormLogos({})).toEqual({ form: null, cover: null });
+    expect(resolveFormLogos({ cover: {}, branding: {} })).toEqual({ form: null, cover: null });
+  });
+
+  it('LEGACY: a cover-only logo still reaches every screen', () => {
+    // Every config written before the form logo had its own field looks like
+    // this. `branding.logo` is ABSENT (not null), which is what makes the form
+    // surface inherit — these must render exactly as they always did.
+    expect(resolveFormLogos({ cover: { logo: WHITE } })).toEqual({ form: WHITE, cover: WHITE });
+  });
+
+  it('LEGACY: a brand-kit logo with no cover logo reaches every screen', () => {
+    expect(resolveFormLogos({ branding: { logo: WHITE } })).toEqual({ form: WHITE, cover: WHITE });
+  });
+
+  it('the two fields are independent once both are set', () => {
+    expect(resolveFormLogos({ cover: { logo: BLACK }, branding: { logo: WHITE } })).toEqual({
+      form: WHITE,
+      cover: BLACK,
+    });
+  });
+
+  it('clearing the form logo removes it and does NOT resurrect the cover one', () => {
+    // The reported bug: emptying a logo field brought an old image back, because
+    // an absent value fell through to the other surface's. An explicit null is
+    // the author saying "none", and it has to win.
+    expect(resolveFormLogos({ cover: { logo: BLACK }, branding: { logo: null } })).toEqual({
+      form: null,
+      cover: BLACK,
+    });
+  });
+
+  it('clearing the cover logo removes it and does NOT resurrect the form one', () => {
+    expect(resolveFormLogos({ cover: { logo: null }, branding: { logo: WHITE } })).toEqual({
+      form: WHITE,
+      cover: null,
+    });
+  });
+
+  it('clearing both leaves nothing behind', () => {
+    expect(resolveFormLogos({ cover: { logo: null }, branding: { logo: null } })).toEqual({
+      form: null,
+      cover: null,
+    });
+  });
+
+  it('a cleared form logo on a legacy cover-only config still clears', () => {
+    // The unstick path for a form carrying a brand-kit snapshot nobody could see:
+    // the editor now writes null here, and null is not "inherit".
+    expect(resolveFormLogos({ cover: {}, branding: { logo: null } })).toEqual({
+      form: null,
+      cover: null,
+    });
+  });
+
+  it('ignores cover.enabled — a logo is not part of the cover screen', () => {
+    // Switching the cover off used to drop the author's logo from every screen
+    // and fall back to whatever the brand kit had snapshotted into the form.
+    expect(resolveFormLogos({ cover: { enabled: false, logo: BLACK } })).toEqual({
+      form: BLACK,
+      cover: BLACK,
+    });
   });
 });
 

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -326,7 +326,10 @@ export interface FormCover {
   subheadline?: string | null;
   ctaText?: string | null;
   trustBadge?: string | null;
-  /** Cover logo image URL (falls back to branding.logo, then the product mark). */
+  /**
+   * The COVER SCREEN's logo — see `resolveFormLogos`. `null` means "none here";
+   * absent inherits the form's own (`branding.logo`).
+   */
   logo?: string | null;
   /** Optional "trusted by" marquee shown on the cover. */
   clientLogos?: FormClientLogo[];
@@ -352,6 +355,11 @@ export interface FormCover {
  */
 export interface FormBranding {
   primaryColor?: string | null;
+  /**
+   * The FORM's logo — every question screen, and the one-page hero when there
+   * is no cover — see `resolveFormLogos`. Also where a workspace brand kit
+   * snapshots its logo, so it must stay editable per form: `null` means "none".
+   */
   logo?: string | null;
   clientLogos?: FormClientLogo[];
 
@@ -1768,6 +1776,41 @@ export function showBanner(cover: FormCover | null | undefined, isCover: boolean
  */
 export function showClientLogos(cover: FormCover | null | undefined): boolean {
   return cover?.showClientLogos !== false;
+}
+
+/** The logo each surface of a form shows. `null` on either axis means "none". */
+export interface FormLogos {
+  /** The form's own logo — the top bar on slides, the hero on one page. */
+  form: string | null;
+  /** The cover screen's logo. */
+  cover: string | null;
+}
+
+/**
+ * Resolve the two logos a form can show.
+ *
+ * They are INDEPENDENT axes with their own editor controls: `branding.logo` is
+ * the form's logo and `cover.logo` is the cover screen's. The distinction that
+ * makes this work is `null` (explicitly cleared — show NOTHING) versus ABSENT
+ * (never set — inherit). Without it, clearing a logo fell through to the other
+ * one and the old image came back, with no control anywhere that could remove
+ * it: `branding.logo` is written by the workspace brand-kit snapshot, so a form
+ * carried a logo that neither the Design tab (which showed `cover.logo`) nor the
+ * brand kit (which shows the ACCOUNT kit, not the form's copy of it) displayed.
+ *
+ * ABSENT inheriting is what keeps every config written before the two fields
+ * were separately editable rendering exactly as it always did: those carry only
+ * `cover.logo`, and it still reaches every screen. The first edit to either
+ * field takes ownership of that axis.
+ */
+export function resolveFormLogos(config: {
+  cover?: FormCover | null;
+  branding?: FormBranding | null;
+}): FormLogos {
+  const coverLogo = config.cover?.logo;
+  const brandingLogo = config.branding?.logo;
+  const form = brandingLogo !== undefined ? brandingLogo : (coverLogo ?? null);
+  return { form: form ?? null, cover: (coverLogo !== undefined ? coverLogo : form) ?? null };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -808,6 +808,8 @@ export interface FormsMessages {
         progressNone: string;
         layoutTitle: string;
         layoutSubtitle: string;
+        formLogo: string;
+        formLogoHint: string;
         logoSize: string;
         sizeSm: string;
         sizeMd: string;
@@ -1758,8 +1760,8 @@ export const en: FormsMessages = {
         branding: 'Branding',
         primaryColor: 'Primary color',
         primaryColorHint: 'Drives the accent on the public form. Auto-adjusted for contrast.',
-        logo: 'Logo URL',
-        logoHint: 'Shown at the top of the form. An https:// image URL.',
+        logo: 'Cover logo URL',
+        logoHint: 'Shown on the cover screen only. Leave empty for no logo there.',
         logoInvalid: 'This URL protocol is not allowed for images.',
         clientLogos: 'Client logos',
         clientLogosHint: 'A “trusted by” marquee on the cover. The name shows when no image is set.',
@@ -1867,6 +1869,8 @@ export const en: FormsMessages = {
         progressNone: 'Hidden',
         layoutTitle: 'Layout',
         layoutSubtitle: 'Where things sit and how the form moves between steps.',
+        formLogo: 'Form logo URL',
+        formLogoHint: 'Shown on every question screen. Leave empty for no logo.',
         logoSize: 'Logo size',
         sizeSm: 'Small',
         sizeMd: 'Medium',
@@ -2810,8 +2814,8 @@ export const es: FormsMessages = {
         branding: 'Marca',
         primaryColor: 'Color primario',
         primaryColorHint: 'Define el acento del formulario público. Se ajusta para contraste.',
-        logo: 'URL del logo',
-        logoHint: 'Se muestra en la parte superior del formulario. Una URL de imagen https://.',
+        logo: 'URL del logo de la portada',
+        logoHint: 'Solo en la portada. Vacío = sin logo ahí.',
         logoInvalid: 'Este protocolo de URL no está permitido para imágenes.',
         clientLogos: 'Logos de clientes',
         clientLogosHint: 'Una marquesina de «confían en nosotros» en la portada. El nombre se muestra si no hay imagen.',
@@ -2920,6 +2924,8 @@ export const es: FormsMessages = {
         progressNone: 'Oculto',
         layoutTitle: 'Distribución',
         layoutSubtitle: 'Dónde va cada cosa y cómo se mueve el formulario entre pasos.',
+        formLogo: 'URL del logo del formulario',
+        formLogoHint: 'Se muestra en cada pantalla de pregunta. Vacío = sin logo.',
         logoSize: 'Tamaño del logo',
         sizeSm: 'Pequeño',
         sizeMd: 'Mediano',


### PR DESCRIPTION
## El bug

Poner un logo funciona. **Reemplazarlo o quitarlo, no**: vuelve el viejo, y el cambio solo se ve en la portada.

Un form carga **dos** logos, y hasta ahora solo uno tenía control:

| campo | quién lo escribía | dónde se ve |
|---|---|---|
| `config.branding.logo` | **solo** el snapshot del brand kit (al crear el form y en cada Apply) | pantallas de pregunta, scheduler, hero de una-sola-página |
| `config.cover.logo` | el campo "Logo URL" del tab Design | portada |

`branding.logo` no lo mostraba **ninguna** de las dos pantallas del admin: el tab Design mostraba `cover.logo`, y la página del brand kit muestra el kit de la CUENTA, no la copia que el form se quedó. Un form podía renderizar un logo que ningún campo admitía tener.

De ahí salían dos fallas:

1. **Vaciar el campo no borraba.** Escribía `cover.logo = null` y la cadena `cover.logo ?? branding.logo` de los renderers caía directo al snapshot. Volvía el logo viejo y nada podía sacarlo.
2. **Con la portada apagada, el cambio no llegaba al form.** Los topbars leían esa cadena desde un valor ya anulado por `cover.enabled === false`, así que apagar la portada tiraba el logo del autor de todas las pantallas y servía el snapshot — mientras el preview del builder (que lee `config.cover` sin ese gate) seguía mostrando el nuevo. Editor y página pública en desacuerdo.

## El fix

`resolveFormLogos` en el engine resuelve los dos ejes en un solo lugar, para renderers públicos y preview del builder por igual. La regla que lo sostiene:

| valor | significa |
|---|---|
| URL | ese logo |
| `null` — el autor vació el campo | **ninguno**, no cae a nada |
| ABSENT — nunca se tocó | hereda del otro eje |

Esa distinción es lo que evita una migración: todo config escrito antes de que los dos campos existieran lleva solo `cover.logo`, sigue heredando, y **renderiza idéntico**. El primer edit de cualquiera de los dos campos toma posesión de ese eje.

También ignora `cover.enabled` — un logo es cromo del formulario, no parte de la pantalla de portada. Es la misma corrección que `showBanner` ya traía.

El tab Design ahora ofrece los dos campos, **atados al valor resuelto** (no al guardado), así el panel no puede mostrar una caja vacía mientras hay un logo renderizando. El campo de portada se oculta cuando no hay portada, en vez de ofrecer un control que no cambia nada.

## Verificación

Reproducido y verificado contra la app corriendo (SQLite local), leyendo el `<img class="pf__logo-img">` del HTML servido:

```
1. logo blanco, portada apagada    → blanco
2. cambio la portada a negro       → blanco   (son dos logos: correcto)
3. cambio el LOGO DEL FORM a negro → negro    ← antes imposible
4. borro el logo del form          → (vacío)  ← antes volvía el blanco
```

Back-compat, config viejo con solo `cover.logo`:

```
portada ENCENDIDA → sale el logo
portada APAGADA   → sale el logo   ← antes se perdía
```

Y los dos campos del editor, manejados con Playwright, mostrando el valor real de cada superficie:

```
Form logo URL   → https://example.com/WHITE-LOGO.png
Cover logo URL  → https://example.com/WHITE-LOGO.png   (heredado)
```

Gate completo verde: `typecheck`, `lint`, y `test` — 238 en engine (9 nuevos, cubriendo legacy / null explícito / los dos seteados / `cover.enabled`), 183 api, 115 web, 69 db, 51 destinations, 40 shared, 34 notifications.

## Invariantes

- **#4 config v1 extendido, no roto** — cero campos nuevos en el schema; solo cambia cómo se resuelven dos que ya existían, y los configs viejos renderizan igual (con tests que lo fijan).
- **#2 engine puro** — `resolveFormLogos` es una función pura con tests, sin I/O.
- **#8 i18n EN + ES** — dos claves nuevas en ambos locales; corregido el hint del logo de portada, que prometía "Shown at the top of the form" cuando el campo no podía cumplirlo.
- Sin migración, sin cambios de schema, sin tocar la DB.

## Fuera de alcance, a propósito

`clientLogos` (el marquee "trusted by") tiene el mismo defecto — `cover.clientLogos ?? branding.clientLogos`, con el mismo fantasma al vaciarlo. Es otra feature, con su propio toggle; queda para un PR aparte en vez de ensanchar este diff.

## Para destrabar un form ya roto

Abrir el tab Design: el campo **Form logo URL** ahora muestra el logo que estaba escondido. Vaciarlo lo borra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)