### PR TITLE
fix: stop the booking sync from losing leads silently

### DIFF
--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -30,6 +30,7 @@ import {
   getFormById,
   getNotificationSettings,
   inviteMember,
+  listFailedDeliveries,
   listForms,
   listMembers,
   publishForm,
@@ -286,6 +287,25 @@ export class AdminCrudController {
       limit: parseIntParam(limit),
       offset: parseIntParam(offset),
     });
+  }
+
+  /**
+   * Deliveries for this form that ended without landing.
+   *
+   * A side-effect that died — an expired CRM token, a disconnected scheduling
+   * provider, a form with no resolvable respondent email — used to exist only in
+   * server logs, so a form could stop syncing leads while every visible signal
+   * said it was working.
+   */
+  @Get('forms/:id/deliveries')
+  async formDeliveries(@Req() req: ReqLike, @Param('id') id: string, @Query('limit') limit?: string) {
+    const p = await this.auth.resolveHost(req);
+    // Account scoping twice on purpose: the form lookup proves this caller owns
+    // the form, and the query itself is filtered by account_id in SQL.
+    const f = await getFormById(this.db, p.accountId, id);
+    if (!f) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    const items = await listFailedDeliveries(this.db, p.accountId, id, parseIntParam(limit) ?? 50);
+    return { items };
   }
 
   // --- Members (workspace roster; admin/owner-only) ----------------------

--- a/apps/api/src/booking-effects.ts
+++ b/apps/api/src/booking-effects.ts
@@ -25,6 +25,26 @@ export interface BookingSyncPayload {
 }
 
 /**
+ * How long a `booking_sync` row stays dormant before the worker may drain it.
+ *
+ * A booking made on a mid-form `scheduler` STEP is recorded BEFORE the form
+ * finishes: the renderer awaits `recordBookingAction` and only then advances,
+ * which is what finalizes the submission (see `handleSchedulerBooked`). Drain
+ * the row inside that gap and `loadSubmission` still reads `completed_at = null`
+ * — so the delivery runs as `partial`, and the adapter's complete-only writes
+ * (the outcome property, the static properties, and the Note) are skipped.
+ *
+ * That loss is PERMANENT: the delivery is idempotent per booking event and the
+ * row is closed on success, so nothing re-runs it once the submission completes.
+ *
+ * The gap is one browser→API round trip, but the worker polls on a fixed
+ * interval, so without a delay a few percent of bookings land in it. Waiting
+ * costs nothing — the sync is already asynchronous and retried — and it makes
+ * the ordering explicit instead of leaving it to a race.
+ */
+export const BOOKING_SYNC_DELAY_MS = 15_000;
+
+/**
  * Durable BOOKING → CRM sync enqueue (mirrors EmailEffects). After a booking
  * callback is persisted, the sync is ENQUEUED as an `outbox` row (kind
  * `booking_sync`) instead of delivered inline; the OutboxWorker drains it with
@@ -38,7 +58,7 @@ export class BookingEffects {
   constructor(@Inject(DB) private readonly db: Db) {}
 
   /** Never rejects — the booking handler must not fail on a bad enqueue. */
-  async enqueueBookingSync(payload: BookingSyncPayload): Promise<void> {
+  async enqueueBookingSync(payload: BookingSyncPayload, now: number = Date.now()): Promise<void> {
     try {
       await enqueueOutbox(this.db, {
         kind: 'booking_sync',
@@ -46,6 +66,9 @@ export class BookingEffects {
         subjectUid: payload.bookingEventId,
         accountId: payload.accountId,
         payload: JSON.stringify(payload),
+        now,
+        // Let the submission finish first — see BOOKING_SYNC_DELAY_MS.
+        nextAttemptAt: now + BOOKING_SYNC_DELAY_MS,
       });
     } catch (err) {
       this.log.error(`failed to enqueue booking_sync: ${String(err)}`);

--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -386,6 +386,118 @@ describe('booking_sync delivery', () => {
     expect(answerProps.bz_optin).toBe('Form submitted Producto');
   });
 
+  // The booking page collects a name (and sometimes a phone) that the form never
+  // asks for. Only the address was ever used, so a form whose booking is its
+  // only contact step produced contacts with an address and no name.
+  it('maps what the booking page collected about the invitee', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: {
+        '@invitee_first_name': 'firstname',
+        '@invitee_last_name': 'lastname',
+        '@invitee_phone': 'mobilephone',
+        '@invitee_name': 'full_name',
+      },
+    });
+    await svc.submit('acme', 'lead-qualifier', { sessionId: 'sess-inv', data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-inv',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({
+          resource: {
+            email: 'Invitee@Corp.IO',
+            name: 'Ada Lovelace',
+            first_name: 'Ada',
+            last_name: 'Lovelace',
+            text_reminder_number: '+57 300 111 2233',
+          },
+        }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '88' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.firstname).toBe('Ada');
+    expect(props.lastname).toBe('Lovelace');
+    expect(props.mobilephone).toBe('+57 300 111 2233');
+    expect(props.full_name).toBe('Ada Lovelace');
+  });
+
+  // Calendly always returns `name` and only sometimes the split pair.
+  it('derives first/last from the full name when the provider omits the split pair', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { '@invitee_first_name': 'firstname', '@invitee_last_name': 'lastname' },
+    });
+    await svc.submit('acme', 'lead-qualifier', { sessionId: 'sess-split', data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-split',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({ resource: { email: 'g@corp.io', name: 'Grace Brewster Hopper' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '89' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.firstname).toBe('Grace');
+    expect(props.lastname).toBe('Brewster Hopper');
+  });
+
+  // A question the form actually asks outranks whatever the booking page had.
+  it('a real answer wins over the invitee field mapped to the same key', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { full_name: 'full_name', '@invitee_name': 'booked_as' },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-win',
+      data: { full_name: 'What they typed' },
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-win',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'w@corp.io', name: 'Booked Name' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '90' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.full_name).toBe('What they typed');
+    expect(props.booked_as).toBe('Booked Name');
+  });
+
   it('a free-text answer that merely LOOKS like an email does not suppress the answers sync', async () => {
     // The gate follows the ADAPTER's email semantics (mapping to `email` /
     // an `email` answer) — not the loose booking-key heuristic. A company

--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -22,7 +22,7 @@ import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
 import { SubmissionService } from './submission.service';
 import { EmailEffects } from './email-effects';
 import { DestinationEffects } from './destination-effects';
-import { BookingEffects } from './booking-effects';
+import { BookingEffects, BOOKING_SYNC_DELAY_MS } from './booking-effects';
 import { BookingSyncEffects } from './booking-sync';
 import { OutboxWorker } from './outbox.worker';
 
@@ -47,6 +47,16 @@ function newEmailEffects() {
 function newWorker() {
   const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
   return new OutboxWorker(db, env, newEmailEffects(), new DestinationEffects(db), bookingSync);
+}
+
+/**
+ * Drain with the clock advanced past `BOOKING_SYNC_DELAY_MS`, which is when a
+ * `booking_sync` row first becomes due. Every delivery test goes through this:
+ * calling `drainOnce()` at the real clock claims nothing, which is exactly the
+ * dormancy the delay exists to create.
+ */
+function drainDue() {
+  return newWorker().drainOnce(Date.now() + BOOKING_SYNC_DELAY_MS + 1_000);
 }
 
 /** Record every call; answer per-URL from `responses` (default 200 `{}`). */
@@ -141,6 +151,32 @@ describe('booking callback enqueue', () => {
     expect(payload.inviteeUri).toBe(INVITEE_URI);
     expect(typeof payload.accountId).toBe('string');
   });
+
+  // A booking on a mid-form `scheduler` step is recorded BEFORE the submission
+  // is finalized. Draining inside that gap delivers as `partial`, which drops
+  // the outcome property, the static properties and the Note — permanently,
+  // since the row closes on success. The row therefore starts DORMANT.
+  it('holds the row dormant so the submission can finish first', async () => {
+    await setHubspotDestination(BOOKING_SYNC_CONFIG);
+    const before = Date.now();
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-delay',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const [row] = await listOutbox(db, { kind: 'booking_sync' });
+    expect(row!.nextAttemptAt).toBeGreaterThanOrEqual(before + BOOKING_SYNC_DELAY_MS);
+
+    // Draining at the real clock claims nothing — the row is not due yet.
+    bookingSync.fetchImpl = recordingFetch([]);
+    expect(await newWorker().drainOnce()).toBe(0);
+    expect((await listOutbox(db, { kind: 'booking_sync' }))[0]!.status).toBe('pending');
+
+    // Past the delay it is claimed exactly once.
+    expect(await drainDue()).toBe(1);
+  });
 });
 
 describe('booking_sync delivery', () => {
@@ -164,7 +200,7 @@ describe('booking_sync delivery', () => {
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '123' }] }),
     });
 
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done');
@@ -208,7 +244,7 @@ describe('booking_sync delivery', () => {
     bookingSync.fetchImpl = recordingFetch(calls, {
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '9' }] }),
     });
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done');
@@ -239,7 +275,7 @@ describe('booking_sync delivery', () => {
 
     const calls: RecordedCall[] = [];
     bookingSync.fetchImpl = recordingFetch(calls);
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('skipped'); // a decision, recorded once — not retried
@@ -263,7 +299,7 @@ describe('booking_sync delivery', () => {
     bookingSync.fetchImpl = recordingFetch(calls, {
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ error: 'boom' }, 500),
     });
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('pending'); // retryable — backoff, not terminal
@@ -288,7 +324,7 @@ describe('booking_sync delivery', () => {
 
     const calls: RecordedCall[] = [];
     bookingSync.fetchImpl = recordingFetch(calls);
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('skipped');
@@ -324,7 +360,7 @@ describe('booking_sync delivery', () => {
       [INVITEE_URI]: () => jsonResponse({ resource: { email: 'Invitee@Corp.IO' } }),
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '77' }] }),
     });
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done');
@@ -375,7 +411,7 @@ describe('booking_sync delivery', () => {
       [INVITEE_URI]: () => jsonResponse({ resource: { email: 'real@corp.io' } }),
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '3' }] }),
     });
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done');
@@ -409,7 +445,7 @@ describe('booking_sync delivery', () => {
       [INVITEE_URI]: () => jsonResponse({ resource: { email: 'invitee@corp.io' } }),
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '5' }] }),
     });
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done');
@@ -445,7 +481,7 @@ describe('booking_sync delivery', () => {
       [INVITEE_URI]: () => jsonResponse({ resource: { email: 'solo@corp.io' } }),
       [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '8' }] }),
     });
-    await newWorker().drainOnce();
+    await drainDue();
 
     const rows = await listOutbox(db, { kind: 'booking_sync' });
     expect(rows[0]!.status).toBe('done'); // not skipped — the answers went out

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -6,7 +6,7 @@ import {
   type FormDestination,
   type HubspotDestination,
 } from '@quill/types';
-import { resolveOutcome, type FormConfig } from '@quill/engine';
+import { resolveOutcome, INVITEE_FIELDS, type FormConfig } from '@quill/engine';
 import { createDestination } from '@quill/destinations';
 import type { ServerEnv } from '@quill/config/env';
 import { OutboxSkipError } from './email-effects';
@@ -22,7 +22,53 @@ const CALENDLY_API_HOST = 'api.calendly.com';
 
 /** Calendly GET /scheduled_events/:uuid | /invitees/:uuid response envelope. */
 interface CalendlyResource {
-  resource?: { start_time?: string; email?: string };
+  resource?: {
+    start_time?: string;
+    email?: string;
+    /** Invitee identity. `name` is always set; the split pair only sometimes. */
+    name?: string;
+    first_name?: string;
+    last_name?: string;
+    /** Present only when the event type asks for an SMS reminder number. */
+    text_reminder_number?: string;
+  };
+}
+
+/** What the booking page collected about the person, beyond their address. */
+interface InviteeDetails {
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  phone: string | null;
+}
+
+const NO_INVITEE_DETAILS: InviteeDetails = {
+  name: null,
+  firstName: null,
+  lastName: null,
+  phone: null,
+};
+
+/**
+ * The invitee identity as answer keys, ready to merge into the submission data.
+ *
+ * Calendly always returns `name` and only sometimes the split pair, so a missing
+ * `first_name`/`last_name` is derived from it: everything before the first space
+ * is the first name, the remainder the last. That is a heuristic, and it is the
+ * same one the booking page itself applies when it splits a single field — a
+ * mononym yields a first name and no last, which is the correct outcome.
+ */
+function inviteeAnswers(details: InviteeDetails): Record<string, string> {
+  const out: Record<string, string> = {};
+  const full = details.name?.trim() ?? '';
+  const space = full.indexOf(' ');
+  const first = details.firstName?.trim() || (space > 0 ? full.slice(0, space) : full);
+  const last = details.lastName?.trim() || (space > 0 ? full.slice(space + 1).trim() : '');
+  if (full) out[INVITEE_FIELDS.name] = full;
+  if (first) out[INVITEE_FIELDS.first_name] = first;
+  if (last) out[INVITEE_FIELDS.last_name] = last;
+  if (details.phone?.trim()) out[INVITEE_FIELDS.phone] = details.phone.trim();
+  return out;
 }
 
 /**
@@ -76,9 +122,10 @@ export class BookingSyncEffects {
     const sync = destination.bookingSync;
     const hasStage = Boolean(sync?.stageProperty?.trim() && sync?.stageValue?.trim());
 
-    // --- Calendly enrichment (event start + invitee email) -------------------
+    // --- Calendly enrichment (event start + invitee identity) ----------------
     let startMs = payload.startTime;
     let inviteeEmail: string | null = null;
+    let invitee: InviteeDetails = NO_INVITEE_DETAILS;
     if (payload.provider === 'calendly' && (payload.eventUri || payload.inviteeUri)) {
       // Per-account Calendly token (connected → decrypted), else the env fallback.
       const token = await resolveProviderToken(
@@ -94,7 +141,7 @@ export class BookingSyncEffects {
           'CALENDLY_API_TOKEN not set — booking sync proceeds without Calendly enrichment',
         );
       } else {
-        const [event, invitee] = await Promise.all([
+        const [event, fetchedInvitee] = await Promise.all([
           payload.eventUri ? this.calendlyGet(payload.eventUri, token) : null,
           payload.inviteeUri ? this.calendlyGet(payload.inviteeUri, token) : null,
         ]);
@@ -103,8 +150,18 @@ export class BookingSyncEffects {
           const parsed = Date.parse(fetchedStart);
           if (Number.isFinite(parsed)) startMs = parsed;
         }
-        const fetchedEmail = invitee?.resource?.email?.trim();
+        const fetchedEmail = fetchedInvitee?.resource?.email?.trim();
         if (fetchedEmail) inviteeEmail = fetchedEmail.toLowerCase();
+        // The rest of the identity the booking page collected. Kept whether or
+        // not the account also runs the provider's own CRM integration: both
+        // write the same values to the same contact, and the upsert is
+        // idempotent, so there is no ordering to arbitrate.
+        invitee = {
+          name: fetchedInvitee?.resource?.name?.trim() || null,
+          firstName: fetchedInvitee?.resource?.first_name?.trim() || null,
+          lastName: fetchedInvitee?.resource?.last_name?.trim() || null,
+          phone: fetchedInvitee?.resource?.text_reminder_number?.trim() || null,
+        };
       }
     }
 
@@ -169,7 +226,15 @@ export class BookingSyncEffects {
     const adapterEmail = submission ? adapterResolvableEmail(destination, submission.data) : null;
     const syncedAnswers =
       !adapterEmail && inviteeEmail && submission
-        ? await this.syncAnswersAtBooking(payload, form, destination, hubspotToken, inviteeEmail, submission)
+        ? await this.syncAnswersAtBooking(
+            payload,
+            form,
+            destination,
+            hubspotToken,
+            inviteeEmail,
+            submission,
+            invitee,
+          )
         : false;
 
     if (!wroteBooking && !syncedAnswers) {
@@ -230,6 +295,7 @@ export class BookingSyncEffects {
     token: string,
     inviteeEmail: string,
     submission: SubmissionRow,
+    invitee: InviteeDetails,
   ): Promise<boolean> {
     const { data, score } = submission;
 
@@ -280,8 +346,12 @@ export class BookingSyncEffects {
       phase: submission.completedAt != null ? 'complete' : 'partial',
       submittedAt: submission.submittedAt,
       // The invitee email rides as the `email` answer the adapter keys on; a
-      // stored value would win, but this path only runs when none exists.
-      data: { ...data, email: inviteeEmail },
+      // stored value would win, but this path only runs when none exists. The
+      // rest of the invitee identity rides on reserved `@invitee_*` keys, so an
+      // author maps it to CRM properties exactly like any answer — and a real
+      // ANSWER always wins, since the form asking the question outranks whatever
+      // the booking page happened to collect.
+      data: { ...inviteeAnswers(invitee), ...data, email: inviteeEmail },
       utm: extractUtm(data),
     });
     return result.delivered;

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -3,6 +3,7 @@ import { getFormById, parseJsonColumn, resolveProviderToken, sql, type Db } from
 import {
   formConfigSchema,
   formDestinationSchema,
+  propertiesFor,
   type FormDestination,
   type HubspotDestination,
 } from '@quill/types';
@@ -446,9 +447,9 @@ function adapterResolvableEmail(
   destination: HubspotDestination,
   data: Record<string, unknown>,
 ): string | null {
-  for (const [stepKey, property] of Object.entries(destination.fieldMappings ?? {})) {
+  for (const [stepKey, target] of Object.entries(destination.fieldMappings ?? {})) {
     const value = data[stepKey];
-    if (property?.trim() === 'email' && typeof value === 'string' && value.trim()) {
+    if (propertiesFor(target).includes('email') && typeof value === 'string' && value.trim()) {
       return value.trim();
     }
   }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -448,10 +448,28 @@ export function FormRenderer({
     }
   }, []);
 
-  // Pre-warm the booking embed while the interstitial plays: when the form
-  // opts in (reveal.prewarm) and the PENDING outcome (client-side score over
-  // the answers so far) hands off to a scheduler, warm its origins now so the
-  // embed after submit paints faster. warmBookingEmbed is idempotent + safe.
+  // Pre-warm the booking embed while an interstitial plays, so the booking
+  // screen after it paints faster. `warmBookingEmbed` is idempotent and a no-op
+  // on the server, so warming twice costs nothing.
+  //
+  // Both shapes of "reveal, then book" are covered, because both exist in the
+  // wild at once:
+  //  - LEGACY — `config.reveal.prewarm` plays as its own `phase`, and the
+  //    booking is the PENDING outcome's (client-side score over the answers so
+  //    far). A published config keeps this shape until it is re-saved.
+  //  - STEPS — a `reveal` STEP carries its own `prewarm`, and the booking is the
+  //    next visible `scheduler` step. `migrateRevealToStep` drops
+  //    `config.reveal` the moment the builder opens the form, so reading only
+  //    the legacy field silently disabled prewarm for every edited form.
+  const nextScheduler =
+    phase === 'steps' && step?.type === 'reveal' && step.reveal?.prewarm
+      ? (steps.slice(index + 1).find((s) => s.type === 'scheduler')?.scheduler ?? null)
+      : null;
+  const nextSchedulerUrl = nextScheduler?.url ?? null;
+  const nextSchedulerProvider = nextScheduler?.provider ?? 'calendly';
+  useEffect(() => {
+    if (nextSchedulerUrl) warmBookingEmbed(nextSchedulerProvider, nextSchedulerUrl);
+  }, [nextSchedulerUrl, nextSchedulerProvider]);
   useEffect(() => {
     if (phase !== 'reveal') return;
     if (!config.reveal?.prewarm) return;

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -213,6 +213,10 @@ export interface BuilderMessages {
     /** No account-level HubSpot connection at all. */
     notConnected: string;
     goToConnections: string;
+    /** The form has nothing that can identify a contact. */
+    needsEmail: string;
+    /** A booking would supply the address, but its provider is not connected. */
+    schedulerDisconnected: string;
   };
   rules: {
     ifAnswerIs: string;
@@ -511,6 +515,10 @@ const en: BuilderMessages = {
     configureInConnect: 'Set up in Connect',
     notConnected: 'Connect HubSpot to map answers to contact properties.',
     goToConnections: 'Go to Connections',
+    needsEmail:
+      'This form asks for no email and books nothing, so HubSpot has no way to identify the contact — nothing mapped here would sync. Add an email question, or a booking step.',
+    schedulerDisconnected:
+      'The booking step would supply the address, but Calendly is not connected for this account — so the invitee cannot be read back and nothing mapped here will reach HubSpot.',
   },
   rules: {
     ifAnswerIs: 'If answer is',
@@ -808,6 +816,10 @@ const es: BuilderMessages = {
     configureInConnect: 'Configurar en Conectar',
     notConnected: 'Conecta HubSpot para asignar respuestas a propiedades del contacto.',
     goToConnections: 'Ir a Conexiones',
+    needsEmail:
+      'Este formulario no pide correo ni agenda nada, así que HubSpot no tiene cómo identificar al contacto — nada de lo que mapees acá se va a sincronizar. Agregá una pregunta de correo, o un paso de agenda.',
+    schedulerDisconnected:
+      'El paso de agenda aportaría el correo, pero Calendly no está conectado en esta cuenta — así que no se puede leer al invitado y nada de lo mapeado acá va a llegar a HubSpot.',
   },
   rules: {
     ifAnswerIs: 'Si la respuesta es',

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { adminApi, ApiError, type HubSpotPropertiesResponse } from '@/lib/admin-api';
+import { adminApi, ApiError, type FailedDelivery, type HubSpotPropertiesResponse } from '@/lib/admin-api';
 import { getMessages } from '@quill/shared';
 import type { FormDestination } from '@quill/types';
 
@@ -75,4 +75,19 @@ export async function loadConnectIntegrationsAction(
       calendlyConnected,
     },
   };
+}
+
+/**
+ * Deliveries for this form that ended without landing.
+ *
+ * Degrades to an empty list rather than surfacing an error: this is a diagnostic
+ * panel, and a lookup failure must never make the Connect tab look broken.
+ */
+export async function loadFailedDeliveriesAction(id: string): Promise<FailedDelivery[]> {
+  try {
+    const res = await adminApi.formDeliveries(id);
+    return res.items;
+  } catch {
+    return [];
+  }
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
@@ -19,6 +19,12 @@ export interface ConnectIntegrationsData {
   destinations: FormDestination[];
   hubspot: HubSpotPropertiesResponse;
   hubspotConnected: boolean;
+  /**
+   * Whether the scheduling provider is connected for the account. A form whose
+   * address comes from a scheduler needs this to be true or the invitee can
+   * never be read back — see `contactKeyReadiness`.
+   */
+  calendlyConnected: boolean;
 }
 
 export async function loadConnectIntegrationsAction(
@@ -48,11 +54,16 @@ export async function loadConnectIntegrationsAction(
   // failure degrades to "not connected" — the editor still shows the mapping
   // when the property picker resolved via the server env fallback.
   let hubspotConnected = false;
+  let calendlyConnected = false;
   try {
     const integrations = await adminApi.listIntegrations();
     hubspotConnected = integrations.providers.some((p) => p.provider === 'hubspot' && p.connected);
+    calendlyConnected = integrations.providers.some(
+      (p) => p.provider === 'calendly' && p.connected,
+    );
   } catch {
     hubspotConnected = false;
+    calendlyConnected = false;
   }
 
   return {
@@ -61,6 +72,7 @@ export async function loadConnectIntegrationsAction(
       destinations: (form.config.destinations ?? []) as FormDestination[],
       hubspot,
       hubspotConnected,
+      calendlyConnected,
     },
   };
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { emailSourceFor, type EmailSource, type FormConfig } from '@quill/engine';
+import { contactKeyReadiness, type ContactKeyReadiness, type FormConfig } from '@quill/engine';
 import type { FormTracking } from '@quill/types';
 import { getMessages, type Locale } from '@quill/shared';
 import { Button } from '@/components/ui/button';
@@ -62,17 +62,14 @@ export function ConnectPanel({
     [config.steps],
   );
 
-  // Computed from the LIVE config for the same reason `questions` is: adding an
-  // email question has to unblock the HubSpot mapping immediately, not after a
-  // save and a refetch.
-  const emailSource = useMemo(() => emailSourceFor(config), [config]);
+
 
   return (
     <div data-testid="connect-panel" className="mx-auto flex w-full max-w-[900px] flex-col gap-4">
       <IntegrationsSection
         formId={formId}
         questions={questions}
-        emailSource={emailSource}
+        config={config}
         mc={mc}
         im={im}
         locale={loc}
@@ -93,21 +90,36 @@ type LoadState =
 function IntegrationsSection({
   formId,
   questions,
-  emailSource,
+  config,
   mc,
   im,
   locale,
 }: {
   formId: string;
   questions: QuestionMeta[];
-  /** Where a HubSpot sync could get an address, or null if nowhere. */
-  emailSource: EmailSource;
+  /** The LIVE editor config — readiness is derived here, next to the fetched
+   *  connection state, so both halves of the answer come from one place. */
+  config: FormConfig;
   mc: EditorMessages['connect'];
   im: ReturnType<typeof getMessages>['admin']['integrations'];
   locale: Locale;
 }) {
   const [state, setState] = useState<LoadState>({ status: 'loading' });
   const [attempt, setAttempt] = useState(0);
+
+  // Whether this form can key a CRM contact at all. Derived from the LIVE
+  // config so adding an email question unblocks the mapping immediately, and
+  // crossed with the account's connections because a scheduler only yields an
+  // address while its provider is connected — the config alone cannot answer
+  // "will this sync". While the fetch is in flight, assume connected: a
+  // transient "not connected" warning would be worse than a late one.
+  const readiness: ContactKeyReadiness = useMemo(
+    () =>
+      contactKeyReadiness(config, {
+        scheduler: state.status !== 'ready' || state.data.calendlyConnected,
+      }),
+    [config, state],
+  );
 
   // Fetch on tab activation (the panel mounts only while the Connect tab is
   // active, so re-entering the tab always shows the latest saved destinations).
@@ -160,7 +172,7 @@ function IntegrationsSection({
           hubspot={state.data.hubspot}
           hubspotConnected={state.data.hubspotConnected}
           questions={questions}
-          emailSource={emailSource}
+          readiness={readiness}
           messages={im}
           locale={locale}
         />

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-panel.tsx
@@ -7,7 +7,12 @@ import { getMessages, type Locale } from '@quill/shared';
 import { Button } from '@/components/ui/button';
 import { awaitPendingDestinationWrite } from '@/lib/connect-sync';
 import { IntegrationsEditor, type QuestionMeta } from '../../integrations/integrations-editor';
-import { loadConnectIntegrationsAction, type ConnectIntegrationsData } from './connect-actions';
+import {
+  loadConnectIntegrationsAction,
+  loadFailedDeliveriesAction,
+  type ConnectIntegrationsData,
+} from './connect-actions';
+import type { FailedDelivery } from '@/lib/admin-api';
 import { ConnectEmailsSection } from './connect-emails-section';
 import { Field, PanelSection, TextField } from './fields';
 import type { EditorMessages } from './messages';
@@ -74,9 +79,80 @@ export function ConnectPanel({
         im={im}
         locale={loc}
       />
+      <FailedDeliveriesSection formId={formId} mc={mc} />
       <TrackingSection config={config} onTrackingChange={onTrackingChange} mc={mc} />
       <ConnectEmailsSection formId={formId} m={mc} locale={locale} />
     </div>
+  );
+}
+
+// --- Failed deliveries -------------------------------------------------------
+
+/**
+ * Deliveries for this form that ended without landing.
+ *
+ * Nothing in the admin ever surfaced the outbox, so a delivery that died — an
+ * expired CRM token, a disconnected scheduling provider, a form with no
+ * resolvable respondent email — existed only in server logs. From the outside
+ * everything looked fine: the respondent submitted, the booking succeeded, the
+ * confirmation arrived. The lead simply never reached the CRM.
+ *
+ * Renders nothing when there is nothing wrong: an empty panel here would be
+ * noise on the overwhelming majority of forms.
+ */
+function FailedDeliveriesSection({
+  formId,
+  mc,
+}: {
+  formId: string;
+  mc: EditorMessages['connect'];
+}) {
+  const [items, setItems] = useState<FailedDelivery[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadFailedDeliveriesAction(formId)
+      .then((rows) => {
+        if (!cancelled) setItems(rows);
+      })
+      .catch(() => {
+        // Diagnostics must never break the tab they diagnose.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [formId]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section data-testid="connect-failed-deliveries" className="flex flex-col gap-2">
+      <div className="min-w-0">
+        <h3 className="text-sm font-semibold text-foreground">{mc.deliveriesTitle}</h3>
+        <p className="mt-0.5 text-xs text-muted-foreground">{mc.deliveriesSubtitle}</p>
+      </div>
+      <ul className="flex flex-col gap-1.5">
+        {items.map((d) => (
+          <li
+            key={d.id}
+            data-testid="failed-delivery"
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs font-medium text-foreground">{d.kind}</span>
+              <span className="text-[11px] text-muted-foreground">
+                {new Date(d.updatedAt).toLocaleString()}
+              </span>
+            </div>
+            {/* The worker's own reason, verbatim. Paraphrasing it here would
+                lose the one detail that says what to fix. */}
+            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+              {d.lastError ?? mc.deliveriesNoReason}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
@@ -8,6 +8,7 @@ import { Select, type SelectOption } from '@/components/ui/select';
 import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
 import { TextField } from './fields';
+import { contactKeyReadiness, type FormConfig, type FormStep } from '@quill/engine';
 import { loadConnectIntegrationsAction, type ConnectIntegrationsData } from './connect-actions';
 import { saveQuestionMappingAction } from './question-hubspot-actions';
 import type { BuilderMessages } from './builder-messages';
@@ -94,6 +95,7 @@ type SectionState =
 export function QuestionHubspotSection({
   formId,
   stepKey,
+  steps,
   locale,
   onOpenConnect,
   m,
@@ -101,6 +103,10 @@ export function QuestionHubspotSection({
   formId: string;
   /** The selected question's answer key — the `fieldMappings` entry it owns. */
   stepKey: string;
+  /** The form's steps, to answer "can this form key a contact at all?" here —
+   *  an author who never opens Connect would otherwise map properties on a form
+   *  that can never sync, and nothing would say so. */
+  steps: FormStep[];
   locale: string;
   /** Switch the editor to the Connect tab (destination setup lives there). */
   onOpenConnect: () => void;
@@ -219,6 +225,29 @@ export function QuestionHubspotSection({
       );
     }
     const data = state.data;
+    // Can this form key a contact AT ALL? Config plus connections, the same
+    // answer Connect shows — because an author can map every property from the
+    // Build tab, publish, and never open Connect. Without this the mapping
+    // looks finished and syncs nothing.
+    const readiness = contactKeyReadiness({ version: 1, steps } as unknown as FormConfig, {
+      scheduler: data.calendlyConnected,
+    });
+    if (!readiness.ok) {
+      return (
+        <div className="flex flex-col items-start gap-2" data-testid="qs-hubspot-unready">
+          <p role="alert" className="text-xs text-muted-foreground">
+            {readiness.blocker === 'no_source' ? m.needsEmail : m.schedulerDisconnected}
+          </p>
+          <Link
+            href="/admin/integrations"
+            className={buttonVariants({ variant: 'outline', size: 'sm' })}
+          >
+            {m.goToConnections}
+            <i aria-hidden className="pi pi-arrow-right" style={{ fontSize: 11 }} />
+          </Link>
+        </div>
+      );
+    }
     // Usable when the account is connected OR the property picker resolved via
     // the server env fallback (self-host) — mirrors the integrations editor.
     if (!data.hubspotConnected && !data.hubspot.enabled) {

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
 import { TextField } from './fields';
 import { contactKeyReadiness, type FormConfig, type FormStep } from '@quill/engine';
+import { propertiesFor } from '@quill/types';
 import { loadConnectIntegrationsAction, type ConnectIntegrationsData } from './connect-actions';
 import { saveQuestionMappingAction } from './question-hubspot-actions';
 import type { BuilderMessages } from './builder-messages';
@@ -80,7 +81,13 @@ function withMapping(
     destinations: data.destinations.map((d) => {
       if (d.type !== 'hubspot') return d;
       const fieldMappings = { ...(d.fieldMappings ?? {}) };
-      if (property) fieldMappings[stepKey] = property;
+      // This panel edits ONE property — the first. A mapping that fans out to
+      // several is authored in Connect, and clearing the field here must not
+      // silently drop the others, so the tail is preserved either way.
+      const rest = propertiesFor(fieldMappings[stepKey]).slice(1);
+      const next = property ? [property, ...rest] : rest;
+      if (next.length > 1) fieldMappings[stepKey] = next;
+      else if (next.length === 1) fieldMappings[stepKey] = next[0]!;
       else delete fieldMappings[stepKey];
       return { ...d, fieldMappings };
     }),
@@ -282,7 +289,8 @@ export function QuestionHubspotSection({
         </div>
       );
     }
-    const value = dest.fieldMappings?.[stepKey] ?? '';
+    const targets = propertiesFor(dest.fieldMappings?.[stepKey]);
+    const value = targets[0] ?? '';
     return (
       <div data-testid="qs-hubspot-mapto" className="flex flex-col gap-1.5">
         <div className="flex items-center justify-between gap-2">

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -661,6 +661,7 @@ export function QuestionSettings({
         <QuestionHubspotSection
           formId={formId}
           stepKey={step.key}
+          steps={steps}
           locale={locale}
           onOpenConnect={onOpenConnect}
           m={bm.hubspot}

--- a/apps/web/app/admin/forms/[id]/edit/_components/results-view.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/results-view.tsx
@@ -5,6 +5,7 @@ import type { FormConfig, FormOutcome, FormStep } from '@quill/engine';
 import { createEmptyOutcome } from '@quill/engine';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/cn';
 import { HelpTip } from '@/components/ui/help-tip';
 import { TextField, NumberField } from './fields';
@@ -275,6 +276,74 @@ export function ResultsView({
                   />
                   <p className="text-[11px] text-muted-foreground">{rm.redirectHelp}</p>
                 </div>
+                {/* How long the thank-you shows before the redirect. Stored
+                    since V5-B1 with no control anywhere, so a form could sit on
+                    a delay nobody could see, change, or explain. Only relevant
+                    with a destination — without one there is nothing to delay. */}
+                {o.redirectUrl?.trim() ? (
+                  <div className="mt-2.5 flex flex-col gap-1 pl-[64px]">
+                    <span className="flex items-center gap-1.5">
+                      <label
+                        htmlFor={`outcome-delay-${o.id}`}
+                        className="text-xs font-medium text-foreground"
+                      >
+                        {rm.redirectDelayLabel}
+                      </label>
+                      <HelpTip text={rm.redirectDelayHelp} label={rm.redirectDelayLabel} />
+                    </span>
+                    <Input
+                      id={`outcome-delay-${o.id}`}
+                      type="number"
+                      min={0}
+                      step={100}
+                      className="max-w-[160px]"
+                      data-testid="outcome-redirect-delay"
+                      value={String(o.redirectDelayMs ?? 0)}
+                      onChange={(e) => {
+                        const n = Number(e.target.value);
+                        update(index, {
+                          redirectDelayMs: Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0,
+                        });
+                      }}
+                    />
+                    <p className="text-[11px] text-muted-foreground">{rm.redirectDelayHint}</p>
+                  </div>
+                ) : null}
+                {/* Answer-forced overrides. These beat the score outright, so a
+                    range can read "6 and up" while a lead who cleared it still
+                    lands here — the one rule that made the panel lie. Shown
+                    read-only with a way to remove it: authoring a new one needs
+                    a field+bound picker, and being able to SEE it is what was
+                    actually missing. */}
+                {o.overrides?.length ? (
+                  <div className="mt-2.5 flex flex-col gap-1 pl-[64px]">
+                    <span className="text-xs font-medium text-foreground">{rm.overridesLabel}</span>
+                    {o.overrides.map((rule, ri) => (
+                      <div
+                        key={`${rule.field}-${ri}`}
+                        data-testid="outcome-override"
+                        className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-1.5"
+                      >
+                        <code className="min-w-0 truncate text-[11px] text-muted-foreground">
+                          {describeOverride(rule, rm)}
+                        </code>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={rm.overrideRemove}
+                          onClick={() =>
+                            update(index, {
+                              overrides: (o.overrides ?? []).filter((_, j) => j !== ri),
+                            })
+                          }
+                        >
+                          {rm.overrideRemove}
+                        </Button>
+                      </div>
+                    ))}
+                    <p className="text-[11px] text-muted-foreground">{rm.overridesHelp}</p>
+                  </div>
+                ) : null}
               </div>
             );
           })}
@@ -293,6 +362,31 @@ export function ResultsView({
       </section>
     </div>
   );
+}
+
+/**
+ * An answer-forced override, read back as a sentence.
+ *
+ * The stored shape is `{ field, maxValue?, minValue?, values? }` and it decides
+ * which outcome a lead lands in BEFORE any score is compared — so leaving it
+ * invisible meant the range labels could be read carefully and still be wrong.
+ * A clause the schema allows but nothing sets renders as the bare field, which
+ * is honest: it says a rule exists without inventing what it means.
+ */
+function describeOverride(
+  rule: { field: string; maxValue?: number; minValue?: number; values?: string[] },
+  rm: EditorMessages['resultsHelp'],
+): string {
+  if (rule.maxValue != null) {
+    return tb(rm.overrideAtMost, { field: rule.field, bound: String(rule.maxValue) });
+  }
+  if (rule.minValue != null) {
+    return tb(rm.overrideAtLeast, { field: rule.field, bound: String(rule.minValue) });
+  }
+  if (rule.values?.length) {
+    return tb(rm.overrideIsAnyOf, { field: rule.field, bound: rule.values.join(', ') });
+  }
+  return rule.field;
 }
 
 /** A segmented bar of the score ranges, from cold (muted) to hot (lime). */

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { EmailSource } from '@quill/engine';
+import { INVITEE_FIELDS, type EmailSource } from '@quill/engine';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import type { FormsMessages, Locale } from '@quill/shared';
@@ -37,6 +37,17 @@ export type { QuestionMeta } from './auto-map';
 const LocaleContext = createContext<Locale>('en');
 
 const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const;
+
+/**
+ * A submission-data key the form never asks for but still carries — a UTM off
+ * the URL, or something the booking page collected. Labelled because the key
+ * itself is a token: `@invitee_first_name` is not a name anyone wants to read
+ * in a dropdown.
+ */
+interface SystemKey {
+  key: string;
+  label: string;
+}
 
 /** Sentinel option values for the key pickers — never valid step keys. */
 const CUSTOM_KEY_OPTION = '__custom_key__';
@@ -589,15 +600,20 @@ function KeySelect({
   onChange: (v: string) => void;
   /** Pickable question entries — already filtered/ordered by the caller. */
   questionOptions: QuestionMeta[];
-  /** Auto-captured submission-data keys (UTMs). Empty = omit the group. */
-  systemKeys: readonly string[];
+  /**
+   * Submission-data keys the form does not ask for but still carries: UTMs from
+   * the URL, and what the booking page collected about the invitee. Labelled,
+   * because a raw `@invitee_first_name` is a token, not a name. Empty = omit
+   * the group.
+   */
+  systemKeys: readonly SystemKey[];
   m: Msgs;
   testId: string;
   customTestId: string;
 }) {
   const locale = useContext(LocaleContext);
   const selectable = (v: string): boolean =>
-    systemKeys.includes(v) || questionOptions.some((q) => q.key === v);
+    systemKeys.some((k) => k.key === v) || questionOptions.some((q) => q.key === v);
   // Stored keys that match neither group (hidden/legacy) open in custom mode.
   const [customMode, setCustomMode] = useState(() => value !== '' && !selectable(value));
 
@@ -634,7 +650,7 @@ function KeySelect({
   }
   if (systemKeys.length > 0) {
     options.push({ value: KEY_GROUP_SYSTEM, label: m.keyGroupSystem, disabled: true });
-    options.push(...systemKeys.map((k) => ({ value: k, label: k })));
+    options.push(...systemKeys.map((k) => ({ value: k.key, label: k.label })));
   }
   options.push({ value: CUSTOM_KEY_OPTION, label: m.keyCustomOption });
 
@@ -947,6 +963,22 @@ function HubspotCard({
   const utmValues = useMemo(() => state.utmMappings, [state.utmMappings]);
   const questionKeys = useMemo(() => new Set(questions.map((q) => q.key)), [questions]);
 
+  // What this form carries beyond its own answers. The invitee's details only
+  // exist when a SCHEDULER is what supplies the address — a form that asks for
+  // an email itself never books, so offering them there would map keys that
+  // stay empty forever.
+  const systemKeyOptions = useMemo<SystemKey[]>(() => {
+    const utm: SystemKey[] = UTM_KEYS.map((k) => ({ key: k, label: k }));
+    if (emailSource?.kind !== 'scheduler') return utm;
+    return [
+      ...utm,
+      { key: INVITEE_FIELDS.name, label: m.inviteeName },
+      { key: INVITEE_FIELDS.first_name, label: m.inviteeFirstName },
+      { key: INVITEE_FIELDS.last_name, label: m.inviteeLastName },
+      { key: INVITEE_FIELDS.phone, label: m.inviteePhone },
+    ];
+  }, [emailSource, m]);
+
   // Nothing to key a contact on → mapping is pointless and, worse, silently
   // lossy: HubSpot's upsert is BY EMAIL, so a submission with no address
   // resolves as a permanent no-op and that lead is never synced. Say so here,
@@ -1138,7 +1170,9 @@ function HubspotCard({
                 <KeySelect
                   value={pair.key}
                   questionOptions={unmappedQuestions}
-                  systemKeys={UTM_KEYS.filter((k) => k === pair.key || !usedKeys.has(k))}
+                  systemKeys={systemKeyOptions.filter(
+                    (k) => k.key === pair.key || !usedKeys.has(k.key),
+                  )}
                   m={m}
                   testId="mapping-key-select"
                   customTestId="mapping-key-custom"

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -5,7 +5,6 @@ import {
   INVITEE_FIELDS,
   emailMappingsConflictingWithScheduler,
   type ContactKeyReadiness,
-  type EmailSource,
 } from '@quill/engine';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { propertiesFor } from '@quill/types';
 import {
   INVITEE_FIELDS,
   emailMappingsConflictingWithScheduler,
@@ -153,7 +154,12 @@ function initialHubspot(destinations: FormDestination[]): HubspotState {
   if (h && h.type === 'hubspot') {
     return {
       enabled: h.enabled,
-      fieldMappings: Object.entries(h.fieldMappings ?? {}).map(([key, property]) => ({ key, property })),
+      // One ROW per target property: a mapping that fans out to several shows
+      // as several rows with the same key, which is the shape the editor can
+      // actually author. `buildDestinations` groups them back.
+      fieldMappings: Object.entries(h.fieldMappings ?? {}).flatMap(([key, target]) =>
+        propertiesFor(target).map((property) => ({ key, property })),
+      ),
       utmMappings: { ...(h.utmMappings ?? {}) },
       scoreProperty: h.scoreProperty ?? '',
       dateProperty: h.dateProperty ?? '',
@@ -307,10 +313,21 @@ export function IntegrationsEditor({
     }
     // else: empty url (switch on or off) → no webhook persisted. An enabled
     // webhook with no URL is incomplete, not stored; clearing the URL removes it.
-    const fieldMappings: Record<string, string> = {};
+    // Rows GROUP by key rather than overwriting. The old flatten was
+    // last-one-wins and silent: two rows on the same question — the escape
+    // hatch the UI itself offers via "Custom key…" — quietly discarded the
+    // first mapping on save.
+    const grouped = new Map<string, string[]>();
     for (const p of hs.fieldMappings) {
-      if (p.key.trim() && p.property.trim()) fieldMappings[p.key.trim()] = p.property.trim();
+      const key = p.key.trim();
+      const property = p.property.trim();
+      if (!key || !property) continue;
+      const list = grouped.get(key) ?? [];
+      if (!list.includes(property)) list.push(property);
+      grouped.set(key, list);
     }
+    const fieldMappings: Record<string, string | string[]> = {};
+    for (const [key, list] of grouped) fieldMappings[key] = list.length === 1 ? list[0]! : list;
     const utmMappings: Record<string, string> = {};
     for (const [k, v] of Object.entries(hs.utmMappings)) {
       if (v && v.trim()) utmMappings[k] = v.trim();
@@ -1081,7 +1098,10 @@ function HubspotCard({
   // already mapped drop out of a custom row's picker (no double-mapping); a
   // row's own key is always kept so its selection stays visible.
   const usedKeys = new Set(state.fieldMappings.map((p) => p.key));
-  const unmappedQuestions = questions.filter((q) => !usedKeys.has(q.key));
+  // Every question stays pickable. Hiding the mapped ones was how the editor
+  // enforced one-property-per-answer; now a second row on the same question IS
+  // the way to send it somewhere else too.
+  const unmappedQuestions = questions;
 
   // Value maps translate answers, so choice-type questions (fixed option
   // lists) lead the picker; free-text questions follow. Plain computation —

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { INVITEE_FIELDS, type EmailSource } from '@quill/engine';
+import {
+  INVITEE_FIELDS,
+  emailMappingsConflictingWithScheduler,
+  type ContactKeyReadiness,
+  type EmailSource,
+} from '@quill/engine';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import type { FormsMessages, Locale } from '@quill/shared';
@@ -48,6 +53,9 @@ interface SystemKey {
   key: string;
   label: string;
 }
+
+/** No config supplied → nothing can key a contact. Never claims readiness. */
+const NOT_READY: ContactKeyReadiness = { ok: false, blocker: 'no_source', source: null };
 
 /** Sentinel option values for the key pickers — never valid step keys. */
 const CUSTOM_KEY_OPTION = '__custom_key__';
@@ -202,7 +210,7 @@ export function IntegrationsEditor({
   hubspot: hubspotProps,
   hubspotConnected,
   questions,
-  emailSource = null,
+  readiness = NOT_READY,
   messages: m,
   locale,
 }: {
@@ -213,8 +221,12 @@ export function IntegrationsEditor({
   hubspotConnected: boolean;
   /** The form's mappable questions (from its steps). */
   questions: QuestionMeta[];
-  /** Where a HubSpot sync could get the address it keys contacts on. */
-  emailSource?: EmailSource;
+  /**
+   * Whether this form can key a CRM contact — config AND connections. The
+   * screen must not promise a sync it cannot deliver, so the copy below reads
+   * this rather than the config alone.
+   */
+  readiness?: ContactKeyReadiness;
   messages: Msgs;
   locale: Locale;
 }) {
@@ -486,7 +498,7 @@ export function IntegrationsEditor({
           pickerEnabled={pickerEnabled}
           accountConnected={hubspotConnected}
           showMapping={showMapping}
-          emailSource={emailSource}
+          readiness={readiness}
           questions={questions}
           m={m}
         />
@@ -945,7 +957,7 @@ function HubspotCard({
   pickerEnabled,
   accountConnected,
   showMapping,
-  emailSource,
+  readiness,
   questions,
   m,
 }: {
@@ -955,11 +967,12 @@ function HubspotCard({
   pickerEnabled: boolean;
   accountConnected: boolean;
   showMapping: boolean;
-  emailSource: EmailSource;
+  readiness: ContactKeyReadiness;
   questions: QuestionMeta[];
   m: Msgs;
 }) {
   const { success, toast } = useToast();
+  const emailSource = readiness.source;
   const utmValues = useMemo(() => state.utmMappings, [state.utmMappings]);
   const questionKeys = useMemo(() => new Set(questions.map((q) => q.key)), [questions]);
 
@@ -978,6 +991,23 @@ function HubspotCard({
       { key: INVITEE_FIELDS.phone, label: m.inviteePhone },
     ];
   }, [emailSource, m]);
+
+  // Questions pointed at the `email` property while a SCHEDULER is what supplies
+  // the address. The booking-time sync only runs when the adapter cannot resolve
+  // an address itself, so this mapping switches it off and the lead stops
+  // arriving — with no error anywhere.
+  const emailConflicts = useMemo(
+    () =>
+      emailMappingsConflictingWithScheduler(
+        emailSource,
+        Object.fromEntries(
+          state.fieldMappings
+            .filter((p) => p.key.trim() && p.property.trim())
+            .map((p) => [p.key.trim(), p.property.trim()]),
+        ),
+      ),
+    [emailSource, state.fieldMappings],
+  );
 
   // Nothing to key a contact on → mapping is pointless and, worse, silently
   // lossy: HubSpot's upsert is BY EMAIL, so a submission with no address
@@ -1102,24 +1132,48 @@ function HubspotCard({
 
       {/* What the sync actually does. "Map a question to a property" does not
           tell anyone that the CONTACT is matched by email and created when
-          absent — which is the one rule that decides whether a lead lands. */}
+          absent — which is the one rule that decides whether a lead lands.
+
+          The body is per-source, not one paragraph for everyone: the generic
+          copy ends "a form that never asks for an email cannot be synced",
+          which is FALSE for a form whose address comes from the booking — and
+          it sat directly above the note saying the opposite. */}
       <div
         data-testid="hubspot-how"
         className="rounded-md border border-border bg-muted/30 p-3"
       >
         <p className="text-xs font-medium text-foreground">{m.hubspotHowTitle}</p>
-        <p className="mt-1 text-xs text-muted-foreground">{m.hubspotHowBody}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {emailSource?.kind === 'scheduler' ? m.hubspotHowBodyScheduler : m.hubspotHowBody}
+        </p>
         {emailSource?.kind === 'scheduler' ? (
           <p data-testid="hubspot-scheduler-note" className="mt-2 text-xs text-muted-foreground">
-            {m.emailFromScheduler}
+            {readiness.ok ? m.emailFromScheduler : m.schedulerDisconnected}
           </p>
         ) : null}
       </div>
 
+      {/* The mapping the old help text INSTRUCTED, which switches the sync off.
+          Named per question so it can be found, not just described. */}
+      {emailConflicts.length > 0 ? (
+        <div
+          data-testid="hubspot-email-conflict"
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3"
+        >
+          <p className="text-xs font-medium text-foreground">{m.emailMappingConflictTitle}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {fill(m.emailMappingConflictBody, { keys: emailConflicts.join(', ') })}
+          </p>
+        </div>
+      ) : null}
+
       {/* Map questions — each form question → a HubSpot contact property */}
       <Section
         title={m.mapQuestions}
-        help={m.mapQuestionsHelp}
+        help={
+          emailSource?.kind === 'scheduler' ? m.mapQuestionsHelpScheduler : m.mapQuestionsHelp
+        }
         action={
           <Button variant="outline" size="sm" onClick={autoMap} disabled={questions.length === 0}>
             <i aria-hidden className="pi pi-bolt" style={{ fontSize: 12 }} />

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -211,6 +211,18 @@ export interface HubSpotProperty {
 }
 
 /** The property-picker response: disabled (no server token) or the property list. */
+/** One side-effect that never landed, as the admin surfaces it. */
+export interface FailedDelivery {
+  id: string;
+  kind: string;
+  /** `failed` = retries exhausted; `skipped` = a permanent gap, never retried. */
+  status: 'failed' | 'skipped';
+  lastError: string | null;
+  attempts: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export type HubSpotPropertiesResponse =
   | { enabled: false; reason: string }
   | { enabled: true; cached: boolean; properties: HubSpotProperty[] };
@@ -366,6 +378,9 @@ export const adminApi = {
   // Integrations
   hubspotProperties: () =>
     req<HubSpotPropertiesResponse>('GET', '/v1/integrations/hubspot/properties'),
+  /** Deliveries for this form that ended without landing (the failure log). */
+  formDeliveries: (id: string) =>
+    req<{ items: FailedDelivery[] }>('GET', `/v1/forms/${id}/deliveries`),
   /** Calendly event types for the scheduler step's picker (per-account token). */
   calendlyEventTypes: () =>
     req<CalendlyEventTypesResponse>('GET', '/v1/integrations/calendly/event-types'),

--- a/packages/db/src/outbox.spec.ts
+++ b/packages/db/src/outbox.spec.ts
@@ -12,6 +12,7 @@ import {
   claimDueOutbox,
   markOutboxRetry,
   markOutboxDone,
+  listFailedDeliveries,
 } from './outbox';
 
 let db: Db;
@@ -91,5 +92,65 @@ describe('claimDueOutbox', () => {
     await claimDueOutbox(db, now, { workerId: 'A' });
     await markOutboxDone(db, id, now);
     expect(await claimDueOutbox(db, now + 1_000_000, { workerId: 'B', staleClaimMs: 0 })).toHaveLength(0);
+  });
+});
+
+
+/**
+ * The admin's failure log. Account scoping is the invariant under test: these
+ * rows carry delivery reasons for one tenant and must never be readable from
+ * another, which is why the filter is in SQL and not applied afterwards.
+ */
+describe('listFailedDeliveries', () => {
+  const ACC = 'acc-1';
+  const OTHER = 'acc-2';
+  const FORM = 'form-1';
+
+  async function seedRow(
+    accountId: string,
+    formId: string,
+    status: 'failed' | 'skipped' | 'done',
+    lastError: string | null,
+  ) {
+    const id = await enqueueOutbox(db, {
+      kind: 'booking_sync',
+      action: 'crm_update',
+      accountId,
+      payload: JSON.stringify({ formId, sessionId: 's' }),
+      now: 1_000,
+    });
+    await db.run(
+      sql`UPDATE outbox SET status = ${status}, last_error = ${lastError}, updated_at = 2000 WHERE id = ${id}`,
+    );
+    return id;
+  }
+
+  it('returns only this account and this form, and only what did not land', async () => {
+    const wanted = await seedRow(ACC, FORM, 'failed', 'hubspot 500');
+    const skipped = await seedRow(ACC, FORM, 'skipped', 'no respondent email resolvable');
+    await seedRow(ACC, FORM, 'done', null); // landed — not a failure
+    await seedRow(ACC, 'form-2', 'failed', 'other form');
+    await seedRow(OTHER, FORM, 'failed', 'another tenant');
+
+    const rows = await listFailedDeliveries(db, ACC, FORM);
+    expect(rows.map((r) => r.id).sort()).toEqual([skipped, wanted].sort());
+    expect(rows.map((r) => r.lastError).sort()).toEqual(
+      ['hubspot 500', 'no respondent email resolvable'].sort(),
+    );
+  });
+
+  it('caps the list and ignores rows whose payload cannot be read', async () => {
+    for (let i = 0; i < 3; i++) await seedRow(ACC, FORM, 'failed', `e${i}`);
+    const bad = await enqueueOutbox(db, {
+      kind: 'booking_sync',
+      action: 'crm_update',
+      accountId: ACC,
+      payload: 'not json',
+      now: 1_000,
+    });
+    await db.run(sql`UPDATE outbox SET status = 'failed' WHERE id = ${bad}`);
+
+    expect(await listFailedDeliveries(db, ACC, FORM)).toHaveLength(3);
+    expect(await listFailedDeliveries(db, ACC, FORM, 2)).toHaveLength(2);
   });
 });

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -268,20 +268,97 @@ export async function markOutboxFailed(
   );
 }
 
-/** Inspect the queue / delivery log (tests, a future admin view). */
+/** Inspect the queue / delivery log (tests, the admin deliveries view). */
 export async function listOutbox(
   db: Db,
-  filter: { status?: OutboxStatus; kind?: OutboxKind; subjectUid?: string } = {},
+  filter: {
+    status?: OutboxStatus;
+    kind?: OutboxKind;
+    subjectUid?: string;
+    /** Scope to one account — required by any admin-facing caller. */
+    accountId?: string;
+  } = {},
 ): Promise<OutboxRow[]> {
   const conds = [sql`1 = 1`];
   if (filter.status) conds.push(sql`status = ${filter.status}`);
   if (filter.kind) conds.push(sql`kind = ${filter.kind}`);
   if (filter.subjectUid) conds.push(sql`subject_uid = ${filter.subjectUid}`);
+  if (filter.accountId) conds.push(sql`account_id = ${filter.accountId}`);
   const where = sql.join(conds, sql` AND `);
   const rows = await db.all<Record<string, unknown>>(
     sql`SELECT * FROM outbox WHERE ${where} ORDER BY created_at ASC`,
   );
   return rows.map(mapRow);
+}
+
+/** A side-effect that did not land, in the terms the person who owns the form has. */
+export interface FailedDelivery {
+  id: string;
+  /** `booking_sync`, `destination`, `email`… — what was being delivered. */
+  kind: OutboxKind;
+  /** `failed` = retries exhausted; `skipped` = a permanent gap, never retried. */
+  status: 'failed' | 'skipped';
+  /** The reason the worker recorded. This is the whole point of the view. */
+  lastError: string | null;
+  attempts: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Deliveries for one form that ended without landing.
+ *
+ * Nothing in the admin surfaced the outbox, so a delivery that died — an expired
+ * CRM token, a disconnected scheduling provider, a form with no resolvable
+ * respondent email — existed only in server logs. From the outside everything
+ * looked fine: the respondent submitted, the booking succeeded, the confirmation
+ * arrived. The lead simply never reached the CRM, and the person who owned the
+ * form had no way to find out.
+ *
+ * The form is matched from the row's serialized payload rather than a column:
+ * `outbox` is deliberately generic (kind + payload), and adding a form column
+ * would mean a destructive migration on a table every deployment already has.
+ * The account IS a column, so the scope that matters for isolation is enforced
+ * in SQL; the form filter narrows within one account's own rows.
+ */
+export async function listFailedDeliveries(
+  db: Db,
+  accountId: string,
+  formId: string,
+  limit = 50,
+): Promise<FailedDelivery[]> {
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT * FROM outbox
+        WHERE account_id = ${accountId} AND status IN ('failed', 'skipped')
+        ORDER BY updated_at DESC`,
+  );
+  const out: FailedDelivery[] = [];
+  for (const raw of rows) {
+    const row = mapRow(raw);
+    if (!payloadTargetsForm(row.payload, formId)) continue;
+    out.push({
+      id: row.id,
+      kind: row.kind,
+      status: row.status as 'failed' | 'skipped',
+      lastError: row.lastError,
+      attempts: row.attempts,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/** Does this row's payload name the form? Malformed payloads simply do not match. */
+function payloadTargetsForm(payload: string | null, formId: string): boolean {
+  if (!payload) return false;
+  try {
+    const parsed = JSON.parse(payload) as { formId?: unknown };
+    return typeof parsed.formId === 'string' && parsed.formId === formId;
+  } catch {
+    return false;
+  }
 }
 
 /** Count rows in a status (readiness/backlog reporting). */

--- a/packages/destinations/src/adapters/hubspot.spec.ts
+++ b/packages/destinations/src/adapters/hubspot.spec.ts
@@ -56,6 +56,41 @@ describe('HubspotDestination.buildProperties', () => {
     expect(props.submitted_date).toBe(String(Date.UTC(2026, 0, 15)));
   });
 
+  // One answer, several properties. The workaround before this was a SECOND
+  // hubspot destination — which the integrations screen cannot see and the
+  // booking sync never delivers, so it wrote nothing at all.
+  it('fans one answer out to every property it targets', () => {
+    const dest = new HubspotDestination({
+      token: 't',
+      fieldMappings: { goal: ['typeform_use_case', 'goal_ai_agent'], name: 'firstname' },
+      valueMaps: { goal: { leads_frios: 'AI Calls' } },
+    });
+    const props = dest.buildProperties(ctx({ data: { goal: 'leads_frios', name: 'Ada' } }));
+    // The value map is per STEP, so both properties receive the TRANSLATED
+    // value — sending the raw slug to one of them is the bug this replaces.
+    expect(props.typeform_use_case).toBe('AI Calls');
+    expect(props.goal_ai_agent).toBe('AI Calls');
+    expect(props.firstname).toBe('Ada'); // a plain string still maps
+  });
+
+  it('resolves email when it is one of several properties an answer feeds', () => {
+    const dest = new HubspotDestination({
+      token: 't',
+      fieldMappings: { work: ['email', 'work_email'] },
+    });
+    expect(dest.resolveEmail(ctx({ data: { work: 'lead@acme.io' } }))).toBe('lead@acme.io');
+  });
+
+  it('drops blank targets instead of writing an empty property name', () => {
+    const dest = new HubspotDestination({
+      token: 't',
+      fieldMappings: { name: ['  ', 'firstname'], other: '   ' },
+    });
+    const props = dest.buildProperties(ctx({ data: { name: 'Ada', other: 'x' } }));
+    expect(props.firstname).toBe('Ada');
+    expect(Object.keys(props)).not.toContain('');
+  });
+
   it('omits the score property on a partial submission', () => {
     const dest = new HubspotDestination({ token: 't', ...MAPPING });
     expect(dest.buildProperties(ctx({ phase: 'partial' })).lead_score).toBeUndefined();

--- a/packages/destinations/src/adapters/hubspot.ts
+++ b/packages/destinations/src/adapters/hubspot.ts
@@ -1,3 +1,4 @@
+import { propertiesFor } from '@quill/types';
 import type {
   DestinationContext,
   DestinationResult,
@@ -15,7 +16,7 @@ export interface HubspotDestinationOptions {
   /** HubSpot private-app token (server-side only; never sent to the browser). */
   token: string;
   /** stepKey -> contact property. One mapping's property SHOULD be `email`. */
-  fieldMappings: Record<string, string>;
+  fieldMappings: Record<string, string | string[]>;
   /** utmKey (utm_source…) -> contact property. */
   utmMappings?: Record<string, string>;
   /** Contact property to write the server-computed score to (complete only). */
@@ -102,12 +103,16 @@ export class HubspotDestination implements SubmissionDestination {
     // Field mappings: stepKey -> contact property, with per-step value maps
     // translating a raw answer to its CRM picklist value (unmapped raw values
     // pass through unchanged).
-    for (const [stepKey, property] of Object.entries(this.opts.fieldMappings)) {
-      if (!property?.trim()) continue;
+    for (const [stepKey, target] of Object.entries(this.opts.fieldMappings)) {
+      const properties = propertiesFor(target);
+      if (properties.length === 0) continue;
       const value = ctx.data[stepKey];
       if (value !== undefined && value !== null && String(value).trim() !== '') {
         const raw = String(value).trim();
-        props[property.trim()] = this.opts.valueMaps?.[stepKey]?.[raw] ?? raw;
+        // The value map is per STEP, so every property this answer feeds gets
+        // the same translated value — which is the whole point of fanning out.
+        const translated = this.opts.valueMaps?.[stepKey]?.[raw] ?? raw;
+        for (const property of properties) props[property] = translated;
       }
     }
 
@@ -163,8 +168,8 @@ export class HubspotDestination implements SubmissionDestination {
 
   /** Resolve the respondent email from the field mappings, then the raw data. */
   resolveEmail(ctx: DestinationContext): string | null {
-    for (const [stepKey, property] of Object.entries(this.opts.fieldMappings)) {
-      if (property?.trim() === 'email' && ctx.data[stepKey]) {
+    for (const [stepKey, target] of Object.entries(this.opts.fieldMappings)) {
+      if (propertiesFor(target).includes('email') && ctx.data[stepKey]) {
         return String(ctx.data[stepKey]).trim();
       }
     }

--- a/packages/engine/src/contact-key.spec.ts
+++ b/packages/engine/src/contact-key.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Whether a form can hand the CRM an address to key its contact on — the config
+ * half AND the connection half, which is the pair the admin screens got wrong:
+ * they promised the sync purely because a scheduler step existed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  contactKeyReadiness,
+  emailMappingsConflictingWithScheduler,
+  emailSourceFor,
+  type FormConfig,
+} from './form-logic';
+
+function config(steps: Array<Record<string, unknown>>): FormConfig {
+  return { version: 1, steps } as unknown as FormConfig;
+}
+
+const EMAIL_STEP = { key: 'email', type: 'email', question: 'Your email' };
+const SCHEDULER_STEP = { key: 'book', type: 'scheduler', question: 'Pick a time' };
+const PLAIN_STEP = { key: 'company', type: 'text', question: 'Company' };
+
+describe('contactKeyReadiness', () => {
+  it('is blocked when the form asks for no address and books nothing', () => {
+    const r = contactKeyReadiness(config([PLAIN_STEP]), { scheduler: true });
+    expect(r).toEqual({ ok: false, blocker: 'no_source', source: null });
+  });
+
+  it('is ready on an email question regardless of the scheduling provider', () => {
+    for (const scheduler of [true, false]) {
+      const r = contactKeyReadiness(config([EMAIL_STEP, PLAIN_STEP]), { scheduler });
+      expect(r).toEqual({ ok: true, source: { kind: 'question', key: 'email' } });
+    }
+  });
+
+  it('is ready on a scheduler only while its provider is connected', () => {
+    const c = config([PLAIN_STEP, SCHEDULER_STEP]);
+    expect(contactKeyReadiness(c, { scheduler: true })).toEqual({
+      ok: true,
+      source: { kind: 'scheduler', key: 'book' },
+    });
+    // The config is unchanged and still valid — what is missing is the token
+    // that reads the invitee back. Without it the booking succeeds and the lead
+    // never reaches the CRM, so this must NOT read as ready.
+    expect(contactKeyReadiness(c, { scheduler: false })).toEqual({
+      ok: false,
+      blocker: 'scheduler_disconnected',
+      source: { kind: 'scheduler', key: 'book' },
+    });
+  });
+
+  it('an email question outranks a scheduler, so a disconnected provider is irrelevant', () => {
+    const c = config([EMAIL_STEP, SCHEDULER_STEP]);
+    expect(emailSourceFor(c)).toEqual({ kind: 'question', key: 'email' });
+    expect(contactKeyReadiness(c, { scheduler: false }).ok).toBe(true);
+  });
+});
+
+describe('emailMappingsConflictingWithScheduler', () => {
+  const schedulerSource = { kind: 'scheduler', key: 'book' } as const;
+
+  it('names every question pointed at the email property', () => {
+    expect(
+      emailMappingsConflictingWithScheduler(schedulerSource, {
+        company: 'company',
+        work: 'email',
+        alt: '  EMAIL  ',
+      }),
+    ).toEqual(['work', 'alt']);
+  });
+
+  it('is silent when nothing is mapped to email', () => {
+    expect(
+      emailMappingsConflictingWithScheduler(schedulerSource, { company: 'company' }),
+    ).toEqual([]);
+    expect(emailMappingsConflictingWithScheduler(schedulerSource, undefined)).toEqual([]);
+  });
+
+  // With an email QUESTION the adapter is supposed to resolve the address
+  // itself — mapping a question to `email` is the correct setup, not a conflict.
+  it('is silent when the address comes from a question', () => {
+    expect(
+      emailMappingsConflictingWithScheduler({ kind: 'question', key: 'email' }, { email: 'email' }),
+    ).toEqual([]);
+    expect(emailMappingsConflictingWithScheduler(null, { work: 'email' })).toEqual([]);
+  });
+});

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -714,6 +714,72 @@ export function emailSourceFor(config: FormConfig): EmailSource {
   return null;
 }
 
+/** Why a form cannot give the CRM an address to key its contact on. */
+export type ContactKeyBlocker =
+  /** It asks for no address and books nothing — there is no source at all. */
+  | 'no_source'
+  /**
+   * A scheduler WOULD supply it, but the account has not connected that
+   * provider — so nothing can read the invitee back and the sync dies with
+   * "no respondent email resolvable", silently, after a booking that looked
+   * perfectly successful to the respondent.
+   */
+  | 'scheduler_disconnected';
+
+/** Whether a form can key a CRM contact, and what is missing when it cannot. */
+export type ContactKeyReadiness =
+  | { ok: true; source: NonNullable<EmailSource> }
+  | { ok: false; blocker: ContactKeyBlocker; source: EmailSource };
+
+/**
+ * Can this form actually identify a contact at delivery time?
+ *
+ * {@link emailSourceFor} answers the CONFIG half — is there anything that could
+ * produce an address. That is necessary and not sufficient: a scheduler only
+ * yields one if the account has connected the provider, because the address
+ * comes from reading the invitee back over that provider's API. A form can
+ * therefore be perfectly configured and still sync nothing.
+ *
+ * Both halves belong together in one answer so the builder, the Connect screen
+ * and publish cannot disagree about whether a form is ready — and so the screen
+ * stops promising "contacts will be keyed on the address the booking collects"
+ * without checking that anyone can read it.
+ *
+ * Stays pure: the connection state is passed IN, never fetched here.
+ */
+export function contactKeyReadiness(
+  config: FormConfig,
+  connected: { scheduler: boolean },
+): ContactKeyReadiness {
+  const source = emailSourceFor(config);
+  if (!source) return { ok: false, blocker: 'no_source', source: null };
+  if (source.kind === 'scheduler' && !connected.scheduler) {
+    return { ok: false, blocker: 'scheduler_disconnected', source };
+  }
+  return { ok: true, source };
+}
+
+/**
+ * Does this destination's mapping fight the scheduler for the contact key?
+ *
+ * The booking path only runs when the ADAPTER cannot resolve an address on its
+ * own (`adapterResolvableEmail`). Pointing any question at the `email` property
+ * satisfies it, so the answers stop syncing at booking and the submit-time
+ * delivery tries to identify the contact with that answer instead. The lead
+ * quietly stops arriving.
+ *
+ * Returns the offending step keys so the editor can name them.
+ */
+export function emailMappingsConflictingWithScheduler(
+  source: EmailSource,
+  fieldMappings: Record<string, string> | undefined,
+): string[] {
+  if (source?.kind !== 'scheduler' || !fieldMappings) return [];
+  return Object.entries(fieldMappings)
+    .filter(([, property]) => property.trim().toLowerCase() === 'email')
+    .map(([stepKey]) => stepKey);
+}
+
 /**
  * The visibility operators offered for a referenced field's TYPE — the builder
  * shows exactly these in the operator dropdown, and they are the only ops the

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -772,11 +772,12 @@ export function contactKeyReadiness(
  */
 export function emailMappingsConflictingWithScheduler(
   source: EmailSource,
-  fieldMappings: Record<string, string> | undefined,
+  fieldMappings: Record<string, string | string[]> | undefined,
 ): string[] {
   if (source?.kind !== 'scheduler' || !fieldMappings) return [];
+  const targets = (v: string | string[]): string[] => (Array.isArray(v) ? v : [v]);
   return Object.entries(fieldMappings)
-    .filter(([, property]) => property.trim().toLowerCase() === 'email')
+    .filter(([, target]) => targets(target).some((p) => p.trim().toLowerCase() === 'email'))
     .map(([stepKey]) => stepKey);
 }
 

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -649,6 +649,37 @@ function findEmailKey(config: FormConfig): string | null {
   return config.steps.find((s) => s.type === 'email')?.key ?? null;
 }
 
+/**
+ * Answer keys carrying what the SCHEDULING PROVIDER collected from the invitee,
+ * for forms that do not ask for those details themselves.
+ *
+ * A booking form always collects a name and an email, and often a phone. Only
+ * the email was ever used — to key the contact — and the rest was discarded, so
+ * a form whose booking is its only contact step produced CRM records with an
+ * address and no name. The gap was invisible because most accounts also run the
+ * provider's own CRM integration, which writes those fields independently; a
+ * customer without it silently got nameless contacts.
+ *
+ * These ride in the submission `data` at delivery time, so they map to CRM
+ * properties through the ordinary `fieldMappings` — the same mechanism as an
+ * answer, with no special case in any adapter.
+ *
+ * `@` is outside the step-key grammar (`sanitizeStepKey` keeps `[a-z0-9_]`), so
+ * these can never collide with a real question's key — same guarantee as
+ * {@link SCORE_FIELD}.
+ */
+export const INVITEE_FIELDS = {
+  /** Full name as the provider recorded it (often the only one populated). */
+  name: '@invitee_name',
+  first_name: '@invitee_first_name',
+  last_name: '@invitee_last_name',
+  /** Only present when the booking page asked for a number. */
+  phone: '@invitee_phone',
+} as const;
+
+/** Every invitee key, for the builder's pickers and the delivery-side injection. */
+export const INVITEE_FIELD_KEYS = Object.values(INVITEE_FIELDS);
+
 /** Where a HubSpot sync could get the address it keys the contact on. */
 export type EmailSource =
   /** An `email`-typed question this form asks directly. */

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -677,9 +677,6 @@ export const INVITEE_FIELDS = {
   phone: '@invitee_phone',
 } as const;
 
-/** Every invitee key, for the builder's pickers and the delivery-side injection. */
-export const INVITEE_FIELD_KEYS = Object.values(INVITEE_FIELDS);
-
 /** Where a HubSpot sync could get the address it keys the contact on. */
 export type EmailSource =
   /** An `email`-typed question this form asks directly. */

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1076,6 +1076,11 @@ export interface FormsMessages {
       keyGroupQuestions: string;
       keyGroupSystem: string;
       keyCustomOption: string;
+      /** Labels for what the booking page collected about the invitee. */
+      inviteeName: string;
+      inviteeFirstName: string;
+      inviteeLastName: string;
+      inviteePhone: string;
       keyCustomBack: string;
       selectKeyPlaceholder: string;
       webhookEvents: string;
@@ -2129,6 +2134,10 @@ export const en: FormsMessages = {
       keyGroupQuestions: 'Form questions',
       keyGroupSystem: 'System fields',
       keyCustomOption: 'Custom key…',
+      inviteeName: 'Booking — full name',
+      inviteeFirstName: 'Booking — first name',
+      inviteeLastName: 'Booking — last name',
+      inviteePhone: 'Booking — phone',
       keyCustomBack: 'Back to list',
       selectKeyPlaceholder: 'Select a field…',
       webhookEvents: 'Trigger on',
@@ -3183,6 +3192,10 @@ export const es: FormsMessages = {
       keyGroupQuestions: 'Preguntas del formulario',
       keyGroupSystem: 'Campos del sistema',
       keyCustomOption: 'Clave personalizada…',
+      inviteeName: 'Agenda — nombre completo',
+      inviteeFirstName: 'Agenda — nombre',
+      inviteeLastName: 'Agenda — apellido',
+      inviteePhone: 'Agenda — teléfono',
       keyCustomBack: 'Volver a la lista',
       selectKeyPlaceholder: 'Selecciona un campo…',
       webhookEvents: 'Disparar en',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1032,6 +1032,14 @@ export interface FormsMessages {
       emailFromScheduler: string;
       hubspotHowTitle: string;
       hubspotHowBody: string;
+      /** Same explanation for a form whose address comes from the booking. */
+      hubspotHowBodyScheduler: string;
+      /** A scheduler supplies the address, but its provider is not connected. */
+      schedulerDisconnected: string;
+      mapQuestionsHelpScheduler: string;
+      emailMappingConflictTitle: string;
+      /** `{keys}` — the questions pointed at the email property. */
+      emailMappingConflictBody: string;
       /** Send one sample delivery to the configured webhook. */
       pingWebhook: string;
       pingSending: string;
@@ -2093,6 +2101,15 @@ export const en: FormsMessages = {
       hubspotHowTitle: 'How the sync works',
       hubspotHowBody:
         'Every submission is matched to a contact by email address: an existing contact is updated, and a new one is created when there is no match. A form that never asks for an email cannot be synced.',
+      hubspotHowBodyScheduler:
+        'Every submission is matched to a contact by email address: an existing contact is updated, and a new one is created when there is no match. This form does not ask for one — the booking collects it, so nothing here should be mapped to “email”.',
+      schedulerDisconnected:
+        'Calendly is not connected for this account, so the invitee’s address cannot be read back and nothing will reach HubSpot — the booking still succeeds, which is why this fails quietly. Connect Calendly in Connections.',
+      mapQuestionsHelpScheduler:
+        'Send each answer to a HubSpot contact property. Do not map anything to “email” — the booking supplies it, and a mapping here takes over and stops the sync.',
+      emailMappingConflictTitle: 'This mapping stops the sync',
+      emailMappingConflictBody:
+        'The booking already supplies the address. A question mapped to “email” takes over as the contact key, so answers stop reaching HubSpot after a booking. Remove the mapping on: {keys}.',
       pingWebhook: 'Send test',
       pingSending: 'Sending…',
       pingOk: 'Test delivered — your endpoint accepted it.',
@@ -3151,6 +3168,15 @@ export const es: FormsMessages = {
       hubspotHowTitle: 'Cómo funciona la sincronización',
       hubspotHowBody:
         'Cada envío se busca en HubSpot por correo: si el contacto existe se actualiza, y si no, se crea uno nuevo. Un formulario que nunca pide correo no se puede sincronizar.',
+      hubspotHowBodyScheduler:
+        'Cada envío se busca en HubSpot por correo: si el contacto existe se actualiza, y si no, se crea uno nuevo. Este formulario no lo pide — lo recoge la agenda, así que acá no hay que mapear nada a «email».',
+      schedulerDisconnected:
+        'Calendly no está conectado en esta cuenta, así que no se puede leer el correo del invitado y no va a llegar nada a HubSpot — la reserva igual funciona, por eso falla en silencio. Conectá Calendly en Conexiones.',
+      mapQuestionsHelpScheduler:
+        'Mandá cada respuesta a una propiedad de contacto de HubSpot. No mapees nada a «email»: lo aporta la agenda, y un mapeo acá lo reemplaza y apaga la sincronización.',
+      emailMappingConflictTitle: 'Este mapeo apaga la sincronización',
+      emailMappingConflictBody:
+        'La agenda ya aporta el correo. Una pregunta mapeada a «email» pasa a ser la llave del contacto, así que las respuestas dejan de llegar a HubSpot después de agendar. Quitá el mapeo en: {keys}.',
       pingWebhook: 'Enviar prueba',
       pingSending: 'Enviando…',
       pingOk: 'Prueba entregada: tu endpoint la aceptó.',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -852,6 +852,10 @@ export interface FormsMessages {
         integrationsSubtitle: string;
         integrationsLoadError: string;
         retry: string;
+        /** Deliveries that ended without landing — hidden when there are none. */
+        deliveriesTitle: string;
+        deliveriesSubtitle: string;
+        deliveriesNoReason: string;
         trackingTitle: string;
         trackingSubtitle: string;
         /** V5-QA — these ride the draft, unlike the integrations above them. */
@@ -1934,6 +1938,10 @@ export const en: FormsMessages = {
           'Send each submission to your CRM or a webhook. Delivery is durable and retried.',
         integrationsLoadError: 'Could not load integrations.',
         retry: 'Retry',
+        deliveriesTitle: 'Deliveries that did not land',
+        deliveriesSubtitle:
+          'Submissions reached this form, but these deliveries never completed. The respondent saw nothing wrong, so this is the only place it shows.',
+        deliveriesNoReason: 'No reason was recorded.',
         trackingTitle: 'Tracking & pixels',
         trackingSubtitle:
           'Measure visits and conversions on this form’s public page. Each tag loads only when its ID is set.',
@@ -3011,6 +3019,10 @@ export const es: FormsMessages = {
           'Envía cada respuesta a tu CRM o a un webhook. La entrega es duradera y con reintentos.',
         integrationsLoadError: 'No se pudieron cargar las integraciones.',
         retry: 'Reintentar',
+        deliveriesTitle: 'Entregas que no llegaron',
+        deliveriesSubtitle:
+          'Las respuestas llegaron al formulario, pero estas entregas nunca se completaron. Quien respondió no vio ningún problema, así que este es el único lugar donde aparece.',
+        deliveriesNoReason: 'No se registró un motivo.',
         trackingTitle: 'Seguimiento y píxeles',
         trackingSubtitle:
           'Mide visitas y conversiones en la página pública de este formulario. Cada etiqueta se carga solo cuando su ID está configurado.',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -372,6 +372,16 @@ export interface FormsMessages {
         outcomeHeadingHelp: string;
         /** V5-A1 — why the ranges are inert while scoring is off. */
         outcomesInert: string;
+        redirectDelayLabel: string;
+        redirectDelayHelp: string;
+        redirectDelayHint: string;
+        overridesLabel: string;
+        overridesHelp: string;
+        overrideRemove: string;
+        /** `{field}` `{bound}` — an override read back as a sentence. */
+        overrideAtMost: string;
+        overrideAtLeast: string;
+        overrideIsAnyOf: string;
         /** V5-B5 — the heading field's tooltip (it IS the thank-you headline). */
         outcomeHeadingHelp2: string;
         /** V5-B5 — spells out that a redirect replaces the screen entirely. */
@@ -1487,6 +1497,17 @@ export const en: FormsMessages = {
           'If you set this, the thank-you screen above is never shown for this range — the respondent goes straight to the URL. Leave it empty to show the screen.',
         outcomesInert:
           'Scoring is off, so no range can be reached — everyone sees the form’s own thank-you screen. Anything set on a range is skipped too, including its redirect and its scheduling handoff. Your ranges are kept; turn scoring on to use them again.',
+        redirectDelayLabel: 'Show the thank-you first (ms)',
+        redirectDelayHelp:
+          'How long the thank-you screen stays up before the redirect happens. 0 leaves immediately.',
+        redirectDelayHint: '0 = redirect immediately. 1500 shows the message for a second and a half.',
+        overridesLabel: 'Forced by an answer',
+        overridesHelp:
+          'These beat the score outright: a respondent matching one lands here no matter what they scored. Shown so the range above can be trusted.',
+        overrideRemove: 'Remove',
+        overrideAtMost: '{field} is at most {bound}',
+        overrideAtLeast: '{field} is at least {bound}',
+        overrideIsAnyOf: '{field} is any of {bound}',
         redirectLabel: 'Redirect URL (optional)',
         redirectHelp:
           'Leave empty to show the thank-you screen. If set, respondents are sent here instead.',
@@ -2552,6 +2573,17 @@ export const es: FormsMessages = {
           'Si la defines, la pantalla de agradecimiento de arriba nunca se muestra para este rango — el respondiente va directo a la URL. Déjala vacía para mostrar la pantalla.',
         outcomesInert:
           'El puntaje está apagado, así que ningún rango puede alcanzarse — todos ven la pantalla de agradecimiento del formulario. También se omite todo lo configurado en un rango, incluida su redirección y su agenda. Tus rangos se conservan; enciende el puntaje para volver a usarlos.',
+        redirectDelayLabel: 'Mostrar el agradecimiento antes (ms)',
+        redirectDelayHelp:
+          'Cuánto se queda la pantalla de agradecimiento antes de redirigir. 0 se va de inmediato.',
+        redirectDelayHint: '0 = redirige de inmediato. 1500 muestra el mensaje segundo y medio.',
+        overridesLabel: 'Forzado por una respuesta',
+        overridesHelp:
+          'Estas le ganan al puntaje: quien las cumpla cae acá sin importar cuánto sumó. Se muestran para que el rango de arriba se pueda creer.',
+        overrideRemove: 'Quitar',
+        overrideAtMost: '{field} es como máximo {bound}',
+        overrideAtLeast: '{field} es al menos {bound}',
+        overrideIsAnyOf: '{field} es alguno de {bound}',
         redirectLabel: 'URL de redirección (opcional)',
         redirectHelp:
           'Déjalo vacío para mostrar la pantalla de agradecimiento. Si lo defines, se redirige ahí a los respondientes.',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -483,6 +483,37 @@ export type DestinationType = (typeof destinationType)[number];
 const propertyMapSchema = z.record(z.string().min(1).max(200), z.string().min(1).max(200));
 
 /**
+ * What ONE answer writes to: a property, or several.
+ *
+ * A single string was the shape for a long time and stays valid, so every
+ * stored config keeps parsing. The array exists because one answer legitimately
+ * feeds more than one CRM property — a use-case field that a reporting property
+ * mirrors, say — and a record keyed by step key can only hold one value per
+ * key, so the workaround was a SECOND destination. That second destination is
+ * invisible to the integrations screen (it reads the first) and is never
+ * delivered by the booking sync (same), which made it config that looks correct
+ * in an audit and writes nothing.
+ */
+const propertyTargetsSchema = z.union([
+  z.string().min(1).max(200),
+  z.array(z.string().min(1).max(200)).min(1).max(20),
+]);
+
+/** stepKey -> one property or several. Read it through {@link propertiesFor}. */
+const fieldMapSchema = z.record(z.string().min(1).max(200), propertyTargetsSchema);
+
+/**
+ * The properties one mapping targets, as a list — the single reader for both
+ * stored shapes, so no call site has to remember that a string is also valid.
+ * Blank entries are dropped, so a half-typed row never writes an empty property.
+ */
+export function propertiesFor(target: string | string[] | undefined | null): string[] {
+  if (target == null) return [];
+  const list = Array.isArray(target) ? target : [target];
+  return list.map((p) => p.trim()).filter((p) => p.length > 0);
+}
+
+/**
  * Webhook destination — POST each submission as JSON to a URL, optionally HMAC
  * signed. The secret is server-side config, never leaked to the public renderer
  * (the API strips `destinations` before serving a public form).
@@ -554,8 +585,9 @@ export const hubspotDestinationSchema = z.object({
   type: z.literal('hubspot'),
   enabled: z.boolean().default(false),
   settings: z.object({ note: z.boolean().optional() }).default({}),
-  /** stepKey -> contact property (one property SHOULD be `email`). */
-  fieldMappings: propertyMapSchema.default({}),
+  /** stepKey -> contact property, or several (one SHOULD be `email` unless a
+   *  scheduler supplies the address). */
+  fieldMappings: fieldMapSchema.default({}),
   /** utm_source/medium/campaign/term/content -> contact property. */
   utmMappings: propertyMapSchema.default({}),
   /** Contact property to receive the score (complete submissions). */


### PR DESCRIPTION
Eight fixes found while migrating the `dapta_bookings` qualification quiz onto a
`scheduler` STEP. They share one theme: the product had surfaces that told the
operator something was working when it was not.

Full write-up, with the ordering rationale: `BACKLOG-AJUSTES.md`.

## The one that is losing data today

**The booking sync raced the submission.** A booking on a mid-form scheduler is
recorded BEFORE the form finishes — the renderer awaits `recordBookingAction`
and only then advances, which is what finalizes the submission. The outbox
worker polls on a fixed interval, so a poll landing in that gap delivered while
`completed_at` was still null, and the delivery ran as `partial`.

A partial delivery skips the adapter's complete-only writes: the outcome
property, the static properties, and the Note. The loss is permanent — the
delivery is idempotent per booking event and the row closes on success, so
nothing re-runs it once the submission completes.

`booking_sync` now enqueues dormant. `enqueueOutbox` already accepted
`nextAttemptAt`, so this is a scheduling change, not new machinery.

## Surfaces that lied

**Connect promised a sync it could not deliver.** Everything was decided from
`emailSourceFor`, which reads the config and nothing else. A scheduler step made
the screen claim "contacts will be keyed on the address the booking collects" —
true only while the scheduling provider is connected, since that address comes
from reading the invitee back over its API. Disconnect it and the booking still
succeeds, the respondent sees nothing wrong, and the lead never reaches the CRM.

`contactKeyReadiness` crosses the config with the account's connections and is
now the single answer Connect and the builder's per-question HubSpot panel both
read. That panel had no gate at all: an author could map every property from the
Build tab, publish, and never learn the form could not sync.

**Two pieces of copy were not just wrong but harmful.** "A form that never asks
for an email cannot be synced" sat directly above the note saying the opposite.
And "One question should map to `email`" INSTRUCTED the one mapping that breaks
a booking form: the booking-time sync only runs when the adapter cannot resolve
an address itself, so satisfying it switches the sync off and the submit-time
delivery keys the contact on that answer instead. Both are per-source now, and a
question already pointed at `email` raises a named alert.

**Nothing surfaced the outbox.** Its only mention in the whole web app was in
the public renderer, so a delivery that died lived solely in server logs. New:
`listFailedDeliveries` + `GET /v1/forms/:id/deliveries` + a Connect section that
renders only when something is wrong, showing the worker's reason verbatim.

**Two outcome fields decided things invisibly.** `redirectDelayMs` is how long
the thank-you shows; it now has a control. `overrides` is worse — an
answer-forced rule that beats the score outright, so a range could read "6 and
up" while a lead who cleared it landed elsewhere. It renders read-only, as a
sentence, with a way to remove one. Authoring a new rule needs a field-and-bound
picker; being able to SEE it is what was missing.

## Limits that forced bad workarounds

**One answer could only reach one property.** `fieldMappings` was
`Record<string, string>`, so an answer feeding a second property meant a SECOND
HubSpot destination — and that workaround is worse than the limitation. A second
destination is invisible to the integrations screen (it reads the first and
writes one, so touching the tab deletes it) and is never delivered by the
booking sync (also the first). It looks correct in an audit and writes nothing.

`fieldMappings` now accepts a string OR an array, read through `propertiesFor`,
so every stored config keeps parsing. In Connect a fan-out is several rows on
the same question, and rows GROUP by key instead of last-one-wins — which also
fixes a silent loss reachable today through the "Custom key…" escape hatch.

**The invitee's name and phone were discarded.** Only the address was read back;
the rest was thrown away, so a form whose booking is its only contact step
produced contacts with an address and no name. Invisible in practice because
most accounts also run the scheduling provider's own CRM integration, which
writes those fields independently — a customer without it silently got nameless
contacts. They now ride as reserved `@invitee_*` answer keys and map through the
ordinary `fieldMappings`, with a real answer always winning.

**The reveal's pre-warm died on first edit.** It read `config.reveal.prewarm`,
which `migrateRevealToStep` deletes as soon as the builder opens a form.

## Verification

`pnpm test` 737 · `pnpm lint` clean · `pnpm typecheck` 16/16 · `pnpm build` 9/9.

New coverage: outbox dormancy (a same-tick drain claims nothing), the invitee
mapping including the name-splitting fallback and answer-wins precedence,
`contactKeyReadiness` across both blockers, the `email`-mapping conflict
detector, adapter fan-out with the per-step value map applied to every target,
and `listFailedDeliveries` account scoping.

Every delivery test now drains with the clock advanced past the delay, which is
what makes the dormancy load-bearing rather than incidental.

## Deliberately not in this PR

- **The publish button does not check readiness.** Connect and the builder warn;
  publish does not, so a form that cannot sync can still be published past two
  warnings.
- **`overrides` is read-only.**
- **The builder's per-question panel edits one property**, the first, preserving
  the rest. Fan-out is authored in Connect.
- **`ci-cd.yml:15`** carried a false claim about `NEXT_PUBLIC_API_URL`; that
  fix lives in `dapta-forms-deploy` (branch `docs/correct-next-public-note`).

Merge with a **merge commit** — squashing this branch re-opens the divergence
the last three releases each had to repair.
