### PR TITLE
feat(analytics): record where a workspace came from

### DIFF
--- a/.changeset/inbound-attribution.md
+++ b/.changeset/inbound-attribution.md
@@ -7,8 +7,15 @@ Record where a workspace came from, once. A campaign link arrives with its UTM
 tags on the query string, but the root page redirects into the identity provider
 and that round-trip leaves our origin — the tags never come back, so nothing was
 ever stored and every signup looked like it appeared out of nowhere.
-`parseAttribution` allowlists and caps the inbound tags, `claimAccountAttribution`
-writes them to `account.attribution` only while it is still NULL, and the web
-parks them in a short-lived httpOnly cookie across the login hand-off. First
-touch, not last: overwriting on a later untagged visit is how paid campaigns lose
-the signups they paid for.
+
+`parseAttribution` maps the URL's snake_case tags onto the camelCase shape
+`attributionSchema` has always declared for this column (plus `gclid`/`fbclid`,
+the paid-click ids), allowlisting and truncating as it goes.
+`claimAccountAttribution` writes them to `account.attribution` while it is still
+NULL **and the account is newborn** — NULL alone is not evidence of a new
+workspace, since every account predating this feature has a NULL column, so
+without the age bound the first tagged login by a long-time customer would
+permanently stamp their workspace with a campaign it predates. The web parks the
+tags in a short-lived httpOnly cookie across the login hand-off. First touch,
+not last: overwriting on a later untagged visit is how paid campaigns lose the
+signups they paid for.

--- a/.changeset/inbound-attribution.md
+++ b/.changeset/inbound-attribution.md
@@ -1,0 +1,14 @@
+---
+'@quill/types': minor
+'@quill/db': minor
+---
+
+Record where a workspace came from, once. A campaign link arrives with its UTM
+tags on the query string, but the root page redirects into the identity provider
+and that round-trip leaves our origin — the tags never come back, so nothing was
+ever stored and every signup looked like it appeared out of nowhere.
+`parseAttribution` allowlists and caps the inbound tags, `claimAccountAttribution`
+writes them to `account.attribution` only while it is still NULL, and the web
+parks them in a short-lived httpOnly cookie across the login hand-off. First
+touch, not last: overwriting on a later untagged visit is how paid campaigns lose
+the signups they paid for.

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -7,6 +7,7 @@ import {
   Get,
   HttpCode,
   Inject,
+  Logger,
   NotFoundException,
   Optional,
   Param,
@@ -19,6 +20,7 @@ import {
 import type { Db, NotificationSetting } from '@quill/db';
 import {
   changeMemberRole,
+  claimAccountAttribution,
   createForm,
   getAccountBranding,
   mergeKitIntoBranding,
@@ -52,6 +54,7 @@ import {
   type SubmissionEmailKey,
 } from '@quill/notifications';
 import {
+  accountAttributionSchema,
   formInputSchema,
   maskConfigSecrets,
   memberInviteSchema,
@@ -105,6 +108,8 @@ function maskForm<T extends { config: unknown; draftConfig?: unknown }>(form: T)
 /** Host-authed CRUD for forms + submissions + members, and identity/vanity. */
 @Controller('v1')
 export class AdminCrudController {
+  private readonly log = new Logger('AdminCrudController');
+
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(AuthService) private readonly auth: AuthService,
@@ -125,6 +130,43 @@ export class AdminCrudController {
   async me(@Req() req: ReqLike) {
     const p = await this.auth.resolveHost(req);
     return this.admin.me(p);
+  }
+
+  /**
+   * Record where this workspace came from. First touch, once, ever.
+   *
+   * POSTed by the web the moment a login completes, carrying the acquisition
+   * tags it stashed BEFORE bouncing to the identity provider. That bounce leaves
+   * our origin, so the query string never comes back — this request is the only
+   * point at which those values exist server-side. Miss it and the campaign that
+   * paid for the signup is unrecoverable.
+   *
+   * `accountId` comes from the resolved principal, NEVER the body. The body is
+   * attacker-supplied by definition (anyone can craft a link), so letting it name
+   * an account would let a stranger overwrite someone else's attribution.
+   *
+   * Never throws on a bad payload and never blocks: attribution is an observer of
+   * the product, not a participant. A login must not fail because a UTM could not
+   * be stored, which is why the caller gets `{ recorded }` instead of a 4xx.
+   */
+  @Post('account/attribution')
+  async recordAttribution(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const parsed = accountAttributionSchema.safeParse(body ?? {});
+    // `{}` passes the schema but is nothing to store, and storing it would SPEND
+    // the write-once claim — the real campaign could never be recorded after.
+    if (!parsed.success || Object.keys(parsed.data).length === 0) return { recorded: false };
+
+    const first = await claimAccountAttribution(this.db, p.accountId, parsed.data).catch((err) => {
+      // Same shape as the activation claim: a lock or a dead connection must not
+      // turn a completed login into a 500 on the way to the dashboard.
+      this.log.warn(`attribution claim failed for account ${p.accountId}: ${String(err)}`);
+      return false;
+    });
+    if (first && this.productAnalytics?.enabled) {
+      await this.productAnalytics.captureForMember('attribution_captured', p, { ...parsed.data });
+    }
+    return { recorded: first };
   }
 
   /**

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -54,7 +54,7 @@ import {
   type SubmissionEmailKey,
 } from '@quill/notifications';
 import {
-  accountAttributionSchema,
+  attributionSchema,
   formInputSchema,
   maskConfigSecrets,
   memberInviteSchema,
@@ -145,26 +145,41 @@ export class AdminCrudController {
    * attacker-supplied by definition (anyone can craft a link), so letting it name
    * an account would let a stranger overwrite someone else's attribution.
    *
-   * Never throws on a bad payload and never blocks: attribution is an observer of
-   * the product, not a participant. A login must not fail because a UTM could not
-   * be stored, which is why the caller gets `{ recorded }` instead of a 4xx.
+   * Admin-gated like every other workspace-level write in this controller: a
+   * plain `member` must not be able to rewrite the workspace's acquisition
+   * record. The intended caller is a brand-new account whose first member IS the
+   * owner, so the happy path is unaffected — and a 403 here cannot break the
+   * login, because the web discards this response entirely.
+   *
+   * Past the principal checks it never throws on a bad payload and never blocks:
+   * attribution is an observer of the product, not a participant. A login must
+   * not fail because a UTM could not be stored, which is why a junk body gets
+   * `{ recorded: false }` rather than a 400.
    */
   @Post('account/attribution')
   async recordAttribution(@Req() req: ReqLike, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
-    const parsed = accountAttributionSchema.safeParse(body ?? {});
-    // `{}` passes the schema but is nothing to store, and storing it would SPEND
-    // the write-once claim — the real campaign could never be recorded after.
-    if (!parsed.success || Object.keys(parsed.data).length === 0) return { recorded: false };
+    assertAdmin(p);
+    const parsed = attributionSchema.safeParse(body ?? {});
+    if (!parsed.success) return { recorded: false };
 
-    const first = await claimAccountAttribution(this.db, p.accountId, parsed.data).catch((err) => {
+    // Every field of the schema is nullable, so drop the empties BEFORE deciding
+    // there is something to store. `{}` — and `{ utmSource: null }`, which a
+    // hand-written body can produce — would otherwise SPEND the write-once claim
+    // and the real campaign could never be recorded afterwards.
+    const tags = Object.fromEntries(
+      Object.entries(parsed.data).filter(([, v]) => v != null && v !== ''),
+    ) as Record<string, string>;
+    if (Object.keys(tags).length === 0) return { recorded: false };
+
+    const first = await claimAccountAttribution(this.db, p.accountId, tags).catch((err) => {
       // Same shape as the activation claim: a lock or a dead connection must not
       // turn a completed login into a 500 on the way to the dashboard.
       this.log.warn(`attribution claim failed for account ${p.accountId}: ${String(err)}`);
       return false;
     });
     if (first && this.productAnalytics?.enabled) {
-      await this.productAnalytics.captureForMember('attribution_captured', p, { ...parsed.data });
+      await this.productAnalytics.captureForMember('attribution_captured', p, { ...tags });
     }
     return { recorded: first };
   }

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -54,6 +54,7 @@ import {
   type SubmissionEmailKey,
 } from '@quill/notifications';
 import {
+  attributionEventProps,
   attributionSchema,
   formInputSchema,
   maskConfigSecrets,
@@ -166,10 +167,14 @@ export class AdminCrudController {
     // Every field of the schema is nullable, so drop the empties BEFORE deciding
     // there is something to store. `{}` — and `{ utmSource: null }`, which a
     // hand-written body can produce — would otherwise SPEND the write-once claim
-    // and the real campaign could never be recorded afterwards.
-    const tags = Object.fromEntries(
-      Object.entries(parsed.data).filter(([, v]) => v != null && v !== ''),
-    ) as Record<string, string>;
+    // and the real campaign could never be recorded afterwards. The `typeof`
+    // check is not decoration: `firstSeenAt` is a NUMBER, so a crafted
+    // `{"firstSeenAt":0}` would survive a mere null-check and spend the claim
+    // carrying nothing.
+    const tags: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed.data)) {
+      if (typeof value === 'string' && value !== '') tags[key] = value;
+    }
     if (Object.keys(tags).length === 0) return { recorded: false };
 
     const first = await claimAccountAttribution(this.db, p.accountId, tags).catch((err) => {
@@ -179,7 +184,11 @@ export class AdminCrudController {
       return false;
     });
     if (first && this.productAnalytics?.enabled) {
-      await this.productAnalytics.captureForMember('attribution_captured', p, { ...tags });
+      await this.productAnalytics.captureForMember(
+        'attribution_captured',
+        p,
+        attributionEventProps(tags),
+      );
     }
     return { recorded: first };
   }

--- a/apps/api/src/analytics-events.spec.ts
+++ b/apps/api/src/analytics-events.spec.ts
@@ -448,10 +448,17 @@ describe('attribution — first touch, recorded once', () => {
     expect(await names()).toContain('forms_attribution_captured');
   });
 
-  it('carries the tags as event properties so PostHog can group by source', async () => {
-    await controller.recordAttribution(asOwner(), { utmSource: 'landing' });
+  it('stores camelCase but emits snake_case event properties', async () => {
+    // Two conventions on purpose, pinned together so neither drifts: the COLUMN
+    // uses the camelCase shape `attributionSchema` declares, while the analytics
+    // wire is snake_case like every other property this product sends
+    // (`form_id`, `is_first_publish`). That project is shared with the rest of the
+    // Dapta estate, so property naming there is a cross-product contract.
+    await controller.recordAttribution(asOwner(), { utmSource: 'landing', utmMedium: 'cpc' });
+    expect(await stored()).toEqual({ utmSource: 'landing', utmMedium: 'cpc' });
     const event = (await captured()).find((c) => c.event === 'forms_attribution_captured');
-    expect(event?.props).toMatchObject({ utmSource: 'landing' });
+    expect(event?.props).toMatchObject({ utm_source: 'landing', utm_medium: 'cpc' });
+    expect(event?.props).not.toHaveProperty('utmSource');
   });
 
   it('keeps the FIRST touch and emits nothing the second time', async () => {

--- a/apps/api/src/analytics-events.spec.ts
+++ b/apps/api/src/analytics-events.spec.ts
@@ -6,6 +6,7 @@
  * where and as often as the funnel assumes it does.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
 import {
   createDb,
   migrate,
@@ -32,6 +33,7 @@ let productAnalytics: AnalyticsEffects;
 let formId: string;
 
 const asOwner = (): ReqLike => ({ headers: {} });
+const asEmail = (email: string): ReqLike => ({ headers: { 'x-quill-email': email } });
 
 const ANALYTICS_ON = { PRODUCT_ANALYTICS_KEY: 'phc_test', PRODUCT_ANALYTICS_HOST: 'https://x.test' };
 const LOCAL_ENV = {
@@ -509,6 +511,17 @@ describe('attribution — first touch, recorded once', () => {
       accountId: 'someone-else',
     });
     expect(await stored()).toEqual({ utmSource: 'landing' });
+  });
+
+  it('refuses a plain member — acquisition is workspace-level data', async () => {
+    // The gate exists because a review found it missing; without this case it can be
+    // deleted and every other test still passes. Same shape as the other
+    // admin-gated writes in this controller.
+    await controller.inviteMember(asOwner(), { email: 'plain@acme.test', role: 'member' });
+    await expect(
+      controller.recordAttribution(asEmail('plain@acme.test'), { utmSource: 'landing' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(await stored()).toBeNull();
   });
 
   it('never throws on a malformed body', async () => {

--- a/apps/api/src/analytics-events.spec.ts
+++ b/apps/api/src/analytics-events.spec.ts
@@ -437,49 +437,71 @@ describe('attribution — first touch, recorded once', () => {
       : (raw as Record<string, string>);
   }
 
-  it('stores the allowlisted tags and reports that it recorded them', async () => {
+  it('stores the tags under the documented field names and says it recorded them', async () => {
     const res = await controller.recordAttribution(asOwner(), {
-      utm_source: 'landing',
-      utm_medium: 'cpc',
-      utm_campaign: 'launch',
+      utmSource: 'landing',
+      utmMedium: 'cpc',
+      utmCampaign: 'launch',
     });
     expect(res).toEqual({ recorded: true });
-    expect(await stored()).toEqual({ utm_source: 'landing', utm_medium: 'cpc', utm_campaign: 'launch' });
+    expect(await stored()).toEqual({ utmSource: 'landing', utmMedium: 'cpc', utmCampaign: 'launch' });
     expect(await names()).toContain('forms_attribution_captured');
   });
 
   it('carries the tags as event properties so PostHog can group by source', async () => {
-    await controller.recordAttribution(asOwner(), { utm_source: 'landing' });
+    await controller.recordAttribution(asOwner(), { utmSource: 'landing' });
     const event = (await captured()).find((c) => c.event === 'forms_attribution_captured');
-    expect(event?.props).toMatchObject({ utm_source: 'landing' });
+    expect(event?.props).toMatchObject({ utmSource: 'landing' });
   });
 
   it('keeps the FIRST touch and emits nothing the second time', async () => {
-    await controller.recordAttribution(asOwner(), { utm_source: 'google-ads' });
-    const res = await controller.recordAttribution(asOwner(), { utm_source: 'direct' });
+    await controller.recordAttribution(asOwner(), { utmSource: 'google-ads' });
+    const res = await controller.recordAttribution(asOwner(), { utmSource: 'direct' });
     expect(res).toEqual({ recorded: false });
-    expect(await stored()).toEqual({ utm_source: 'google-ads' });
+    expect(await stored()).toEqual({ utmSource: 'google-ads' });
     // Exactly one event: a second one would double-count the acquisition.
     expect((await names()).filter((n) => n === 'forms_attribution_captured')).toHaveLength(1);
+  });
+
+  it('refuses a workspace that is older than the claim window', async () => {
+    // Every account predating this feature has a NULL column, so NULL alone is not
+    // evidence of a new workspace. Age it past the window and the claim must
+    // decline — otherwise a campaign link clicked by a long-time customer would
+    // permanently record their workspace as acquired by that campaign.
+    await db.run(sql`UPDATE account SET created_at = ${Date.now() - 24 * 60 * 60_000} WHERE code = 'acme'`);
+    expect(await controller.recordAttribution(asOwner(), { utmSource: 'landing' })).toEqual({
+      recorded: false,
+    });
+    expect(await stored()).toBeNull();
+    expect(await names()).not.toContain('forms_attribution_captured');
   });
 
   it('ignores an empty payload rather than spending the claim on it', async () => {
     expect(await controller.recordAttribution(asOwner(), {})).toEqual({ recorded: false });
     expect(await stored()).toBeNull();
     // The real campaign must still be recordable afterwards.
-    expect(await controller.recordAttribution(asOwner(), { utm_source: 'landing' })).toEqual({
+    expect(await controller.recordAttribution(asOwner(), { utmSource: 'landing' })).toEqual({
       recorded: true,
     });
+  });
+
+  it('treats an all-null payload as empty', async () => {
+    // Every field of the schema is nullable, so a hand-written body can pass
+    // validation while carrying nothing. It must not spend the claim.
+    expect(await controller.recordAttribution(asOwner(), { utmSource: null, gclid: null })).toEqual({
+      recorded: false,
+    });
+    expect(await stored()).toBeNull();
   });
 
   it('drops keys that are not on the allowlist', async () => {
     // The body is attacker-supplied — anyone can craft the link that produced it.
     await controller.recordAttribution(asOwner(), {
-      utm_source: 'landing',
+      utmSource: 'landing',
       evil: 'nope',
       accountId: 'someone-else',
     });
-    expect(await stored()).toEqual({ utm_source: 'landing' });
+    expect(await stored()).toEqual({ utmSource: 'landing' });
   });
 
   it('never throws on a malformed body', async () => {

--- a/apps/api/src/analytics-events.spec.ts
+++ b/apps/api/src/analytics-events.spec.ts
@@ -423,3 +423,69 @@ describe('forms_form_published — concurrency', () => {
     expect(publishes).toHaveLength(1);
   });
 });
+
+describe('attribution — first touch, recorded once', () => {
+  /** The stored value, dialect-neutral (jsonb parsed on pg, TEXT on sqlite). */
+  async function stored(): Promise<Record<string, string> | null> {
+    const row = await db.get<{ attribution: unknown }>(
+      sql`SELECT attribution FROM account WHERE code = 'acme'`,
+    );
+    const raw = row?.attribution ?? null;
+    if (raw == null) return null;
+    return typeof raw === 'string'
+      ? (JSON.parse(raw) as Record<string, string>)
+      : (raw as Record<string, string>);
+  }
+
+  it('stores the allowlisted tags and reports that it recorded them', async () => {
+    const res = await controller.recordAttribution(asOwner(), {
+      utm_source: 'landing',
+      utm_medium: 'cpc',
+      utm_campaign: 'launch',
+    });
+    expect(res).toEqual({ recorded: true });
+    expect(await stored()).toEqual({ utm_source: 'landing', utm_medium: 'cpc', utm_campaign: 'launch' });
+    expect(await names()).toContain('forms_attribution_captured');
+  });
+
+  it('carries the tags as event properties so PostHog can group by source', async () => {
+    await controller.recordAttribution(asOwner(), { utm_source: 'landing' });
+    const event = (await captured()).find((c) => c.event === 'forms_attribution_captured');
+    expect(event?.props).toMatchObject({ utm_source: 'landing' });
+  });
+
+  it('keeps the FIRST touch and emits nothing the second time', async () => {
+    await controller.recordAttribution(asOwner(), { utm_source: 'google-ads' });
+    const res = await controller.recordAttribution(asOwner(), { utm_source: 'direct' });
+    expect(res).toEqual({ recorded: false });
+    expect(await stored()).toEqual({ utm_source: 'google-ads' });
+    // Exactly one event: a second one would double-count the acquisition.
+    expect((await names()).filter((n) => n === 'forms_attribution_captured')).toHaveLength(1);
+  });
+
+  it('ignores an empty payload rather than spending the claim on it', async () => {
+    expect(await controller.recordAttribution(asOwner(), {})).toEqual({ recorded: false });
+    expect(await stored()).toBeNull();
+    // The real campaign must still be recordable afterwards.
+    expect(await controller.recordAttribution(asOwner(), { utm_source: 'landing' })).toEqual({
+      recorded: true,
+    });
+  });
+
+  it('drops keys that are not on the allowlist', async () => {
+    // The body is attacker-supplied — anyone can craft the link that produced it.
+    await controller.recordAttribution(asOwner(), {
+      utm_source: 'landing',
+      evil: 'nope',
+      accountId: 'someone-else',
+    });
+    expect(await stored()).toEqual({ utm_source: 'landing' });
+  });
+
+  it('never throws on a malformed body', async () => {
+    // A login already succeeded by the time this runs; it must not turn into a 500.
+    expect(await controller.recordAttribution(asOwner(), 'not-an-object')).toEqual({ recorded: false });
+    expect(await controller.recordAttribution(asOwner(), null)).toEqual({ recorded: false });
+    expect(await stored()).toBeNull();
+  });
+});

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -42,14 +42,18 @@ async function recordAttribution(
   const parked = jar.get(ATTRIBUTION_COOKIE)?.value;
   if (!parked) return;
   try {
-    await fetch(`${serverApiUrl}/v1/account/attribution`, {
+    const res = await fetch(`${serverApiUrl}/v1/account/attribution`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${accessToken}` },
       body: parked,
       cache: 'no-store',
       signal: AbortSignal.timeout(3000),
     });
-    jar.delete(ATTRIBUTION_COOKIE);
+    // `fetch` resolves for EVERY status, so the status has to be read: a 500 from a
+    // failed-over database, or a 502 from the ingress while a pod drains, is not the
+    // API having its say — it is the same transient failure as a dead socket, and
+    // deleting here would lose the tags for good.
+    if (res.status < 500) jar.delete(ATTRIBUTION_COOKIE);
   } catch {
     // Kept for a retry — see the note above. Never rethrown: the login succeeded.
   }

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -1,10 +1,49 @@
 import { timingSafeEqual } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
+import { serverApiUrl } from '@/lib/api-url';
 import { setSession } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
 const OAUTH_STATE_COOKIE = 'quill_oauth_state';
+const ATTRIBUTION_COOKIE = 'quill_attribution';
+
+/**
+ * Hand the parked acquisition tags to the API, which stores them write-once.
+ *
+ * Uses the freshly-minted access token directly instead of reading the session
+ * back: `setSession` writes its cookie on the OUTGOING response, so a read in
+ * this same request is not guaranteed to see it.
+ *
+ * This POST doubles as the first authenticated call, so it is what MATERIALIZES
+ * the workspace — the API resolves the principal, which JIT-creates the account.
+ * It therefore has to run before the redirect: after it, the dashboard's own
+ * first request would win the race and the tags would arrive to an account whose
+ * first touch had already been claimed as empty.
+ *
+ * Never throws, and gives up after a few seconds. Attribution is an observer of
+ * the product, never a participant: a slow or down API must not strand somebody
+ * who just logged in successfully.
+ */
+async function recordAttribution(
+  jar: Awaited<ReturnType<typeof cookies>>,
+  accessToken: string,
+): Promise<void> {
+  const parked = jar.get(ATTRIBUTION_COOKIE)?.value;
+  jar.delete(ATTRIBUTION_COOKIE);
+  if (!parked) return;
+  try {
+    await fetch(`${serverApiUrl}/v1/account/attribution`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${accessToken}` },
+      body: parked,
+      cache: 'no-store',
+      signal: AbortSignal.timeout(4000),
+    });
+  } catch {
+    // Swallowed on purpose — see the note above.
+  }
+}
 
 /** Constant-time string equality (guards length leak). */
 function safeEqual(a: string, b: string): boolean {
@@ -73,5 +112,6 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     refreshToken: tokens.refresh_token,
     sessionId: tokens.session_id,
   });
+  await recordAttribution(jar, tokens.access_token);
   return NextResponse.redirect(new URL('/admin', origin));
 }

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -20,17 +20,26 @@ const ATTRIBUTION_COOKIE = 'quill_attribution';
  * killed. Nothing races it — `claimAccountAttribution` is the column's only
  * writer, so the dashboard's first request cannot claim anything.
  *
- * The timeout is deliberately short. This is the one request where somebody is
- * already waiting on a login that has succeeded, and it is a same-cluster call:
- * attribution is an observer of the product, never a participant, so a slow API
- * must cost the person milliseconds, not seconds.
+ * Do NOT read the timeout as "this is a cheap call". Being the first authenticated
+ * request makes it the most expensive one in the product: `resolveHost` inserts the
+ * account and the member, derives a unique handle, seeds the demo form, and fires
+ * the signup event. The bound exists because somebody is sitting in front of a
+ * login that already succeeded — attribution is an observer, never a participant —
+ * not because the work is small.
+ *
+ * The cookie survives a transport failure on purpose. It is deleted once the API
+ * has ANSWERED (2xx or 4xx — either way it had its say), but a timeout or a dead
+ * connection leaves it in place, so the next login on this browser retries. That is
+ * safe precisely because the write is claimed once and bounded by account age: a
+ * replay cannot double-count or overwrite. The residual cost is that a DIFFERENT
+ * person logging in on the same browser inside the cookie's 10 minutes inherits the
+ * tags — the same window the CSRF state cookie already accepts.
  */
 async function recordAttribution(
   jar: Awaited<ReturnType<typeof cookies>>,
   accessToken: string,
 ): Promise<void> {
   const parked = jar.get(ATTRIBUTION_COOKIE)?.value;
-  jar.delete(ATTRIBUTION_COOKIE);
   if (!parked) return;
   try {
     await fetch(`${serverApiUrl}/v1/account/attribution`, {
@@ -38,10 +47,11 @@ async function recordAttribution(
       headers: { 'content-type': 'application/json', authorization: `Bearer ${accessToken}` },
       body: parked,
       cache: 'no-store',
-      signal: AbortSignal.timeout(1500),
+      signal: AbortSignal.timeout(3000),
     });
+    jar.delete(ATTRIBUTION_COOKIE);
   } catch {
-    // Swallowed on purpose — see the note above.
+    // Kept for a retry — see the note above. Never rethrown: the login succeeded.
   }
 }
 

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -15,15 +15,15 @@ const ATTRIBUTION_COOKIE = 'quill_attribution';
  * back: `setSession` writes its cookie on the OUTGOING response, so a read in
  * this same request is not guaranteed to see it.
  *
- * This POST doubles as the first authenticated call, so it is what MATERIALIZES
- * the workspace — the API resolves the principal, which JIT-creates the account.
- * It therefore has to run before the redirect: after it, the dashboard's own
- * first request would win the race and the tags would arrive to an account whose
- * first touch had already been claimed as empty.
+ * It runs BEFORE the redirect for a mundane reason: a route handler cannot
+ * outlive its own response, so work started here and not awaited may simply be
+ * killed. Nothing races it — `claimAccountAttribution` is the column's only
+ * writer, so the dashboard's first request cannot claim anything.
  *
- * Never throws, and gives up after a few seconds. Attribution is an observer of
- * the product, never a participant: a slow or down API must not strand somebody
- * who just logged in successfully.
+ * The timeout is deliberately short. This is the one request where somebody is
+ * already waiting on a login that has succeeded, and it is a same-cluster call:
+ * attribution is an observer of the product, never a participant, so a slow API
+ * must cost the person milliseconds, not seconds.
  */
 async function recordAttribution(
   jar: Awaited<ReturnType<typeof cookies>>,
@@ -38,7 +38,7 @@ async function recordAttribution(
       headers: { 'content-type': 'application/json', authorization: `Bearer ${accessToken}` },
       body: parked,
       cache: 'no-store',
-      signal: AbortSignal.timeout(4000),
+      signal: AbortSignal.timeout(1500),
     });
   } catch {
     // Swallowed on purpose — see the note above.

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -54,7 +54,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const attribution = parseAttribution(
     Object.fromEntries([...new Set(sp.keys())].map((k) => [k, sp.getAll(k)])),
   );
-  if (attribution) {
+  // An already-parked value is NOT overwritten. The account-level claim is genuine
+  // first-touch, but at this point no account exists yet, so nothing else enforces
+  // it ACROSS login attempts: arrive from campaign A, abandon at the provider, come
+  // back from campaign B inside ten minutes, and last-wins would credit B.
+  if (attribution && !jar.get(ATTRIBUTION_COOKIE)) {
     jar.set(ATTRIBUTION_COOKIE, JSON.stringify(attribution), {
       path: '/',
       httpOnly: true,

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -46,7 +46,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // would attribute a later signup to a campaign the person saw days ago.
   // Absent tags set no cookie — the callback then has nothing to send, which is
   // what keeps a direct visit from spending the write-once first-touch claim.
-  const attribution = parseAttribution(Object.fromEntries(new URL(req.url).searchParams));
+  // `getAll` per key, not `Object.fromEntries`: that collapses a repeated param to
+  // the LAST value, which would quietly invert `parseAttribution`'s first-wins rule
+  // — and this route is directly reachable, so it is the one surface that sees a
+  // raw query string somebody else composed.
+  const sp = new URL(req.url).searchParams;
+  const attribution = parseAttribution(
+    Object.fromEntries([...new Set(sp.keys())].map((k) => [k, sp.getAll(k)])),
+  );
   if (attribution) {
     jar.set(ATTRIBUTION_COOKIE, JSON.stringify(attribution), {
       path: '/',

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,10 +1,20 @@
 import { randomBytes } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
+import { parseAttribution } from '@quill/types';
 import { authProvider } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
 const OAUTH_STATE_COOKIE = 'quill_oauth_state';
+/**
+ * Acquisition tags, parked for the identity round-trip.
+ *
+ * A cookie and not the `returnTo` URL: `returnTo` is handed to an external
+ * service and echoed back, so anything in it is visible and editable by whoever
+ * holds the link. The cookie stays on this origin, is httpOnly, and expires with
+ * the login attempt — the callback is the only reader.
+ */
+const ATTRIBUTION_COOKIE = 'quill_attribution';
 
 /**
  * WorkOS login hand-off (AUTH-WEB-CONTRACT §3.1). The web holds NO WorkOS secret;
@@ -22,13 +32,30 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   const state = randomBytes(24).toString('base64url');
-  (await cookies()).set(OAUTH_STATE_COOKIE, state, {
+  const jar = await cookies();
+  jar.set(OAUTH_STATE_COOKIE, state, {
     path: '/',
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 600, // 10 min — just long enough to finish the round-trip
   });
+
+  // Park the acquisition tags the root page forwarded. Same lifetime as the CSRF
+  // state: they are only meaningful for THIS login attempt, and a stale cookie
+  // would attribute a later signup to a campaign the person saw days ago.
+  // Absent tags set no cookie — the callback then has nothing to send, which is
+  // what keeps a direct visit from spending the write-once first-touch claim.
+  const attribution = parseAttribution(Object.fromEntries(new URL(req.url).searchParams));
+  if (attribution) {
+    jar.set(ATTRIBUTION_COOKIE, JSON.stringify(attribution), {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 600,
+    });
+  }
 
   const returnTo = `${origin}/api/auth/callback`;
   const res = await fetch(

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,67 +1,33 @@
 import { headers } from 'next/headers';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { parseAttribution, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
 import { BrandLockup } from '@/components/brand/brand';
+import { attributionHandoffQuery } from '@/lib/attribution';
 import { authProvider, getSession } from '@/lib/auth-session';
+import { selfHost } from '@/lib/request-origin';
 
 /**
  * Carry the acquisition tags into the login hand-off.
  *
  * `redirect()` drops the query string, and the identity round-trip leaves our
- * origin entirely — so tags not forwarded HERE are gone for good. This is the
- * only surface the campaign link actually lands on.
+ * origin entirely — so tags not forwarded HERE are gone for good. This is the only
+ * surface the campaign link actually lands on.
  *
- * Only allowlisted keys travel: forwarding the raw query would let a crafted
- * link smuggle arbitrary params into the login route.
+ * The pure part lives in `lib/attribution.ts` so it can be unit-tested; a redirect
+ * cannot. `landing_path` is deliberately not set: it would be '/' on every visit,
+ * making the parse non-empty for a plain bookmark hit and burning the write-once
+ * claim on a value that says nothing.
  */
 async function loginHandoff(params: Record<string, string | string[] | undefined>): Promise<string> {
   const h = await headers();
-  const referer = h.get('referer');
-  let referrer: string | undefined;
-  if (referer) {
-    // Drop a SAME-ORIGIN referer. `attribution` is written once and never again,
-    // so storing "came from our own page" would spend first touch on a value that
-    // says nothing, and the real campaign could never be recorded afterwards.
-    //
-    // The comparison host comes from PUBLIC_APP_URL first, the way
-    // `requestOrigin` resolves it: `Host` / `X-Forwarded-Host` are client-supplied
-    // and this app runs behind a proxy, so trusting them means a crafted `Host:`
-    // makes our own pages look external and burns the claim on a useless value.
-    let selfHost: string | null = null;
-    try {
-      selfHost = process.env.PUBLIC_APP_URL ? new URL(process.env.PUBLIC_APP_URL).host : null;
-    } catch {
-      selfHost = null;
-    }
-    selfHost ??= h.get('x-forwarded-host') ?? h.get('host');
-    try {
-      referrer = new URL(referer).host === selfHost ? undefined : referer;
-    } catch {
-      referrer = undefined;
-    }
-  }
-  // `landing_path` is deliberately NOT set here: it would be '/' on every visit,
-  // which would make the parse non-empty for a plain bookmark hit and burn the
-  // claim. It is for surfaces where the path itself carries information.
-  const candidate: Record<string, string | string[] | undefined> = { ...params, referrer };
-
-  // Decide with the SAME parser the login route will use, so the two can never
-  // disagree about what counts as "nothing to carry".
-  if (!parseAttribution(candidate)) return '/api/auth/login';
-
-  // Forward the WIRE format (snake_case), not the parsed shape: parsing belongs at
-  // the end of the chain, and re-emitting camelCase here would hand the login
-  // route keys its own parser does not recognize — the tags would vanish while
-  // every unit test still passed.
-  const qs = new URLSearchParams();
-  for (const key of ATTRIBUTION_QUERY_KEYS) {
-    const raw = candidate[key];
-    // First of a repeated param, matching the parser's first-wins rule.
-    const value = Array.isArray(raw) ? raw[0] : raw;
-    if (typeof value === 'string' && value.trim()) qs.set(key, value.trim());
-  }
-  return `/api/auth/login?${qs.toString()}`;
+  const query = attributionHandoffQuery(
+    params,
+    h.get('referer'),
+    // Same trust order as `requestOrigin`: PUBLIC_APP_URL first, headers only as a
+    // self-host fallback. `Host` / `X-Forwarded-Host` are client-supplied.
+    selfHost((n) => h.get(n)),
+  );
+  return query ? `/api/auth/login?${query}` : '/api/auth/login';
 }
 
 // Per-request render: the workos-vs-local branch reads RUNTIME env + cookies.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,41 @@
+import { headers } from 'next/headers';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { parseAttribution } from '@quill/types';
 import { BrandLockup } from '@/components/brand/brand';
 import { authProvider, getSession } from '@/lib/auth-session';
+
+/**
+ * Carry the acquisition tags into the login hand-off.
+ *
+ * `redirect()` drops the query string, and the identity round-trip leaves our
+ * origin entirely — so tags not forwarded HERE are gone for good. This is the
+ * only surface the campaign link actually lands on.
+ *
+ * Only allowlisted keys travel: forwarding the raw query would let a crafted
+ * link smuggle arbitrary params into the login route.
+ */
+async function loginHandoff(params: Record<string, string | string[] | undefined>): Promise<string> {
+  const h = await headers();
+  const referer = h.get('referer');
+  let referrer: string | undefined;
+  if (referer) {
+    // Drop a SAME-ORIGIN referer. `attribution` is written once and never again,
+    // so storing "came from our own page" would spend first touch on a value that
+    // says nothing, and the real campaign could never be recorded afterwards.
+    try {
+      referrer = new URL(referer).host === h.get('host') ? undefined : referer;
+    } catch {
+      referrer = undefined;
+    }
+  }
+  // `landing_path` is deliberately NOT set here: it would be '/' on every visit,
+  // which would make the parse non-empty for a plain bookmark hit and burn the
+  // claim. It is for surfaces where the path itself carries information.
+  const attribution = parseAttribution({ ...params, referrer });
+  if (!attribution) return '/api/auth/login';
+  return `/api/auth/login?${new URLSearchParams(Object.entries(attribution)).toString()}`;
+}
 
 // Per-request render: the workos-vs-local branch reads RUNTIME env + cookies.
 // Without this, next build (no AUTH_PROVIDER in the builder) bakes the OSS
@@ -15,10 +49,15 @@ export const dynamic = 'force-dynamic';
  *    hosted login (no intermediate sign-in card).
  *  - local/OSS fork: keep the clone-and-run landing with the demo form.
  */
-export default async function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   if (authProvider() === 'workos') {
     const session = await getSession();
-    redirect(session ? '/admin' : '/api/auth/login');
+    if (session) redirect('/admin');
+    redirect(await loginHandoff(await searchParams));
   }
 
   return (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,7 @@
 import { headers } from 'next/headers';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { parseAttribution } from '@quill/types';
+import { parseAttribution, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
 import { BrandLockup } from '@/components/brand/brand';
 import { authProvider, getSession } from '@/lib/auth-session';
 
@@ -23,8 +23,20 @@ async function loginHandoff(params: Record<string, string | string[] | undefined
     // Drop a SAME-ORIGIN referer. `attribution` is written once and never again,
     // so storing "came from our own page" would spend first touch on a value that
     // says nothing, and the real campaign could never be recorded afterwards.
+    //
+    // The comparison host comes from PUBLIC_APP_URL first, the way
+    // `requestOrigin` resolves it: `Host` / `X-Forwarded-Host` are client-supplied
+    // and this app runs behind a proxy, so trusting them means a crafted `Host:`
+    // makes our own pages look external and burns the claim on a useless value.
+    let selfHost: string | null = null;
     try {
-      referrer = new URL(referer).host === h.get('host') ? undefined : referer;
+      selfHost = process.env.PUBLIC_APP_URL ? new URL(process.env.PUBLIC_APP_URL).host : null;
+    } catch {
+      selfHost = null;
+    }
+    selfHost ??= h.get('x-forwarded-host') ?? h.get('host');
+    try {
+      referrer = new URL(referer).host === selfHost ? undefined : referer;
     } catch {
       referrer = undefined;
     }
@@ -32,9 +44,24 @@ async function loginHandoff(params: Record<string, string | string[] | undefined
   // `landing_path` is deliberately NOT set here: it would be '/' on every visit,
   // which would make the parse non-empty for a plain bookmark hit and burn the
   // claim. It is for surfaces where the path itself carries information.
-  const attribution = parseAttribution({ ...params, referrer });
-  if (!attribution) return '/api/auth/login';
-  return `/api/auth/login?${new URLSearchParams(Object.entries(attribution)).toString()}`;
+  const candidate: Record<string, string | string[] | undefined> = { ...params, referrer };
+
+  // Decide with the SAME parser the login route will use, so the two can never
+  // disagree about what counts as "nothing to carry".
+  if (!parseAttribution(candidate)) return '/api/auth/login';
+
+  // Forward the WIRE format (snake_case), not the parsed shape: parsing belongs at
+  // the end of the chain, and re-emitting camelCase here would hand the login
+  // route keys its own parser does not recognize — the tags would vanish while
+  // every unit test still passed.
+  const qs = new URLSearchParams();
+  for (const key of ATTRIBUTION_QUERY_KEYS) {
+    const raw = candidate[key];
+    // First of a repeated param, matching the parser's first-wins rule.
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof value === 'string' && value.trim()) qs.set(key, value.trim());
+  }
+  return `/api/auth/login?${qs.toString()}`;
 }
 
 // Per-request render: the workos-vs-local branch reads RUNTIME env + cookies.

--- a/apps/web/lib/attribution.spec.ts
+++ b/apps/web/lib/attribution.spec.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { parseAttribution, attributionSchema, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
+import { attributionHandoffQuery, crossOriginReferer } from './attribution';
 
 describe('parseAttribution — snake_case URL in, camelCase blob out', () => {
   it('maps the UTM set and the paid-click ids onto the stored field names', () => {
@@ -87,5 +88,68 @@ describe('parseAttribution — snake_case URL in, camelCase blob out', () => {
       referrer: 'https://app.example.com/home',
       landingPath: '/admin',
     });
+  });
+});
+
+describe('attributionHandoffQuery — hop 1, the seam that already broke', () => {
+  /** What the login route does with whatever hop 1 emitted. */
+  const receive = (query: string) => {
+    const sp = new URLSearchParams(query);
+    return parseAttribution(Object.fromEntries([...new Set(sp.keys())].map((k) => [k, sp.getAll(k)])));
+  };
+
+  it('round-trips every tag through both hops', () => {
+    // The regression this pins: emitting the PARSED (camelCase) shape here loses
+    // every utm_* tag while gclid/fbclid survive, because only those two keys are
+    // spelled the same in both casings. Nothing throws, no other test fails, and
+    // the write-once claim is then spent on a half-empty blob.
+    const query = attributionHandoffQuery(
+      { utm_source: 'google', utm_medium: 'cpc', utm_campaign: 'launch', gclid: 'CJ0abc' },
+      null,
+      null,
+    );
+    expect(receive(query)).toEqual({
+      utmSource: 'google',
+      utmMedium: 'cpc',
+      utmCampaign: 'launch',
+      gclid: 'CJ0abc',
+    });
+  });
+
+  it('emits nothing for an untagged visit, so no cookie is set downstream', () => {
+    expect(attributionHandoffQuery({}, null, null)).toBe('');
+    expect(attributionHandoffQuery({ unrelated: 'x' }, null, null)).toBe('');
+  });
+
+  it('carries a cross-origin referer and drops a same-origin one', () => {
+    expect(receive(attributionHandoffQuery({}, 'https://ads.example.com/x', 'forms.example.com'))).toEqual(
+      { referrer: 'https://ads.example.com/x' },
+    );
+    // Same origin says nothing, and storing it would spend first touch.
+    expect(attributionHandoffQuery({}, 'https://forms.example.com/pricing', 'forms.example.com')).toBe('');
+  });
+
+  it('keeps the first of a repeated param across the hop', () => {
+    expect(receive(attributionHandoffQuery({ utm_source: ['real', 'injected'] }, null, null))).toEqual({
+      utmSource: 'real',
+    });
+  });
+
+  it('caps a forwarded value so the redirect cannot carry a huge Location header', () => {
+    const query = attributionHandoffQuery({ utm_source: 'a'.repeat(4096) }, null, null);
+    expect(new URLSearchParams(query).get('utm_source')).toHaveLength(512);
+  });
+});
+
+describe('crossOriginReferer', () => {
+  it('treats a malformed referer as absent', () => {
+    expect(crossOriginReferer('not a url', 'forms.example.com')).toBeUndefined();
+    expect(crossOriginReferer(null, 'forms.example.com')).toBeUndefined();
+  });
+
+  it('keeps a referer when our own host is unknown', () => {
+    // A self-host with no PUBLIC_APP_URL and no proxy headers: better to record the
+    // referer than to silently treat every visit as internal.
+    expect(crossOriginReferer('https://ads.example.com/x', null)).toBe('https://ads.example.com/x');
   });
 });

--- a/apps/web/lib/attribution.spec.ts
+++ b/apps/web/lib/attribution.spec.ts
@@ -1,17 +1,20 @@
 /**
- * Inbound acquisition context — the wire contract in @quill/types.
+ * Inbound acquisition context — the mapping in @quill/types between the URL's
+ * snake_case tags and the camelCase shape stored on `account.attribution`.
  *
  * Tested from here rather than from the types package: `packages/types` ships no
  * test runner (its `test` script is a placeholder), and adding one would mean a
- * new devDependency plus a lockfile change in a PR that should stay surgical.
- * The web is the side that reads these tags off a real request, so this is the
+ * new devDependency plus a lockfile change in a PR that should stay surgical. The
+ * web is the side that reads these tags off a real request, so this is the
  * closest real consumer.
  */
 import { describe, it, expect } from 'vitest';
-import { parseAttribution, accountAttributionSchema, ATTRIBUTION_KEYS, ATTRIBUTION_VALUE_MAX } from '@quill/types';
+import { parseAttribution, attributionSchema, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
 
-describe('parseAttribution — inbound acquisition context', () => {
-  it('keeps the UTM set and the paid-click ids', () => {
+describe('parseAttribution — snake_case URL in, camelCase blob out', () => {
+  it('maps the UTM set and the paid-click ids onto the stored field names', () => {
+    // The landing appends snake_case (the ad-platform convention); the column
+    // stores camelCase (what `attributionSchema` has always declared).
     expect(
       parseAttribution({
         utm_source: 'landing',
@@ -23,22 +26,29 @@ describe('parseAttribution — inbound acquisition context', () => {
         fbclid: 'xyz789',
       }),
     ).toEqual({
-      utm_source: 'landing',
-      utm_medium: 'cpc',
-      utm_campaign: 'launch',
-      utm_term: 'forms',
-      utm_content: 'hero',
+      utmSource: 'landing',
+      utmMedium: 'cpc',
+      utmCampaign: 'launch',
+      utmTerm: 'forms',
+      utmContent: 'hero',
       gclid: 'abc123',
       fbclid: 'xyz789',
     });
   });
 
+  it('produces a value the documented reader accepts', () => {
+    // The whole point of collapsing to one schema: whatever the writer stores,
+    // `attributionSchema.parse` must return it intact rather than stripping it to
+    // `{}` because the casing disagreed.
+    const parsed = parseAttribution({ utm_source: 'landing', gclid: 'abc' })!;
+    expect(attributionSchema.parse(parsed)).toEqual(parsed);
+  });
+
   it('drops any key not on the allowlist', () => {
-    // The payload is attacker-supplied — anyone can craft a link — and it lands
-    // in a JSONB column that later feeds a CRM. A copy-everything parser would
-    // let a stranger write their own keys into our analytics.
+    // The input is attacker-supplied — anyone can craft a link — and it lands in a
+    // column that later feeds a CRM.
     expect(parseAttribution({ utm_source: 'x', evil: 'drop me', password: 'hunter2' })).toEqual({
-      utm_source: 'x',
+      utmSource: 'x',
     });
   });
 
@@ -50,47 +60,32 @@ describe('parseAttribution — inbound acquisition context', () => {
     expect(parseAttribution({ unrelated: 'value' })).toBeNull();
   });
 
-  it('trims, and caps each value', () => {
-    const long = 'a'.repeat(ATTRIBUTION_VALUE_MAX + 50);
-    const out = parseAttribution({ utm_campaign: '  spaced  ', fbclid: long })!;
-    expect(out.utm_campaign).toBe('spaced');
-    expect(out.fbclid).toHaveLength(ATTRIBUTION_VALUE_MAX);
+  it('trims, and TRUNCATES rather than failing the whole parse', () => {
+    // A single over-long value (a hostile URL, or just a very long fbclid) must
+    // not discard the campaign alongside it.
+    const out = parseAttribution({ utm_campaign: '  spaced  ', fbclid: 'a'.repeat(900) })!;
+    expect(out.utmCampaign).toBe('spaced');
+    expect(out.fbclid).toHaveLength(512);
+  });
+
+  it('never returns null because a value was too long', () => {
+    // Guards the cap table against drifting past the schema's own `.max()`: if it
+    // ever did, safeParse would fail and the whole payload would be dropped.
+    const hostile = Object.fromEntries(ATTRIBUTION_QUERY_KEYS.map((k) => [k, 'z'.repeat(4096)]));
+    expect(parseAttribution(hostile)).not.toBeNull();
   });
 
   it('takes the FIRST value of a repeated param', () => {
     // Last-wins would let an appended duplicate override the real campaign.
-    expect(parseAttribution({ utm_source: ['real', 'injected'] })).toEqual({ utm_source: 'real' });
+    expect(parseAttribution({ utm_source: ['real', 'injected'] })).toEqual({ utmSource: 'real' });
   });
 
   it('records referrer and landing path, which catch untagged in-product buttons', () => {
-    expect(parseAttribution({ referrer: 'https://app.dapta.ai/home', landing_path: '/admin' })).toEqual({
-      referrer: 'https://app.dapta.ai/home',
-      landing_path: '/admin',
+    expect(
+      parseAttribution({ referrer: 'https://app.example.com/home', landing_path: '/admin' }),
+    ).toEqual({
+      referrer: 'https://app.example.com/home',
+      landingPath: '/admin',
     });
-  });
-});
-
-describe('accountAttributionSchema — what the API accepts off the wire', () => {
-  it('strips unknown keys instead of rejecting the request', () => {
-    // No `.strict()` on purpose: a stranger appending `?password=…` should be
-    // ignored, not answered with a 400 that tells them the shape.
-    const parsed = accountAttributionSchema.parse({ utm_source: 'landing', password: 'hunter2' });
-    expect(parsed).toEqual({ utm_source: 'landing' });
-  });
-
-  it('rejects a value past the cap rather than truncating it server-side', () => {
-    const long = 'a'.repeat(ATTRIBUTION_VALUE_MAX + 1);
-    expect(accountAttributionSchema.safeParse({ utm_source: long }).success).toBe(false);
-    expect(accountAttributionSchema.safeParse({ utm_source: 'a'.repeat(ATTRIBUTION_VALUE_MAX) }).success).toBe(true);
-  });
-
-  it('accepts an empty object — the CALLER decides that is nothing to store', () => {
-    // The schema's job is shape, not policy. Refusing to spend the write-once
-    // claim on `{}` belongs to parseAttribution and to the route.
-    expect(accountAttributionSchema.safeParse({}).success).toBe(true);
-  });
-
-  it('ATTRIBUTION_KEYS is derived from the schema, so the two cannot drift', () => {
-    expect([...ATTRIBUTION_KEYS].sort()).toEqual(Object.keys(accountAttributionSchema.shape).sort());
   });
 });

--- a/apps/web/lib/attribution.spec.ts
+++ b/apps/web/lib/attribution.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Inbound acquisition context — the wire contract in @quill/types.
+ *
+ * Tested from here rather than from the types package: `packages/types` ships no
+ * test runner (its `test` script is a placeholder), and adding one would mean a
+ * new devDependency plus a lockfile change in a PR that should stay surgical.
+ * The web is the side that reads these tags off a real request, so this is the
+ * closest real consumer.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseAttribution, accountAttributionSchema, ATTRIBUTION_KEYS, ATTRIBUTION_VALUE_MAX } from '@quill/types';
+
+describe('parseAttribution — inbound acquisition context', () => {
+  it('keeps the UTM set and the paid-click ids', () => {
+    expect(
+      parseAttribution({
+        utm_source: 'landing',
+        utm_medium: 'cpc',
+        utm_campaign: 'launch',
+        utm_term: 'forms',
+        utm_content: 'hero',
+        gclid: 'abc123',
+        fbclid: 'xyz789',
+      }),
+    ).toEqual({
+      utm_source: 'landing',
+      utm_medium: 'cpc',
+      utm_campaign: 'launch',
+      utm_term: 'forms',
+      utm_content: 'hero',
+      gclid: 'abc123',
+      fbclid: 'xyz789',
+    });
+  });
+
+  it('drops any key not on the allowlist', () => {
+    // The payload is attacker-supplied — anyone can craft a link — and it lands
+    // in a JSONB column that later feeds a CRM. A copy-everything parser would
+    // let a stranger write their own keys into our analytics.
+    expect(parseAttribution({ utm_source: 'x', evil: 'drop me', password: 'hunter2' })).toEqual({
+      utm_source: 'x',
+    });
+  });
+
+  it('returns null when nothing is present, so first touch is not burned', () => {
+    // The column is write-once. Persisting `{}` on a direct visit would spend
+    // first touch and the real campaign could never be recorded afterwards.
+    expect(parseAttribution({})).toBeNull();
+    expect(parseAttribution({ utm_source: '', utm_medium: '   ' })).toBeNull();
+    expect(parseAttribution({ unrelated: 'value' })).toBeNull();
+  });
+
+  it('trims, and caps each value', () => {
+    const long = 'a'.repeat(ATTRIBUTION_VALUE_MAX + 50);
+    const out = parseAttribution({ utm_campaign: '  spaced  ', fbclid: long })!;
+    expect(out.utm_campaign).toBe('spaced');
+    expect(out.fbclid).toHaveLength(ATTRIBUTION_VALUE_MAX);
+  });
+
+  it('takes the FIRST value of a repeated param', () => {
+    // Last-wins would let an appended duplicate override the real campaign.
+    expect(parseAttribution({ utm_source: ['real', 'injected'] })).toEqual({ utm_source: 'real' });
+  });
+
+  it('records referrer and landing path, which catch untagged in-product buttons', () => {
+    expect(parseAttribution({ referrer: 'https://app.dapta.ai/home', landing_path: '/admin' })).toEqual({
+      referrer: 'https://app.dapta.ai/home',
+      landing_path: '/admin',
+    });
+  });
+});
+
+describe('accountAttributionSchema — what the API accepts off the wire', () => {
+  it('strips unknown keys instead of rejecting the request', () => {
+    // No `.strict()` on purpose: a stranger appending `?password=…` should be
+    // ignored, not answered with a 400 that tells them the shape.
+    const parsed = accountAttributionSchema.parse({ utm_source: 'landing', password: 'hunter2' });
+    expect(parsed).toEqual({ utm_source: 'landing' });
+  });
+
+  it('rejects a value past the cap rather than truncating it server-side', () => {
+    const long = 'a'.repeat(ATTRIBUTION_VALUE_MAX + 1);
+    expect(accountAttributionSchema.safeParse({ utm_source: long }).success).toBe(false);
+    expect(accountAttributionSchema.safeParse({ utm_source: 'a'.repeat(ATTRIBUTION_VALUE_MAX) }).success).toBe(true);
+  });
+
+  it('accepts an empty object — the CALLER decides that is nothing to store', () => {
+    // The schema's job is shape, not policy. Refusing to spend the write-once
+    // claim on `{}` belongs to parseAttribution and to the route.
+    expect(accountAttributionSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('ATTRIBUTION_KEYS is derived from the schema, so the two cannot drift', () => {
+    expect([...ATTRIBUTION_KEYS].sort()).toEqual(Object.keys(accountAttributionSchema.shape).sort());
+  });
+});

--- a/apps/web/lib/attribution.ts
+++ b/apps/web/lib/attribution.ts
@@ -1,0 +1,71 @@
+/**
+ * Hop 1 of carrying acquisition tags to the server: the root page reads them off
+ * the campaign URL and hands them to the login route.
+ *
+ * It lives here, apart from the page, because the page is a redirect and cannot be
+ * unit-tested — and this is the seam that already broke once. Emitting the PARSED
+ * (camelCase) shape instead of the wire (snake_case) one loses every `utm_*` tag
+ * while `gclid`/`fbclid` survive, because only those two keys are spelled the same
+ * in both. Nothing throws, no test fails, and the write-once claim is then spent
+ * on a half-empty blob: unrecoverable. `attribution.spec.ts` pins both hops.
+ */
+import { parseAttribution, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
+
+/**
+ * Forwarded values are capped here as well as at the far end. The inbound URL was
+ * already this long, but a redirect turns it into a `Location` header, and header
+ * limits are much smaller than URL limits.
+ */
+const FORWARD_MAX = 512;
+
+/**
+ * The referer, but only when it came from somewhere else.
+ *
+ * A SAME-ORIGIN referer is dropped: `account.attribution` is written once and
+ * never again, so recording "came from our own page" would spend first touch on a
+ * value that says nothing, and the real campaign could never be recorded.
+ */
+export function crossOriginReferer(
+  referer: string | null | undefined,
+  self: string | null,
+): string | undefined {
+  if (!referer) return undefined;
+  try {
+    return new URL(referer).host === self ? undefined : referer;
+  } catch {
+    // Not a URL at all — nothing worth attributing to.
+    return undefined;
+  }
+}
+
+/**
+ * The query string to hand `/api/auth/login`, or `''` when there is nothing to
+ * carry.
+ *
+ * `''` rather than an empty object is what keeps an untagged visit from spending
+ * the claim: no query means the login route sets no cookie, so the callback has
+ * nothing to POST.
+ */
+export function attributionHandoffQuery(
+  params: Readonly<Record<string, string | string[] | undefined>>,
+  referer: string | null | undefined,
+  self: string | null,
+): string {
+  const candidate: Record<string, string | string[] | undefined> = {
+    ...params,
+    referrer: crossOriginReferer(referer, self),
+  };
+
+  // Decide with the SAME parser the login route will use, so the two can never
+  // disagree about what counts as "nothing to carry".
+  if (!parseAttribution(candidate)) return '';
+
+  const qs = new URLSearchParams();
+  for (const key of ATTRIBUTION_QUERY_KEYS) {
+    const raw = candidate[key];
+    // First of a repeated param, matching the parser's first-wins rule.
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof value === 'string' && value.trim()) qs.set(key, value.trim().slice(0, FORWARD_MAX));
+  }
+  return qs.toString();
+}

--- a/apps/web/lib/request-origin.ts
+++ b/apps/web/lib/request-origin.ts
@@ -23,9 +23,29 @@ export function requestOrigin(req: NextRequest): string {
     }
   }
   const proto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
-  const host =
-    req.headers.get('x-forwarded-host')?.split(',')[0]?.trim() ||
-    req.headers.get('host')?.trim();
+  const host = selfHost((n) => req.headers.get(n));
   if (proto && host) return `${proto}://${host}`;
   return new URL(req.url).origin;
+}
+
+/**
+ * The host this deployment answers on, in the SAME trust order as `requestOrigin`:
+ * `PUBLIC_APP_URL` when configured, request headers only as a fallback for a
+ * self-host clone that has not set it.
+ *
+ * Takes a header getter rather than a `NextRequest` so a server component holding
+ * `headers()` can call it too. Exported so there is ONE implementation: a second
+ * copy is how a chained proxy's `x-forwarded-host: a.example, b.example` becomes a
+ * "host" that equals nothing, and every same-origin check silently inverts.
+ */
+export function selfHost(get: (name: string) => string | null | undefined): string | null {
+  const configured = process.env.PUBLIC_APP_URL?.trim();
+  if (configured) {
+    try {
+      return new URL(configured).host;
+    } catch {
+      // Same fall-through as above: a bad env var must not break the request.
+    }
+  }
+  return get('x-forwarded-host')?.split(',')[0]?.trim() || get('host')?.trim() || null;
 }

--- a/packages/db/src/milestones.spec.ts
+++ b/packages/db/src/milestones.spec.ts
@@ -177,7 +177,12 @@ describe('touchMemberLastSeen', () => {
   });
 });
 
-describe('claimAccountAttribution — first touch, once, ever', () => {
+describe('claimAccountAttribution — first touch, once, and only for a NEW account', () => {
+  // Seeded accounts are born at epoch-ms 1000, so `now` is passed explicitly:
+  // the claim is bounded by account AGE, and Date.now() would put these accounts
+  // decades outside the window. That is the behaviour under test, not a nuisance.
+  const JUST_BORN = 2000;
+
   async function storedAttribution(accountId: string): Promise<Record<string, string> | null> {
     const row = await db.get<{ attribution: unknown }>(
       sql`SELECT attribution FROM account WHERE id = ${accountId}`,
@@ -191,39 +196,61 @@ describe('claimAccountAttribution — first touch, once, ever', () => {
   }
 
   it('the first caller wins and the payload round-trips', async () => {
-    expect(await claimAccountAttribution(db, ACCOUNT, { utm_source: 'landing', utm_medium: 'cpc' })).toBe(true);
-    expect(await storedAttribution(ACCOUNT)).toEqual({ utm_source: 'landing', utm_medium: 'cpc' });
+    expect(
+      await claimAccountAttribution(db, ACCOUNT, { utmSource: 'landing', utmMedium: 'cpc' }, JUST_BORN),
+    ).toBe(true);
+    expect(await storedAttribution(ACCOUNT)).toEqual({ utmSource: 'landing', utmMedium: 'cpc' });
   });
 
   it('keeps FIRST touch, not last', async () => {
     // Overwriting would credit whichever link the customer clicked most recently
     // — usually an untagged direct return — and the paid campaign loses the
     // signup it paid for.
-    await claimAccountAttribution(db, ACCOUNT, { utm_source: 'google-ads' });
-    expect(await claimAccountAttribution(db, ACCOUNT, { utm_source: 'direct' })).toBe(false);
-    expect(await storedAttribution(ACCOUNT)).toEqual({ utm_source: 'google-ads' });
+    await claimAccountAttribution(db, ACCOUNT, { utmSource: 'google-ads' }, JUST_BORN);
+    expect(await claimAccountAttribution(db, ACCOUNT, { utmSource: 'direct' }, JUST_BORN)).toBe(false);
+    expect(await storedAttribution(ACCOUNT)).toEqual({ utmSource: 'google-ads' });
+  });
+
+  it('REFUSES an account older than the window, even though its column is NULL', async () => {
+    // The guard that matters most in production: every account that predates this
+    // feature has a NULL column. Without the age bound, the first tagged login by
+    // anyone — the owner of a year-old workspace clicking a campaign link, or an
+    // invited member just browsing — would permanently stamp that workspace as
+    // acquired by a campaign it predates. Write-once, so unrecoverable.
+    const wayLater = 1000 + 10 * 60_000 + 1;
+    expect(await claimAccountAttribution(db, ACCOUNT, { utmSource: 'landing' }, wayLater)).toBe(false);
+    expect(await storedAttribution(ACCOUNT)).toBeNull();
+  });
+
+  it('honours a caller-supplied window', async () => {
+    const wayLater = 1000 + 60 * 60_000;
+    expect(
+      await claimAccountAttribution(db, ACCOUNT, { utmSource: 'landing' }, wayLater, 2 * 60 * 60_000),
+    ).toBe(true);
   });
 
   it('CONCURRENT callers produce exactly one winner', async () => {
     // Only has teeth on POSTGRES (better-sqlite3 is synchronous, so Promise.all
     // serializes) — the Postgres parity job is where the row lock is exercised.
     const results = await Promise.all([
-      claimAccountAttribution(db, ACCOUNT, { utm_source: 'a' }),
-      claimAccountAttribution(db, ACCOUNT, { utm_source: 'b' }),
-      claimAccountAttribution(db, ACCOUNT, { utm_source: 'c' }),
+      claimAccountAttribution(db, ACCOUNT, { utmSource: 'a' }, JUST_BORN),
+      claimAccountAttribution(db, ACCOUNT, { utmSource: 'b' }, JUST_BORN),
+      claimAccountAttribution(db, ACCOUNT, { utmSource: 'c' }, JUST_BORN),
     ]);
     expect(results.filter(Boolean)).toHaveLength(1);
   });
 
   it('does not leak across accounts', async () => {
-    await claimAccountAttribution(db, ACCOUNT, { utm_source: 'landing' });
-    expect(await claimAccountAttribution(db, OTHER_ACCOUNT, { utm_source: 'other' })).toBe(true);
-    expect(await storedAttribution(OTHER_ACCOUNT)).toEqual({ utm_source: 'other' });
+    await claimAccountAttribution(db, ACCOUNT, { utmSource: 'landing' }, JUST_BORN);
+    expect(await claimAccountAttribution(db, OTHER_ACCOUNT, { utmSource: 'other' }, JUST_BORN)).toBe(
+      true,
+    );
+    expect(await storedAttribution(OTHER_ACCOUNT)).toEqual({ utmSource: 'other' });
   });
 
   it('is independent of the timestamp milestones on the same row', async () => {
-    await claimAccountActivation(db, ACCOUNT, 2000);
-    await claimAccountFirstView(db, ACCOUNT, 2000);
-    expect(await claimAccountAttribution(db, ACCOUNT, { utm_source: 'landing' })).toBe(true);
+    await claimAccountActivation(db, ACCOUNT, 1500);
+    await claimAccountFirstView(db, ACCOUNT, 1500);
+    expect(await claimAccountAttribution(db, ACCOUNT, { utmSource: 'landing' }, JUST_BORN)).toBe(true);
   });
 });

--- a/packages/db/src/milestones.spec.ts
+++ b/packages/db/src/milestones.spec.ts
@@ -10,6 +10,7 @@ import {
   claimAccountFirstView,
   getAccountOwner,
   touchMemberLastSeen,
+  claimAccountAttribution,
 } from './milestones';
 
 let db: Db;
@@ -173,5 +174,56 @@ describe('touchMemberLastSeen', () => {
     await touchMemberLastSeen(db, `m1_${ACCOUNT}`, 10_000);
     await touchMemberLastSeen(db, `m1_${ACCOUNT}`, 10_000 + 15 * 60_000 + 1);
     expect(await lastSeen(`m1_${ACCOUNT}`)).toBe(10_000 + 15 * 60_000 + 1);
+  });
+});
+
+describe('claimAccountAttribution — first touch, once, ever', () => {
+  async function storedAttribution(accountId: string): Promise<Record<string, string> | null> {
+    const row = await db.get<{ attribution: unknown }>(
+      sql`SELECT attribution FROM account WHERE id = ${accountId}`,
+    );
+    const raw = row?.attribution ?? null;
+    if (raw == null) return null;
+    // Postgres `jsonb` comes back parsed; SQLite stores the same value as TEXT
+    // and hands back the string. Same dual-dialect coercion the package applies
+    // to every other JSON column read.
+    return typeof raw === 'string' ? (JSON.parse(raw) as Record<string, string>) : (raw as Record<string, string>);
+  }
+
+  it('the first caller wins and the payload round-trips', async () => {
+    expect(await claimAccountAttribution(db, ACCOUNT, { utm_source: 'landing', utm_medium: 'cpc' })).toBe(true);
+    expect(await storedAttribution(ACCOUNT)).toEqual({ utm_source: 'landing', utm_medium: 'cpc' });
+  });
+
+  it('keeps FIRST touch, not last', async () => {
+    // Overwriting would credit whichever link the customer clicked most recently
+    // — usually an untagged direct return — and the paid campaign loses the
+    // signup it paid for.
+    await claimAccountAttribution(db, ACCOUNT, { utm_source: 'google-ads' });
+    expect(await claimAccountAttribution(db, ACCOUNT, { utm_source: 'direct' })).toBe(false);
+    expect(await storedAttribution(ACCOUNT)).toEqual({ utm_source: 'google-ads' });
+  });
+
+  it('CONCURRENT callers produce exactly one winner', async () => {
+    // Only has teeth on POSTGRES (better-sqlite3 is synchronous, so Promise.all
+    // serializes) — the Postgres parity job is where the row lock is exercised.
+    const results = await Promise.all([
+      claimAccountAttribution(db, ACCOUNT, { utm_source: 'a' }),
+      claimAccountAttribution(db, ACCOUNT, { utm_source: 'b' }),
+      claimAccountAttribution(db, ACCOUNT, { utm_source: 'c' }),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('does not leak across accounts', async () => {
+    await claimAccountAttribution(db, ACCOUNT, { utm_source: 'landing' });
+    expect(await claimAccountAttribution(db, OTHER_ACCOUNT, { utm_source: 'other' })).toBe(true);
+    expect(await storedAttribution(OTHER_ACCOUNT)).toEqual({ utm_source: 'other' });
+  });
+
+  it('is independent of the timestamp milestones on the same row', async () => {
+    await claimAccountActivation(db, ACCOUNT, 2000);
+    await claimAccountFirstView(db, ACCOUNT, 2000);
+    expect(await claimAccountAttribution(db, ACCOUNT, { utm_source: 'landing' })).toBe(true);
   });
 });

--- a/packages/db/src/milestones.ts
+++ b/packages/db/src/milestones.ts
@@ -14,6 +14,7 @@
  */
 import { sql } from 'drizzle-orm';
 import type { Db } from './client';
+import { jsonParam } from './forms';
 
 /**
  * Claim a write-once milestone on `account`, atomically.
@@ -135,4 +136,34 @@ export async function touchMemberLastSeen(
         WHERE id = ${memberId}
           AND (last_seen_at IS NULL OR last_seen_at < ${now - throttleMs})`,
   );
+}
+
+/**
+ * Claim FIRST-TOUCH ATTRIBUTION for an account: where it came from.
+ *
+ * Write-once for the same reason activation is, but the stakes are different:
+ * a timestamp can be recomputed from the rows it summarizes, while acquisition
+ * context exists only in the URL that brought the person here. Once that request
+ * is over it is gone. So this claim is not an optimization — it is the only
+ * chance to record the value at all.
+ *
+ * First touch, not last: overwriting on a later visit would credit whichever
+ * link the customer happened to click most recently (usually a direct return
+ * with no tags at all), which is how paid campaigns lose the signups they paid
+ * for. Callers must pass `null`-free payloads — `parseAttribution` returns null
+ * rather than `{}` precisely so an untagged direct visit cannot spend the claim.
+ */
+export async function claimAccountAttribution(
+  db: Db,
+  accountId: string,
+  attribution: Record<string, string>,
+): Promise<boolean> {
+  // `jsonParam` is the repo's dialect-neutral JSON bind (jsonb on Postgres,
+  // text on SQLite) — the same helper every other JSON column write uses.
+  const claimed = await db.get<{ id: string }>(
+    sql`UPDATE account SET attribution = ${jsonParam(attribution)}
+        WHERE id = ${accountId} AND attribution IS NULL
+        RETURNING id`,
+  );
+  return Boolean(claimed);
 }

--- a/packages/db/src/milestones.ts
+++ b/packages/db/src/milestones.ts
@@ -152,17 +152,30 @@ export async function touchMemberLastSeen(
  * with no tags at all), which is how paid campaigns lose the signups they paid
  * for. Callers must pass `null`-free payloads — `parseAttribution` returns null
  * rather than `{}` precisely so an untagged direct visit cannot spend the claim.
+ *
+ * `maxAccountAgeMs` is the second, load-bearing guard: NULL alone is not evidence
+ * of a new workspace. Every account that predates this feature has a NULL column,
+ * so without an age bound the first tagged login by anyone — the owner of a
+ * year-old workspace clicking a campaign link, or an invited member browsing —
+ * would permanently stamp that workspace as "acquired from" a campaign it
+ * predates. The window makes "first touch" mean the account's BIRTH, which is the
+ * discriminator `attributionSchema` already documents: an absent blob means "not
+ * known", and old-versus-new is told apart by `created_at`.
  */
 export async function claimAccountAttribution(
   db: Db,
   accountId: string,
   attribution: Record<string, string>,
+  now: number = Date.now(),
+  maxAccountAgeMs: number = 10 * 60_000,
 ): Promise<boolean> {
   // `jsonParam` is the repo's dialect-neutral JSON bind (jsonb on Postgres,
   // text on SQLite) — the same helper every other JSON column write uses.
   const claimed = await db.get<{ id: string }>(
     sql`UPDATE account SET attribution = ${jsonParam(attribution)}
-        WHERE id = ${accountId} AND attribution IS NULL
+        WHERE id = ${accountId}
+          AND attribution IS NULL
+          AND created_at > ${now - maxAccountAgeMs}
         RETURNING id`,
   );
   return Boolean(claimed);

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -17,7 +17,7 @@ export const account = pgTable('account', {
   vanitySlug: text('vanity_slug').unique(),
   daptaEntitlement: text('dapta_entitlement'),
   entitlementCheckedAt: bigint('entitlement_checked_at', { mode: 'number' }),
-  /** RESERVED — first-touch acquisition context; nothing writes it yet (see 0010). */
+  /** First-touch acquisition context (see 0010). Written once by `claimAccountAttribution`. */
   attribution: jsonb('attribution'),
   /** Milestone CLAIM: epoch-ms of the first completed submission. Written once, via UPDATE…WHERE IS NULL. */
   activatedAt: bigint('activated_at', { mode: 'number' }),

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -26,7 +26,7 @@ export const account = sqliteTable('account', {
   vanitySlug: text('vanity_slug').unique(),
   daptaEntitlement: text('dapta_entitlement'),
   entitlementCheckedAt: integer('entitlement_checked_at'),
-  /** RESERVED — first-touch acquisition context (TEXT JSON); nothing writes it yet (see 0010). */
+  /** First-touch acquisition context (TEXT JSON, see 0010). Written once by `claimAccountAttribution`. */
   attribution: text('attribution'),
   /** Milestone CLAIM: epoch-ms of the first completed submission. Written once, via UPDATE…WHERE IS NULL. */
   activatedAt: integer('activated_at'),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -792,7 +792,12 @@ export const attributionSchema = z.object({
   referrer: z.string().max(512).nullable().optional(),
   /** Path-only entry point (never the query string — it can carry PII). */
   landingPath: z.string().max(512).nullable().optional(),
-  /** Epoch-ms of that first visit, as the CLIENT clock reported it — may skew. */
+  /**
+   * RESERVED — epoch-ms of that first visit, as the CLIENT clock reported it.
+   * Structurally unwritable today: `ATTRIBUTION_QUERY_MAP` only carries the
+   * string-valued fields, so nothing can populate a number. Kept because the
+   * landing already computes it and a reader must keep parsing rows that have it.
+   */
   firstSeenAt: z.number().int().nonnegative().nullable().optional(),
 });
 export type Attribution = z.infer<typeof attributionSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1201,3 +1201,86 @@ export const apiErrorSchema = z.object({
   message: z.string(),
 });
 export type ApiError = z.infer<typeof apiErrorSchema>;
+
+/* ---------------------------------------------------------------------------
+ * Inbound acquisition context ("where did this workspace come from?").
+ *
+ * Lives here, not in @quill/shared: this is a WIRE CONTRACT. The web reads the
+ * tags off the first request and hands them to the API, which stores them on
+ * `account.attribution` exactly once. `@quill/shared` is dependency-free (no
+ * zod) and the API does not depend on it, so a shared parser there could not be
+ * validated on the receiving end.
+ *
+ * Why write-once matters for the shape: acquisition context exists only in the
+ * URL that brought the person here. A timestamp can be recomputed from the rows
+ * it summarizes; this cannot be recovered after the request ends.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Per-value cap. Real `fbclid`s run past 200 characters, so this is generous on
+ * purpose — but it IS a cap, because the payload lands in a JSONB column and an
+ * unbounded string is how one row becomes a megabyte.
+ */
+export const ATTRIBUTION_VALUE_MAX = 256;
+
+/**
+ * The ONLY keys ever stored, and the validator for the POST body.
+ *
+ * An allowlist rather than "copy every query param": anyone can craft a link, so
+ * this value is attacker-supplied, and it feeds a column that later feeds a CRM.
+ * zod's default behavior STRIPS unknown keys (no `.strict()` on purpose — a
+ * stranger appending `?password=…` should be ignored, not answered with a 400
+ * that tells them the shape).
+ *
+ * `gclid` / `fbclid` are the paid-click ids Google and Meta append; the existing
+ * Dapta booking links already carry them, and they are what reconciles a signup
+ * with a row of ad spend when UTMs alone are ambiguous.
+ */
+export const accountAttributionSchema = z.object({
+  utm_source: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  utm_medium: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  utm_campaign: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  utm_term: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  utm_content: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  gclid: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  fbclid: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  /** Where the browser came from. Catches in-product buttons that carry no UTM. */
+  referrer: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+  /** Path of the first page seen on this deployment, WITHOUT its query string. */
+  landing_path: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
+});
+export type AccountAttribution = z.infer<typeof accountAttributionSchema>;
+
+/**
+ * Derived from the schema, never hand-maintained: a second literal list would
+ * drift from the validator the first time someone adds a key to one of them.
+ */
+export const ATTRIBUTION_KEYS = Object.keys(
+  accountAttributionSchema.shape,
+) as ReadonlyArray<keyof AccountAttribution>;
+
+/**
+ * Normalize inbound query params into the stored shape, or `null` when there is
+ * nothing worth storing.
+ *
+ * Returning `null` for "no keys present" is load-bearing: the column is
+ * write-once, so persisting `{}` for an untagged direct visit would SPEND first
+ * touch, and the real campaign could never be recorded afterwards.
+ */
+export function parseAttribution(
+  params: Readonly<Record<string, string | string[] | undefined | null>>,
+): AccountAttribution | null {
+  const out: Record<string, string> = {};
+  for (const key of ATTRIBUTION_KEYS) {
+    const raw = params[key];
+    // A repeated param (`?utm_source=a&utm_source=b`) arrives as an array. Take
+    // the FIRST: last-wins would let an appended duplicate override the real one.
+    const value = (Array.isArray(raw) ? raw[0] : raw) ?? '';
+    const trimmed = String(value).trim();
+    if (!trimmed) continue;
+    out[key] = trimmed.slice(0, ATTRIBUTION_VALUE_MAX);
+  }
+  const parsed = accountAttributionSchema.safeParse(out);
+  if (!parsed.success) return null;
+  return Object.keys(parsed.data).length > 0 ? parsed.data : null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1228,9 +1228,19 @@ export type ApiError = z.infer<typeof apiErrorSchema>;
  *
  * The cap is applied by TRUNCATING before validation, not by letting zod reject:
  * a single over-long value (a hostile URL, or just a very long `fbclid`) would
- * otherwise fail the whole parse and discard the campaign along with it.
- * `attribution-caps` in the spec asserts these stay in step with the schema.
+ * otherwise fail the whole parse and discard the campaign along with it. The spec
+ * case "never returns null because a value was too long" pins that.
  */
+/**
+ * Only the STRING-valued fields can appear in the map. `attributionSchema` also
+ * has the numeric `firstSeenAt`, and the loop below assigns a string — mapping it
+ * would make `safeParse` fail and silently drop the ENTIRE payload. The compiler
+ * refuses it instead.
+ */
+type AttributionStringKey = {
+  [K in keyof Attribution]-?: NonNullable<Attribution[K]> extends string ? K : never;
+}[keyof Attribution];
+
 const ATTRIBUTION_QUERY_MAP = [
   ['utm_source', 'utmSource', 128],
   ['utm_medium', 'utmMedium', 128],
@@ -1241,7 +1251,7 @@ const ATTRIBUTION_QUERY_MAP = [
   ['fbclid', 'fbclid', 512],
   ['referrer', 'referrer', 512],
   ['landing_path', 'landingPath', 512],
-] as const satisfies ReadonlyArray<readonly [string, keyof Attribution, number]>;
+] as const satisfies ReadonlyArray<readonly [string, AttributionStringKey, number]>;
 
 /** The query parameters this product reads. Everything else is ignored. */
 export const ATTRIBUTION_QUERY_KEYS: ReadonlyArray<string> = ATTRIBUTION_QUERY_MAP.map(([q]) => q);
@@ -1274,4 +1284,22 @@ export function parseAttribution(
   if (Object.keys(out).length === 0) return null;
   const parsed = attributionSchema.safeParse(out);
   return parsed.success ? parsed.data : null;
+}
+
+/**
+ * The stored blob re-keyed to snake_case, for the product-analytics wire.
+ *
+ * The column stores camelCase, but every other property this product sends is
+ * snake_case (`form_id`, `is_first_publish`), and the analytics project is shared
+ * with the rest of the Dapta estate — property naming there is a cross-product
+ * contract, not a local style choice. Non-string values are dropped, so a numeric
+ * field can never arrive where a tag is expected.
+ */
+export function attributionEventProps(attribution: Attribution): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [queryKey, field] of ATTRIBUTION_QUERY_MAP) {
+    const value = attribution[field];
+    if (typeof value === 'string' && value) out[queryKey] = value;
+  }
+  return out;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -752,11 +752,15 @@ export type FormTracking = z.infer<typeof formTrackingSchema>;
  * FIRST-TOUCH acquisition context for an account — what the browser saw the
  * very first time this visitor arrived, on the landing or the app.
  *
- * RESERVED: nothing in this repo writes it yet. The landing already captures
- * this shape and forwards it on the CTA as query parameters; the server-side
- * writer that persists it to `account.attribution` (migration 0010) lands with
- * the signup form. Defined here first so both ends agree on the shape before
- * either is built — and so the column is never populated ad hoc.
+ * The landing captures this shape and forwards it on the CTA as query
+ * parameters — in snake_case, the URL convention (`utm_source`), which
+ * `parseAttribution` below maps onto these camelCase field names. The web parks
+ * the result across the login round-trip and the API persists it to
+ * `account.attribution` (migration 0010) with a write-once claim.
+ *
+ * ONE shape for the column, deliberately: a second schema would let a writer
+ * store keys the documented reader strips, and the mismatch would be silent —
+ * `parse` returns `{}` for unknown keys rather than throwing.
  *
  * FIRST touch, never last: the values are written on the first visit and never
  * overwritten, so a user who arrives from an ad, leaves, and returns via a
@@ -776,6 +780,14 @@ export const attributionSchema = z.object({
   utmCampaign: z.string().max(128).nullable().optional(),
   utmContent: z.string().max(128).nullable().optional(),
   utmTerm: z.string().max(128).nullable().optional(),
+  /**
+   * Paid-click ids Google and Meta append to an ad destination. They reconcile a
+   * signup with a row of ad spend when the UTM set alone is ambiguous, and the
+   * existing Dapta booking links already carry them. Longer cap: a real `fbclid`
+   * runs well past 200 characters.
+   */
+  gclid: z.string().max(512).nullable().optional(),
+  fbclid: z.string().max(512).nullable().optional(),
   /** `document.referrer` as the browser reported it; '' (blank) is normalized to null. */
   referrer: z.string().max(512).nullable().optional(),
   /** Path-only entry point (never the query string — it can carry PII). */
@@ -1203,84 +1215,63 @@ export const apiErrorSchema = z.object({
 export type ApiError = z.infer<typeof apiErrorSchema>;
 
 /* ---------------------------------------------------------------------------
- * Inbound acquisition context ("where did this workspace come from?").
+ * Reading the inbound tags off a request.
  *
- * Lives here, not in @quill/shared: this is a WIRE CONTRACT. The web reads the
- * tags off the first request and hands them to the API, which stores them on
- * `account.attribution` exactly once. `@quill/shared` is dependency-free (no
- * zod) and the API does not depend on it, so a shared parser there could not be
- * validated on the receiving end.
- *
- * Why write-once matters for the shape: acquisition context exists only in the
- * URL that brought the person here. A timestamp can be recomputed from the rows
- * it summarizes; this cannot be recovered after the request ends.
+ * The wire format is snake_case because that is the URL convention every ad
+ * platform emits (`utm_source`, `gclid`). The STORED format is `attributionSchema`
+ * above. This is the one place the two are mapped, so neither side has to know
+ * about the other's casing.
  * ------------------------------------------------------------------------- */
 
 /**
- * Per-value cap. Real `fbclid`s run past 200 characters, so this is generous on
- * purpose — but it IS a cap, because the payload lands in a JSONB column and an
- * unbounded string is how one row becomes a megabyte.
- */
-export const ATTRIBUTION_VALUE_MAX = 256;
-
-/**
- * The ONLY keys ever stored, and the validator for the POST body.
+ * Inbound query key -> stored field, with the cap that field allows.
  *
- * An allowlist rather than "copy every query param": anyone can craft a link, so
- * this value is attacker-supplied, and it feeds a column that later feeds a CRM.
- * zod's default behavior STRIPS unknown keys (no `.strict()` on purpose — a
- * stranger appending `?password=…` should be ignored, not answered with a 400
- * that tells them the shape).
- *
- * `gclid` / `fbclid` are the paid-click ids Google and Meta append; the existing
- * Dapta booking links already carry them, and they are what reconciles a signup
- * with a row of ad spend when UTMs alone are ambiguous.
+ * The cap is applied by TRUNCATING before validation, not by letting zod reject:
+ * a single over-long value (a hostile URL, or just a very long `fbclid`) would
+ * otherwise fail the whole parse and discard the campaign along with it.
+ * `attribution-caps` in the spec asserts these stay in step with the schema.
  */
-export const accountAttributionSchema = z.object({
-  utm_source: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  utm_medium: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  utm_campaign: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  utm_term: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  utm_content: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  gclid: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  fbclid: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  /** Where the browser came from. Catches in-product buttons that carry no UTM. */
-  referrer: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-  /** Path of the first page seen on this deployment, WITHOUT its query string. */
-  landing_path: z.string().trim().min(1).max(ATTRIBUTION_VALUE_MAX).optional(),
-});
-export type AccountAttribution = z.infer<typeof accountAttributionSchema>;
+const ATTRIBUTION_QUERY_MAP = [
+  ['utm_source', 'utmSource', 128],
+  ['utm_medium', 'utmMedium', 128],
+  ['utm_campaign', 'utmCampaign', 128],
+  ['utm_content', 'utmContent', 128],
+  ['utm_term', 'utmTerm', 128],
+  ['gclid', 'gclid', 512],
+  ['fbclid', 'fbclid', 512],
+  ['referrer', 'referrer', 512],
+  ['landing_path', 'landingPath', 512],
+] as const satisfies ReadonlyArray<readonly [string, keyof Attribution, number]>;
 
-/**
- * Derived from the schema, never hand-maintained: a second literal list would
- * drift from the validator the first time someone adds a key to one of them.
- */
-export const ATTRIBUTION_KEYS = Object.keys(
-  accountAttributionSchema.shape,
-) as ReadonlyArray<keyof AccountAttribution>;
+/** The query parameters this product reads. Everything else is ignored. */
+export const ATTRIBUTION_QUERY_KEYS: ReadonlyArray<string> = ATTRIBUTION_QUERY_MAP.map(([q]) => q);
 
 /**
  * Normalize inbound query params into the stored shape, or `null` when there is
  * nothing worth storing.
  *
- * Returning `null` for "no keys present" is load-bearing: the column is
- * write-once, so persisting `{}` for an untagged direct visit would SPEND first
- * touch, and the real campaign could never be recorded afterwards.
+ * Returning `null` for "no keys present" is load-bearing: the column is written
+ * once and never again, so persisting `{}` for an untagged direct visit would
+ * SPEND first touch and the real campaign could never be recorded afterwards.
+ *
+ * An allowlist rather than "copy every query param": anyone can craft a link, so
+ * this input is attacker-supplied, and it lands in a column that later feeds a
+ * CRM. Nothing here is ever used for authorization or rendered as markup.
  */
 export function parseAttribution(
   params: Readonly<Record<string, string | string[] | undefined | null>>,
-): AccountAttribution | null {
+): Attribution | null {
   const out: Record<string, string> = {};
-  for (const key of ATTRIBUTION_KEYS) {
-    const raw = params[key];
+  for (const [queryKey, field, cap] of ATTRIBUTION_QUERY_MAP) {
+    const raw = params[queryKey];
     // A repeated param (`?utm_source=a&utm_source=b`) arrives as an array. Take
     // the FIRST: last-wins would let an appended duplicate override the real one.
     const value = (Array.isArray(raw) ? raw[0] : raw) ?? '';
     const trimmed = String(value).trim();
     if (!trimmed) continue;
-    out[key] = trimmed.slice(0, ATTRIBUTION_VALUE_MAX);
+    out[field] = trimmed.slice(0, cap);
   }
-  const parsed = accountAttributionSchema.safeParse(out);
-  if (!parsed.success) return null;
-  return Object.keys(parsed.data).length > 0 ? parsed.data : null;
+  if (Object.keys(out).length === 0) return null;
+  const parsed = attributionSchema.safeParse(out);
+  return parsed.success ? parsed.data : null;
 }


### PR DESCRIPTION
## La idea, en una frase

Hoy sabemos **cuántas** cuentas se registran. Después de esto sabemos **de dónde vienen**.

## El problema

Alguien ve un anuncio, entra a `daptaforms.ai`, hace clic en "Empezar gratis" y se registra. Ese clic trae pegada la información de la campaña en la dirección — de qué anuncio vino, de qué medio, de qué pieza.

Pero para registrarse hay que pasar por el login, y ese salto sale de nuestro dominio y vuelve. En el camino la dirección se limpia y **esa información se pierde**. Cada registro terminaba pareciendo que apareció de la nada.

La columna donde debía guardarse ya existía desde hace un mes, marcada como reservada. Nadie la escribía.

## Qué cambia

La información de campaña se guarda **en el momento en que llega**, se lleva de la mano a través del login, y se escribe en la cuenta apenas nace. Una sola vez.

**Primer toque, no último.** Si la persona llega por un anuncio, se va, y vuelve una semana después escribiendo la dirección a mano, el crédito sigue siendo del anuncio. Sobrescribir con la visita más reciente es exactamente cómo las campañas pagadas pierden los registros que pagaron.

**Solo para cuentas recién nacidas.** Una cuenta que existe desde hace seis meses no se "adquirió" hoy porque su dueño hizo clic en un link de campaña. Sin ese límite, el primer clic de un cliente antiguo habría marcado su workspace para siempre con una campaña que ni existía cuando se registró.

## Qué se puede responder ahora

- ¿Cuántos registros vinieron de la landing, de Google Ads, de un botón dentro de la plataforma?
- ¿Qué campaña trae gente que además **activa** — que publica un formulario y recibe respuestas — y qué campaña trae gente que se va?
- Más adelante, esta es la información que ventas necesita en HubSpot.

En PostHog aparece como un evento nuevo, así que el embudo de activación se puede abrir por origen.

## Qué NO cambia

- Nadie que ya tenga cuenta ve nada distinto.
- Si el login falla, el registro no. Esta parte es un observador: nunca bloquea, nunca hace fallar una sesión, y si la API no responde se reintenta en el próximo ingreso.
- Un fork del proyecto sin nada configurado sigue funcionando igual — todo esto está detrás del proveedor de identidad, que un fork no tiene.
- No hay migración de base de datos. La columna ya estaba.

## Sobre los datos

Solo se guardan las etiquetas de campaña de la dirección, de una lista cerrada y con largo limitado. Cualquiera puede fabricar un link, así que se trata como entrada no confiable: nada de lo que llega ahí se usa para permisos ni se muestra como HTML. La cuenta a la que se escribe sale siempre de la sesión, nunca de lo que manda el navegador.

## Revisión

Tres rondas del `forms-reviewer`. Encontró y se arreglaron: un segundo esquema para la misma columna que habría hecho que el lector documentado devolviera vacío; el límite de edad de cuenta que faltaba; un host interno en un archivo de prueba que rompía el escaneo de secretos; y el salto sin test que ya se había roto una vez durante el desarrollo — ahora tiene un caso que falla si se reintroduce.

Suite completa verde, paridad de Postgres verde, lint y tipos verdes.