### PR TITLE
ci: stop re-linting released history on the develop → main PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,18 @@ jobs:
     # Enforce Conventional Commits on every PR commit so history stays legible and
     # Changesets/release automation can hook off the types. PR-only: it lints the
     # commits the PR adds (base..head), never rewrites or fails existing history.
-    if: github.event_name == 'pull_request'
+    #
+    # A release PR (develop -> main) is the one case where base..head is NOT what
+    # the PR adds — it is every commit that entered `develop` since the last
+    # release, each already linted by its own PR on the way in. Re-linting them
+    # here fails on history nobody can fix without rewriting a shared branch, which
+    # is exactly what the line above promises not to do. Earlier releases hid this
+    # by squashing; squashing is what orphaned the SHAs and forced the back-merges
+    # in #34/#38/#54, so the fix belongs here rather than in the merge strategy.
+    # Any OTHER PR into main (a hotfix off a topic branch) is still linted.
+    if: >-
+      github.event_name == 'pull_request' &&
+      !(github.base_ref == 'main' && github.head_ref == 'develop')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Desbloquea #59, que tiene el check `Commit messages (Conventional Commits)` en rojo.

## El problema

El job promete, en su propio comentario:

> PR-only: it lints the commits the PR adds (base..head), **never rewrites or fails existing history**.

En un PR de release `develop → main` esa promesa se rompe: `base..head` no es lo que el PR agrega — es **todo** lo que entró a `develop` desde el release anterior, y cada uno de esos commits ya pasó commitlint cuando entró por su propio PR.

Resultado: #59 falla por cuatro commits mergeados hace semanas.

| commit | motivo |
|---|---|
| `fix: Typeform-parity metrics — correct Views/Starts/…` | subject en sentence-case |
| `feat: Scheduler question type — book a Calendly meeting…` | subject en sentence-case |
| `fix: V5 round A — scoring/slider/token/logic guards…` | subject en sentence-case |
| `fix(web): make the destructive input border actually paint…` | header de 101 caracteres |

Nadie puede arreglarlos sin reescribir una rama compartida, que es peor que el check rojo — y es justo lo que el comentario dice que el job no hace.

## Por qué recién aparece

Los releases anteriores se squashearon, colapsando todo en un solo subject limpio. El squash tapaba esto. Y el squash es también lo que huerfanó los SHAs y forzó los back-merges de #34, #38 y #54.

O sea: el check rojo y los conflictos de merge tienen la misma causa. Arreglar el merge strategy destapó el otro síntoma.

## El cambio

Saltear el job **solo** para `develop → main`:

```yaml
if: >-
  github.event_name == 'pull_request' &&
  !(github.base_ref == 'main' && github.head_ref == 'develop')
```

Cualquier otro PR a `main` — un hotfix desde una rama de tema — se sigue lintando. Y todo PR a `develop` también, que es donde el gate realmente sirve: ahí es donde se decide qué entra.

## Alternativas que descarté

- **Reescribir los 4 commits** — `develop` es compartida; forzaría a todos a re-clonar y rompería los SHAs de nuevo.
- **Seguir squasheando** — hace verde el check y vuelve a romper el historial. Es cambiar un problema por el que acabamos de arreglar.
- **Relajar las reglas de commitlint** — bajaría el estándar para todos los PRs futuros por cuatro commits viejos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)