### PR TITLE
feat: map a booking's own fields from the question panel

### DIFF
--- a/.changeset/olive-pugs-invite.md
+++ b/.changeset/olive-pugs-invite.md
@@ -1,0 +1,10 @@
+---
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+Map a booking's own fields from the question panel. A scheduler step answers with
+a booking — the meeting time under its own key, the invitee's name and phone under
+theirs — but the builder offered one unlabelled "Map to" picker that bound only
+the first of those and never said which. `bookingFieldsFor` names the whole set so
+the question panel and the Connect screen read one list.

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -217,6 +217,12 @@ export interface BuilderMessages {
     needsEmail: string;
     /** A booking would supply the address, but its provider is not connected. */
     schedulerDisconnected: string;
+    /** A SCHEDULER step maps several booking facts, not one answer. */
+    bookingIntro: string;
+    /** Why the meeting time arrives as text, and where a real date lives. */
+    bookingStartHint: string;
+    /** Why the invitee's email is not in the list. */
+    bookingEmailNote: string;
   };
   rules: {
     ifAnswerIs: string;
@@ -519,6 +525,11 @@ const en: BuilderMessages = {
       'This form asks for no email and books nothing, so HubSpot has no way to identify the contact — nothing mapped here would sync. Add an email question, or a booking step.',
     schedulerDisconnected:
       'The booking step would supply the address, but Calendly is not connected for this account — so the invitee cannot be read back and nothing mapped here will reach HubSpot.',
+    bookingIntro: 'A booking produces these. Send each one to a contact property.',
+    bookingStartHint:
+      'Sent as text, exactly as the booking reported it. For a real HubSpot date property, use the booking sync in Connect.',
+    bookingEmailNote:
+      'The invitee’s email is the contact key — the booking supplies it, so it is never mapped here.',
   },
   rules: {
     ifAnswerIs: 'If answer is',
@@ -820,6 +831,11 @@ const es: BuilderMessages = {
       'Este formulario no pide correo ni agenda nada, así que HubSpot no tiene cómo identificar al contacto — nada de lo que mapees acá se va a sincronizar. Agregá una pregunta de correo, o un paso de agenda.',
     schedulerDisconnected:
       'El paso de agenda aportaría el correo, pero Calendly no está conectado en esta cuenta — así que no se puede leer al invitado y nada de lo mapeado acá va a llegar a HubSpot.',
+    bookingIntro: 'Una reserva produce estos datos. Mandá cada uno a una propiedad del contacto.',
+    bookingStartHint:
+      'Se envía como texto, tal cual lo reportó la reserva. Para una propiedad de fecha real de HubSpot, usá la sincronización de reservas en Conectar.',
+    bookingEmailNote:
+      'El correo del invitado es la llave del contacto: lo aporta la reserva, por eso no se mapea acá.',
   },
   rules: {
     ifAnswerIs: 'Si la respuesta es',

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot-actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { adminApi, ApiError } from '@/lib/admin-api';
-import type { FormDestination } from '@quill/types';
+import { propertiesFor, type FormDestination } from '@quill/types';
 
 /**
  * Partial mapping write for the Build tab's per-question "Map to" picker:
@@ -95,8 +95,17 @@ export async function saveQuestionMappingAction(
     if (!current?.enabled) return { ok: false, code: 'no_destination' };
 
     const fieldMappings = { ...(current.fieldMappings ?? {}) };
-    const next = property?.trim();
-    if (next) fieldMappings[stepKey] = next;
+    // The panel edits ONE property — the first. A mapping that fans out to
+    // several is authored in Connect, and a pick here must not silently drop the
+    // others, so the tail rides through either way. Mirrors the optimistic
+    // `withMapping` on the client, which already preserved it: without this the
+    // server write put the two out of step and the extra properties vanished on
+    // the next load.
+    const rest = propertiesFor(fieldMappings[stepKey]).slice(1);
+    const first = property?.trim();
+    const next = first ? [first, ...rest] : rest;
+    if (next.length > 1) fieldMappings[stepKey] = next;
+    else if (next.length === 1) fieldMappings[stepKey] = next[0]!;
     else delete fieldMappings[stepKey];
 
     const updated = await adminApi.updateFormDestinations(

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
@@ -8,8 +8,10 @@ import { Select, type SelectOption } from '@/components/ui/select';
 import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
 import { TextField } from './fields';
-import { contactKeyReadiness, type FormConfig, type FormStep } from '@quill/engine';
+import { bookingFieldsFor, contactKeyReadiness, type FormConfig, type FormStep } from '@quill/engine';
+import { getMessages, type Locale } from '@quill/shared';
 import { propertiesFor } from '@quill/types';
+import { bookingLabel } from '@/lib/booking-fields';
 import { loadConnectIntegrationsAction, type ConnectIntegrationsData } from './connect-actions';
 import { saveQuestionMappingAction } from './question-hubspot-actions';
 import type { BuilderMessages } from './builder-messages';
@@ -19,6 +21,15 @@ import type { BuilderMessages } from './builder-messages';
  * block (Typeform parity): pick the contact property this answer writes to,
  * saved immediately against the LIVE config's hubspot destination (the same
  * single source of truth the Connect tab's "Map questions" list edits).
+ *
+ * A SCHEDULER step is the exception, and it gets a LIST instead of one picker.
+ * Its answer is a booking, and a booking is several facts under several keys:
+ * the meeting time under the step's own key, the invitee's name and phone under
+ * {@link bookingFieldsFor}'s. A single unlabelled picker bound only the first of
+ * those and never said which — an author could map "the booking" without ever
+ * learning the value behind it is a timestamp, while the invitee's details were
+ * reachable only from the Connect screen. Same rows, same labels, same keys as
+ * Connect: the two screens read from `bookingFieldsFor` so they cannot drift.
  *
  * States:
  *  - account connected + enabled hubspot destination → searchable property
@@ -122,11 +133,14 @@ export function QuestionHubspotSection({
   const { error: toastError } = useToast();
   const [state, setState] = useState<SectionState>({ status: 'loading' });
   const [attempt, setAttempt] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [flash, setFlash] = useState(false);
+  // Which mapping KEY is mid-save / just saved, not a bare boolean: a scheduler
+  // renders five rows and each saves on its own, so the indicator has to name
+  // the row it belongs to or it lights up on all of them at once.
+  const [saving, setSaving] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
   const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  /** Monotonic save id — only the LATEST pick's response applies (rapid rebinds). */
-  const saveSeq = useRef(0);
+  /** Monotonic save id PER KEY — only the LATEST pick's response applies. */
+  const saveSeq = useRef(new Map<string, number>());
 
   useEffect(() => {
     let cancelled = false;
@@ -143,8 +157,8 @@ export function QuestionHubspotSection({
 
   // Transient indicators belong to the question that triggered them.
   useEffect(() => {
-    setSaving(false);
-    setFlash(false);
+    setSaving(null);
+    setFlash(null);
   }, [stepKey]);
 
   useEffect(
@@ -163,31 +177,49 @@ export function QuestionHubspotSection({
     ],
     [properties, m.none],
   );
+  // `email` is off the table on a booking's rows: the booking IS what supplies
+  // the contact key, and pointing any field at that property takes the role over
+  // and stops the sync. It can never be what the author meant, so it is not
+  // offered rather than warned about once the leads have stopped arriving.
+  const bookingOptions = useMemo<SelectOption[]>(
+    () => options.filter((o) => o.value.trim().toLowerCase() !== 'email'),
+    [options],
+  );
+  // Booking row labels come from the SHARED catalog — the same strings Connect
+  // prints, so neither screen can rename a row the other still calls by its old
+  // name.
+  const im = useMemo(() => {
+    const loc: Locale = locale === 'es' ? 'es' : 'en';
+    return getMessages(loc).admin.integrations;
+  }, [locale]);
 
   function retry() {
     invalidateQuestionHubspotCache(formId);
     setAttempt((n) => n + 1);
   }
 
-  function save(nextValue: string) {
+  /** Bind ONE mapping key to a property (empty unmaps). `key` is the question's
+   *  own step key, or one of the booking's keys on a scheduler. */
+  function save(key: string, nextValue: string) {
     if (state.status !== 'ready') return;
     const before = state.data;
     const dest = hubspotOf(before.destinations);
     if (!dest) return;
-    if ((dest.fieldMappings?.[stepKey] ?? '') === nextValue) return;
+    if ((propertiesFor(dest.fieldMappings?.[key])[0] ?? '') === nextValue) return;
 
     // Optimistic: show the pick immediately; roll back if the save fails.
-    const optimistic = withMapping(before, stepKey, nextValue);
+    const optimistic = withMapping(before, key, nextValue);
     setState({ status: 'ready', data: optimistic });
-    setSaving(true);
-    setFlash(false);
+    setSaving(key);
+    setFlash(null);
     if (flashTimer.current) clearTimeout(flashTimer.current);
 
-    const seq = ++saveSeq.current;
-    void saveQuestionMappingAction(formId, stepKey, nextValue || null)
+    const seq = (saveSeq.current.get(key) ?? 0) + 1;
+    saveSeq.current.set(key, seq);
+    void saveQuestionMappingAction(formId, key, nextValue || null)
       .then((res) => {
-        if (seq !== saveSeq.current) return; // superseded by a newer pick
-        setSaving(false);
+        if (seq !== saveSeq.current.get(key)) return; // superseded by a newer pick
+        setSaving((k) => (k === key ? null : k));
         if (res.ok) {
           const confirmed: ConnectIntegrationsData = {
             ...optimistic,
@@ -195,8 +227,8 @@ export function QuestionHubspotSection({
           };
           setState({ status: 'ready', data: confirmed });
           cacheData(formId, confirmed);
-          setFlash(true);
-          flashTimer.current = setTimeout(() => setFlash(false), 2500);
+          setFlash(key);
+          flashTimer.current = setTimeout(() => setFlash((k) => (k === key ? null : k)), 2500);
         } else if (res.code === 'no_destination') {
           // Destination disabled/removed since load — resync to the CTA state.
           toastError(m.saveError);
@@ -207,8 +239,8 @@ export function QuestionHubspotSection({
         }
       })
       .catch(() => {
-        if (seq !== saveSeq.current) return;
-        setSaving(false);
+        if (seq !== saveSeq.current.get(key)) return;
+        setSaving((k) => (k === key ? null : k));
         setState({ status: 'ready', data: before });
         toastError(m.saveError);
       });
@@ -289,42 +321,66 @@ export function QuestionHubspotSection({
         </div>
       );
     }
-    const targets = propertiesFor(dest.fieldMappings?.[stepKey]);
-    const value = targets[0] ?? '';
-    return (
-      <div data-testid="qs-hubspot-mapto" className="flex flex-col gap-1.5">
-        <div className="flex items-center justify-between gap-2">
-          <label className="text-sm font-medium text-foreground">{m.mapTo}</label>
-          <span
-            aria-live="polite"
-            className={cn('text-[11px]', flash ? 'text-primary' : 'text-muted-foreground')}
-          >
-            {saving ? (
-              m.saving
-            ) : flash ? (
-              <span data-testid="qs-hubspot-saved">{m.saved}</span>
-            ) : null}
-          </span>
+    /** The property a mapping key is bound to right now — the first of a fan-out. */
+    const bound = (key: string) => propertiesFor(dest.fieldMappings?.[key])[0] ?? '';
+
+    // A SCHEDULER answers with a BOOKING, which is several facts under several
+    // keys — so it maps a list, not a value. The invitee rows appear only when
+    // the booking is also what keys the contact: with an email question present
+    // the adapter resolves the address itself, the booking-time enrichment never
+    // runs, and those keys would stay empty forever. Same rule the Connect screen
+    // applies to its system-key list.
+    if (steps.find((s) => s.key === stepKey)?.type === 'scheduler') {
+      const bookingKeysContact = readiness.source.kind === 'scheduler';
+      const rows = bookingFieldsFor(stepKey).filter(
+        (f) => f.kind === 'start_time' || bookingKeysContact,
+      );
+      return (
+        <div data-testid="qs-hubspot-booking" className="flex flex-col gap-3">
+          <p className="text-xs text-muted-foreground">{m.bookingIntro}</p>
+          {rows.map((f) => (
+            <MappingRow
+              key={f.key}
+              testId={`qs-hubspot-booking-${f.kind}`}
+              label={bookingLabel(f.kind, im)}
+              // Only the meeting time needs explaining: it rides through as text,
+              // exactly as the booking reported it, so a HubSpot `date` property
+              // would reject it. The typed one is Connect's booking sync.
+              hint={f.kind === 'start_time' ? m.bookingStartHint : undefined}
+              value={bound(f.key)}
+              options={bookingOptions}
+              pickerReady={data.hubspot.enabled}
+              locale={locale}
+              saving={saving === f.key}
+              saved={flash === f.key}
+              m={m}
+              onSave={(v) => save(f.key, v)}
+            />
+          ))}
+          {/* Only true while the BOOKING is the contact key. With an email
+              question present that question keys the contact, the invitee rows
+              are gone above, and this note would name the wrong source. */}
+          {bookingKeysContact ? (
+            <p className="text-xs text-muted-foreground">{m.bookingEmailNote}</p>
+          ) : null}
         </div>
-        {data.hubspot.enabled ? (
-          <Select
-            ariaLabel={m.mapTo}
-            value={value}
-            onChange={save}
-            options={options}
-            // A mapped property missing from the list still shows its raw name.
-            placeholder={value}
-            searchable
-            locale={locale}
-          />
-        ) : (
-          // Picker unavailable (properties lookup failed) but the account is
-          // connected: free-text property name, committed on blur/Enter —
-          // mirrors the integrations editor's fallback input.
-          <FreeTextMapping value={value} ariaLabel={m.mapTo} onCommit={save} />
-        )}
-        <p className="text-xs text-muted-foreground">{m.mapToHint}</p>
-      </div>
+      );
+    }
+
+    return (
+      <MappingRow
+        testId="qs-hubspot-mapto"
+        label={m.mapTo}
+        hint={m.mapToHint}
+        value={bound(stepKey)}
+        options={options}
+        pickerReady={data.hubspot.enabled}
+        locale={locale}
+        saving={saving === stepKey}
+        saved={flash === stepKey}
+        m={m}
+        onSave={(v) => save(stepKey, v)}
+      />
     );
   }
 
@@ -339,6 +395,72 @@ export function QuestionHubspotSection({
       </p>
       {body()}
     </section>
+  );
+}
+
+/**
+ * One "this value → that contact property" row, with its own save indicator.
+ *
+ * Shared by the ordinary one-answer case and every row of a scheduler's booking
+ * list, so a five-row panel cannot drift from the single-picker one in layout,
+ * ARIA, or how a failed lookup degrades.
+ */
+function MappingRow({
+  label,
+  hint,
+  value,
+  options,
+  /** False when the property lookup failed — degrades to a free-text name. */
+  pickerReady,
+  locale,
+  saving,
+  saved,
+  m,
+  onSave,
+  testId,
+}: {
+  label: string;
+  hint?: string;
+  value: string;
+  options: SelectOption[];
+  pickerReady: boolean;
+  locale: string;
+  saving: boolean;
+  saved: boolean;
+  m: HubspotMessages;
+  onSave: (value: string) => void;
+  testId?: string;
+}) {
+  return (
+    <div data-testid={testId} className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <label className="text-sm font-medium text-foreground">{label}</label>
+        <span
+          aria-live="polite"
+          className={cn('text-[11px]', saved ? 'text-primary' : 'text-muted-foreground')}
+        >
+          {saving ? m.saving : saved ? <span data-testid="qs-hubspot-saved">{m.saved}</span> : null}
+        </span>
+      </div>
+      {pickerReady ? (
+        <Select
+          ariaLabel={label}
+          value={value}
+          onChange={onSave}
+          options={options}
+          // A mapped property missing from the list still shows its raw name.
+          placeholder={value}
+          searchable
+          locale={locale}
+        />
+      ) : (
+        // Picker unavailable (properties lookup failed) but the account is
+        // connected: free-text property name, committed on blur/Enter —
+        // mirrors the integrations editor's fallback input.
+        <FreeTextMapping value={value} ariaLabel={label} onCommit={onSave} />
+      )}
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
   );
 }
 

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -2,7 +2,7 @@
 
 import { propertiesFor } from '@quill/types';
 import {
-  INVITEE_FIELDS,
+  bookingFieldsFor,
   emailMappingsConflictingWithScheduler,
   type ContactKeyReadiness,
 } from '@quill/engine';
@@ -18,6 +18,7 @@ import { Switch } from '@/components/ui/switch';
 import { ProviderLogo, type LogoProvider } from '@/components/ui/provider-logo';
 import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
+import { bookingLabel } from '@/lib/booking-fields';
 import type {
   HubSpotPropertiesResponse,
   WebhookPingReason,
@@ -999,12 +1000,15 @@ function HubspotCard({
   const systemKeyOptions = useMemo<SystemKey[]>(() => {
     const utm: SystemKey[] = UTM_KEYS.map((k) => ({ key: k, label: k }));
     if (emailSource?.kind !== 'scheduler') return utm;
+    // One list with the builder's question panel, so neither screen can offer a
+    // booking field the other has never heard of. The meeting time is dropped
+    // here: it lives under the scheduler's own step key and is already a
+    // QUESTION row, so keeping it would put the same mapping on screen twice.
     return [
       ...utm,
-      { key: INVITEE_FIELDS.name, label: m.inviteeName },
-      { key: INVITEE_FIELDS.first_name, label: m.inviteeFirstName },
-      { key: INVITEE_FIELDS.last_name, label: m.inviteeLastName },
-      { key: INVITEE_FIELDS.phone, label: m.inviteePhone },
+      ...bookingFieldsFor(emailSource.key)
+        .filter((f) => f.kind !== 'start_time')
+        .map((f) => ({ key: f.key, label: bookingLabel(f.kind, m) })),
     ];
   }, [emailSource, m]);
 

--- a/apps/web/lib/booking-fields.ts
+++ b/apps/web/lib/booking-fields.ts
@@ -1,0 +1,30 @@
+import type { BookingFieldKind } from '@quill/engine';
+import type { FormsMessages } from '@quill/shared';
+
+type IntegrationsMessages = FormsMessages['admin']['integrations'];
+
+/**
+ * The shared catalog's name for one of a booking's facts.
+ *
+ * `bookingFieldsFor` in `@quill/engine` says WHICH facts a booking produces and
+ * under which keys; this says what to call them. Both the builder's question
+ * panel and the Connect screen resolve their row labels through here, so neither
+ * can rename a row the other still prints by its old name.
+ *
+ * It lives in the web app rather than the engine because the engine holds no
+ * user-facing copy — see the i18n invariant in CLAUDE.md.
+ */
+export function bookingLabel(kind: BookingFieldKind, m: IntegrationsMessages): string {
+  switch (kind) {
+    case 'start_time':
+      return m.bookingStart;
+    case 'name':
+      return m.inviteeName;
+    case 'first_name':
+      return m.inviteeFirstName;
+    case 'last_name':
+      return m.inviteeLastName;
+    case 'phone':
+      return m.inviteePhone;
+  }
+}

--- a/packages/engine/src/contact-key.spec.ts
+++ b/packages/engine/src/contact-key.spec.ts
@@ -5,6 +5,8 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
+  INVITEE_FIELDS,
+  bookingFieldsFor,
   contactKeyReadiness,
   emailMappingsConflictingWithScheduler,
   emailSourceFor,
@@ -82,5 +84,48 @@ describe('emailMappingsConflictingWithScheduler', () => {
       emailMappingsConflictingWithScheduler({ kind: 'question', key: 'email' }, { email: 'email' }),
     ).toEqual([]);
     expect(emailMappingsConflictingWithScheduler(null, { work: 'email' })).toEqual([]);
+  });
+});
+
+describe('bookingFieldsFor', () => {
+  it('leads with the scheduler own key — that is where the meeting time lands', () => {
+    const fields = bookingFieldsFor('book');
+    expect(fields[0]).toEqual({ key: 'book', kind: 'start_time' });
+  });
+
+  it('carries the invitee identity under the @-prefixed keys the sync writes', () => {
+    expect(bookingFieldsFor('book')).toEqual([
+      { key: 'book', kind: 'start_time' },
+      { key: INVITEE_FIELDS.name, kind: 'name' },
+      { key: INVITEE_FIELDS.first_name, kind: 'first_name' },
+      { key: INVITEE_FIELDS.last_name, kind: 'last_name' },
+      { key: INVITEE_FIELDS.phone, kind: 'phone' },
+    ]);
+  });
+
+  // The address is the contact KEY the booking supplies. Offering it as a
+  // mappable field is what `emailMappingsConflictingWithScheduler` exists to
+  // catch after the fact — the list must not put it there in the first place.
+  it('never offers the invitee email as a mappable field', () => {
+    const keys = bookingFieldsFor('book').map((f) => f.key);
+    expect(keys).not.toContain('email');
+    expect(keys.some((k) => k.toLowerCase().includes('email'))).toBe(false);
+  });
+
+  // Only the first entry is the step's; the rest are fixed system keys, so two
+  // schedulers in one form share the invitee rows and differ on the time row.
+  it('rekeys only the meeting time when the scheduler step is renamed', () => {
+    const before = bookingFieldsFor('book');
+    const after = bookingFieldsFor('demo_slot');
+    expect(after[0]!.key).toBe('demo_slot');
+    expect(after.slice(1)).toEqual(before.slice(1));
+  });
+
+  // `@` is outside the step-key grammar, so a question can never collide with
+  // one of these — the guarantee INVITEE_FIELDS documents, asserted here.
+  it('keeps the system keys outside the step-key grammar', () => {
+    for (const f of bookingFieldsFor('book').slice(1)) {
+      expect(f.key.startsWith('@')).toBe(true);
+    }
   });
 });

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -786,6 +786,44 @@ export function emailMappingsConflictingWithScheduler(
     .map(([stepKey]) => stepKey);
 }
 
+/** Which fact of a booking a {@link BookingField} carries. */
+export type BookingFieldKind = 'start_time' | 'name' | 'first_name' | 'last_name' | 'phone';
+
+/** One fact a booking produces, as the key it arrives under in the submission. */
+export interface BookingField {
+  /** The submission-data key — exactly what `fieldMappings` is keyed by. */
+  key: string;
+  kind: BookingFieldKind;
+}
+
+/**
+ * Everything a booking on `schedulerKey` can send to a CRM.
+ *
+ * A scheduler's OWN step key holds the meeting start time; {@link INVITEE_FIELDS}
+ * hold who booked. Both already reach the CRM through the ordinary `fieldMappings`
+ * — but nothing ever said so. The builder offered one unlabelled picker on the
+ * scheduler's key, so an author could map "the booking" without learning the value
+ * behind it is a timestamp, and the invitee's name and phone were reachable only
+ * from the Connect screen. One list here so the two screens cannot drift on what a
+ * booking actually offers.
+ *
+ * The invitee's EMAIL is deliberately absent: it is the contact key the booking
+ * supplies, and pointing any field at `email` takes that role over and stops the
+ * sync — see {@link emailMappingsConflictingWithScheduler}.
+ *
+ * `kind` names the fact and the CALLER supplies the label: this package holds no
+ * user-facing copy.
+ */
+export function bookingFieldsFor(schedulerKey: string): BookingField[] {
+  return [
+    { key: schedulerKey, kind: 'start_time' },
+    { key: INVITEE_FIELDS.name, kind: 'name' },
+    { key: INVITEE_FIELDS.first_name, kind: 'first_name' },
+    { key: INVITEE_FIELDS.last_name, kind: 'last_name' },
+    { key: INVITEE_FIELDS.phone, kind: 'phone' },
+  ];
+}
+
 /**
  * The visibility operators offered for a referenced field's TYPE — the builder
  * shows exactly these in the operator dropdown, and they are the only ops the

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1105,6 +1105,8 @@ export interface FormsMessages {
       inviteeFirstName: string;
       inviteeLastName: string;
       inviteePhone: string;
+      /** The meeting slot itself — the scheduler step's own answer. */
+      bookingStart: string;
       keyCustomBack: string;
       selectKeyPlaceholder: string;
       webhookEvents: string;
@@ -2188,6 +2190,7 @@ export const en: FormsMessages = {
       inviteeFirstName: 'Booking — first name',
       inviteeLastName: 'Booking — last name',
       inviteePhone: 'Booking — phone',
+      bookingStart: 'Booking — meeting time',
       keyCustomBack: 'Back to list',
       selectKeyPlaceholder: 'Select a field…',
       webhookEvents: 'Trigger on',
@@ -3272,6 +3275,7 @@ export const es: FormsMessages = {
       inviteeFirstName: 'Agenda — nombre',
       inviteeLastName: 'Agenda — apellido',
       inviteePhone: 'Agenda — teléfono',
+      bookingStart: 'Agenda — hora de la reunión',
       keyCustomBack: 'Volver a la lista',
       selectKeyPlaceholder: 'Selecciona un campo…',
       webhookEvents: 'Disparar en',


### PR DESCRIPTION
## El problema

Un step `scheduler` responde con una **reserva**, y una reserva son varios datos bajo varias claves. El panel de la pregunta ofrecía **un solo picker sin etiqueta** («Asignar a») atado a `step.key`, cuyo valor real es:

```ts
answers[schedStep.key] = details.startTime ?? 'booked'
```

O sea la hora de inicio en ISO. Nada en el UI lo decía. Y los datos del invitado (`@invitee_name`, `@invitee_first_name`, `@invitee_last_name`, `@invitee_phone`, que llegaron con #56) solo se podían mapear desde Conectar.

Resultado: se podía mapear «la reserva» sin saber nunca qué se estaba mapeando.

## Lo que cambia

El panel del scheduler ahora lista los cinco datos, cada uno con su propio destino:

| fila | clave |
|---|---|
| Agenda — hora de la reunión | `step.key` |
| Agenda — nombre completo | `@invitee_name` |
| Agenda — nombre | `@invitee_first_name` |
| Agenda — apellido | `@invitee_last_name` |
| Agenda — teléfono | `@invitee_phone` |

Las dos pantallas leen `bookingFieldsFor` del engine y resuelven los labels por el mismo helper, así ninguna puede ofrecer un campo que la otra no conoce ni renombrar una fila que la otra sigue llamando por el nombre viejo.

## Combinaciones que la lista no produce

- **`email` no se ofrece** como destino en ninguna fila. La reserva *es* lo que aporta la llave del contacto; apuntar un campo a esa propiedad se la quita y apaga el sync — justo lo que `emailMappingsConflictingWithScheduler` reporta cuando los leads ya dejaron de llegar.
- **Las filas del invitado aparecen solo mientras la reserva sea la llave del contacto.** Con una pregunta de correo presente el adapter resuelve la dirección solo, el enriquecimiento al reservar nunca corre y esas claves quedarían vacías para siempre. La nota final sobre el correo va con la misma condición, porque si no nombra la fuente equivocada.
- **La hora lleva hint**: pasa como texto, tal cual lo reportó la reserva, así que una propiedad `date` de HubSpot la rechaza. La tipada es `bookingSync` en Conectar.

## Bug de paso

`saveQuestionMappingAction` pisaba un mapeo fan-out (`string[]`) en vez de preservar la cola, así que un pick desde Build borraba en silencio las propiedades extra escritas en Conectar. El estado optimista del cliente sí la preservaba, o sea que los dos estaban en desacuerdo hasta la siguiente carga. Con cinco filas en vez de una esto se vuelve mucho más alcanzable, así que va acá.

## Legacy

Sin migración. Un `fieldMappings[schedulerKey]` existente **es** la fila de la hora, ahora con nombre.

## Verificación

Contra el editor corriendo, con un form con scheduler, HubSpot habilitado y Calendly conectado:

- las 5 filas con sus labels, el hint solo en la hora, la nota del correo al final;
- una pregunta normal sigue mostrando el picker único;
- con pregunta de correo presente queda solo la fila de la hora y desaparece la nota;
- un pick en `@invitee_name` persiste: `"@invitee_name":"firstname"` en `config.destinations`;
- fan-out preservado: `["firstname","custom_tail_prop"]` → `["lastname","custom_tail_prop"]`.

`pnpm lint`, `typecheck`, `test` y `build` en verde. 5 tests nuevos en `contact-key.spec.ts`.