### PR TITLE
feat(onboarding): first-run wizard that builds the account's first form

### DIFF
--- a/.changeset/first-run-onboarding.md
+++ b/.changeset/first-run-onboarding.md
@@ -1,0 +1,28 @@
+---
+'@quill/types': minor
+'@quill/db': minor
+'@quill/shared': minor
+'@quill/config': minor
+---
+
+First-run onboarding wizard, behind `ONBOARDING_WIZARD` (default off).
+
+A brand-new workspace is asked three questions — role, industry, and what they
+want to use Forms for — and then picks the template its first form is built from,
+replacing the demo form that used to be seeded for everyone. The two are mutually
+exclusive by construction: the seed only writes into an account with zero forms,
+so `ONBOARDING_WIZARD` suppresses it rather than relying on operators to switch
+both correctly.
+
+- `@quill/types`: `accountOnboardingSchema` and the answer enums, the template id
+  union, and the use-case → template mapping.
+- `@quill/db`: migration 0011 (`account.onboarding`, `account.onboarding_completed_at`,
+  backfilled so accounts that predate the wizard are never sent through it), the
+  progress/claim repository, and four form templates.
+- `@quill/shared`: `admin.onboarding.*` copy in English and Spanish.
+- `@quill/config`: the `ONBOARDING_WIZARD` flag.
+
+Progress is written on every step advance, not only at completion, so an
+abandoned onboarding leaves a record — `account.onboarding.lastStep` joins to the
+first-touch tags already on `account.attribution`, which makes drop-off per
+campaign a single query.

--- a/.env.example
+++ b/.env.example
@@ -175,6 +175,17 @@ MAIL_FROM_NAME=Forms
 # (log-only degradation). Never sent to the browser.
 # CALENDLY_API_TOKEN=
 
+# --- First-run onboarding ---------------------------------------------------
+# SEED_DEMO_FORM (default true) auto-seeds one polished demo form into every
+# brand-new account so the admin is never empty.
+# SEED_DEMO_FORM=true
+#
+# ONBOARDING_WIZARD (default false) replaces that with a first-run wizard: three
+# qualifying questions, then the person picks the template their first form is
+# built from. Turning it ON SUPPRESSES the demo seed — the seed only writes into
+# an account with zero forms, so a seeded demo would block the wizard's own form.
+# ONBOARDING_WIZARD=false
+
 # --- Premium entitlements (vanity slug; Forms itself is always free) --------
 # open (default) -> every feature unlocked (a bare OSS fork gets everything).
 # locked         -> premium gates on the upstream entitlement service below.

--- a/.env.example
+++ b/.env.example
@@ -180,11 +180,12 @@ MAIL_FROM_NAME=Forms
 # brand-new account so the admin is never empty.
 # SEED_DEMO_FORM=true
 #
-# ONBOARDING_WIZARD (default false) replaces that with a first-run wizard: three
+# ONBOARDING_WIZARD (default true) replaces that with a first-run wizard: three
 # qualifying questions, then the person picks the template their first form is
-# built from. Turning it ON SUPPRESSES the demo seed — the seed only writes into
+# built from. While ON it SUPPRESSES the demo seed — the seed only writes into
 # an account with zero forms, so a seeded demo would block the wizard's own form.
-# ONBOARDING_WIZARD=false
+# Set to false to opt out (kill switch / forks that want the demo seed instead).
+# ONBOARDING_WIZARD=true
 
 # --- Premium entitlements (vanity slug; Forms itself is always free) --------
 # open (default) -> every feature unlocked (a bare OSS fork gets everything).

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -62,6 +62,8 @@ import {
   memberPatchSchema,
   notificationSettingPatchSchema,
   memberProfileSchema,
+  onboardingCompleteSchema,
+  onboardingProgressSchema,
 } from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
@@ -191,6 +193,71 @@ export class AdminCrudController {
       );
     }
     return { recorded: first };
+  }
+
+  // --- Onboarding (first-run wizard) ---------------------------------------
+
+  /**
+   * Record one screen's worth of onboarding progress.
+   *
+   * Called on EVERY advance, not just at the end, because a person who quits
+   * halfway is the one the funnel is actually about — and they never reach the
+   * end to be recorded. `accountId` comes from the principal, never the body.
+   *
+   * Admin-gated like every workspace-level write here: onboarding describes the
+   * WORKSPACE, so an invited member must not be able to rewrite the owner's
+   * answers. The intended caller is a brand-new account whose only member IS the
+   * owner, so the happy path is untouched.
+   *
+   * Never throws on a bad payload. This runs behind a wizard the person cannot
+   * skip; a 400 there is a dead end with no recovery, and losing one screen's
+   * telemetry is strictly better than that. An unparseable body is reported as
+   * `{ saved: false }` and the wizard carries on.
+   */
+  @Patch('account/onboarding')
+  async saveOnboarding(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    const parsed = onboardingProgressSchema.safeParse(body ?? {});
+    if (!parsed.success) return { saved: false, onboarding: null };
+    const onboarding = await this.admin.saveOnboarding(p, parsed.data);
+    return { saved: onboarding != null, onboarding };
+  }
+
+  /**
+   * Finish the wizard: claim completion and create the first form from the
+   * chosen template.
+   *
+   * `completed` is true ONLY for the caller whose claim won. A double-click or a
+   * retried request gets `completed: false` with the winner's `formId`, so both
+   * land on the same form and the account never ends up with two "first" ones.
+   * Anything counting onboarding conversions must read this flag, not infer it
+   * from a 200.
+   *
+   * A bad template id is a 400 here rather than a silent fallback: the person
+   * PICKED something, and quietly building them a different form than the one
+   * they chose is worse than telling them to pick again.
+   */
+  @Post('account/onboarding/complete')
+  async completeOnboarding(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    const parsed = onboardingCompleteSchema.safeParse(body ?? {});
+    if (!parsed.success) {
+      throw new BadRequestException({ error: 'INVALID_TEMPLATE', message: 'Unknown template.' });
+    }
+
+    const result = await this.admin.completeOnboarding(p, parsed.data.template);
+    if (result.completed && this.productAnalytics?.enabled) {
+      // Emitted server-side, from the CLAIM's winner, so the completion count is
+      // the count of accounts that finished — not of browsers that reached the
+      // last screen, which double-counts a retry and misses a closed tab.
+      await this.productAnalytics.captureForMember('onboarding_completed', p, {
+        template: parsed.data.template,
+        form_id: result.formId,
+      });
+    }
+    return result;
   }
 
   /**

--- a/apps/api/src/admin.service.ts
+++ b/apps/api/src/admin.service.ts
@@ -1,10 +1,21 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import type { Db } from '@quill/db';
-import { cacheEntitlement, getMe, setVanitySlug, sql, type VanityOutcome } from '@quill/db';
+import {
+  cacheEntitlement,
+  claimOnboardingComplete,
+  createForm,
+  getFormTemplate,
+  getMe,
+  saveOnboardingProgress,
+  setVanitySlug,
+  sql,
+  type VanityOutcome,
+} from '@quill/db';
 import { canClaimVanitySlug } from '@quill/engine';
+import type { FormTemplateId, OnboardingProgressInput } from '@quill/types';
 import type { HostPrincipal } from './auth.service';
 import { DisabledEntitlementsProvider, type EntitlementsProvider } from './entitlements.provider';
-import { DB, ENTITLEMENTS, PREMIUM_MODE } from './tokens';
+import { DB, ENTITLEMENTS, ONBOARDING_ENABLED, PREMIUM_MODE } from './tokens';
 
 /** How long a cached Dapta AI entitlement verdict stays fresh before re-asking upstream. */
 const ENTITLEMENT_TTL_MS = 6 * 3600_000;
@@ -20,10 +31,88 @@ export class AdminService {
     @Inject(ENTITLEMENTS)
     private readonly entitlements: EntitlementsProvider = new DisabledEntitlementsProvider(),
     @Optional() @Inject(PREMIUM_MODE) private readonly premiumMode: 'open' | 'locked' = 'open',
+    // Whether the first-run wizard is switched on for this deployment. Optional
+    // + default false so every direct construction (tests, forks) behaves as it
+    // did before the feature existed.
+    @Optional() @Inject(ONBOARDING_ENABLED) private readonly onboardingEnabled: boolean = false,
   ) {}
 
-  me(p: HostPrincipal) {
-    return getMe(this.db, p.accountId, p.memberId);
+  /**
+   * The caller's identity, plus `onboardingRequired`.
+   *
+   * That flag is computed HERE, not in the web app, and that is the point: the
+   * dashboard must not carry its own copy of the feature switch. If it did, an
+   * environment with the flag on in the web and off in the API would bounce
+   * every user into a wizard whose endpoints refuse to serve it — a login loop
+   * with no way out. One authority, one answer.
+   */
+  async me(p: HostPrincipal) {
+    const view = await getMe(this.db, p.accountId, p.memberId);
+    if (!view) return view;
+    return {
+      ...view,
+      onboardingRequired: this.onboardingEnabled && view.onboardingCompletedAt == null,
+    };
+  }
+
+  // --- Onboarding (first-run wizard) ---------------------------------------
+
+  /**
+   * Record one screen's worth of progress.
+   *
+   * Returns null when the wizard is off, the account is gone, or its onboarding
+   * is already complete — every one of which the caller reports the same way,
+   * because none of them is an error the person can act on. A stale tab patching
+   * a finished onboarding is normal, not a fault.
+   */
+  async saveOnboarding(p: HostPrincipal, patch: OnboardingProgressInput) {
+    if (!this.onboardingEnabled) return null;
+    return saveOnboardingProgress(this.db, p.accountId, patch);
+  }
+
+  /**
+   * Finish the wizard: claim completion and create the account's first form from
+   * the chosen template.
+   *
+   * Order matters and is not interchangeable. The CLAIM runs first, and only its
+   * winner creates a form. Creating first would mean a double-submit produced two
+   * "first" forms — the exact mess the demo-form seed's idempotence was written
+   * to avoid, reintroduced on the one screen every new user passes through.
+   *
+   * The template id is resolved to a config HERE, from a server-side registry, so
+   * the request body can only ever name a starting point — never supply one.
+   */
+  async completeOnboarding(
+    p: HostPrincipal,
+    templateId: FormTemplateId,
+  ): Promise<{ completed: boolean; formId: string | null }> {
+    if (!this.onboardingEnabled) return { completed: false, formId: null };
+
+    const template = getFormTemplate(templateId);
+    if (!template) return { completed: false, formId: null };
+
+    const won = await claimOnboardingComplete(this.db, p.accountId, templateId);
+    if (!won) {
+      // A loser must not create a second form. It still needs somewhere to send
+      // the person, so hand back the form the WINNER made (the account's first).
+      const existing = await this.db.get<{ id: string }>(
+        sql`SELECT id FROM form WHERE account_id = ${p.accountId}
+            ORDER BY created_at ASC LIMIT 1`,
+      );
+      return { completed: false, formId: existing?.id ?? null };
+    }
+
+    const created = await createForm(
+      this.db,
+      p.accountId,
+      { name: template.name, ...(template.config ? { config: template.config } : {}) },
+      p.memberId,
+    );
+    // A failed create must NOT un-claim the completion: the person answered the
+    // questions and those answers are stored. Sending them back through the
+    // wizard to re-answer would lose the thing we actually wanted. They land on
+    // an empty dashboard instead, where "New form" is the obvious next click.
+    return { completed: true, formId: created.ok ? created.value.id : null };
   }
 
   // --- Vanity slug (premium — included with the Dapta AI subscription) ------

--- a/apps/api/src/analytics-events.spec.ts
+++ b/apps/api/src/analytics-events.spec.ts
@@ -41,6 +41,7 @@ const LOCAL_ENV = {
   DEV_LOGIN_EMAIL: undefined,
   AUTH_LOCAL_STRICT: undefined,
   SEED_DEMO_FORM: false,
+  ONBOARDING_WIZARD: false,
 } as never;
 
 /** Same env, cast once so the provider factory's ServerEnv shape is satisfied. */

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,7 +2,17 @@ import { Module } from '@nestjs/common';
 import { createDb } from '@quill/db';
 import { createEmailProvider, SubmissionNotifier, type EmailProvider } from '@quill/notifications';
 import { loadServerEnv, type ServerEnv } from '@quill/config/env';
-import { AUTH_PROVIDER, DB, EMAIL, ENTITLEMENTS, ENV, NOTIFIER, PREMIUM_MODE, RATE_LIMITER } from './tokens';
+import {
+  AUTH_PROVIDER,
+  DB,
+  EMAIL,
+  ENTITLEMENTS,
+  ENV,
+  NOTIFIER,
+  ONBOARDING_ENABLED,
+  PREMIUM_MODE,
+  RATE_LIMITER,
+} from './tokens';
 import { SubmissionService } from './submission.service';
 import { AdminService } from './admin.service';
 import { AuthService } from './auth.service';
@@ -80,6 +90,15 @@ import {
     // disabled provider + PREMIUM_FEATURES=open (everything unlocked).
     { provide: ENTITLEMENTS, useFactory: (env: ServerEnv) => resolveEntitlementsProvider(env), inject: [ENV] },
     { provide: PREMIUM_MODE, useFactory: (env: ServerEnv) => env.PREMIUM_FEATURES, inject: [ENV] },
+    // The first-run wizard's switch, resolved ONCE and injected, so the API is
+    // the single authority on whether onboarding is required. The web app reads
+    // the answer off `/v1/me` rather than keeping its own copy of the flag —
+    // two copies that disagree would strand every user in a redirect loop.
+    {
+      provide: ONBOARDING_ENABLED,
+      useFactory: (env: ServerEnv) => env.ONBOARDING_WIZARD,
+      inject: [ENV],
+    },
     // Host auth backend selected by AUTH_PROVIDER (local stub / WorkOS overlay).
     {
       provide: AUTH_PROVIDER,

--- a/apps/api/src/auth.provider.ts
+++ b/apps/api/src/auth.provider.ts
@@ -77,6 +77,9 @@ export function header(req: ReqLike, name: string): string | undefined {
   return Array.isArray(v) ? v[0] : v;
 }
 
+/** The two switches that decide whether a new account gets a demo form. */
+export type SeedDemoEnv = Pick<ServerEnv, 'SEED_DEMO_FORM' | 'ONBOARDING_WIZARD'>;
+
 /**
  * Best-effort demo-form seed, shared by every AuthProvider that JIT-creates a
  * new account+owner. Gated by `SEED_DEMO_FORM` (env, default ON) and idempotent
@@ -84,14 +87,25 @@ export function header(req: ReqLike, name: string): string | undefined {
  * forms), so a repeat login never duplicates it. Seeding NEVER fails a login: a
  * DB error here is logged and swallowed — the user still lands in their (empty)
  * workspace rather than being locked out over a cosmetic sample.
+ *
+ * `ONBOARDING_WIZARD` SUPPRESSES it, and the rule lives here rather than at each
+ * call site so the two features cannot be switched on together by accident. The
+ * conflict is structural: the seed only writes into an account with zero forms,
+ * so a demo seeded at first login makes the account non-empty and the form the
+ * wizard is supposed to create — the one the person chose a template for — is
+ * silently never made.
+ *
+ * Suppressing it is also what makes abandonment MEASURABLE. With the wizard on,
+ * someone who quits partway is left with zero forms, and that is a fact the
+ * funnel can see; with a demo seeded for everyone, the state is invisible.
  */
 export async function maybeSeedDemoForm(
   db: Db,
   accountId: string,
-  enabled: boolean,
+  env: SeedDemoEnv,
   log: Logger,
 ): Promise<void> {
-  if (!enabled) return;
+  if (!env.SEED_DEMO_FORM || env.ONBOARDING_WIZARD) return;
   try {
     const form = await seedDemoFormForAccount(db, accountId);
     if (form) log.log(`Seeded demo form ${form.id} for new account ${accountId}`);
@@ -147,7 +161,7 @@ export class LocalAuthProvider implements AuthProvider {
     private readonly db: Db,
     private readonly env: Pick<
       ServerEnv,
-      'NODE_ENV' | 'DEV_LOGIN_EMAIL' | 'AUTH_LOCAL_STRICT' | 'SEED_DEMO_FORM'
+      'NODE_ENV' | 'DEV_LOGIN_EMAIL' | 'AUTH_LOCAL_STRICT' | 'SEED_DEMO_FORM' | 'ONBOARDING_WIZARD'
     >,
     /** Optional; omitted means nothing observes signups (the fork default). */
     private readonly onSignup?: SignupObserver,
@@ -223,7 +237,7 @@ export class LocalAuthProvider implements AuthProvider {
     // A fresh account (its first member is the owner) gets the polished demo form
     // so the dashboard is never empty. Idempotent + best-effort (never blocks login).
     if (role === 'owner') {
-      await maybeSeedDemoForm(this.db, account.id, this.env.SEED_DEMO_FORM, this.log);
+      await maybeSeedDemoForm(this.db, account.id, this.env, this.log);
     }
     // Fires only on the JIT path — every early return above is an EXISTING
     // member signing in again, which is not a signup.

--- a/apps/api/src/auth.provider.workos.ts
+++ b/apps/api/src/auth.provider.workos.ts
@@ -34,7 +34,10 @@ import {
 } from './auth.provider';
 import { verifyJwtHs256, JwtError, type JwtClaims } from './jwt';
 
-type WorkOsEnv = Pick<ServerEnv, 'JWT_SECRET' | 'JWT_ISSUER' | 'JWT_AUDIENCE' | 'SEED_DEMO_FORM'>;
+type WorkOsEnv = Pick<
+  ServerEnv,
+  'JWT_SECRET' | 'JWT_ISSUER' | 'JWT_AUDIENCE' | 'SEED_DEMO_FORM' | 'ONBOARDING_WIZARD'
+>;
 
 function unauthenticated(message: string): UnauthorizedException {
   return new UnauthorizedException({ error: 'UNAUTHENTICATED', message });
@@ -187,7 +190,7 @@ export class WorkOsAuthProvider implements AuthProvider {
     // A fresh account (its first member is the owner) gets the polished demo form
     // so the dashboard is never empty. Idempotent + best-effort (never blocks login).
     if (role === 'owner') {
-      await maybeSeedDemoForm(this.db, accountId, this.env.SEED_DEMO_FORM, this.log);
+      await maybeSeedDemoForm(this.db, accountId, this.env, this.log);
     }
     // Fires only here, after the INSERT won: every earlier return in this method
     // is an existing member signing in again, which is not a signup. `row.id`

--- a/apps/api/src/draft-publish.spec.ts
+++ b/apps/api/src/draft-publish.spec.ts
@@ -40,6 +40,7 @@ beforeEach(async () => {
     DEV_LOGIN_EMAIL: undefined,
     AUTH_LOCAL_STRICT: undefined,
     SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
   });
   const auth = new AuthService(db, provider);
   const admin = new AdminService(db);

--- a/apps/api/src/integrations-connect.spec.ts
+++ b/apps/api/src/integrations-connect.spec.ts
@@ -90,6 +90,7 @@ function build(env: ServerEnv, fetchImpl: typeof fetch): void {
     DEV_LOGIN_EMAIL: undefined,
     AUTH_LOCAL_STRICT: undefined,
     SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
   });
   const auth = new AuthService(db, provider);
   const hubspot = new HubspotPropertiesService(env, db, fetchImpl);

--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -52,6 +52,7 @@ beforeEach(async () => {
     DEV_LOGIN_EMAIL: undefined,
     AUTH_LOCAL_STRICT: undefined,
     SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
   });
   const auth = new AuthService(db, provider);
   const admin = new AdminService(db);
@@ -216,6 +217,7 @@ describe('invite → first-login adoption (WorkOS JIT model)', () => {
       JWT_ISSUER: undefined,
       JWT_AUDIENCE: undefined,
       SEED_DEMO_FORM: false,
+      ONBOARDING_WIZARD: false,
     });
     const nowSec = Math.floor(Date.now() / 1000);
     const token = signJwtHs256(

--- a/apps/api/src/notifications.controller.spec.ts
+++ b/apps/api/src/notifications.controller.spec.ts
@@ -42,6 +42,7 @@ beforeEach(async () => {
     DEV_LOGIN_EMAIL: undefined,
     AUTH_LOCAL_STRICT: undefined,
     SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
   });
   const auth = new AuthService(db, provider);
   const admin = new AdminService(db);

--- a/apps/api/src/onboarding.controller.spec.ts
+++ b/apps/api/src/onboarding.controller.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * The onboarding endpoints at their real call sites: the progress PATCH, the
+ * completion POST, the gate `/v1/me` reports, and the mutual exclusion with the
+ * demo-form seed.
+ *
+ * The things worth pinning here are the ones a unit test of the repository
+ * cannot see — that the feature is inert with the flag off, that the account id
+ * comes from the principal and never the body, that a double-submit produces one
+ * form rather than two, and that a member cannot rewrite the owner's answers.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException, BadRequestException } from '@nestjs/common';
+import {
+  createDb,
+  migrate,
+  getAccountOnboarding,
+  listOutbox,
+  sql,
+  type Db,
+  type OutboxRow,
+} from '@quill/db';
+import { AdminCrudController } from './admin-crud.controller';
+import { AdminService } from './admin.service';
+import { AuthService } from './auth.service';
+import { LocalAuthProvider, maybeSeedDemoForm, type ReqLike } from './auth.provider';
+import { AnalyticsEffects } from './analytics-effects';
+import { Logger } from '@nestjs/common';
+
+let db: Db;
+let accountId: string;
+let ownerId: string;
+let memberId: string;
+
+const asOwner = (): ReqLike => ({ headers: { 'x-quill-account': accountId, 'x-quill-member': ownerId } });
+const asMember = (): ReqLike => ({ headers: { 'x-quill-account': accountId, 'x-quill-member': memberId } });
+
+const LOCAL_ENV = {
+  NODE_ENV: 'test',
+  DEV_LOGIN_EMAIL: undefined,
+  AUTH_LOCAL_STRICT: undefined,
+  SEED_DEMO_FORM: false,
+  ONBOARDING_WIZARD: false,
+} as never;
+
+const ANALYTICS_ON = { PRODUCT_ANALYTICS_KEY: 'phc_test', PRODUCT_ANALYTICS_HOST: 'https://x.test' };
+
+/**
+ * A controller wired with the wizard on or off. `onboardingEnabled` is the
+ * fourth AdminService argument, which is exactly the switch under test.
+ */
+function controllerWith(enabled: boolean, productAnalytics?: AnalyticsEffects) {
+  const auth = new AuthService(db, new LocalAuthProvider(db, LOCAL_ENV));
+  return new AdminCrudController(
+    db,
+    auth,
+    new AdminService(db, undefined, undefined, enabled),
+    {} as never,
+    {} as never,
+    undefined,
+    productAnalytics,
+  );
+}
+
+async function formCount(): Promise<number> {
+  const row = await db.get<{ n: number }>(
+    sql`SELECT COUNT(*) AS n FROM form WHERE account_id = ${accountId}`,
+  );
+  return Number(row?.n ?? 0);
+}
+
+async function capturedEvents(): Promise<string[]> {
+  const rows: OutboxRow[] = await listOutbox(db, { kind: 'analytics' });
+  return rows.map((r) => (JSON.parse(String(r.payload)) as { event: string }).event);
+}
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  accountId = 'acc_onb';
+  ownerId = 'mem_owner';
+  memberId = 'mem_plain';
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at) VALUES (${accountId}, ${'onb'}, ${'Onb'}, 1000)`,
+  );
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, role, status, created_at)
+        VALUES (${ownerId}, ${accountId}, ${'owner@test.local'}, ${'owner'}, ${'active'}, 1000)`,
+  );
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, role, status, created_at)
+        VALUES (${memberId}, ${accountId}, ${'member@test.local'}, ${'member'}, ${'active'}, 1000)`,
+  );
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('/v1/me — the dashboard gate', () => {
+  it('never requires onboarding while the flag is OFF', async () => {
+    // The whole feature has to be inert by default: a deployment that has not
+    // opted in must not start bouncing people into a wizard.
+    const me = await controllerWith(false).me(asOwner());
+    expect(me?.onboardingRequired).toBe(false);
+  });
+
+  it('requires it for a brand-new account when the flag is ON', async () => {
+    const me = await controllerWith(true).me(asOwner());
+    expect(me?.onboardingRequired).toBe(true);
+    expect(me?.onboardingCompletedAt).toBeNull();
+  });
+
+  it('stops requiring it once the wizard is finished', async () => {
+    const c = controllerWith(true);
+    await c.completeOnboarding(asOwner(), { template: 'blank' });
+    const me = await c.me(asOwner());
+    expect(me?.onboardingRequired).toBe(false);
+    expect(me?.onboardingCompletedAt).toBeGreaterThan(0);
+  });
+
+  it('does not require it for an account that PREDATES the wizard', async () => {
+    // Migration 0011 backfills these, which is what keeps existing users out of
+    // a wizard they never asked for. Modelled by the stamped column.
+    await db.run(sql`UPDATE account SET onboarding_completed_at = 500 WHERE id = ${accountId}`);
+    const me = await controllerWith(true).me(asOwner());
+    expect(me?.onboardingRequired).toBe(false);
+  });
+});
+
+describe('PATCH /v1/account/onboarding', () => {
+  it('stores the answer and reports it back', async () => {
+    const res = await controllerWith(true).saveOnboarding(asOwner(), {
+      role: 'founder',
+      lastStep: 'role',
+    });
+    expect(res.saved).toBe(true);
+    expect(res.onboarding).toMatchObject({ version: 1, role: 'founder', lastStep: 'role' });
+  });
+
+  it('writes nothing while the flag is OFF', async () => {
+    const res = await controllerWith(false).saveOnboarding(asOwner(), {
+      role: 'founder',
+      lastStep: 'role',
+    });
+    expect(res.saved).toBe(false);
+    expect((await getAccountOnboarding(db, accountId))?.onboarding).toBeNull();
+  });
+
+  it('scopes the write to the PRINCIPAL, ignoring an account id in the body', async () => {
+    // Anyone can craft a body; letting it name an account would let a stranger
+    // overwrite someone else's onboarding.
+    const other = 'acc_other';
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at) VALUES (${other}, ${'oth'}, ${'Oth'}, 1000)`,
+    );
+    await controllerWith(true).saveOnboarding(asOwner(), {
+      accountId: other,
+      role: 'sales',
+      lastStep: 'role',
+    } as never);
+    expect((await getAccountOnboarding(db, other))?.onboarding).toBeNull();
+    expect((await getAccountOnboarding(db, accountId))?.onboarding).toMatchObject({ role: 'sales' });
+  });
+
+  it('rejects a plain member — onboarding describes the WORKSPACE', async () => {
+    await expect(
+      controllerWith(true).saveOnboarding(asMember(), { role: 'sales', lastStep: 'role' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('does not throw on a junk body — a 400 behind an unskippable wizard is a dead end', async () => {
+    const res = await controllerWith(true).saveOnboarding(asOwner(), { role: 'astronaut' });
+    expect(res.saved).toBe(false);
+  });
+
+  it('strips an enum value the product does not offer', async () => {
+    // The body is client-supplied, so the schema is the only thing keeping a
+    // made-up role out of the column the funnel groups by.
+    const res = await controllerWith(true).saveOnboarding(asOwner(), {
+      role: 'sales',
+      industry: 'not-a-real-industry',
+      lastStep: 'industry',
+    });
+    expect(res.saved).toBe(false);
+    expect((await getAccountOnboarding(db, accountId))?.onboarding).toBeNull();
+  });
+});
+
+describe('POST /v1/account/onboarding/complete', () => {
+  it('creates the first form from the chosen template', async () => {
+    const res = await controllerWith(true).completeOnboarding(asOwner(), {
+      template: 'lead-qualifier',
+    });
+    expect(res.completed).toBe(true);
+    expect(res.formId).toBeTruthy();
+
+    const form = await db.get<{ name: string; config: unknown }>(
+      sql`SELECT name, config FROM form WHERE id = ${res.formId!}`,
+    );
+    expect(form?.name).toBe('Lead qualifier');
+    // The config comes from the server-side registry, never the request body.
+    expect(JSON.stringify(form?.config)).toContain('team_size');
+  });
+
+  it('records the AUTHOR from the principal', async () => {
+    const res = await controllerWith(true).completeOnboarding(asOwner(), { template: 'blank' });
+    const row = await db.get<{ created_by: string | null }>(
+      sql`SELECT created_by FROM form WHERE id = ${res.formId!}`,
+    );
+    expect(row?.created_by).toBe(ownerId);
+  });
+
+  it('leaves `blank` as an empty form, matching the dashboard default', async () => {
+    const res = await controllerWith(true).completeOnboarding(asOwner(), { template: 'blank' });
+    const form = await db.get<{ config: unknown }>(
+      sql`SELECT config FROM form WHERE id = ${res.formId!}`,
+    );
+    expect(JSON.parse(String(form?.config)).steps).toEqual([]);
+  });
+
+  it('a SECOND call creates no second form and points at the first', async () => {
+    // A double-click must not leave the account with two "first" forms.
+    const c = controllerWith(true);
+    const first = await c.completeOnboarding(asOwner(), { template: 'lead-qualifier' });
+    const second = await c.completeOnboarding(asOwner(), { template: 'application' });
+
+    expect(second.completed).toBe(false);
+    expect(second.formId).toBe(first.formId);
+    expect(await formCount()).toBe(1);
+  });
+
+  it('a second call does not overwrite the recorded template', async () => {
+    const c = controllerWith(true);
+    await c.completeOnboarding(asOwner(), { template: 'lead-qualifier' });
+    await c.completeOnboarding(asOwner(), { template: 'application' });
+    expect((await getAccountOnboarding(db, accountId))?.onboarding?.template).toBe('lead-qualifier');
+  });
+
+  it('rejects an unknown template rather than quietly building a different form', async () => {
+    await expect(
+      controllerWith(true).completeOnboarding(asOwner(), { template: 'nope' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await formCount()).toBe(0);
+  });
+
+  it('rejects a prototype-chain key smuggled in as a template', async () => {
+    await expect(
+      controllerWith(true).completeOnboarding(asOwner(), { template: 'constructor' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects a plain member', async () => {
+    await expect(
+      controllerWith(true).completeOnboarding(asMember(), { template: 'blank' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('creates nothing while the flag is OFF', async () => {
+    const res = await controllerWith(false).completeOnboarding(asOwner(), { template: 'blank' });
+    expect(res).toEqual({ completed: false, formId: null });
+    expect(await formCount()).toBe(0);
+  });
+
+  it('emits forms_onboarding_completed exactly once', async () => {
+    const analytics = new AnalyticsEffects(db, ANALYTICS_ON as never);
+    const c = controllerWith(true, analytics);
+    await c.completeOnboarding(asOwner(), { template: 'customer-feedback' });
+    await c.completeOnboarding(asOwner(), { template: 'blank' });
+
+    const events = (await capturedEvents()).filter((e) => e === 'forms_onboarding_completed');
+    expect(events).toHaveLength(1);
+  });
+
+  it('preserves the answers gathered on the way', async () => {
+    const c = controllerWith(true);
+    await c.saveOnboarding(asOwner(), { role: 'marketing', lastStep: 'role' });
+    await c.saveOnboarding(asOwner(), { industry: 'agency', lastStep: 'industry' });
+    await c.saveOnboarding(asOwner(), { useCase: 'feedback', lastStep: 'use_case' });
+    await c.completeOnboarding(asOwner(), { template: 'customer-feedback' });
+
+    expect((await getAccountOnboarding(db, accountId))?.onboarding).toMatchObject({
+      role: 'marketing',
+      industry: 'agency',
+      useCase: 'feedback',
+      template: 'customer-feedback',
+      lastStep: 'template',
+    });
+  });
+});
+
+describe('the wizard and the demo seed are mutually exclusive', () => {
+  const log = new Logger('test');
+
+  it('seeds the demo form when only SEED_DEMO_FORM is on', async () => {
+    await maybeSeedDemoForm(db, accountId, { SEED_DEMO_FORM: true, ONBOARDING_WIZARD: false }, log);
+    expect(await formCount()).toBe(1);
+  });
+
+  it('seeds NOTHING when the wizard is on', async () => {
+    // Structural, not stylistic: `seedDemoFormForAccount` only writes into an
+    // account with zero forms, so a demo seeded at first login would make the
+    // account non-empty and the form the person picked a template for would
+    // silently never be created.
+    await maybeSeedDemoForm(db, accountId, { SEED_DEMO_FORM: true, ONBOARDING_WIZARD: true }, log);
+    expect(await formCount()).toBe(0);
+  });
+
+  it('lets the wizard create the first form on an account the seed skipped', async () => {
+    await maybeSeedDemoForm(db, accountId, { SEED_DEMO_FORM: true, ONBOARDING_WIZARD: true }, log);
+    const res = await controllerWith(true).completeOnboarding(asOwner(), { template: 'application' });
+    expect(res.completed).toBe(true);
+    expect(await formCount()).toBe(1);
+  });
+});

--- a/apps/api/src/tokens.ts
+++ b/apps/api/src/tokens.ts
@@ -7,3 +7,4 @@ export const AUTH_PROVIDER = Symbol('AUTH_PROVIDER');
 export const RATE_LIMITER = Symbol('RATE_LIMITER');
 export const ENTITLEMENTS = Symbol('ENTITLEMENTS');
 export const PREMIUM_MODE = Symbol('PREMIUM_MODE');
+export const ONBOARDING_ENABLED = Symbol('ONBOARDING_ENABLED');

--- a/apps/api/src/webhook-ping.spec.ts
+++ b/apps/api/src/webhook-ping.spec.ts
@@ -46,6 +46,7 @@ describe('webhook ping', () => {
       DEV_LOGIN_EMAIL: undefined,
       AUTH_LOCAL_STRICT: undefined,
       SEED_DEMO_FORM: false,
+      ONBOARDING_WIZARD: false,
     });
     const auth = new AuthService(db, provider);
     controller = new FormDestinationsController(db, auth);

--- a/apps/api/src/workspace-switch.spec.ts
+++ b/apps/api/src/workspace-switch.spec.ts
@@ -55,6 +55,7 @@ describe('workspace switch', () => {
       DEV_LOGIN_EMAIL: undefined,
       AUTH_LOCAL_STRICT: undefined,
       SEED_DEMO_FORM: false,
+      ONBOARDING_WIZARD: false,
     });
     auth = new AuthService(db, provider);
   });

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.css
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.css
@@ -1,0 +1,113 @@
+/**
+ * Builder coach marks.
+ *
+ * Fixed positioning against viewport coordinates, because that is what
+ * `getBoundingClientRect` returns — an absolutely positioned card would be
+ * offset by every scrolled ancestor in the builder's nested layout.
+ */
+
+.bt {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  /* The layer never eats clicks: the card and the ring opt back in below. The
+     builder has to stay usable while the tip is on screen, or the tour becomes
+     a series of modals. */
+  pointer-events: none;
+}
+
+/* Highlights the anchor without dimming everything else. A full-screen scrim
+   would hide the very thing the copy is pointing at. */
+.bt__ring {
+  position: fixed;
+  border: 2px solid var(--primary);
+  border-radius: calc(var(--radius) + 2px);
+  box-shadow: 0 0 0 9999px color-mix(in oklab, var(--background) 55%, transparent);
+  transition:
+    top 160ms ease,
+    left 160ms ease,
+    width 160ms ease,
+    height 160ms ease;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bt__ring {
+    transition: none;
+  }
+}
+
+.bt__card {
+  position: fixed;
+  pointer-events: auto;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
+}
+
+.bt__card:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.bt__step {
+  margin: 0 0 0.375rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+.bt__title {
+  margin: 0 0 0.375rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.bt__body {
+  margin: 0 0 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
+.bt__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.bt__dismiss {
+  background: none;
+  border: 0;
+  padding: 0.375rem 0;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.bt__dismiss:hover {
+  color: var(--foreground);
+}
+
+.bt__next {
+  padding: 0.4375rem 0.875rem;
+  border: 0;
+  border-radius: var(--radius);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.bt__dismiss:focus-visible,
+.bt__next:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+/**
+ * The three coach marks a person sees the first time they land in the builder,
+ * straight out of the onboarding wizard.
+ *
+ * Armed by `?tour=1` on the redirect, never by a cookie or a stored flag. That
+ * choice is what makes it un-repeatable without any bookkeeping: the parameter
+ * only exists on the one navigation the wizard performs, so reloading the editor
+ * later, or bookmarking it, simply does not carry it.
+ *
+ * Three steps, and every one of them dismissible. A tour that cannot be closed
+ * is a modal dialog wearing a costume, and the person it interrupts most is the
+ * one who already knows what they are doing.
+ *
+ * Anchors are looked up as `[data-tour="…"]` rather than passed as refs, so the
+ * builder's own tree stays unaware of the tour: adding or moving a step here
+ * touches this file and one attribute, never the editor's render path.
+ */
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { getMessages, type Locale } from '@quill/shared';
+import { captureEvent } from '@/lib/product-analytics';
+import { fill } from '@/lib/onboarding';
+import './builder-tour.css';
+
+type TourMessages = ReturnType<typeof getMessages>['admin']['onboarding']['tour'];
+
+/** Anchor attribute value → which copy goes with it, in order. */
+const STEPS = ['edit', 'preview', 'publish'] as const;
+type TourStep = (typeof STEPS)[number];
+
+interface Placement {
+  top: number;
+  left: number;
+  anchor: { top: number; left: number; width: number; height: number };
+}
+
+const CARD_WIDTH = 300;
+/** Assumed card height until the real one is measured (see `cardHeight`). */
+const CARD_HEIGHT_ESTIMATE = 180;
+const GAP = 12;
+const MARGIN = 8;
+/** An anchor taller than this fraction of the viewport is treated as a REGION. */
+const TALL_ANCHOR_RATIO = 0.5;
+
+/**
+ * Where the card goes for a given anchor.
+ *
+ * Two things make this less trivial than "put it underneath":
+ *
+ *  - Some anchors are REGIONS, not controls. The builder's question spine runs
+ *    the full height of the page, so its bottom edge sits below the fold and a
+ *    card placed against it would render off-screen entirely — which is exactly
+ *    what happened before this handled the case. A tall anchor is measured from
+ *    its TOP instead, next to the part of it the person can actually see.
+ *  - The publish button is in the top-RIGHT corner, so a card centred on it
+ *    overflows the right edge.
+ *
+ * Both are covered by the same final clamp: whatever the preferred position, the
+ * card is pushed back inside the viewport on both axes before it is returned. A
+ * coach mark that cannot be read is worse than no coach mark.
+ */
+function place(el: Element, cardHeight: number): Placement {
+  const r = el.getBoundingClientRect();
+  const anchor = { top: r.top, left: r.left, width: r.width, height: r.height };
+  const vh = window.innerHeight;
+  const vw = window.innerWidth;
+  const tall = r.height > vh * TALL_ANCHOR_RATIO;
+
+  // For a region, hang the card off the top of the visible part; for a control,
+  // off its actual bottom edge.
+  const belowY = (tall ? Math.max(r.top, 0) + Math.min(r.height, 96) : r.bottom) + GAP;
+  const aboveY = r.top - GAP - cardHeight;
+  const preferred = belowY + cardHeight + MARGIN <= vh || aboveY < MARGIN ? belowY : aboveY;
+
+  return {
+    top: Math.max(MARGIN, Math.min(preferred, vh - cardHeight - MARGIN)),
+    left: Math.max(
+      MARGIN,
+      Math.min(r.left + r.width / 2 - CARD_WIDTH / 2, vw - CARD_WIDTH - MARGIN),
+    ),
+    anchor,
+  };
+}
+
+export function BuilderTour({ locale }: { locale: Locale }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const armed = params.get('tour') === '1';
+
+  const m: TourMessages = getMessages(locale).admin.onboarding.tour;
+  const [index, setIndex] = useState(0);
+  const [placement, setPlacement] = useState<Placement | null>(null);
+  const [done, setDone] = useState(false);
+  // The real card height, once it has rendered. Copy length differs per step,
+  // so a fixed estimate mis-places the tallest one against the bottom edge.
+  const [cardHeight, setCardHeight] = useState(CARD_HEIGHT_ESTIMATE);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const step: TourStep | undefined = STEPS[index];
+
+  /**
+   * Drop `?tour=1` from the URL once the tour is over.
+   *
+   * `replace` rather than `push` so the browser's Back button does not walk the
+   * person back into a tour they just finished. Running it on finish rather than
+   * on mount is what lets a mid-tour refresh resume rather than silently cancel.
+   */
+  const clearParam = useCallback(() => {
+    const next = new URLSearchParams(params.toString());
+    next.delete('tour');
+    const qs = next.toString();
+    router.replace(qs ? `?${qs}` : window.location.pathname, { scroll: false });
+  }, [params, router]);
+
+  const finish = useCallback(
+    (reason: 'completed' | 'dismissed') => {
+      setDone(true);
+      captureEvent('onboarding_tour_finished', { reason, last_step: step ?? null });
+      clearParam();
+    },
+    [clearParam, step],
+  );
+
+  const advance = useCallback(() => {
+    setIndex((i) => {
+      const next = i + 1;
+      if (next >= STEPS.length) {
+        // Deferred: calling `finish` inside the updater would set state during
+        // another component's render phase.
+        queueMicrotask(() => finish('completed'));
+        return i;
+      }
+      return next;
+    });
+  }, [finish]);
+
+  /**
+   * Measure the anchor. `useLayoutEffect` so the card is positioned before paint
+   * — with a plain effect it flashes at the top-left corner for one frame.
+   *
+   * The anchor may not exist yet (the editor streams in), so this retries on the
+   * next frame rather than giving up and showing a card pinned to nothing.
+   */
+  useLayoutEffect(() => {
+    if (!armed || done || !step) return;
+    let frame = 0;
+    const measure = () => {
+      const el = document.querySelector(`[data-tour="${step}"]`);
+      if (!el) {
+        frame = requestAnimationFrame(measure);
+        return;
+      }
+      setPlacement(place(el, cardHeight));
+    };
+    measure();
+    return () => cancelAnimationFrame(frame);
+  }, [armed, done, step, cardHeight]);
+
+  /** Keep the card glued to its anchor while the page moves under it. */
+  useEffect(() => {
+    if (!armed || done || !step) return;
+    const reposition = () => {
+      const el = document.querySelector(`[data-tour="${step}"]`);
+      if (el) setPlacement(place(el, cardHeight));
+    };
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [armed, done, step, cardHeight]);
+
+  /** One `tour_step` event per step ARRIVAL, not per reposition. */
+  const seen = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!armed || done || !step || seen.current.has(step)) return;
+    seen.current.add(step);
+    captureEvent('onboarding_tour_step', { tour_step: step, step_index: index });
+  }, [armed, done, step, index]);
+
+  /** Escape closes it. The most direct way out should not need a mouse. */
+  useEffect(() => {
+    if (!armed || done) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish('dismissed');
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [armed, done, finish]);
+
+  /**
+   * Measure the rendered card and re-place if the estimate was off. Guarded on a
+   * real difference so this cannot loop: `setCardHeight` re-runs placement, which
+   * re-runs this, which finds the height unchanged and stops.
+   */
+  useLayoutEffect(() => {
+    const h = cardRef.current?.offsetHeight;
+    if (h && Math.abs(h - cardHeight) > 1) setCardHeight(h);
+  }, [cardHeight, placement, step]);
+
+  /** Move focus to the card so a keyboard user is not left behind it. */
+  useEffect(() => {
+    if (placement && !done) cardRef.current?.focus();
+  }, [placement, done]);
+
+  if (!armed || done || !step || !placement) return null;
+
+  const copy = m[step];
+  const last = index === STEPS.length - 1;
+
+  return (
+    <div className="bt" role="presentation">
+      {/* A ring around the anchor rather than a full-screen scrim: the point is
+          to point AT something, and dimming the whole builder hides the thing
+          the copy is talking about. `pointer-events: none` keeps the app usable
+          underneath, so someone can act on the tip while reading it. */}
+      <div
+        className="bt__ring"
+        style={{
+          top: placement.anchor.top - 4,
+          left: placement.anchor.left - 4,
+          width: placement.anchor.width + 8,
+          height: placement.anchor.height + 8,
+        }}
+      />
+      <div
+        ref={cardRef}
+        className="bt__card"
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="bt-title"
+        tabIndex={-1}
+        // `top` is already the card's absolute position — no transform. An
+        // earlier translateY(-100%) for the "above" case shifted it a second
+        // time and put the card outside the viewport.
+        style={{ top: placement.top, left: placement.left, width: CARD_WIDTH }}
+      >
+        <p className="bt__step">{fill(m.step, { current: index + 1, total: STEPS.length })}</p>
+        <h2 className="bt__title" id="bt-title">
+          {copy.title}
+        </h2>
+        <p className="bt__body">{copy.body}</p>
+        <div className="bt__actions">
+          <button type="button" className="bt__dismiss" onClick={() => finish('dismissed')}>
+            {m.dismiss}
+          </button>
+          <button type="button" className="bt__next" onClick={advance}>
+            {last ? m.done : m.next}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx
@@ -139,30 +139,53 @@ export function BuilderTour({ locale }: { locale: Locale }) {
    * Measure the anchor. `useLayoutEffect` so the card is positioned before paint
    * — with a plain effect it flashes at the top-left corner for one frame.
    *
-   * The anchor may not exist yet (the editor streams in), so this retries on the
-   * next frame rather than giving up and showing a card pinned to nothing.
+   * Two ways an anchor is unusable, and they need opposite handling:
+   *
+   *  - NOT THERE YET. The editor streams in, so the element can be missing for a
+   *    few frames. Retry, bounded — an unbounded rAF loop would spin forever on
+   *    a step whose anchor was renamed.
+   *  - THERE BUT HIDDEN. The question spine is `hidden lg:block`, so below
+   *    1024px it is in the DOM with a 0×0 rect. `querySelector` finds it and
+   *    `getBoundingClientRect()` returns all zeros, which used to draw the ring
+   *    around nothing in the top-left corner. Retrying cannot help — the anchor
+   *    is genuinely not on this screen — so the step is SKIPPED.
    */
   useLayoutEffect(() => {
     if (!armed || done || !step) return;
     let frame = 0;
+    let tries = 0;
     const measure = () => {
       const el = document.querySelector(`[data-tour="${step}"]`);
-      if (!el) {
+      const rect = el?.getBoundingClientRect();
+      if (rect && (rect.width > 0 || rect.height > 0)) {
+        setPlacement(place(el as Element, cardHeight));
+        return;
+      }
+      // ~2s at 60fps. Past that, either the anchor does not exist or this
+      // viewport does not render it; move on rather than sit on a blank step.
+      if (tries++ < 120) {
         frame = requestAnimationFrame(measure);
         return;
       }
-      setPlacement(place(el, cardHeight));
+      setPlacement(null);
+      advance();
     };
     measure();
     return () => cancelAnimationFrame(frame);
-  }, [armed, done, step, cardHeight]);
+  }, [armed, done, step, cardHeight, advance]);
 
   /** Keep the card glued to its anchor while the page moves under it. */
   useEffect(() => {
     if (!armed || done || !step) return;
     const reposition = () => {
       const el = document.querySelector(`[data-tour="${step}"]`);
-      if (el) setPlacement(place(el, cardHeight));
+      const rect = el?.getBoundingClientRect();
+      // Same visibility guard: a resize can HIDE the anchor (dragging a window
+      // below the lg breakpoint), and re-placing against a 0×0 rect would snap
+      // the ring to the corner mid-tour.
+      if (el && rect && (rect.width > 0 || rect.height > 0)) {
+        setPlacement(place(el, cardHeight));
+      }
     };
     window.addEventListener('resize', reposition);
     window.addEventListener('scroll', reposition, true);

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -563,6 +563,7 @@ export function FormEditor({
 
           <button
             type="button"
+            data-tour="preview"
             onClick={() => setPreviewOpen(true)}
             className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
@@ -623,7 +624,7 @@ export function FormEditor({
             // past 360 at xl, so a 13" laptop keeps the canvas width it had.
             <div className="grid h-full grid-cols-1 lg:grid-cols-[260px_minmax(0,1fr)_360px] xl:grid-cols-[280px_minmax(0,1fr)_420px] 2xl:grid-cols-[300px_minmax(0,1fr)_460px]">
               {/* Left spine */}
-              <aside className="hidden min-h-0 overflow-y-auto lg:block">
+              <aside className="hidden min-h-0 overflow-y-auto lg:block" data-tour="edit">
                 <QuestionSpine
                   steps={config.steps}
                   selectedIndex={selected}

--- a/apps/web/app/admin/forms/[id]/edit/page.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/page.tsx
@@ -1,8 +1,10 @@
+import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { FormEditor } from './form-editor';
+import { BuilderTour } from './_components/builder-tour';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,16 +25,25 @@ export default async function EditFormPage({ params }: { params: Promise<{ id: s
   const publicPath = `/${me.accountCode}/${me.handle ?? 'me'}/${form.slug}`;
 
   return (
-    <FormEditor
-      id={form.id}
-      initialName={form.name}
-      // Edit the pending DRAFT when one exists; autosave keeps writing the
-      // draft, and the explicit Publish action makes it live.
-      initialConfig={form.draftConfig ?? form.config}
-      initialHasDraft={form.draftConfig != null}
-      publicPath={publicPath}
-      locale={locale}
-      m={m}
-    />
+    <>
+      <FormEditor
+        id={form.id}
+        initialName={form.name}
+        // Edit the pending DRAFT when one exists; autosave keeps writing the
+        // draft, and the explicit Publish action makes it live.
+        initialConfig={form.draftConfig ?? form.config}
+        initialHasDraft={form.draftConfig != null}
+        publicPath={publicPath}
+        locale={locale}
+        m={m}
+      />
+      {/* First-run coach marks, armed only by `?tour=1` on the wizard's own
+          redirect. Suspense because `useSearchParams` suspends; the fallback is
+          nothing, since a tour that has not measured its anchor yet should show
+          nothing rather than a card pinned to the corner. */}
+      <Suspense fallback={null}>
+        <BuilderTour locale={locale} />
+      </Suspense>
+    </>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/publish-button.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/publish-button.tsx
@@ -56,7 +56,7 @@ export function PublishButton({
   }
 
   return (
-    <div className="flex shrink-0 items-center gap-2">
+    <div className="flex shrink-0 items-center gap-2" data-tour="publish">
       {hasDraft && !publishing ? (
         // The full label only fits once the topbar is wide (`2xl`); below that
         // it collapses to the dot — still announced, via `sr-only`, and titled

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -23,6 +23,17 @@ export default async function AdminLayout({ children }: { children: ReactNode })
     throw e;
   }
 
+  // The first-run gate. The API decides — `onboardingRequired` already folds in
+  // the feature flag — so the dashboard never carries a second copy of the
+  // switch that could disagree with it.
+  //
+  // The wizard lives at `/onboarding`, NOT under `/admin`, and that is what
+  // keeps this from looping: a child of this route would re-enter this layout,
+  // be redirected again, and the person would never reach a page. It also wants
+  // none of the chrome below — no sidebar to wander off into before the first
+  // form exists.
+  if (me.onboardingRequired) redirect('/onboarding');
+
   // Server-read the collapse pref so the sidebar renders at the right width on
   // first paint (no rail FOUC).
   const initialCollapsed = jar.get('forms.nav.collapsed')?.value === '1';

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -59,6 +59,12 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           accountId: me.accountId,
           accountCode: me.accountCode,
           role: me.role,
+          // The campaign tags belong on the `forms_account` GROUP, and this is
+          // where nearly every product event is emitted from — the wizard is a
+          // handful of screens, the dashboard is the rest of the product.
+          // Passing them only on the wizard would leave every funnel that starts
+          // after onboarding un-sliceable by campaign, which is most of them.
+          attribution: me.attribution,
         }}
       />
       <AdminShell

--- a/apps/web/app/onboarding/actions.ts
+++ b/apps/web/app/onboarding/actions.ts
@@ -5,6 +5,28 @@ import { revalidatePath } from 'next/cache';
 import { adminApi, type OnboardingProgress } from '@/lib/admin-api';
 
 /**
+ * Is this the control-flow exception `redirect()` throws?
+ *
+ * `adminApi` redirects to /login from inside the request helper when the API
+ * answers 401, and it does that by THROWING — Next's redirect is an exception,
+ * not a return. A bare `catch {}` around an api call therefore swallows the
+ * sign-out and the person silently continues in a dead session. Every catch in
+ * this file has to let it through.
+ *
+ * Identified by the `digest` string rather than an instanceof, because the error
+ * class lives behind a `next/dist/...` internal path that is not part of the
+ * public API and moves between releases.
+ */
+function isRedirect(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    typeof (error as { digest?: unknown }).digest === 'string' &&
+    (error as { digest: string }).digest.startsWith('NEXT_REDIRECT')
+  );
+}
+
+/**
  * Persist one screen's worth of answers.
  *
  * Never throws into the wizard. This runs behind a screen the person cannot
@@ -16,7 +38,9 @@ import { adminApi, type OnboardingProgress } from '@/lib/admin-api';
 export async function saveOnboardingStepAction(patch: OnboardingProgress): Promise<void> {
   try {
     await adminApi.saveOnboarding(patch);
-  } catch {
+  } catch (e) {
+    // An expired session must still sign them out — see `isRedirect`.
+    if (isRedirect(e)) throw e;
     /* progress is an observer of the wizard, never a participant */
   }
 }
@@ -41,11 +65,15 @@ export async function completeOnboardingAction(template: string): Promise<void> 
   try {
     const result = await adminApi.completeOnboarding({ template });
     if (result.formId) target = `/admin/forms/${result.formId}/edit?tour=1`;
-  } catch {
+  } catch (e) {
+    if (isRedirect(e)) throw e;
     // The answers are already stored and the completion may well have been
     // claimed. Sending them back through the wizard would ask them to redo work
     // that is done; the dashboard is the honest fallback.
   }
   revalidatePath('/admin', 'layout');
+  // OUTSIDE the try: `redirect` throws, so calling it inside would hand the
+  // catch above its own control-flow exception and this action would fall
+  // through to no navigation at all.
   redirect(target);
 }

--- a/apps/web/app/onboarding/actions.ts
+++ b/apps/web/app/onboarding/actions.ts
@@ -1,0 +1,51 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
+import { adminApi, type OnboardingProgress } from '@/lib/admin-api';
+
+/**
+ * Persist one screen's worth of answers.
+ *
+ * Never throws into the wizard. This runs behind a screen the person cannot
+ * skip, so a failed save must not become a dead end — the wizard advances
+ * regardless and the API simply never hears about that step. Losing one
+ * breadcrumb of telemetry is strictly better than trapping someone on question
+ * two because the network blipped.
+ */
+export async function saveOnboardingStepAction(patch: OnboardingProgress): Promise<void> {
+  try {
+    await adminApi.saveOnboarding(patch);
+  } catch {
+    /* progress is an observer of the wizard, never a participant */
+  }
+}
+
+/**
+ * Finish the wizard and go to the new form.
+ *
+ * The API is the one that decides what gets created — it resolves the template
+ * id against a server-side registry — so this action forwards a name, never a
+ * config.
+ *
+ * `?tour=1` is what turns the builder's coach marks on. It rides the redirect
+ * rather than a cookie so a person who bookmarks or reloads the editor later
+ * does not get the tour a second time.
+ *
+ * When the claim was already spent (a double-submit, a second tab) the API hands
+ * back the WINNER's form id and this still lands there — both tabs end up on the
+ * same form instead of one of them on an error page.
+ */
+export async function completeOnboardingAction(template: string): Promise<void> {
+  let target = '/admin';
+  try {
+    const result = await adminApi.completeOnboarding({ template });
+    if (result.formId) target = `/admin/forms/${result.formId}/edit?tour=1`;
+  } catch {
+    // The answers are already stored and the completion may well have been
+    // claimed. Sending them back through the wizard would ask them to redo work
+    // that is done; the dashboard is the honest fallback.
+  }
+  revalidatePath('/admin', 'layout');
+  redirect(target);
+}

--- a/apps/web/app/onboarding/onboarding.css
+++ b/apps/web/app/onboarding/onboarding.css
@@ -35,6 +35,22 @@
   min-width: 8rem;
 }
 
+/* The switcher's own visible caption. It is load-bearing for assistive tech (it
+   becomes the select's accessible name) but redundant next to a control that
+   already reads "English" / "Español", so it is hidden visually rather than
+   passed as an empty string. */
+.ob__lang label > span:first-child {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .ob__stages {
   display: flex;
   align-items: center;

--- a/apps/web/app/onboarding/onboarding.css
+++ b/apps/web/app/onboarding/onboarding.css
@@ -19,36 +19,39 @@
   color: var(--foreground);
 }
 
-/* --- Top bar: the three stages + the language switcher -------------------- */
+/* --- Top bar: the product mark + the three stages ------------------------- */
 
+/* Three equal columns rather than a flex row: with `space-between` the stage bar
+   was centred in the LEFTOVER space, which put it visibly left of the viewport's
+   middle. The empty third column mirrors the logo's width so the middle column
+   is the true centre no matter how wide the mark renders. */
 .ob__top {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
   padding: 1.25rem 1.5rem;
   border-bottom: 1px solid var(--border);
 }
 
-.ob__lang {
-  flex: 0 0 auto;
-  min-width: 8rem;
+.ob__brand {
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 
-/* The switcher's own visible caption. It is load-bearing for assistive tech (it
-   becomes the select's accessible name) but redundant next to a control that
-   already reads "English" / "Español", so it is hidden visually rather than
-   passed as an empty string. */
-.ob__lang label > span:first-child {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
+/* `currentColor` ink — the mark follows the theme with no second asset. */
+.ob__logo {
+  height: 1.5rem;
+  width: auto;
+  color: var(--foreground);
+}
+
+/* Wide by default, the F alone on a phone. `display: none` (rather than
+   visibility or opacity) is what keeps the hidden one out of the accessibility
+   tree, so a screen reader never announces the brand twice. */
+.ob__logo--compact {
+  display: none;
 }
 
 .ob__stages {
@@ -64,6 +67,7 @@
      current label truncates instead. */
   flex-wrap: nowrap;
   min-width: 0;
+  justify-self: center;
 }
 
 .ob__stage {
@@ -139,8 +143,12 @@
     width: 0.75rem;
     margin-right: 0;
   }
-  .ob__lang {
-    min-width: 0;
+  .ob__logo--wide {
+    display: none;
+  }
+  .ob__logo--compact {
+    display: block;
+    height: 1.25rem;
   }
 }
 
@@ -311,8 +319,59 @@
   grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
 }
 
+/* Rows, not tiles. Nine roles as a 3x3 grid of cards read as a wall next to the
+   five-tile use-case screen two questions later; stacked full-width rows scan
+   top-to-bottom in a single pass and keep the card treatment meaningful where
+   it is actually used. Narrower than the card grid on purpose — a row that runs
+   the full 44rem is mostly empty space with a label at one end. */
+.ob__list {
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  max-width: 32rem;
+}
+
+.ob__row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: left;
+  padding: 0.8125rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+  color: var(--card-foreground);
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.ob__row:hover {
+  border-color: var(--primary);
+  background: var(--muted);
+}
+
+.ob__row:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.ob__row[data-selected] {
+  border-color: var(--primary);
+  background: color-mix(in oklab, var(--primary) 12%, var(--card));
+}
+
 .ob__templates {
   grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+/* "Start from scratch" is the fifth card in a two-column grid, so on its own it
+   sat as a half-width orphan below the four real templates. Spanning the row
+   makes it read as what it is: the alternative to all of them, not a fifth
+   sibling. */
+.ob__templates-wide {
+  grid-column: 1 / -1;
 }
 
 .ob__card,
@@ -378,6 +437,18 @@
 .ob__card-label {
   font-size: 0.9375rem;
   font-weight: 500;
+}
+
+.ob__template-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ob__template-icon {
+  font-size: 1.125rem;
+  line-height: 1;
+  flex: 0 0 auto;
 }
 
 .ob__template-name {
@@ -453,4 +524,106 @@
 .ob__cta:disabled {
   cursor: default;
   opacity: 0.5;
+}
+
+/* --- The "building your form" interstitial --------------------------------
+ *
+ * Shown between "Create my form" and the builder. The wait is a real round trip
+ * — claim the completion, resolve the template, create the form — and it ends on
+ * a screen the person has never seen. Leaving the picker up with a greyed-out
+ * button reads as a hang; an interstitial reads as work happening.
+ *
+ * Mirrors the reveal step a respondent already gets mid-form (`.pf-reveal__*`),
+ * so this is the product's existing loading language rather than a new one.
+ */
+
+.ob--creating {
+  align-items: center;
+  justify-content: center;
+}
+
+.ob__creating {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2rem 1.5rem;
+  max-width: 26rem;
+  animation: ob-enter 220ms ease-out;
+}
+
+.ob__creating-mark {
+  height: 2.5rem;
+  width: auto;
+  color: var(--foreground);
+  margin-bottom: 1.75rem;
+  animation: ob-pulse 1.6s ease-in-out infinite;
+}
+
+.ob__creating-headline {
+  font-size: clamp(1.25rem, 4vw, 1.5rem);
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0 0 0.5rem;
+  text-wrap: balance;
+}
+
+.ob__creating-sub {
+  font-size: 0.9375rem;
+  color: var(--muted-foreground);
+  margin: 0 0 1.75rem;
+  line-height: 1.5;
+  text-wrap: balance;
+}
+
+.ob__creating-track {
+  width: 16rem;
+  max-width: 100%;
+  height: 0.5rem;
+  background: var(--muted);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+/* Indeterminate: the bar sweeps rather than reporting a percentage, because
+   there is ONE round trip and no measurable steps to report. A determinate bar
+   filling to a made-up number is a lie the person can feel when it stalls. */
+.ob__creating-fill {
+  width: 40%;
+  height: 100%;
+  background: var(--primary);
+  border-radius: 999px;
+  animation: ob-sweep 1.25s ease-in-out infinite;
+}
+
+@keyframes ob-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(250%);
+  }
+}
+
+@keyframes ob-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/* Motion here is decoration on a screen that lasts about a second. Someone with
+   vestibular sensitivity gets a static bar and the same information. */
+@media (prefers-reduced-motion: reduce) {
+  .ob__creating,
+  .ob__creating-mark,
+  .ob__creating-fill {
+    animation: none;
+  }
+  .ob__creating-fill {
+    width: 100%;
+  }
 }

--- a/apps/web/app/onboarding/onboarding.css
+++ b/apps/web/app/onboarding/onboarding.css
@@ -18,6 +18,48 @@
  * wrong in a light fork.
  */
 
+/* --- Shell: give the desktop card its missing centring ---------------------
+ *
+ * On desktop the renderer composes topbar + body into ONE framed card — but it
+ * centres that card (and pads the canvas around it) on `.pf__main`, a wrapper
+ * a real form has and this wizard's markup does not. Without a stand-in the
+ * card sits glued to the viewport top with zero margin. `.ob` itself takes the
+ * job: canvas padding on the root, and the pair centred with auto margins
+ * (top-auto on the bar, bottom-auto on the body) rather than
+ * `justify-content` — auto margins collapse to zero when the card is taller
+ * than the window, so a short viewport degrades to a normal scroll instead of
+ * clipping the question off the top.
+ *
+ * The `:not()` chains repeat the renderer's own card selectors on purpose:
+ * they tie on specificity, and this sheet importing after `public-form.css`
+ * is what lets these win. The card is also widened past the renderer's 560px —
+ * the role question packs nine options into two columns, and they need the
+ * room to hold one line each.
+ */
+
+@media (min-width: 769px) {
+  .ob {
+    padding: 24px;
+  }
+  .ob:not(.pf--cover):not(.pf--reveal):not(.pf--done) .pf__topbar {
+    max-width: 680px;
+    margin: auto auto 0;
+    padding: 22px 24px 16px;
+  }
+  /* The renderer's 40px card padding, trimmed vertically: the template screen
+     is the tallest of the five and 40-top + 36-bottom is exactly what pushed
+     its CTA twelve pixels past a 720px viewport. */
+  .ob:not(.pf--cover):not(.pf--reveal):not(.pf--done) .pf__body {
+    max-width: 680px;
+    margin: 0 auto auto;
+    padding: 32px 40px;
+  }
+}
+
+.ob .pf__inner {
+  max-width: 620px;
+}
+
 /* --- The product mark, in the topbar slot a form gives its own logo -------- */
 
 .ob__brand {
@@ -27,9 +69,11 @@
   min-width: 0;
 }
 
-/* `currentColor` ink — the mark follows the theme with no second asset. */
+/* `currentColor` ink — the mark follows the theme with no second asset. A
+   touch larger than a form's 24px logo band: with the bar transparent the mark
+   is the header, not a tenant of it. */
 .ob__logo {
-  height: 24px;
+  height: 26px;
   width: auto;
   color: var(--foreground);
 }
@@ -115,13 +159,79 @@
 
 /* The step counter above the question. The renderer has no equivalent — a form
    shows a progress bar, not "Question 1 of 3" — but a count alongside three
-   named stages is what keeps a wizard feeling short. */
+   named stages is what keeps a wizard feeling short. Set as a micro-label
+   (uppercase, tracked out) so it reads as a caption to the question rather
+   than a smaller sentence above it. */
 .ob__eyebrow {
   text-align: center;
-  font-size: 13px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
   color: var(--muted-foreground);
-  margin: 0 0 10px;
-  letter-spacing: 0.02em;
+  margin: 0 0 12px;
+  letter-spacing: 0.1em;
+}
+
+/* --- The question screens, packed to one viewport --------------------------
+ *
+ * The renderer stacks single-select options as full-width rows — right for a
+ * respondent's phone, but the role question has NINE of them, and nine 56px
+ * rows push the last options (and any sense of "three quick taps") below the
+ * fold. On the wizard they pack into two columns of shorter rows, so the
+ * whole question fits one desktop viewport. Scoped to `.ob`: real forms keep
+ * the renderer's own layout.
+ */
+
+.ob .pf-choices--list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+/* An odd count leaves the last row half-empty; the catch-all ("Other") spans
+   it instead — the same treatment "start from scratch" gets among the
+   templates, and it reads the same way: the alternative to the grid above it,
+   not a ninth sibling. */
+.ob .pf-choices--list > :last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}
+
+.ob .pf-choice-list {
+  min-height: 52px;
+  padding: 8px 14px;
+  gap: 11px;
+  font-size: 14px;
+  border-radius: 12px;
+}
+
+.ob .pf-choice-list__icon,
+.ob .pf-choice-list__circle {
+  width: 32px;
+  height: 32px;
+  font-size: 16px;
+}
+
+/* The industry dropdown at the grid's 640px reads as a search bar; cap it at
+   the question's own measure so it reads as a field under it. */
+.ob .pf-dropdown {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.ob .pf__fields {
+  margin-top: 28px;
+}
+
+@media (max-width: 40rem) {
+  /* One column again on a phone — two 160px columns would wrap every label to
+     three lines. Vertical scroll is the natural gesture there; the one-screen
+     promise is a desktop promise. */
+  .ob .pf-choices--list {
+    grid-template-columns: 1fr;
+  }
+  .ob .pf-choices--list > :last-child:nth-child(odd) {
+    grid-column: auto;
+  }
 }
 
 /* The label is the part that has to give way first on a phone — the numbered
@@ -160,8 +270,8 @@
 .ob__templates {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-  gap: var(--pf-gap);
-  margin: 0 0 24px;
+  gap: 10px;
+  margin: 0 0 18px;
   padding: 0;
   list-style: none;
 }
@@ -180,9 +290,9 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 5px;
   text-align: left;
-  padding: 16px;
+  padding: 14px 16px;
   font-family: inherit;
   border: 1px solid var(--border);
   border-radius: var(--pf-radius);
@@ -226,9 +336,9 @@
 }
 
 .ob__template-desc {
-  font-size: 13px;
+  font-size: 12.5px;
   color: var(--muted-foreground);
-  line-height: 1.45;
+  line-height: 1.4;
 }
 
 .ob__badge {

--- a/apps/web/app/onboarding/onboarding.css
+++ b/apps/web/app/onboarding/onboarding.css
@@ -1,0 +1,440 @@
+/**
+ * First-run wizard styling.
+ *
+ * Its own stylesheet rather than the public form's: `public-form.css` is built
+ * for a full-viewport BRANDED form, where the author's accent colour and cover
+ * art drive everything. The wizard is our surface, not theirs, so it uses the
+ * admin design tokens directly and stays legible on whatever the deployment's
+ * theme is.
+ *
+ * Every colour is a token (`--card`, `--border`, `--primary`…) — a hardcoded hex
+ * here would look right in the dark default and wrong in a light fork.
+ */
+
+.ob {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+/* --- Top bar: the three stages + the language switcher -------------------- */
+
+.ob__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.ob__lang {
+  flex: 0 0 auto;
+  min-width: 8rem;
+}
+
+.ob__stages {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  /* NEVER wrap. Wrapping put each stage on its own line at phone width and ate
+     a third of the screen before the question was even visible — the opposite
+     of what a compact progress indicator is for. It stays one line and the
+     current label truncates instead. */
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+.ob__stage {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  min-width: 0;
+}
+
+.ob__stage-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The connector between stages. A pseudo-element so the markup stays a plain
+   ordered list and screen readers announce three items, not five. */
+.ob__stage + .ob__stage::before {
+  content: '';
+  width: 1.5rem;
+  height: 1px;
+  background: var(--border);
+  margin-right: 0.25rem;
+}
+
+.ob__stage-mark {
+  display: grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.75rem;
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+
+.ob__stage[data-state='done'] .ob__stage-mark {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.ob__stage[data-state='current'] {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.ob__stage[data-state='current'] .ob__stage-mark {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+/* The label is the part that has to give way first on a phone — the numbered
+   marks alone still communicate "three steps, you are on the second". */
+@media (max-width: 40rem) {
+  .ob__top {
+    padding: 0.875rem 1rem;
+    gap: 0.5rem;
+  }
+  .ob__stage-label {
+    display: none;
+  }
+  .ob__stage[data-state='current'] .ob__stage-label {
+    display: inline;
+  }
+  /* The connectors are the first thing to go: with the labels already hidden
+     they connect nothing a reader can name, and every pixel here is one the
+     question above the fold does not get. */
+  .ob__stage + .ob__stage::before {
+    width: 0.75rem;
+    margin-right: 0;
+  }
+  .ob__lang {
+    min-width: 0;
+  }
+}
+
+/* --- The question screen -------------------------------------------------- */
+
+.ob__body {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.ob__screen {
+  width: 100%;
+  max-width: 44rem;
+  animation: ob-enter 220ms ease-out;
+}
+
+/* Honour a reduced-motion preference: the entrance is decoration, and for
+   someone with vestibular sensitivity it is the opposite of a welcome. */
+@media (prefers-reduced-motion: reduce) {
+  .ob__screen {
+    animation: none;
+  }
+}
+
+@keyframes ob-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.ob__eyebrow {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.02em;
+}
+
+.ob__question {
+  font-size: clamp(1.5rem, 4vw, 2rem);
+  line-height: 1.2;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.ob__helper {
+  color: var(--muted-foreground);
+  margin: 0 0 2rem;
+  font-size: 0.9375rem;
+}
+
+.ob__search {
+  max-width: 28rem;
+}
+
+/* --- The searchable dropdown ---------------------------------------------
+ *
+ * `SearchableDropdown` is shared with the public renderer and styles itself with
+ * `.pf-*` class names that live in `public-form.css`. That sheet is NOT imported
+ * here (it is built for a full-viewport branded form and carries a pile of
+ * form-specific assumptions), so without these rules the component renders as
+ * naked HTML: an unpadded input and an unstyled, un-layered list that overlaps
+ * whatever is beneath it.
+ *
+ * Scoped under `.ob` so they can never leak onto a real form page, and written
+ * against the admin tokens rather than the renderer's `--pf-*` ones, which the
+ * wizard does not define.
+ */
+
+.ob .pf-dropdown {
+  position: relative;
+}
+
+.ob .pf-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.75rem 0.875rem;
+  font-family: inherit;
+  font-size: 1rem;
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--input);
+  border-radius: var(--radius);
+  outline: none;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.ob .pf-input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
+}
+
+.ob .pf-dropdown__list {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  left: 0;
+  right: 0;
+  /* Above the option cards below it; below the builder tour's own layer. */
+  z-index: 50;
+  margin: 0;
+  padding: 0.375rem;
+  list-style: none;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.35);
+  max-height: 15rem;
+  overflow-y: auto;
+}
+
+.ob .pf-dropdown__option {
+  display: block;
+  width: 100%;
+  padding: 0.6875rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  text-align: left;
+  color: inherit;
+  background: none;
+  border: 0;
+  border-radius: calc(var(--radius) - 2px);
+  cursor: pointer;
+  transition: background 100ms ease;
+}
+
+.ob .pf-dropdown__option:hover,
+.ob .pf-dropdown__option:focus-visible {
+  background: var(--muted);
+}
+
+.ob .pf-dropdown__option--selected {
+  background: color-mix(in oklab, var(--primary) 18%, var(--popover));
+  font-weight: 600;
+}
+
+.ob .pf-dropdown__empty {
+  padding: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+/* --- Option cards --------------------------------------------------------- */
+
+.ob__cards,
+.ob__templates {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* `auto-fit` + `minmax` rather than a fixed column count: nine roles and five
+   templates have to look deliberate at every width, and a grid tuned for three
+   looks broken with one. */
+.ob__cards {
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+}
+
+.ob__templates {
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.ob__card,
+.ob__template {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  gap: 0.75rem;
+  text-align: left;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+  color: var(--card-foreground);
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    transform 120ms ease;
+}
+
+.ob__card {
+  align-items: center;
+}
+
+.ob__template {
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.ob__card:hover,
+.ob__template:hover:not(:disabled) {
+  border-color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.ob__card:focus-visible,
+.ob__template:focus-visible,
+.ob__cta:focus-visible,
+.ob__back:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.ob__card[data-selected],
+.ob__template[data-selected] {
+  border-color: var(--primary);
+  background: color-mix(in oklab, var(--primary) 12%, var(--card));
+}
+
+.ob__template:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.ob__card-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.ob__card-label {
+  font-size: 0.9375rem;
+  font-weight: 500;
+}
+
+.ob__template-name {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.ob__template-desc {
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+
+.ob__badge {
+  align-self: flex-start;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  margin-bottom: 0.25rem;
+}
+
+/* --- Actions -------------------------------------------------------------- */
+
+.ob__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  flex-wrap: wrap;
+}
+
+.ob__back {
+  margin-top: 1.5rem;
+  padding: 0.5rem 0;
+  background: none;
+  border: 0;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+/* Inside the action row the back link is already spaced by the flex gap. */
+.ob__actions .ob__back {
+  margin-top: 0;
+}
+
+.ob__back:hover:not(:disabled) {
+  color: var(--foreground);
+}
+
+.ob__back:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.ob__cta {
+  padding: 0.75rem 1.5rem;
+  border: 0;
+  border-radius: var(--radius);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ob__cta:disabled {
+  cursor: default;
+  opacity: 0.5;
+}

--- a/apps/web/app/onboarding/onboarding.css
+++ b/apps/web/app/onboarding/onboarding.css
@@ -1,48 +1,35 @@
 /**
- * First-run wizard styling.
+ * First-run wizard — the DELTA on top of the public renderer.
  *
- * Its own stylesheet rather than the public form's: `public-form.css` is built
- * for a full-viewport BRANDED form, where the author's accent colour and cover
- * art drive everything. The wizard is our surface, not theirs, so it uses the
- * admin design tokens directly and stays legible on whatever the deployment's
- * theme is.
+ * The wizard renders as a real `.pf` surface and imports `public-form.css`, so
+ * the shell, the topbar, the body rhythm, the question type scale and every
+ * option control already come from the form renderer itself. What is left here
+ * is only what a real form has no equivalent for: the three-stage bar in
+ * `FormProgress`'s slot, the template picker, and the "building your form"
+ * interstitial.
  *
- * Every colour is a token (`--card`, `--border`, `--primary`…) — a hardcoded hex
- * here would look right in the dark default and wrong in a light fork.
+ * An earlier version of this file hand-copied the renderer's styles. That is
+ * exactly what made the wizard look almost-but-not-quite like a Dapta form, and
+ * it let the two drift apart — hence the import, and hence this file's job being
+ * subtraction rather than imitation.
+ *
+ * Every rule is scoped under `.ob` (which always sits alongside `.pf`), and every
+ * colour is a token — a hardcoded hex would look right in the dark default and
+ * wrong in a light fork.
  */
 
-.ob {
-  min-height: 100dvh;
-  display: flex;
-  flex-direction: column;
-  background: var(--background);
-  color: var(--foreground);
-}
-
-/* --- Top bar: the product mark + the three stages ------------------------- */
-
-/* Three equal columns rather than a flex row: with `space-between` the stage bar
-   was centred in the LEFTOVER space, which put it visibly left of the viewport's
-   middle. The empty third column mirrors the logo's width so the middle column
-   is the true centre no matter how wide the mark renders. */
-.ob__top {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid var(--border);
-}
+/* --- The product mark, in the topbar slot a form gives its own logo -------- */
 
 .ob__brand {
   display: flex;
   align-items: center;
+  justify-content: center;
   min-width: 0;
 }
 
 /* `currentColor` ink — the mark follows the theme with no second asset. */
 .ob__logo {
-  height: 1.5rem;
+  height: 24px;
   width: auto;
   color: var(--foreground);
 }
@@ -54,12 +41,16 @@
   display: none;
 }
 
+/* --- The three stages, where a form puts its progress bar ------------------ */
+
 .ob__stages {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin: 0;
+  justify-content: center;
+  gap: 8px;
+  margin: 0 auto;
   padding: 0;
+  max-width: 480px;
   list-style: none;
   /* NEVER wrap. Wrapping put each stage on its own line at phone width and ate
      a third of the screen before the question was even visible — the opposite
@@ -67,14 +58,13 @@
      current label truncates instead. */
   flex-wrap: nowrap;
   min-width: 0;
-  justify-self: center;
 }
 
 .ob__stage {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: 8px;
+  font-size: 13px;
   color: var(--muted-foreground);
   min-width: 0;
 }
@@ -89,28 +79,28 @@
    ordered list and screen readers announce three items, not five. */
 .ob__stage + .ob__stage::before {
   content: '';
-  width: 1.5rem;
+  width: 20px;
   height: 1px;
   background: var(--border);
-  margin-right: 0.25rem;
+  margin-right: 4px;
 }
 
 .ob__stage-mark {
   display: grid;
   place-items: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 22px;
+  height: 22px;
   border-radius: 999px;
   border: 1px solid var(--border);
-  font-size: 0.75rem;
+  font-size: 11px;
   font-weight: 600;
   flex: 0 0 auto;
 }
 
 .ob__stage[data-state='done'] .ob__stage-mark {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: var(--primary-foreground);
+  background: var(--pf-primary);
+  border-color: var(--pf-primary);
+  color: var(--pf-primary-contrast);
 }
 
 .ob__stage[data-state='current'] {
@@ -119,17 +109,24 @@
 }
 
 .ob__stage[data-state='current'] .ob__stage-mark {
-  border-color: var(--primary);
-  color: var(--primary);
+  border-color: var(--pf-primary);
+  color: var(--pf-primary);
+}
+
+/* The step counter above the question. The renderer has no equivalent — a form
+   shows a progress bar, not "Question 1 of 3" — but a count alongside three
+   named stages is what keeps a wizard feeling short. */
+.ob__eyebrow {
+  text-align: center;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  margin: 0 0 10px;
+  letter-spacing: 0.02em;
 }
 
 /* The label is the part that has to give way first on a phone — the numbered
    marks alone still communicate "three steps, you are on the second". */
 @media (max-width: 40rem) {
-  .ob__top {
-    padding: 0.875rem 1rem;
-    gap: 0.5rem;
-  }
   .ob__stage-label {
     display: none;
   }
@@ -140,7 +137,7 @@
      they connect nothing a reader can name, and every pixel here is one the
      question above the fold does not get. */
   .ob__stage + .ob__stage::before {
-    width: 0.75rem;
+    width: 12px;
     margin-right: 0;
   }
   .ob__logo--wide {
@@ -148,222 +145,25 @@
   }
   .ob__logo--compact {
     display: block;
-    height: 1.25rem;
+    height: 20px;
   }
 }
 
-/* --- The question screen -------------------------------------------------- */
-
-.ob__body {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1.5rem 4rem;
-}
-
-.ob__screen {
-  width: 100%;
-  max-width: 44rem;
-  animation: ob-enter 220ms ease-out;
-}
-
-/* Honour a reduced-motion preference: the entrance is decoration, and for
-   someone with vestibular sensitivity it is the opposite of a welcome. */
-@media (prefers-reduced-motion: reduce) {
-  .ob__screen {
-    animation: none;
-  }
-}
-
-@keyframes ob-enter {
-  from {
-    opacity: 0;
-    transform: translateY(0.5rem);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-.ob__eyebrow {
-  font-size: 0.8125rem;
-  color: var(--muted-foreground);
-  margin: 0 0 0.5rem;
-  letter-spacing: 0.02em;
-}
-
-.ob__question {
-  font-size: clamp(1.5rem, 4vw, 2rem);
-  line-height: 1.2;
-  font-weight: 600;
-  margin: 0 0 0.5rem;
-}
-
-.ob__helper {
-  color: var(--muted-foreground);
-  margin: 0 0 2rem;
-  font-size: 0.9375rem;
-}
-
-.ob__search {
-  max-width: 28rem;
-}
-
-/* --- The searchable dropdown ---------------------------------------------
+/* --- The template picker --------------------------------------------------
  *
- * `SearchableDropdown` is shared with the public renderer and styles itself with
- * `.pf-*` class names that live in `public-form.css`. That sheet is NOT imported
- * here (it is built for a full-viewport branded form and carries a pile of
- * form-specific assumptions), so without these rules the component renders as
- * naked HTML: an unpadded input and an unstyled, un-layered list that overlaps
- * whatever is beneath it.
- *
- * Scoped under `.ob` so they can never leak onto a real form page, and written
- * against the admin tokens rather than the renderer's `--pf-*` ones, which the
- * wizard does not define.
+ * The one screen with no form-renderer equivalent: a choice option carries a
+ * label, these carry a name, a description and a recommendation badge. Built on
+ * the renderer's own card tokens (`--pf-radius`, `--pf-gap`, `--pf-primary`) so
+ * it still reads as the same surface.
  */
 
-.ob .pf-dropdown {
-  position: relative;
-}
-
-.ob .pf-input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 0.75rem 0.875rem;
-  font-family: inherit;
-  font-size: 1rem;
-  color: var(--foreground);
-  background: var(--background);
-  border: 1px solid var(--input);
-  border-radius: var(--radius);
-  outline: none;
-  transition:
-    border-color 120ms ease,
-    box-shadow 120ms ease;
-}
-
-.ob .pf-input:focus {
-  border-color: var(--ring);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
-}
-
-.ob .pf-dropdown__list {
-  position: absolute;
-  top: calc(100% + 0.375rem);
-  left: 0;
-  right: 0;
-  /* Above the option cards below it; below the builder tour's own layer. */
-  z-index: 50;
-  margin: 0;
-  padding: 0.375rem;
-  list-style: none;
-  background: var(--popover);
-  color: var(--popover-foreground);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 0.35);
-  max-height: 15rem;
-  overflow-y: auto;
-}
-
-.ob .pf-dropdown__option {
-  display: block;
-  width: 100%;
-  padding: 0.6875rem 0.75rem;
-  font-family: inherit;
-  font-size: 0.9375rem;
-  text-align: left;
-  color: inherit;
-  background: none;
-  border: 0;
-  border-radius: calc(var(--radius) - 2px);
-  cursor: pointer;
-  transition: background 100ms ease;
-}
-
-.ob .pf-dropdown__option:hover,
-.ob .pf-dropdown__option:focus-visible {
-  background: var(--muted);
-}
-
-.ob .pf-dropdown__option--selected {
-  background: color-mix(in oklab, var(--primary) 18%, var(--popover));
-  font-weight: 600;
-}
-
-.ob .pf-dropdown__empty {
-  padding: 0.75rem;
-  font-size: 0.875rem;
-  color: var(--muted-foreground);
-  text-align: center;
-}
-
-/* --- Option cards --------------------------------------------------------- */
-
-.ob__cards,
 .ob__templates {
   display: grid;
-  gap: 0.75rem;
-  margin: 0;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: var(--pf-gap);
+  margin: 0 0 24px;
   padding: 0;
   list-style: none;
-}
-
-/* `auto-fit` + `minmax` rather than a fixed column count: nine roles and five
-   templates have to look deliberate at every width, and a grid tuned for three
-   looks broken with one. */
-.ob__cards {
-  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
-}
-
-/* Rows, not tiles. Nine roles as a 3x3 grid of cards read as a wall next to the
-   five-tile use-case screen two questions later; stacked full-width rows scan
-   top-to-bottom in a single pass and keep the card treatment meaningful where
-   it is actually used. Narrower than the card grid on purpose — a row that runs
-   the full 44rem is mostly empty space with a label at one end. */
-.ob__list {
-  grid-template-columns: 1fr;
-  gap: 0.5rem;
-  max-width: 32rem;
-}
-
-.ob__row {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  text-align: left;
-  padding: 0.8125rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--card);
-  color: var(--card-foreground);
-  cursor: pointer;
-  transition:
-    border-color 120ms ease,
-    background 120ms ease;
-}
-
-.ob__row:hover {
-  border-color: var(--primary);
-  background: var(--muted);
-}
-
-.ob__row:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-}
-
-.ob__row[data-selected] {
-  border-color: var(--primary);
-  background: color-mix(in oklab, var(--primary) 12%, var(--card));
-}
-
-.ob__templates {
-  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
 }
 
 /* "Start from scratch" is the fifth card in a two-column grid, so on its own it
@@ -374,156 +174,74 @@
   grid-column: 1 / -1;
 }
 
-.ob__card,
 .ob__template {
   position: relative;
   width: 100%;
   height: 100%;
   display: flex;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 6px;
   text-align: left;
-  padding: 1rem;
+  padding: 16px;
+  font-family: inherit;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: var(--pf-radius);
   background: var(--card);
   color: var(--card-foreground);
   cursor: pointer;
   transition:
-    border-color 120ms ease,
-    background 120ms ease,
-    transform 120ms ease;
+    border-color 0.12s var(--pf-ease),
+    background 0.12s var(--pf-ease),
+    transform 0.08s var(--pf-ease);
 }
 
-.ob__card {
-  align-items: center;
+.ob__template:hover {
+  border-color: var(--pf-primary);
 }
 
-.ob__template {
-  flex-direction: column;
-  gap: 0.375rem;
+.ob__template:active {
+  transform: scale(0.995);
 }
 
-.ob__card:hover,
-.ob__template:hover:not(:disabled) {
-  border-color: var(--primary);
-  transform: translateY(-1px);
-}
-
-.ob__card:focus-visible,
-.ob__template:focus-visible,
-.ob__cta:focus-visible,
-.ob__back:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-}
-
-.ob__card[data-selected],
 .ob__template[data-selected] {
-  border-color: var(--primary);
-  background: color-mix(in oklab, var(--primary) 12%, var(--card));
-}
-
-.ob__template:disabled {
-  cursor: default;
-  opacity: 0.6;
-}
-
-.ob__card-icon {
-  font-size: 1.25rem;
-  line-height: 1;
-  flex: 0 0 auto;
-}
-
-.ob__card-label {
-  font-size: 0.9375rem;
-  font-weight: 500;
+  border-color: var(--pf-primary);
+  background: color-mix(in oklab, var(--pf-primary) 12%, var(--card));
 }
 
 .ob__template-head {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
 }
 
 .ob__template-icon {
-  font-size: 1.125rem;
+  font-size: 18px;
   line-height: 1;
   flex: 0 0 auto;
 }
 
 .ob__template-name {
-  font-size: 1rem;
+  font-size: 15px;
   font-weight: 600;
 }
 
 .ob__template-desc {
-  font-size: 0.875rem;
+  font-size: 13px;
   color: var(--muted-foreground);
   line-height: 1.45;
 }
 
 .ob__badge {
   align-self: flex-start;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  padding: 0.125rem 0.5rem;
+  padding: 2px 8px;
   border-radius: 999px;
-  background: var(--primary);
-  color: var(--primary-foreground);
-  margin-bottom: 0.25rem;
-}
-
-/* --- Actions -------------------------------------------------------------- */
-
-.ob__actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-top: 2rem;
-  flex-wrap: wrap;
-}
-
-.ob__back {
-  margin-top: 1.5rem;
-  padding: 0.5rem 0;
-  background: none;
-  border: 0;
-  color: var(--muted-foreground);
-  font-size: 0.875rem;
-  cursor: pointer;
-}
-
-/* Inside the action row the back link is already spaced by the flex gap. */
-.ob__actions .ob__back {
-  margin-top: 0;
-}
-
-.ob__back:hover:not(:disabled) {
-  color: var(--foreground);
-}
-
-.ob__back:disabled {
-  cursor: default;
-  opacity: 0.5;
-}
-
-.ob__cta {
-  padding: 0.75rem 1.5rem;
-  border: 0;
-  border-radius: var(--radius);
-  background: var(--primary);
-  color: var(--primary-foreground);
-  font-size: 0.9375rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.ob__cta:disabled {
-  cursor: default;
-  opacity: 0.5;
+  background: var(--pf-primary);
+  color: var(--pf-primary-contrast);
+  margin-bottom: 2px;
 }
 
 /* --- The "building your form" interstitial --------------------------------
@@ -547,39 +265,40 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 2rem 1.5rem;
-  max-width: 26rem;
+  padding: 40px 24px;
+  max-width: 420px;
   animation: ob-enter 220ms ease-out;
 }
 
 .ob__creating-mark {
-  height: 2.5rem;
+  height: 44px;
   width: auto;
   color: var(--foreground);
-  margin-bottom: 1.75rem;
+  margin-bottom: 28px;
   animation: ob-pulse 1.6s ease-in-out infinite;
 }
 
 .ob__creating-headline {
-  font-size: clamp(1.25rem, 4vw, 1.5rem);
-  font-weight: 600;
-  line-height: 1.25;
-  margin: 0 0 0.5rem;
+  font-size: clamp(21px, 5vw, 28px);
+  font-weight: 700;
+  line-height: 1.22;
+  letter-spacing: -0.015em;
+  margin: 0 0 12px;
   text-wrap: balance;
 }
 
 .ob__creating-sub {
-  font-size: 0.9375rem;
+  font-size: 15px;
   color: var(--muted-foreground);
-  margin: 0 0 1.75rem;
+  margin: 0 0 24px;
   line-height: 1.5;
   text-wrap: balance;
 }
 
 .ob__creating-track {
-  width: 16rem;
+  width: 260px;
   max-width: 100%;
-  height: 0.5rem;
+  height: 8px;
   background: var(--muted);
   border-radius: 999px;
   overflow: hidden;
@@ -591,9 +310,20 @@
 .ob__creating-fill {
   width: 40%;
   height: 100%;
-  background: var(--primary);
+  background: var(--pf-primary);
   border-radius: 999px;
   animation: ob-sweep 1.25s ease-in-out infinite;
+}
+
+@keyframes ob-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 @keyframes ob-sweep {

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,0 +1,56 @@
+import { redirect } from 'next/navigation';
+import { getMessages } from '@quill/shared';
+import { adminApi, ApiError } from '@/lib/admin-api';
+import { preferredLocale } from '@/lib/locale';
+import { resolveProductAnalytics } from '@/lib/product-analytics';
+import { ProductAnalytics } from '@/components/analytics/product-analytics';
+import { OnboardingWizard } from './wizard';
+
+/**
+ * The first-run wizard.
+ *
+ * Lives OUTSIDE `/admin` on purpose. The admin layout redirects here when the
+ * API says onboarding is owed, so a route nested under it would re-enter that
+ * layout, be redirected again, and loop forever. It also wants none of the admin
+ * chrome — no sidebar to wander into before a first form exists.
+ *
+ * The guard runs in both directions: the layout sends people here, and this page
+ * sends them back the moment the API says the wizard is done. That second half
+ * is what makes the URL safe to hit directly, on a bookmark or a back button,
+ * without re-running an onboarding that already happened.
+ */
+export default async function OnboardingPage() {
+  let me: Awaited<ReturnType<typeof adminApi.me>>;
+  try {
+    me = await adminApi.me();
+  } catch (e) {
+    // `req` already redirects to /login on a 401; anything else is a real
+    // outage and belongs on the error boundary rather than silently swallowed.
+    if (e instanceof ApiError && e.status === 401) redirect('/login');
+    throw e;
+  }
+
+  if (!me.onboardingRequired) redirect('/admin');
+
+  // Their browser's language, not the cookie's default — nobody arriving here
+  // has ever seen the switcher.
+  const locale = await preferredLocale();
+  const messages = getMessages(locale).admin.onboarding;
+
+  return (
+    <>
+      <ProductAnalytics
+        analytics={resolveProductAnalytics()}
+        identity={{
+          email: me.email,
+          memberId: me.memberId,
+          accountId: me.accountId,
+          accountCode: me.accountCode,
+          role: me.role,
+          attribution: me.attribution,
+        }}
+      />
+      <OnboardingWizard messages={messages} locale={locale} />
+    </>
+  );
+}

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -4,9 +4,17 @@
  * The first-run wizard: three questions, then the template the first form is
  * built from.
  *
- * One screen at a time, and all three stages named from the very first paint.
- * Seeing that there are three is what stops the second question feeling like the
- * fifth — the same reason a progress bar beats a spinner.
+ * It IS a Dapta form, not a page that resembles one. The chrome is the public
+ * renderer's own — `.pf` shell, centred topbar with the mark, `pf__body` /
+ * `pf__inner` rhythm — and the questions render through `StepInput`, the same
+ * component a respondent meets. Two things follow from that, both of them the
+ * reason for it: the first screen a new user sees demonstrates the product
+ * they just signed up for, and it cannot drift away from the real thing,
+ * because a change to how forms render changes this screen too.
+ *
+ * The stage bar takes `FormProgress`'s slot under the topbar. All three stages
+ * are named from the first paint — seeing that there are three is what stops
+ * the second question feeling like the fifth.
  *
  * There is NO skip on the questions. They are three taps, and an answer that can
  * be skipped is an answer most people skip, which would leave the column this
@@ -20,12 +28,16 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import type { FormsMessages, Locale } from '@quill/shared';
-import { SearchableDropdown } from '@/components/public/searchable-dropdown';
+import { StepInput } from '@/components/public/step-input';
 import { FormsLockup, FormsMark } from '@/components/brand/forms-logo';
 import { captureEvent } from '@/lib/product-analytics';
 import { fill, wizardQuestions, wizardTemplates } from '@/lib/onboarding';
 import { USE_CASE_TEMPLATE, type OnboardingUseCase } from '@quill/types';
 import { saveOnboardingStepAction, completeOnboardingAction } from './actions';
+// The renderer's own stylesheet. Every rule in it is scoped under `.pf`, so
+// importing it here cannot leak into the dashboard — and it is what makes this
+// screen identical to a real form rather than a careful imitation.
+import '../[accountCode]/[handle]/[slug]/public-form.css';
 import './onboarding.css';
 
 type Messages = FormsMessages['admin']['onboarding'];
@@ -93,8 +105,7 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
   const answer = useCallback(
     (value: string) => {
       if (!current) return;
-      const next = { ...answers, [current.field]: value };
-      setAnswers(next);
+      setAnswers((a) => ({ ...a, [current.field]: value }));
       // Changing the use case invalidates an explicit template pick made on a
       // later screen. Without this, going back and choosing a different purpose
       // leaves the OLD card selected while the "Recommended for you" badge moves
@@ -113,7 +124,7 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
       void saveOnboardingStepAction({ [current.field]: value, lastStep: reached });
       setIndex(advancing);
     },
-    [answers, current, index, questions],
+    [current, index, questions],
   );
 
   const back = useCallback(() => setIndex((i) => Math.max(0, i - 1)), []);
@@ -125,8 +136,6 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
         recommended: id === recommended,
         use_case: answers.useCase ?? null,
       });
-      // The server action redirects; the transition keeps the button disabled
-      // and the copy honest until the navigation actually happens.
       startSubmit(() => void completeOnboardingAction(id));
     },
     [answers.useCase, recommended],
@@ -134,140 +143,128 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
 
   const stage = onTemplates ? TEMPLATE_STAGE : QUESTION_STAGE;
 
-  // The form is being created and a redirect is on its way. Nothing on this
-  // screen is actionable any more, so it becomes an interstitial rather than a
-  // disabled copy of itself — the wait is a second of real work, and a frozen
-  // page with a greyed-out button reads as a hang.
+  // The form is being created and a redirect is on its way. Nothing here is
+  // actionable any more, so the screen becomes an interstitial rather than a
+  // disabled copy of itself — a frozen page with a greyed-out button reads as a
+  // hang, and this is the last thing before a screen they have never seen.
   if (submitting) return <CreatingScreen m={m} />;
 
   return (
-    <main className="ob">
-      {/* Three columns, so the stage bar is centred against the VIEWPORT rather
-          than against the space the logo leaves over. A flex row with
-          space-between put it visually left of centre. The empty third column
-          is what balances the logo. */}
-      <header className="ob__top">
-        {/* Two marks, one shown per breakpoint. At phone width the full lockup
-            is ~110px of a 390px header, which squeezed the stage bar out of the
-            centre and left it hard against the logo; the F alone is ~24px and
-            keeps the brand present without taking the room. Only one is exposed
-            to assistive tech — the hidden one is `aria-hidden` via its own CSS. */}
-        <div className="ob__brand">
-          <FormsLockup className="ob__logo ob__logo--wide" title="Dapta Forms" />
-          <FormsMark className="ob__logo ob__logo--compact" title="Dapta Forms" />
+    <div className="pf ob">
+      {/* The renderer's topbar: back · logo · spacer, on a `40px 1fr 40px` grid
+          that centres the mark against the bar rather than against whatever
+          space the back button leaves over. */}
+      <header className="pf__topbar">
+        <div className="pf__topbar-inner">
+          {index > 0 ? (
+            <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+              ←
+            </button>
+          ) : (
+            <span className="pf__back pf__back--placeholder" />
+          )}
+          <span className="ob__brand">
+            <FormsLockup className="ob__logo ob__logo--wide" title="Dapta Forms" />
+            <FormsMark className="ob__logo ob__logo--compact" title="Dapta Forms" />
+          </span>
+          <span className="pf__back pf__back--placeholder" />
         </div>
+        {/* Where a real form puts `FormProgress`. Same slot, same job. */}
         <StageBar m={m} stage={stage} />
-        <div aria-hidden="true" />
       </header>
 
-      <div className="ob__body">
-        {current ? (
-          <section className="ob__screen" key={current.key}>
-            <p className="ob__eyebrow">{fill(m.progress, { current: index + 1, total: questions.length })}</p>
-            <h1 className="ob__question">{current.question}</h1>
-            <p className="ob__helper">{current.helper}</p>
+      <div className="pf__body">
+        <div className="pf__inner">
+          {current ? (
+            <div className="pf__content pf-animate" key={current.key}>
+              <div className="pf__question-wrap">
+                <p className="ob__eyebrow">
+                  {fill(m.progress, { current: index + 1, total: questions.length })}
+                </p>
+                <h1 className="pf__question">{current.step.question}</h1>
+                {current.step.helper ? <p className="pf__helper">{current.step.helper}</p> : null}
+              </div>
 
-            {current.layout === 'search' ? (
-              <div className="ob__search">
-                <SearchableDropdown
-                  options={current.options.map((o) => ({ label: o.label, value: o.value }))}
+              <div className="pf__fields">
+                <StepInput
+                  step={current.step}
                   value={answers[current.field] ?? ''}
+                  answers={answers}
+                  // Only single-select choices and the dropdown are used here,
+                  // and both report through `onSelect`. The other two are
+                  // required by the shared component's contract and are wired to
+                  // no-ops rather than to `answer`: routing them there would
+                  // make a future step type (a slider, a text field) advance the
+                  // wizard on every keystroke.
                   onSelect={answer}
-                  placeholder={m.industry.placeholder}
-                  emptyLabel={m.industry.empty}
+                  onChange={() => {}}
+                  onFieldChange={() => {}}
+                  dropdownPlaceholder={m.industry.placeholder}
+                  dropdownEmpty={m.industry.empty}
+                  locale={locale}
                 />
               </div>
-            ) : (
-              // Same markup for both option layouts — only the list class
-              // differs, so the grid-vs-rows decision lives entirely in CSS and
-              // a third layout costs one rule rather than a second branch here.
-              <ul className={current.layout === 'list' ? 'ob__list' : 'ob__cards'}>
-                {current.options.map((o) => (
-                  <li key={o.value}>
-                    <button
-                      type="button"
-                      className={current.layout === 'list' ? 'ob__row' : 'ob__card'}
-                      aria-pressed={answers[current.field] === o.value}
-                      data-selected={answers[current.field] === o.value || undefined}
-                      onClick={() => answer(o.value)}
-                    >
-                      {o.icon && (
-                        <span className="ob__card-icon" aria-hidden="true">
-                          {o.icon}
-                        </span>
-                      )}
-                      <span className="ob__card-label">{o.label}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            {index > 0 && (
-              <button type="button" className="ob__back" onClick={back}>
-                {m.back}
-              </button>
-            )}
-          </section>
-        ) : (
-          <section className="ob__screen" key="template">
-            <h1 className="ob__question">{m.templates.question}</h1>
-            <p className="ob__helper">{m.templates.helper}</p>
-
-            <ul className="ob__templates">
-              {templates.map((t) => {
-                const isRecommended = t.id === recommended;
-                const selected = (template ?? recommended) === t.id;
-                return (
-                  // `blank` spans the full row: it is the last card and an odd
-                  // one out in a two-column grid, so left alone it sat as a
-                  // half-width orphan under the four real templates.
-                  <li key={t.id} className={t.id === 'blank' ? 'ob__templates-wide' : undefined}>
-                    <button
-                      type="button"
-                      className="ob__template"
-                      aria-pressed={selected}
-                      data-selected={selected || undefined}
-                      disabled={submitting}
-                      onClick={() => setTemplate(t.id)}
-                    >
-                      {isRecommended && <span className="ob__badge">{m.templates.recommended}</span>}
-                      <span className="ob__template-head">
-                        <span className="ob__template-icon" aria-hidden="true">
-                          {t.icon}
-                        </span>
-                        <span className="ob__template-name">{t.name}</span>
-                      </span>
-                      <span className="ob__template-desc">{t.description}</span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-
-            <div className="ob__actions">
-              <button type="button" className="ob__back" onClick={back} disabled={submitting}>
-                {m.back}
-              </button>
-              <button
-                type="button"
-                className="ob__cta"
-                // `?? recommended` so the pre-selected card is genuinely armed:
-                // requiring a redundant click on the option we already
-                // highlighted would make the recommendation a lie.
-                disabled={submitting || !(template ?? recommended)}
-                onClick={() => {
-                  const pick = template ?? recommended;
-                  if (pick) finish(pick);
-                }}
-              >
-                {m.templates.cta}
-              </button>
             </div>
-          </section>
-        )}
+          ) : (
+            <div className="pf__content pf-animate" key="template">
+              <div className="pf__question-wrap">
+                <h1 className="pf__question">{m.templates.question}</h1>
+                <p className="pf__helper">{m.templates.helper}</p>
+              </div>
+
+              <div className="pf__fields">
+                <ul className="ob__templates">
+                  {templates.map((t) => {
+                    const isRecommended = t.id === recommended;
+                    const selected = (template ?? recommended) === t.id;
+                    return (
+                      // `blank` spans the full row: it is the last card and an
+                      // odd one out in a two-column grid, so left alone it sat
+                      // as a half-width orphan under the four real templates.
+                      <li key={t.id} className={t.id === 'blank' ? 'ob__templates-wide' : undefined}>
+                        <button
+                          type="button"
+                          className="ob__template"
+                          aria-pressed={selected}
+                          data-selected={selected || undefined}
+                          onClick={() => setTemplate(t.id)}
+                        >
+                          {isRecommended && (
+                            <span className="ob__badge">{m.templates.recommended}</span>
+                          )}
+                          <span className="ob__template-head">
+                            <span className="ob__template-icon" aria-hidden="true">
+                              {t.icon}
+                            </span>
+                            <span className="ob__template-name">{t.name}</span>
+                          </span>
+                          <span className="ob__template-desc">{t.description}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+
+                <button
+                  type="button"
+                  className="pf__btn ob__cta"
+                  // `?? recommended` so the pre-selected card is genuinely
+                  // armed: requiring a redundant click on the option we already
+                  // highlighted would make the recommendation a lie.
+                  disabled={!(template ?? recommended)}
+                  onClick={() => {
+                    const pick = template ?? recommended;
+                    if (pick) finish(pick);
+                  }}
+                >
+                  {m.templates.cta}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
-    </main>
+    </div>
   );
 }
 
@@ -276,18 +273,14 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
  *
  * The wait is real work — the API claims completion, builds the config from the
  * template registry, and creates the form — and it is the last thing that
- * happens before the person sees a screen they have never seen before. A
- * determinate bar reads as progress where a spinner reads as a stall, and the
- * same pattern is already what a respondent gets on a form's reveal step, so
- * this is the product's own loading language rather than a new one.
- *
- * The bar is CSS-driven and does not report real progress; it cannot, because
- * the work is a single round trip. It runs slightly longer than the request
- * usually takes so it is never seen to finish and then sit there.
+ * happens before the person sees a screen they have never seen before. A moving
+ * bar reads as progress where a spinner reads as a stall, and the same pattern
+ * is already what a respondent gets on a form's reveal step, so this is the
+ * product's own loading language rather than a new one.
  */
 function CreatingScreen({ m }: { m: Messages }) {
   return (
-    <main className="ob ob--creating">
+    <div className="pf ob ob--creating">
       <div className="ob__creating">
         <FormsMark className="ob__creating-mark" title="Dapta Forms" />
         <h1 className="ob__creating-headline">{m.creating}</h1>
@@ -298,7 +291,7 @@ function CreatingScreen({ m }: { m: Messages }) {
           <div className="ob__creating-fill" />
         </div>
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -95,6 +95,12 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
       if (!current) return;
       const next = { ...answers, [current.field]: value };
       setAnswers(next);
+      // Changing the use case invalidates an explicit template pick made on a
+      // later screen. Without this, going back and choosing a different purpose
+      // leaves the OLD card selected while the "Recommended for you" badge moves
+      // to the new one — two highlighted cards saying different things, and the
+      // button builds the one the person no longer asked for.
+      if (current.field === 'useCase') setTemplate(null);
       captureEvent('onboarding_step_answered', {
         step_key: current.key,
         step_index: index,
@@ -133,7 +139,10 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
       <header className="ob__top">
         <StageBar m={m} stage={stage} />
         <div className="ob__lang">
-          <LanguageSwitcher locale={locale} label="" />
+          {/* A real label, not `""`. The switcher renders it into the select's
+              `aria-label`, so an empty string leaves a combobox with no
+              accessible name — the CSS hides it visually, screen readers keep it. */}
+          <LanguageSwitcher locale={locale} label={m.language} />
         </div>
       </header>
 

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+/**
+ * The first-run wizard: three questions, then the template the first form is
+ * built from.
+ *
+ * One screen at a time, and all three stages named from the very first paint.
+ * Seeing that there are three is what stops the second question feeling like the
+ * fifth — the same reason a progress bar beats a spinner.
+ *
+ * There is NO skip on the questions. They are three taps, and an answer that can
+ * be skipped is an answer most people skip, which would leave the column this
+ * whole feature exists to fill mostly empty. The template screen offers "start
+ * from scratch" instead, which is an honest choice rather than a way out.
+ *
+ * Every advance patches the server. That is deliberate and is the difference
+ * between a funnel and a completion count: the person who quits on question two
+ * never reaches the end to be recorded, and they are exactly the one worth
+ * measuring.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import type { FormsMessages, Locale } from '@quill/shared';
+import { SearchableDropdown } from '@/components/public/searchable-dropdown';
+import { LanguageSwitcher } from '@/components/language-switcher';
+import { captureEvent } from '@/lib/product-analytics';
+import { fill, wizardQuestions, wizardTemplates } from '@/lib/onboarding';
+import { USE_CASE_TEMPLATE, type OnboardingUseCase } from '@quill/types';
+import { saveOnboardingStepAction, completeOnboardingAction } from './actions';
+import './onboarding.css';
+
+type Messages = FormsMessages['admin']['onboarding'];
+
+/** Which stage of the three the current screen belongs to. 1 is already done. */
+const QUESTION_STAGE = 2;
+const TEMPLATE_STAGE = 3;
+
+export function OnboardingWizard({ messages: m, locale }: { messages: Messages; locale: Locale }) {
+  const questions = useMemo(() => wizardQuestions(m), [m]);
+  const templates = useMemo(() => wizardTemplates(m), [m]);
+
+  const [index, setIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [template, setTemplate] = useState<string | null>(null);
+  const [submitting, startSubmit] = useTransition();
+
+  /** Past the last question is the template screen. */
+  const onTemplates = index >= questions.length;
+  const current = onTemplates ? null : questions[index];
+  const stepKey = onTemplates ? 'template' : (current?.key ?? 'role');
+
+  /**
+   * The card the previous answer pre-selects. Recomputed rather than stored so
+   * going back and changing the use case actually changes the recommendation —
+   * a stale one would point at a template the person no longer asked for.
+   */
+  const recommended = useMemo(() => {
+    const useCase = answers.useCase as OnboardingUseCase | undefined;
+    return useCase ? USE_CASE_TEMPLATE[useCase] : null;
+  }, [answers.useCase]);
+
+  /**
+   * Emit `step_viewed` once per screen ARRIVAL, not once per render.
+   *
+   * Without the ref this fires on every state change — a keystroke in the
+   * industry search, a re-render from the transition — and the funnel's view
+   * count becomes a typing-speed measurement. React also mounts effects twice in
+   * development StrictMode, which the same guard absorbs.
+   */
+  const viewed = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (viewed.current.has(stepKey)) return;
+    viewed.current.add(stepKey);
+    captureEvent('onboarding_step_viewed', {
+      step_key: stepKey,
+      step_index: index,
+      total_steps: questions.length + 1,
+    });
+    if (index !== 0) return;
+    captureEvent('onboarding_started', { locale });
+    // Claim the FIRST screen on arrival. Every later screen has its `lastStep`
+    // written by the answer that led to it, but nothing precedes this one — so
+    // without this patch, someone who opens the wizard and quits on question one
+    // is indistinguishable in the database from someone who never opened it at
+    // all. Those are opposite problems: one is a wizard failing, the other is a
+    // signup that never arrived.
+    //
+    // Safe to fire alongside `answer`'s patch because it only ever runs for
+    // index 0, which no answer patch targets — the two never race on the row.
+    void saveOnboardingStepAction({ lastStep: 'role' });
+  }, [stepKey, index, questions.length, locale]);
+
+  /** Answer the current question and advance. Choosing IS continuing — one tap. */
+  const answer = useCallback(
+    (value: string) => {
+      if (!current) return;
+      const next = { ...answers, [current.field]: value };
+      setAnswers(next);
+      captureEvent('onboarding_step_answered', {
+        step_key: current.key,
+        step_index: index,
+        value,
+      });
+      const advancing = index + 1;
+      // `lastStep` names the screen being REACHED, which is what makes the
+      // stored value a drop-off bucket rather than a record of the last answer.
+      const reached = questions[advancing]?.key ?? 'template';
+      void saveOnboardingStepAction({ [current.field]: value, lastStep: reached });
+      setIndex(advancing);
+    },
+    [answers, current, index, questions],
+  );
+
+  const back = useCallback(() => setIndex((i) => Math.max(0, i - 1)), []);
+
+  const finish = useCallback(
+    (id: string) => {
+      captureEvent('onboarding_template_picked', {
+        template: id,
+        recommended: id === recommended,
+        use_case: answers.useCase ?? null,
+      });
+      // The server action redirects; the transition keeps the button disabled
+      // and the copy honest until the navigation actually happens.
+      startSubmit(() => void completeOnboardingAction(id));
+    },
+    [answers.useCase, recommended],
+  );
+
+  const stage = onTemplates ? TEMPLATE_STAGE : QUESTION_STAGE;
+
+  return (
+    <main className="ob">
+      <header className="ob__top">
+        <StageBar m={m} stage={stage} />
+        <div className="ob__lang">
+          <LanguageSwitcher locale={locale} label="" />
+        </div>
+      </header>
+
+      <div className="ob__body">
+        {current ? (
+          <section className="ob__screen" key={current.key}>
+            <p className="ob__eyebrow">{fill(m.progress, { current: index + 1, total: questions.length })}</p>
+            <h1 className="ob__question">{current.question}</h1>
+            <p className="ob__helper">{current.helper}</p>
+
+            {current.layout === 'search' ? (
+              <div className="ob__search">
+                <SearchableDropdown
+                  options={current.options.map((o) => ({ label: o.label, value: o.value }))}
+                  value={answers[current.field] ?? ''}
+                  onSelect={answer}
+                  placeholder={m.industry.placeholder}
+                  emptyLabel={m.industry.empty}
+                />
+              </div>
+            ) : (
+              <ul className="ob__cards">
+                {current.options.map((o) => (
+                  <li key={o.value}>
+                    <button
+                      type="button"
+                      className="ob__card"
+                      aria-pressed={answers[current.field] === o.value}
+                      data-selected={answers[current.field] === o.value || undefined}
+                      onClick={() => answer(o.value)}
+                    >
+                      {o.icon && (
+                        <span className="ob__card-icon" aria-hidden="true">
+                          {o.icon}
+                        </span>
+                      )}
+                      <span className="ob__card-label">{o.label}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {index > 0 && (
+              <button type="button" className="ob__back" onClick={back}>
+                {m.back}
+              </button>
+            )}
+          </section>
+        ) : (
+          <section className="ob__screen" key="template">
+            <h1 className="ob__question">{m.templates.question}</h1>
+            <p className="ob__helper">{m.templates.helper}</p>
+
+            <ul className="ob__templates">
+              {templates.map((t) => {
+                const isRecommended = t.id === recommended;
+                const selected = (template ?? recommended) === t.id;
+                return (
+                  <li key={t.id}>
+                    <button
+                      type="button"
+                      className="ob__template"
+                      aria-pressed={selected}
+                      data-selected={selected || undefined}
+                      disabled={submitting}
+                      onClick={() => setTemplate(t.id)}
+                    >
+                      {isRecommended && <span className="ob__badge">{m.templates.recommended}</span>}
+                      <span className="ob__template-name">{t.name}</span>
+                      <span className="ob__template-desc">{t.description}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div className="ob__actions">
+              <button type="button" className="ob__back" onClick={back} disabled={submitting}>
+                {m.back}
+              </button>
+              <button
+                type="button"
+                className="ob__cta"
+                // `?? recommended` so the pre-selected card is genuinely armed:
+                // requiring a redundant click on the option we already
+                // highlighted would make the recommendation a lie.
+                disabled={submitting || !(template ?? recommended)}
+                onClick={() => {
+                  const pick = template ?? recommended;
+                  if (pick) finish(pick);
+                }}
+              >
+                {submitting ? m.creating : m.templates.cta}
+              </button>
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+/**
+ * The three stages, always all visible.
+ *
+ * Stage 1 is complete before this component ever renders — they signed in to get
+ * here — and showing it ticked is the point: the wizard opens already one third
+ * done rather than at zero.
+ */
+function StageBar({ m, stage }: { m: Messages; stage: number }) {
+  const labels = [m.stages.account, m.stages.profile, m.stages.firstForm];
+  return (
+    <ol className="ob__stages">
+      {labels.map((label, i) => {
+        const n = i + 1;
+        const state = n < stage ? 'done' : n === stage ? 'current' : 'todo';
+        return (
+          <li key={label} className="ob__stage" data-state={state}>
+            <span className="ob__stage-mark" aria-hidden="true">
+              {state === 'done' ? '✓' : n}
+            </span>
+            <span className="ob__stage-label">{label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -21,7 +21,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import type { FormsMessages, Locale } from '@quill/shared';
 import { SearchableDropdown } from '@/components/public/searchable-dropdown';
-import { LanguageSwitcher } from '@/components/language-switcher';
+import { FormsLockup, FormsMark } from '@/components/brand/forms-logo';
 import { captureEvent } from '@/lib/product-analytics';
 import { fill, wizardQuestions, wizardTemplates } from '@/lib/onboarding';
 import { USE_CASE_TEMPLATE, type OnboardingUseCase } from '@quill/types';
@@ -134,16 +134,30 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
 
   const stage = onTemplates ? TEMPLATE_STAGE : QUESTION_STAGE;
 
+  // The form is being created and a redirect is on its way. Nothing on this
+  // screen is actionable any more, so it becomes an interstitial rather than a
+  // disabled copy of itself — the wait is a second of real work, and a frozen
+  // page with a greyed-out button reads as a hang.
+  if (submitting) return <CreatingScreen m={m} />;
+
   return (
     <main className="ob">
+      {/* Three columns, so the stage bar is centred against the VIEWPORT rather
+          than against the space the logo leaves over. A flex row with
+          space-between put it visually left of centre. The empty third column
+          is what balances the logo. */}
       <header className="ob__top">
-        <StageBar m={m} stage={stage} />
-        <div className="ob__lang">
-          {/* A real label, not `""`. The switcher renders it into the select's
-              `aria-label`, so an empty string leaves a combobox with no
-              accessible name — the CSS hides it visually, screen readers keep it. */}
-          <LanguageSwitcher locale={locale} label={m.language} />
+        {/* Two marks, one shown per breakpoint. At phone width the full lockup
+            is ~110px of a 390px header, which squeezed the stage bar out of the
+            centre and left it hard against the logo; the F alone is ~24px and
+            keeps the brand present without taking the room. Only one is exposed
+            to assistive tech — the hidden one is `aria-hidden` via its own CSS. */}
+        <div className="ob__brand">
+          <FormsLockup className="ob__logo ob__logo--wide" title="Dapta Forms" />
+          <FormsMark className="ob__logo ob__logo--compact" title="Dapta Forms" />
         </div>
+        <StageBar m={m} stage={stage} />
+        <div aria-hidden="true" />
       </header>
 
       <div className="ob__body">
@@ -164,12 +178,15 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
                 />
               </div>
             ) : (
-              <ul className="ob__cards">
+              // Same markup for both option layouts — only the list class
+              // differs, so the grid-vs-rows decision lives entirely in CSS and
+              // a third layout costs one rule rather than a second branch here.
+              <ul className={current.layout === 'list' ? 'ob__list' : 'ob__cards'}>
                 {current.options.map((o) => (
                   <li key={o.value}>
                     <button
                       type="button"
-                      className="ob__card"
+                      className={current.layout === 'list' ? 'ob__row' : 'ob__card'}
                       aria-pressed={answers[current.field] === o.value}
                       data-selected={answers[current.field] === o.value || undefined}
                       onClick={() => answer(o.value)}
@@ -202,7 +219,10 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
                 const isRecommended = t.id === recommended;
                 const selected = (template ?? recommended) === t.id;
                 return (
-                  <li key={t.id}>
+                  // `blank` spans the full row: it is the last card and an odd
+                  // one out in a two-column grid, so left alone it sat as a
+                  // half-width orphan under the four real templates.
+                  <li key={t.id} className={t.id === 'blank' ? 'ob__templates-wide' : undefined}>
                     <button
                       type="button"
                       className="ob__template"
@@ -212,7 +232,12 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
                       onClick={() => setTemplate(t.id)}
                     >
                       {isRecommended && <span className="ob__badge">{m.templates.recommended}</span>}
-                      <span className="ob__template-name">{t.name}</span>
+                      <span className="ob__template-head">
+                        <span className="ob__template-icon" aria-hidden="true">
+                          {t.icon}
+                        </span>
+                        <span className="ob__template-name">{t.name}</span>
+                      </span>
                       <span className="ob__template-desc">{t.description}</span>
                     </button>
                   </li>
@@ -236,11 +261,42 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
                   if (pick) finish(pick);
                 }}
               >
-                {submitting ? m.creating : m.templates.cta}
+                {m.templates.cta}
               </button>
             </div>
           </section>
         )}
+      </div>
+    </main>
+  );
+}
+
+/**
+ * The interstitial between "Create my form" and the builder.
+ *
+ * The wait is real work — the API claims completion, builds the config from the
+ * template registry, and creates the form — and it is the last thing that
+ * happens before the person sees a screen they have never seen before. A
+ * determinate bar reads as progress where a spinner reads as a stall, and the
+ * same pattern is already what a respondent gets on a form's reveal step, so
+ * this is the product's own loading language rather than a new one.
+ *
+ * The bar is CSS-driven and does not report real progress; it cannot, because
+ * the work is a single round trip. It runs slightly longer than the request
+ * usually takes so it is never seen to finish and then sit there.
+ */
+function CreatingScreen({ m }: { m: Messages }) {
+  return (
+    <main className="ob ob--creating">
+      <div className="ob__creating">
+        <FormsMark className="ob__creating-mark" title="Dapta Forms" />
+        <h1 className="ob__creating-headline">{m.creating}</h1>
+        <p className="ob__creating-sub">{m.creatingSubtitle}</p>
+        {/* `role="progressbar"` with no value: indeterminate, which is the
+            honest reading — there is one round trip, not measurable steps. */}
+        <div className="ob__creating-track" role="progressbar" aria-label={m.creating}>
+          <div className="ob__creating-fill" />
+        </div>
       </div>
     </main>
   );

--- a/apps/web/components/analytics/product-analytics.tsx
+++ b/apps/web/components/analytics/product-analytics.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Script from 'next/script';
 import {
   buildAnalyticsSnippet,
@@ -29,19 +29,36 @@ export function ProductAnalytics({
   identity: AnalyticsIdentity;
 }) {
   const { key, host } = analytics;
-  const { email, memberId, accountId, accountCode, role } = identity;
+  const { email, memberId, accountId, accountCode, role, attribution } = identity;
+
+  // `attribution` is an OBJECT, re-created by every RSC payload, so depending on
+  // it directly would re-run the effect — and re-identify the session — on every
+  // render. The effect depends on a value-derived STRING instead and reads the
+  // object through a ref, which is what keeps "re-run when the tags actually
+  // change" and "do not re-run when only the reference changed" both true.
+  const attributionKey = attribution ? JSON.stringify(attribution) : '';
+  const attributionRef = useRef(attribution);
+  attributionRef.current = attribution;
 
   useEffect(() => {
     if (!key) return;
     // The vendor's loader stub queues calls made before the real script
     // finishes downloading, so identifying here is safe on first paint and
     // needs no readiness check.
-    identifyMember({ email, memberId, accountId, accountCode, role });
+    identifyMember({
+      email,
+      memberId,
+      accountId,
+      accountCode,
+      role,
+      attribution: attributionRef.current,
+    });
     // Re-runs on a workspace switch: `account_id` is a super property and a
     // group, so it has to follow the member into the workspace they are
     // actually looking at, or every event after a switch is filed under the
-    // wrong account.
-  }, [key, email, memberId, accountId, accountCode, role]);
+    // wrong account. The campaign tags are a property of that same WORKSPACE and
+    // change with it, which is why `attributionKey` is here too.
+  }, [key, email, memberId, accountId, accountCode, role, attributionKey]);
 
   if (!key) return null;
 

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -124,6 +124,34 @@ export interface Me {
   email: string | null;
   role: AccountRole;
   status: MemberStatus;
+  /**
+   * Whether this person still owes the first-run wizard. Computed by the API —
+   * the dashboard deliberately does NOT read the feature flag itself. Two copies
+   * of the switch that disagreed would bounce every user into a wizard whose
+   * endpoints refuse to serve it, with no way out.
+   */
+  onboardingRequired: boolean;
+  /** Epoch-ms the wizard was finished; null while still owed. */
+  onboardingCompletedAt: number | null;
+  /**
+   * First-touch acquisition tags, so the browser can attach them as analytics
+   * GROUP properties. Without them the onboarding funnel cannot be sliced by
+   * campaign, which is most of the reason to measure it.
+   */
+  attribution: Record<string, string | number | null | undefined> | null;
+}
+
+/**
+ * One screen's worth of onboarding answers. Every field optional because this is
+ * PATCHed as the person advances — a half-filled body is the normal case, not a
+ * degenerate one.
+ */
+export interface OnboardingProgress {
+  role?: string | null;
+  industry?: string | null;
+  useCase?: string | null;
+  template?: string | null;
+  lastStep?: string | null;
 }
 
 export interface FormSummary {
@@ -343,6 +371,21 @@ export interface FormNotificationsResponse {
 
 export const adminApi = {
   me: () => req<Me>('GET', '/v1/me'),
+
+  // Onboarding (first-run wizard)
+  saveOnboarding: (b: OnboardingProgress) =>
+    req<{ saved: boolean; onboarding: OnboardingProgress | null }>(
+      'PATCH',
+      '/v1/account/onboarding',
+      b,
+    ),
+  completeOnboarding: (b: { template: string }) =>
+    req<{ completed: boolean; formId: string | null }>(
+      'POST',
+      '/v1/account/onboarding/complete',
+      b,
+    ),
+
   vanityStatus: () =>
     req<{ vanitySlug: string | null; shortCode: string; canClaim: boolean }>('GET', '/v1/vanity'),
 

--- a/apps/web/lib/locale.ts
+++ b/apps/web/lib/locale.ts
@@ -14,6 +14,24 @@ export async function getLocale(): Promise<Locale> {
 }
 
 /**
+ * The locale for a surface a brand-new person reaches BEFORE they have ever
+ * touched the language switcher: the persisted choice if there is one, else what
+ * their browser asks for.
+ *
+ * `getLocale` alone is wrong here. It answers English for anyone without the
+ * cookie, and the first-run wizard is precisely the screen nobody has a cookie
+ * for yet — so a Spanish-speaking signup would be greeted in English and have to
+ * find a switcher to fix it, on the one screen they cannot skip.
+ */
+export async function preferredLocale(): Promise<Locale> {
+  const jar = await cookies();
+  const saved = jar.get(LOCALE_COOKIE)?.value;
+  if (saved === 'es' || saved === 'en') return saved;
+  const accept = (await headers()).get('accept-language') ?? '';
+  return accept.trim().toLowerCase().startsWith('es') ? 'es' : 'en';
+}
+
+/**
  * Public-surface locale (no admin cookie there): an explicit ?lang= wins,
  * otherwise the browser's Accept-Language decides. Defaults to English.
  */

--- a/apps/web/lib/onboarding.ts
+++ b/apps/web/lib/onboarding.ts
@@ -29,8 +29,14 @@ export interface WizardQuestion {
   key: Extract<OnboardingStep, 'role' | 'industry' | 'use_case'>;
   /** Which `OnboardingProgress` field this question's answer patches. */
   field: 'role' | 'industry' | 'useCase';
-  /** `cards` renders option tiles; `search` renders the searchable dropdown. */
-  layout: 'cards' | 'search';
+  /**
+   * `list` stacks full-width rows, `cards` renders a tile grid, `search`
+   * renders the searchable dropdown. Nine roles as tiles read as a wall of
+   * cards next to the five-tile use-case screen two questions later — a list
+   * scans top-to-bottom in one pass and keeps the card treatment meaningful
+   * where it is actually used.
+   */
+  layout: 'list' | 'cards' | 'search';
   question: string;
   helper: string;
   options: WizardOption[];
@@ -68,7 +74,7 @@ export function wizardQuestions(m: OnboardingMessages): WizardQuestion[] {
     {
       key: 'role',
       field: 'role',
-      layout: 'cards',
+      layout: 'list',
       question: m.role.question,
       helper: m.role.helper,
       options: ONBOARDING_ROLES.map((value) => ({
@@ -111,7 +117,21 @@ export interface WizardTemplate {
   id: FormTemplateId;
   name: string;
   description: string;
+  icon: string;
 }
+
+/**
+ * One glyph per template, keyed by the id so a new template cannot ship without
+ * one. Deliberately echoes `USE_CASE_ICONS` where the two correspond, so the
+ * card the previous answer pre-selects carries the same symbol that answer did.
+ */
+const TEMPLATE_ICONS: Readonly<Record<FormTemplateId, string>> = {
+  'lead-qualifier': '\u{1F3AF}',
+  'customer-feedback': '\u{1F4DD}',
+  'event-registration': '\u{1F39F}',
+  application: '\u{1F4C4}',
+  blank: '\u{270D}',
+};
 
 /**
  * The template cards, in offer order. `blank` is forced LAST regardless of where
@@ -124,6 +144,7 @@ export function wizardTemplates(m: OnboardingMessages): WizardTemplate[] {
     id,
     name: m.templates.options[id].name,
     description: m.templates.options[id].description,
+    icon: TEMPLATE_ICONS[id],
   }));
 }
 

--- a/apps/web/lib/onboarding.ts
+++ b/apps/web/lib/onboarding.ts
@@ -1,0 +1,135 @@
+/**
+ * The onboarding wizard's question bank — SHAPE only.
+ *
+ * Values are the enums the API validates against (@quill/types); labels come
+ * from the i18n catalog at render time. Keeping copy out of here is what lets
+ * the same bank serve both locales without a parallel Spanish structure that
+ * could silently drift out of step with the English one.
+ */
+import type { FormsMessages } from '@quill/shared';
+import {
+  ONBOARDING_INDUSTRIES,
+  ONBOARDING_ROLES,
+  ONBOARDING_USE_CASES,
+  FORM_TEMPLATE_IDS,
+  type FormTemplateId,
+  type OnboardingStep,
+} from '@quill/types';
+
+type OnboardingMessages = FormsMessages['admin']['onboarding'];
+
+export interface WizardOption {
+  value: string;
+  label: string;
+  /** Emoji glyph for the option card; absent on the searchable dropdown. */
+  icon?: string;
+}
+
+export interface WizardQuestion {
+  key: Extract<OnboardingStep, 'role' | 'industry' | 'use_case'>;
+  /** Which `OnboardingProgress` field this question's answer patches. */
+  field: 'role' | 'industry' | 'useCase';
+  /** `cards` renders option tiles; `search` renders the searchable dropdown. */
+  layout: 'cards' | 'search';
+  question: string;
+  helper: string;
+  options: WizardOption[];
+}
+
+/**
+ * Per-role glyphs, keyed by the enum so a new role cannot ship without one.
+ * Icons are here rather than in the i18n catalog because they are the same in
+ * every language — duplicating them per locale would only create a way for the
+ * two to disagree.
+ */
+const ROLE_ICONS: Readonly<Record<(typeof ONBOARDING_ROLES)[number], string>> = {
+  sales: '\u{1F4B0}',
+  marketing: '\u{1F4E3}',
+  support: '\u{1F4AC}',
+  product: '\u{1F9ED}',
+  founder: '\u{1F680}',
+  engineering: '\u{1F4BB}',
+  hr: '\u{1F91D}',
+  operations: '\u{2699}',
+  other: '\u{2728}',
+};
+
+const USE_CASE_ICONS: Readonly<Record<(typeof ONBOARDING_USE_CASES)[number], string>> = {
+  leads: '\u{1F3AF}',
+  feedback: '\u{1F4DD}',
+  event: '\u{1F39F}',
+  application: '\u{1F4C4}',
+  other: '\u{2728}',
+};
+
+/** The three questions, in the order they are asked. */
+export function wizardQuestions(m: OnboardingMessages): WizardQuestion[] {
+  return [
+    {
+      key: 'role',
+      field: 'role',
+      layout: 'cards',
+      question: m.role.question,
+      helper: m.role.helper,
+      options: ONBOARDING_ROLES.map((value) => ({
+        value,
+        label: m.role.options[value],
+        icon: ROLE_ICONS[value],
+      })),
+    },
+    {
+      // Second, deliberately. It is the most "for us" of the three, and the
+      // middle is where an unglamorous question costs the least.
+      key: 'industry',
+      field: 'industry',
+      layout: 'search',
+      question: m.industry.question,
+      helper: m.industry.helper,
+      options: ONBOARDING_INDUSTRIES.map((value) => ({
+        value,
+        label: m.industry.options[value],
+      })),
+    },
+    {
+      // Last, and adjacent to the template picker on purpose: this answer
+      // pre-selects a card on the very next screen, so the momentum carries.
+      key: 'use_case',
+      field: 'useCase',
+      layout: 'cards',
+      question: m.useCase.question,
+      helper: m.useCase.helper,
+      options: ONBOARDING_USE_CASES.map((value) => ({
+        value,
+        label: m.useCase.options[value],
+        icon: USE_CASE_ICONS[value],
+      })),
+    },
+  ];
+}
+
+export interface WizardTemplate {
+  id: FormTemplateId;
+  name: string;
+  description: string;
+}
+
+/**
+ * The template cards, in offer order. `blank` is forced LAST regardless of where
+ * it sits in the enum: it is the fallback, and a fallback above real options
+ * reads as the recommended path.
+ */
+export function wizardTemplates(m: OnboardingMessages): WizardTemplate[] {
+  const ids = FORM_TEMPLATE_IDS.filter((id) => id !== 'blank');
+  return [...ids, 'blank' as const].map((id) => ({
+    id,
+    name: m.templates.options[id].name,
+    description: m.templates.options[id].description,
+  }));
+}
+
+/** Interpolate `{key}` placeholders — the same convention the renderer uses. */
+export function fill(template: string, values: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key: string) =>
+    key in values ? String(values[key]) : match,
+  );
+}

--- a/apps/web/lib/onboarding.ts
+++ b/apps/web/lib/onboarding.ts
@@ -1,5 +1,11 @@
 /**
- * The onboarding wizard's question bank — SHAPE only.
+ * The onboarding wizard's question bank.
+ *
+ * Each question is a real `FormStep` — the same shape a form author's questions
+ * have — so the wizard renders through `StepInput`, the product's own renderer,
+ * rather than a lookalike built beside it. That is the point: the first thing a
+ * new user sees IS a Dapta form, and it cannot drift away from one, because a
+ * change to how forms render changes this screen too.
  *
  * Values are the enums the API validates against (@quill/types); labels come
  * from the i18n catalog at render time. Keeping copy out of here is what lets
@@ -7,6 +13,7 @@
  * could silently drift out of step with the English one.
  */
 import type { FormsMessages } from '@quill/shared';
+import type { FormStep } from '@quill/engine';
 import {
   ONBOARDING_INDUSTRIES,
   ONBOARDING_ROLES,
@@ -18,28 +25,12 @@ import {
 
 type OnboardingMessages = FormsMessages['admin']['onboarding'];
 
-export interface WizardOption {
-  value: string;
-  label: string;
-  /** Emoji glyph for the option card; absent on the searchable dropdown. */
-  icon?: string;
-}
-
 export interface WizardQuestion {
   key: Extract<OnboardingStep, 'role' | 'industry' | 'use_case'>;
   /** Which `OnboardingProgress` field this question's answer patches. */
   field: 'role' | 'industry' | 'useCase';
-  /**
-   * `list` stacks full-width rows, `cards` renders a tile grid, `search`
-   * renders the searchable dropdown. Nine roles as tiles read as a wall of
-   * cards next to the five-tile use-case screen two questions later — a list
-   * scans top-to-bottom in one pass and keeps the card treatment meaningful
-   * where it is actually used.
-   */
-  layout: 'list' | 'cards' | 'search';
-  question: string;
-  helper: string;
-  options: WizardOption[];
+  /** The step `StepInput` renders — a real form question, not a lookalike. */
+  step: FormStep;
 }
 
 /**
@@ -74,41 +65,57 @@ export function wizardQuestions(m: OnboardingMessages): WizardQuestion[] {
     {
       key: 'role',
       field: 'role',
-      layout: 'list',
-      question: m.role.question,
-      helper: m.role.helper,
-      options: ONBOARDING_ROLES.map((value) => ({
-        value,
-        label: m.role.options[value],
-        icon: ROLE_ICONS[value],
-      })),
+      step: {
+        key: 'role',
+        type: 'multiple_choice',
+        question: m.role.question,
+        helper: m.role.helper,
+        // LIST, not cards. Nine roles as tiles read as a wall next to the
+        // five-tile use-case screen two questions later; rows scan in one pass
+        // and keep the card treatment meaningful where it is actually used.
+        optionLayout: 'list',
+        options: ONBOARDING_ROLES.map((value) => ({
+          value,
+          label: m.role.options[value],
+          icon: ROLE_ICONS[value],
+        })),
+      },
     },
     {
       // Second, deliberately. It is the most "for us" of the three, and the
       // middle is where an unglamorous question costs the least.
       key: 'industry',
       field: 'industry',
-      layout: 'search',
-      question: m.industry.question,
-      helper: m.industry.helper,
-      options: ONBOARDING_INDUSTRIES.map((value) => ({
-        value,
-        label: m.industry.options[value],
-      })),
+      step: {
+        key: 'industry',
+        type: 'dropdown',
+        question: m.industry.question,
+        helper: m.industry.helper,
+        placeholder: m.industry.placeholder,
+        options: ONBOARDING_INDUSTRIES.map((value) => ({
+          value,
+          label: m.industry.options[value],
+        })),
+      },
     },
     {
       // Last, and adjacent to the template picker on purpose: this answer
       // pre-selects a card on the very next screen, so the momentum carries.
       key: 'use_case',
       field: 'useCase',
-      layout: 'cards',
-      question: m.useCase.question,
-      helper: m.useCase.helper,
-      options: ONBOARDING_USE_CASES.map((value) => ({
-        value,
-        label: m.useCase.options[value],
-        icon: USE_CASE_ICONS[value],
-      })),
+      step: {
+        key: 'use_case',
+        type: 'multiple_choice',
+        question: m.useCase.question,
+        helper: m.useCase.helper,
+        optionLayout: 'cards',
+        showIcons: true,
+        options: ONBOARDING_USE_CASES.map((value) => ({
+          value,
+          label: m.useCase.options[value],
+          icon: USE_CASE_ICONS[value],
+        })),
+      },
     },
   ];
 }

--- a/apps/web/lib/product-analytics.ts
+++ b/apps/web/lib/product-analytics.ts
@@ -45,7 +45,30 @@ export interface AnalyticsIdentity {
   accountId: string;
   accountCode: string;
   role: string;
+  /**
+   * The account's first-touch acquisition tags, attached as GROUP properties so
+   * every workspace-level funnel is sliceable by campaign. Absent for direct
+   * traffic and for accounts that predate attribution — which is why they are
+   * only registered when present (see `identifyMember`).
+   */
+  attribution?: Record<string, string | number | null | undefined> | null;
 }
+
+/**
+ * The attribution fields worth carrying into the analytics vendor, re-keyed to
+ * the snake_case every other property here uses.
+ *
+ * An allowlist, not a copy of the blob: the column also holds `gclid`/`fbclid`,
+ * which are per-click ids. Those would give each account a unique group-property
+ * value, which is useless for grouping and needless data to hand a third party.
+ */
+const GROUP_ATTRIBUTION_FIELDS = [
+  ['utmSource', 'utm_source'],
+  ['utmMedium', 'utm_medium'],
+  ['utmCampaign', 'utm_campaign'],
+  ['utmContent', 'utm_content'],
+  ['utmTerm', 'utm_term'],
+] as const;
 
 function clean(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
@@ -150,7 +173,31 @@ export function identifyMember(identity: AnalyticsIdentity): void {
     member_id: identity.memberId,
     role: identity.role,
   });
-  ph.group('forms_account', identity.accountId, { account_code: identity.accountCode });
+  ph.group('forms_account', identity.accountId, {
+    account_code: identity.accountCode,
+    // Campaign tags ride on the GROUP, not the person, because that is what
+    // they describe: the workspace was acquired from a campaign, and every
+    // member who later joins it inherits that fact. Attaching them per-event
+    // instead would leave the vendor's autocaptured events unattributed, so
+    // "which campaign produced accounts that finished onboarding" would only be
+    // answerable across the handful of events we hand-instrument.
+    ...groupAttribution(identity.attribution),
+  });
+}
+
+/** The campaign subset of the attribution blob, snake_cased. Empty when absent. */
+function groupAttribution(
+  attribution: AnalyticsIdentity['attribution'],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!attribution) return out;
+  for (const [field, key] of GROUP_ATTRIBUTION_FIELDS) {
+    const value = attribution[field];
+    // Only non-empty STRINGS: the blob also carries a numeric `firstSeenAt`, and
+    // a number arriving where a tag is expected would break grouping silently.
+    if (typeof value === 'string' && value) out[key] = value;
+  }
+  return out;
 }
 
 /**

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-qa/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -38,7 +38,9 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     ".next-qa/types/**/*.ts",
-    ".next-qa/dev/types/**/*.ts"
+    ".next-qa/dev/types/**/*.ts",
+    ".next-onboarding/types/**/*.ts",
+    ".next-onboarding/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -117,10 +117,13 @@ export const serverEnvSchema = z.object({
   // ship empty workspaces.
   SEED_DEMO_FORM: boolish.default('true'),
 
-  // Onboarding WIZARD: gate the whole first-run experience — three qualifying
+  // Onboarding WIZARD: the whole first-run experience — three qualifying
   // questions, then the person picks the template their first form is built
-  // from. OFF by default so a fork (and this product, until the flag is flipped
-  // per environment) behaves exactly as before.
+  // from. ON by default: the deploy pipeline is the rollout gate (dev
+  // auto-releases first, prd is a manual promotion), so a config-side default
+  // of off would only re-create that gate in a file a second team owns. The
+  // flag stays as an emergency kill switch and a fork's opt-out, not as a
+  // step of the rollout.
   //
   // It also SUPPRESSES the auto-seed above, and must: `seedDemoFormForAccount`
   // only writes when the account has zero forms, so a demo seeded at first login
@@ -131,7 +134,7 @@ export const serverEnvSchema = z.object({
   // Suppressing the seed is also what makes abandonment MEASURABLE: with it off,
   // someone who quits mid-wizard is left with zero forms, which is a fact the
   // funnel can see. With a demo seeded for everyone, that state is invisible.
-  ONBOARDING_WIZARD: boolish.default('false'),
+  ONBOARDING_WIZARD: boolish.default('true'),
 
   // Auth — unset selects the local dev stub.
   AUTH_PROVIDER: z.enum(['local', 'workos']).default('local'),

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -117,6 +117,22 @@ export const serverEnvSchema = z.object({
   // ship empty workspaces.
   SEED_DEMO_FORM: boolish.default('true'),
 
+  // Onboarding WIZARD: gate the whole first-run experience — three qualifying
+  // questions, then the person picks the template their first form is built
+  // from. OFF by default so a fork (and this product, until the flag is flipped
+  // per environment) behaves exactly as before.
+  //
+  // It also SUPPRESSES the auto-seed above, and must: `seedDemoFormForAccount`
+  // only writes when the account has zero forms, so a demo seeded at first login
+  // would make the account non-empty and the wizard's own form would never be
+  // created. The two features are mutually exclusive by construction, not by
+  // convention — see `maybeSeedDemoForm`'s callers.
+  //
+  // Suppressing the seed is also what makes abandonment MEASURABLE: with it off,
+  // someone who quits mid-wizard is left with zero forms, which is a fact the
+  // funnel can see. With a demo seeded for everyone, that state is invisible.
+  ONBOARDING_WIZARD: boolish.default('false'),
+
   // Auth — unset selects the local dev stub.
   AUTH_PROVIDER: z.enum(['local', 'workos']).default('local'),
 

--- a/packages/db/migrations/postgres/0011_onboarding.sql
+++ b/packages/db/migrations/postgres/0011_onboarding.sql
@@ -1,0 +1,51 @@
+-- Onboarding wizard — additive.
+--
+-- Two nullable columns on `account`. Together they answer "who is this workspace
+-- for, and did they ever finish setting it up" — the two questions the schema
+-- could not answer before, and the ones every drop-off report needs.
+--
+--   account.onboarding             — JSON, the wizard's working state AND its
+--                                    result. Shape is `accountOnboardingSchema`
+--                                    in @quill/types:
+--                                      { version, role, industry, useCase,
+--                                        template, lastStep, stepsSeen[],
+--                                        startedAt }
+--                                    Written on EVERY step advance, not only at
+--                                    the end — that is the whole point. A row
+--                                    with `lastStep: 'industry'` and no
+--                                    `onboarding_completed_at` IS the drop-off
+--                                    record; without the incremental write, an
+--                                    abandoned onboarding leaves nothing behind
+--                                    and "where do people quit" is unanswerable.
+--
+--                                    Joins to `account.attribution` (0010) on
+--                                    the same row, so drop-off per campaign is
+--                                    one GROUP BY with no new plumbing.
+--
+--   account.onboarding_completed_at — epoch-ms the wizard was finished. A
+--                                    MILESTONE CLAIM in the 0010 sense: written
+--                                    `UPDATE … WHERE … IS NULL`, so exactly one
+--                                    caller wins and the completion event fires
+--                                    once. Also the gate the dashboard reads —
+--                                    NULL means "send them to the wizard".
+ALTER TABLE account ADD COLUMN IF NOT EXISTS onboarding JSONB;
+ALTER TABLE account ADD COLUMN IF NOT EXISTS onboarding_completed_at BIGINT;
+
+-- Every account that already exists predates the wizard, so it is onboarded BY
+-- DEFINITION. Without this, the gate reads NULL for all of them and every
+-- existing user is bounced out of their dashboard into a wizard they never
+-- asked for, on the first request after this migration runs.
+--
+-- `created_at` rather than `now()`: it keeps "completed before we shipped this"
+-- legible in the data instead of stamping the whole table with the deploy
+-- timestamp and inventing a spike of completions that never happened.
+--
+-- Idempotent (`WHERE … IS NULL`), so it is a no-op for any row a later claim
+-- has already won.
+UPDATE account SET onboarding_completed_at = created_at
+WHERE onboarding_completed_at IS NULL;
+
+-- The funnel query filters on this column ("accounts created since X that have
+-- NOT completed"), which is a scan without it.
+CREATE INDEX IF NOT EXISTS account_onboarding_completed_idx
+  ON account (onboarding_completed_at);

--- a/packages/db/migrations/sqlite/0011_onboarding.sql
+++ b/packages/db/migrations/sqlite/0011_onboarding.sql
@@ -1,0 +1,56 @@
+-- Onboarding wizard — additive.
+--
+-- Two nullable columns on `account`. Together they answer "who is this workspace
+-- for, and did they ever finish setting it up" — the two questions the schema
+-- could not answer before, and the ones every drop-off report needs.
+--
+--   account.onboarding             — TEXT JSON, the wizard's working state AND
+--                                    its result. Shape is
+--                                    `accountOnboardingSchema` in @quill/types:
+--                                      { version, role, industry, useCase,
+--                                        template, lastStep, stepsSeen[],
+--                                        startedAt }
+--                                    Written on EVERY step advance, not only at
+--                                    the end — that is the whole point. A row
+--                                    with `lastStep: 'industry'` and no
+--                                    `onboarding_completed_at` IS the drop-off
+--                                    record; without the incremental write, an
+--                                    abandoned onboarding leaves nothing behind
+--                                    and "where do people quit" is unanswerable.
+--
+--                                    Joins to `account.attribution` (0010) on
+--                                    the same row, so drop-off per campaign is
+--                                    one GROUP BY with no new plumbing.
+--
+--   account.onboarding_completed_at — epoch-ms the wizard was finished. A
+--                                    MILESTONE CLAIM in the 0010 sense: written
+--                                    `UPDATE … WHERE … IS NULL`, so exactly one
+--                                    caller wins and the completion event fires
+--                                    once. Also the gate the dashboard reads —
+--                                    NULL means "send them to the wizard".
+--
+-- SQLite has no ADD COLUMN IF NOT EXISTS. It does not need one: migrate.ts runs
+-- each numbered file exactly once, gated on the _migrations table, so a bare
+-- ADD COLUMN is applied a single time per database — the same contract every
+-- prior SQLite migration here relies on (see 0009, 0010).
+ALTER TABLE account ADD COLUMN onboarding TEXT;
+ALTER TABLE account ADD COLUMN onboarding_completed_at INTEGER;
+
+-- Every account that already exists predates the wizard, so it is onboarded BY
+-- DEFINITION. Without this, the gate reads NULL for all of them and every
+-- existing user is bounced out of their dashboard into a wizard they never
+-- asked for, on the first request after this migration runs.
+--
+-- `created_at` rather than a literal now: it keeps "completed before we shipped
+-- this" legible in the data instead of stamping the whole table with the deploy
+-- timestamp and inventing a spike of completions that never happened.
+--
+-- Idempotent (`WHERE … IS NULL`), so it is a no-op for any row a later claim
+-- has already won.
+UPDATE account SET onboarding_completed_at = created_at
+WHERE onboarding_completed_at IS NULL;
+
+-- The funnel query filters on this column ("accounts created since X that have
+-- NOT completed"), which is a scan without it.
+CREATE INDEX IF NOT EXISTS account_onboarding_completed_idx
+  ON account (onboarding_completed_at);

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -6,7 +6,7 @@
  * so the identical code runs on SQLite (clone-and-run) and Postgres (prod).
  */
 import { randomUUID } from 'node:crypto';
-import { mergeWebhookSecrets } from '@quill/types';
+import { attributionSchema, mergeWebhookSecrets, type Attribution } from '@quill/types';
 import { sql, type Db } from './client';
 import { canonicalPublicCode } from './short-links';
 import type { CrudResult } from './crud';
@@ -85,6 +85,19 @@ export interface MeView {
   email: string | null;
   role: string;
   status: string;
+  /**
+   * Onboarding completion (0011): epoch-ms, or null when the wizard is still
+   * owed. Read on EVERY dashboard request — the layout's redirect gate is the
+   * one consumer — so it rides along on this query rather than costing a second
+   * round trip per page load.
+   */
+  onboardingCompletedAt: number | null;
+  /**
+   * First-touch acquisition tags (0010), so the browser can attach them as
+   * analytics GROUP properties. Without them every onboarding funnel is
+   * un-sliceable by campaign, which is most of the reason to measure it.
+   */
+  attribution: Attribution | null;
 }
 
 /** The authenticated host's identity for the dashboard header + settings. */
@@ -97,8 +110,11 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     email: string | null;
     role: string;
     status: string;
+    onboarding_completed_at: number | null;
+    attribution: unknown;
   }>(
-    sql`SELECT a.code, a.vanity_slug, m.handle, m.display_name, m.email, m.role, m.status
+    sql`SELECT a.code, a.vanity_slug, a.onboarding_completed_at, a.attribution,
+               m.handle, m.display_name, m.email, m.role, m.status
         FROM account a JOIN member m ON m.account_id = a.id
         WHERE a.id = ${accountId} AND m.id = ${memberId} LIMIT 1`,
   );
@@ -114,7 +130,22 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     email: row.email,
     role: row.role,
     status: row.status,
+    // BIGINT — node-postgres returns it as a STRING, SQLite as a number. Coerce
+    // here or `/v1/me` ships a string behind a `number | null` contract.
+    onboardingCompletedAt:
+      row.onboarding_completed_at == null ? null : Number(row.onboarding_completed_at),
+    // `safeParse`, not a cast: this column predates several shapes of writer and
+    // a stale blob must not throw inside the request that renders every
+    // dashboard page. Unreadable tags degrade to "not known", never to a 500.
+    attribution: parseAttributionColumn(row.attribution),
   };
+}
+
+/** Read `account.attribution` defensively — an unparseable blob reads as absent. */
+function parseAttributionColumn(raw: unknown): Attribution | null {
+  if (raw == null) return null;
+  const parsed = attributionSchema.safeParse(parseJsonColumn(raw, null));
+  return parsed.success ? parsed.data : null;
 }
 
 // --- Forms -------------------------------------------------------------------

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,6 +14,8 @@ export * from './analytics';
 export * from './milestones';
 export * from './members';
 export * from './demo-form';
+export * from './onboarding';
+export * from './templates';
 export * from './short-links';
 export * from './outbox';
 export * from './notification-settings';

--- a/packages/db/src/onboarding.spec.ts
+++ b/packages/db/src/onboarding.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Onboarding persistence — the incremental progress write and the write-once
+ * completion claim. Runs on whatever DATABASE_URL is set, so the same assertions
+ * cover SQLite and Postgres.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createDb, migrate, sql, type Db } from './index';
+import {
+  getAccountOnboarding,
+  saveOnboardingProgress,
+  claimOnboardingComplete,
+} from './onboarding';
+
+let db: Db;
+
+/**
+ * Fresh ids per test. On Postgres the suite shares ONE database with every other
+ * spec and with the seeded demo data, so this file must never clear a table to
+ * isolate itself. Unique ids give the same isolation and touch nothing else.
+ */
+let ACCOUNT: string;
+let OTHER_ACCOUNT: string;
+let n = 0;
+
+/**
+ * A brand-new account: `onboarding_completed_at` unset, which is what "still
+ * owed the wizard" means. Migration 0011's backfill has already run by now, so
+ * it cannot touch this row — the INSERT simply leaves the column NULL, exactly
+ * as it does for an account the running app creates at signup.
+ */
+async function seedAccount(accountId: string, code: string): Promise<void> {
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${code}, ${code}, 1000)`,
+  );
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+  const run = `${Date.now()}_${n++}`;
+  ACCOUNT = `acc_ob_a_${run}`;
+  OTHER_ACCOUNT = `acc_ob_b_${run}`;
+  await seedAccount(ACCOUNT, `oa${run}`.slice(0, 20));
+  await seedAccount(OTHER_ACCOUNT, `ob${run}`.slice(0, 20));
+});
+
+afterEach(() => {
+  db.close?.();
+});
+
+describe('getAccountOnboarding', () => {
+  it('reports an untouched account as owed the wizard', async () => {
+    expect(await getAccountOnboarding(db, ACCOUNT)).toEqual({
+      onboarding: null,
+      completedAt: null,
+    });
+  });
+
+  it('returns null for an account that does not exist', async () => {
+    expect(await getAccountOnboarding(db, 'acc_nope')).toBeNull();
+  });
+
+  it('treats an UNPARSEABLE blob as absent rather than throwing', async () => {
+    // An older build could have written a shape this one no longer understands.
+    // A dashboard request must not 500 over it.
+    await db.run(sql`UPDATE account SET onboarding = ${'{"version":99}'} WHERE id = ${ACCOUNT}`);
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding).toBeNull();
+  });
+});
+
+describe('saveOnboardingProgress', () => {
+  it('stamps version and startedAt on the first write', async () => {
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 5000);
+    expect(saved).toMatchObject({ version: 1, role: 'sales', lastStep: 'role', startedAt: 5000 });
+  });
+
+  it('keeps the ORIGINAL startedAt across later writes', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 5000);
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { industry: 'software', lastStep: 'industry' }, 9000);
+    expect(saved?.startedAt).toBe(5000);
+  });
+
+  it('merges answers instead of replacing them', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 5000);
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { industry: 'software', lastStep: 'industry' }, 6000);
+    expect(saved).toMatchObject({ role: 'sales', industry: 'software' });
+  });
+
+  it('does NOT blank an earlier answer when a later patch omits it', async () => {
+    // The bug this pins: spreading the patch wholesale lets an omitted key
+    // arrive as `undefined` and overwrite a stored answer — so navigating back,
+    // which re-patches only `lastStep`, would erase the role.
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'founder', lastStep: 'role' }, 5000);
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'role' }, 6000);
+    expect(saved?.role).toBe('founder');
+  });
+
+  it('accumulates the step trail in order, without repeats', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'role' }, 1);
+    await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'industry' }, 2);
+    // Back-navigation revisits a screen; the trail must not grow a duplicate.
+    await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'role' }, 3);
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'use_case' }, 4);
+    expect(saved?.stepsSeen).toEqual(['role', 'industry', 'use_case']);
+  });
+
+  it('persists — a reread returns what was written', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'marketing', lastStep: 'role' }, 5000);
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding).toMatchObject({ role: 'marketing' });
+    expect(state?.completedAt).toBeNull();
+  });
+
+  it('is account-scoped — one account cannot write another', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 5000);
+    const other = await getAccountOnboarding(db, OTHER_ACCOUNT);
+    expect(other?.onboarding).toBeNull();
+  });
+
+  it('refuses to write once onboarding is COMPLETE', async () => {
+    // A stale tab or a retried request must not rewrite the answers of a
+    // finished onboarding — the record of what was actually chosen is the point.
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', 7000);
+    expect(await saveOnboardingProgress(db, ACCOUNT, { role: 'hr', lastStep: 'role' }, 8000)).toBeNull();
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding?.template).toBe('lead-qualifier');
+    expect(state?.onboarding?.role).toBeUndefined();
+  });
+
+  it('returns null for an account that does not exist', async () => {
+    expect(await saveOnboardingProgress(db, 'acc_nope', { lastStep: 'role' }, 1)).toBeNull();
+  });
+});
+
+describe('claimOnboardingComplete — exactly once, ever', () => {
+  it('the first caller wins', async () => {
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', 7000)).toBe(true);
+  });
+
+  it('every later caller loses', async () => {
+    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', 7000);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', 8000)).toBe(false);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', 9000)).toBe(false);
+  });
+
+  it('the LOSER does not overwrite the winner’s template', async () => {
+    // Losing must be inert. If the second call still wrote, the account would
+    // report a template it never created a form from.
+    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', 8000);
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding?.template).toBe('customer-feedback');
+    expect(state?.completedAt).toBe(7000);
+  });
+
+  it('CONCURRENT callers produce exactly one winner', async () => {
+    // This assertion only has teeth on POSTGRES — better-sqlite3 is synchronous,
+    // so the two calls serialize there regardless. It is the guarded UPDATE, not
+    // the read before it, that makes this single-winner.
+    const results = await Promise.all([
+      claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', 7000),
+      claimOnboardingComplete(db, ACCOUNT, 'application', 7000),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('preserves the answers gathered along the way', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'founder', lastStep: 'role' }, 1000);
+    await saveOnboardingProgress(db, ACCOUNT, { industry: 'ecommerce', lastStep: 'industry' }, 2000);
+    await saveOnboardingProgress(db, ACCOUNT, { useCase: 'leads', lastStep: 'use_case' }, 3000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', 4000);
+
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding).toMatchObject({
+      version: 1,
+      role: 'founder',
+      industry: 'ecommerce',
+      useCase: 'leads',
+      template: 'lead-qualifier',
+      lastStep: 'template',
+      startedAt: 1000,
+    });
+    expect(state?.onboarding?.stepsSeen).toEqual(['role', 'industry', 'use_case', 'template']);
+    expect(state?.completedAt).toBe(4000);
+  });
+
+  it('completes even when the wizard was never patched', async () => {
+    // Someone who lands on the last screen via a restored session still has to
+    // be able to finish; a missing blob is not an error state.
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', 7000)).toBe(true);
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding).toMatchObject({ version: 1, template: 'blank', startedAt: 7000 });
+  });
+
+  it('returns false for an account that does not exist', async () => {
+    expect(await claimOnboardingComplete(db, 'acc_nope', 'blank', 1)).toBe(false);
+  });
+});
+
+describe('the 0011 backfill statement', () => {
+  it('stamps a pre-existing account with its own created_at, not the deploy time', async () => {
+    // What a row that predates the wizard experiences when the migration runs.
+    // Without it the gate reads NULL for every existing user and bounces them
+    // out of their dashboard into a wizard they never asked for. `created_at`
+    // rather than "now" keeps "completed before we shipped this" legible instead
+    // of inventing a spike of completions on deploy day.
+    const run = `${Date.now()}_${n++}`;
+    const id = `acc_ob_legacy_${run}`;
+    // `code` is UNIQUE account-wide and Postgres shares ONE database across the
+    // whole suite, so the code has to carry the per-run suffix. Slicing the id's
+    // PREFIX would hand every test in the same second the same 20 characters.
+    const code = `ol${run}`.slice(0, 20);
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${id}, ${code}, ${'legacy'}, 4242)`,
+    );
+    await db.run(
+      sql`UPDATE account SET onboarding_completed_at = created_at
+          WHERE onboarding_completed_at IS NULL AND id = ${id}`,
+    );
+    const state = await getAccountOnboarding(db, id);
+    expect(state?.completedAt).toBe(4242);
+  });
+});

--- a/packages/db/src/onboarding.ts
+++ b/packages/db/src/onboarding.ts
@@ -1,0 +1,173 @@
+/**
+ * ONBOARDING — the first-run wizard's persistence.
+ *
+ * Two writes, and the difference between them is the whole design:
+ *
+ *   - `saveOnboardingProgress` runs on EVERY step advance. It is what makes an
+ *     ABANDONED onboarding leave a trace. Storing only the finished result would
+ *     mean the people who quit — the only ones a funnel is really about — write
+ *     nothing at all, and "where do they quit" would be unanswerable from the
+ *     database.
+ *   - `claimOnboardingComplete` runs once, as a write-once CLAIM in the same
+ *     sense as `claimAccountMilestone` (see milestones.ts): exactly one caller
+ *     wins, so the first form is created once and the completion event fires
+ *     once, even on a double-click or a replayed request.
+ *
+ * Both guard on `onboarding_completed_at IS NULL`. That guard is not decoration:
+ * without it a PATCH arriving after completion — a stale tab, a retried request —
+ * would rewrite the answers of a finished onboarding, and the record of what the
+ * person actually chose would be lost.
+ */
+import { sql } from 'drizzle-orm';
+import type { Db } from './client';
+import { jsonParam, parseJsonColumn } from './forms';
+import {
+  accountOnboardingSchema,
+  type AccountOnboarding,
+  type FormTemplateId,
+  type OnboardingProgressInput,
+  type OnboardingStep,
+} from '@quill/types';
+
+/** `account.onboarding` + `account.onboarding_completed_at`, as the API reports them. */
+export interface OnboardingState {
+  /** The wizard's answers so far; null when it was never opened. */
+  onboarding: AccountOnboarding | null;
+  /** Epoch-ms of completion; null = still owed the wizard. */
+  completedAt: number | null;
+}
+
+/** An empty, well-formed blob — the shape a first write starts from. */
+function emptyOnboarding(now: number): AccountOnboarding {
+  return { version: 1, stepsSeen: [], startedAt: now };
+}
+
+/**
+ * Read the stored blob, defensively.
+ *
+ * `safeParse` rather than a cast: this column can hold a blob written by an
+ * OLDER build of the product, and one unknown enum value must not throw inside
+ * a dashboard request. A blob that does not parse is treated as absent — the
+ * wizard restarts, which is recoverable; a 500 on every page load is not.
+ */
+function readOnboarding(raw: unknown): AccountOnboarding | null {
+  if (raw == null) return null;
+  const parsed = accountOnboardingSchema.safeParse(parseJsonColumn(raw, null));
+  return parsed.success ? parsed.data : null;
+}
+
+/** Append `step` to the trail unless it is already there (back-navigation repeats). */
+function withStepSeen(seen: readonly OnboardingStep[], step: OnboardingStep | null | undefined) {
+  if (!step || seen.includes(step)) return [...seen];
+  return [...seen, step];
+}
+
+/** The onboarding state for one account, or null when the account does not exist. */
+export async function getAccountOnboarding(
+  db: Db,
+  accountId: string,
+): Promise<OnboardingState | null> {
+  const row = await db.get<{ onboarding: unknown; onboarding_completed_at: number | null }>(
+    sql`SELECT onboarding, onboarding_completed_at FROM account WHERE id = ${accountId} LIMIT 1`,
+  );
+  if (!row) return null;
+  return {
+    onboarding: readOnboarding(row.onboarding),
+    // BIGINT, which node-postgres returns as a STRING while SQLite returns a
+    // number. Coerce at the read site or a Postgres deployment hands the API a
+    // string where its own type says number, and every consumer downstream
+    // compares timestamps as text.
+    completedAt: row.onboarding_completed_at == null ? null : Number(row.onboarding_completed_at),
+  };
+}
+
+/**
+ * Merge one step's worth of progress into `account.onboarding`.
+ *
+ * Returns the stored blob, or null when the account does not exist or its
+ * onboarding is already complete (the guarded UPDATE matched nothing).
+ *
+ * Read-modify-write rather than a SQL-side merge, because there is no jsonb
+ * concatenation SQLite also understands and the dual-dialect rule is not
+ * negotiable. The lost-update window is real but bounded to a SINGLE person
+ * advancing their OWN wizard one screen at a time: two overlapping PATCHes can
+ * drop one entry from `stepsSeen`. The answers themselves survive — each screen
+ * patches a different field — and `lastStep` self-heals on the next advance. A
+ * missing breadcrumb is an acceptable price; a non-portable write is not.
+ */
+export async function saveOnboardingProgress(
+  db: Db,
+  accountId: string,
+  patch: OnboardingProgressInput,
+  now: number = Date.now(),
+): Promise<AccountOnboarding | null> {
+  const current = await getAccountOnboarding(db, accountId);
+  if (!current || current.completedAt != null) return null;
+
+  const base = current.onboarding ?? emptyOnboarding(now);
+  const next: AccountOnboarding = {
+    ...base,
+    version: 1,
+    // Only fields the client actually sent overwrite. Spreading `patch` wholesale
+    // would let an omitted key arrive as `undefined` and blank an earlier answer,
+    // so a back-navigation that re-patches only `lastStep` would erase the role.
+    ...(patch.role !== undefined ? { role: patch.role } : {}),
+    ...(patch.industry !== undefined ? { industry: patch.industry } : {}),
+    ...(patch.useCase !== undefined ? { useCase: patch.useCase } : {}),
+    ...(patch.template !== undefined ? { template: patch.template } : {}),
+    ...(patch.lastStep !== undefined ? { lastStep: patch.lastStep } : {}),
+    stepsSeen: withStepSeen(base.stepsSeen ?? [], patch.lastStep),
+    startedAt: base.startedAt ?? now,
+  };
+
+  const written = await db.get<{ id: string }>(
+    sql`UPDATE account SET onboarding = ${jsonParam(next)}
+        WHERE id = ${accountId} AND onboarding_completed_at IS NULL
+        RETURNING id`,
+  );
+  return written ? next : null;
+}
+
+/**
+ * Claim COMPLETION for an account: the wizard was finished and the first form is
+ * about to be created from `template`.
+ *
+ * True for exactly one caller, ever. The caller that wins is the one that may
+ * create the form and emit the completion event — everyone else (a double-click,
+ * a retried request, a second tab) gets false and must do neither, or the
+ * account ends up with two "first" forms and the funnel counts one person twice.
+ *
+ * Writes the answers and the timestamp in ONE statement so the two can never
+ * disagree: an account is never left marked complete with no record of what was
+ * chosen, nor with a template recorded and no completion.
+ */
+export async function claimOnboardingComplete(
+  db: Db,
+  accountId: string,
+  template: FormTemplateId,
+  now: number = Date.now(),
+): Promise<boolean> {
+  const current = await getAccountOnboarding(db, accountId);
+  if (!current) return false;
+
+  const base = current.onboarding ?? emptyOnboarding(now);
+  const next: AccountOnboarding = {
+    ...base,
+    version: 1,
+    template,
+    lastStep: 'template',
+    stepsSeen: withStepSeen(base.stepsSeen ?? [], 'template'),
+    startedAt: base.startedAt ?? now,
+  };
+
+  // The guard, not the read above, is what makes this single-winner: a caller
+  // that lost a race between the read and this statement finds the column
+  // already set and matches no row.
+  const claimed = await db.get<{ id: string }>(
+    sql`UPDATE account
+        SET onboarding = ${jsonParam(next)}, onboarding_completed_at = ${now}
+        WHERE id = ${accountId} AND onboarding_completed_at IS NULL
+        RETURNING id`,
+  );
+  return Boolean(claimed);
+}

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -23,6 +23,17 @@ export const account = pgTable('account', {
   activatedAt: bigint('activated_at', { mode: 'number' }),
   /** Milestone CLAIM: epoch-ms of the first form view. Same write-once discipline. */
   firstViewedAt: bigint('first_viewed_at', { mode: 'number' }),
+  /**
+   * Onboarding wizard state AND result (see 0011) — `accountOnboardingSchema` in
+   * @quill/types. Written on every step advance, so a row with a `lastStep` and
+   * no `onboardingCompletedAt` IS the drop-off record.
+   */
+  onboarding: jsonb('onboarding'),
+  /**
+   * Milestone CLAIM: epoch-ms the wizard was finished. Also the dashboard gate —
+   * NULL means "send them to the wizard".
+   */
+  onboardingCompletedAt: bigint('onboarding_completed_at', { mode: 'number' }),
   createdAt: bigint('created_at', { mode: 'number' }).notNull(),
 });
 

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -32,6 +32,17 @@ export const account = sqliteTable('account', {
   activatedAt: integer('activated_at'),
   /** Milestone CLAIM: epoch-ms of the first form view. Same write-once discipline. */
   firstViewedAt: integer('first_viewed_at'),
+  /**
+   * Onboarding wizard state AND result (TEXT JSON, see 0011) —
+   * `accountOnboardingSchema` in @quill/types. Written on every step advance, so
+   * a row with a `lastStep` and no `onboardingCompletedAt` IS the drop-off record.
+   */
+  onboarding: text('onboarding'),
+  /**
+   * Milestone CLAIM: epoch-ms the wizard was finished. Also the dashboard gate —
+   * NULL means "send them to the wizard".
+   */
+  onboardingCompletedAt: integer('onboarding_completed_at'),
   createdAt: integer('created_at').notNull(),
 });
 

--- a/packages/db/src/templates/application.ts
+++ b/packages/db/src/templates/application.ts
@@ -1,0 +1,88 @@
+/**
+ * TEMPLATE — Applications and requests. Offered to whoever answers "take
+ * applications or requests" in the onboarding wizard.
+ *
+ * Covers both halves of that answer on purpose: a job application and an inbound
+ * work request ask the same shape of question (who are you, what for, where can
+ * we see your work, when do you need it). Splitting them into two templates
+ * would have meant two near-identical configs and one more decision at the
+ * moment the person just wants to get going.
+ *
+ * No file-upload step: `FORM_FIELD_TYPES` has no `file` kind, so the portfolio
+ * question asks for a LINK. A template must never reference a step type the
+ * engine cannot render.
+ */
+import type { FormConfig } from '@quill/types';
+
+export const APPLICATION_CONFIG: FormConfig = {
+  version: 1,
+  branding: { primaryColor: '#0f766e' },
+  cover: {
+    enabled: true,
+    eyebrow: 'We are reading every one',
+    headline: 'Tell us what you need',
+    subheadline: 'Five questions. No account, no login — just the details so we can get moving.',
+    ctaText: 'Start my request',
+  },
+  steps: [
+    {
+      key: 'name',
+      type: 'name',
+      question: 'What is your name?',
+      required: true,
+      flowGroup: 'lead_capture',
+    },
+    {
+      key: 'email',
+      type: 'email',
+      question: 'How do we reach you?',
+      placeholder: 'you@company.com',
+      required: true,
+      flowGroup: 'lead_capture',
+    },
+    {
+      key: 'request_type',
+      type: 'multiple_choice',
+      question: 'What is this about?',
+      required: true,
+      showIcons: true,
+      options: [
+        { label: 'A role you are hiring for', value: 'job', icon: '\u{1F4BC}' },
+        { label: 'A project or piece of work', value: 'project', icon: '\u{1F6E0}' },
+        { label: 'Support with something', value: 'support', icon: '\u{1F198}' },
+        { label: 'Something else', value: 'other', icon: '\u{2728}' },
+      ],
+    },
+    {
+      key: 'details',
+      type: 'textarea',
+      question: 'Tell us more',
+      placeholder: 'What you need, and anything that would help us understand it.',
+      required: true,
+    },
+    {
+      key: 'portfolio',
+      type: 'text',
+      question: 'Somewhere we can see your work?',
+      helper: 'A link to a site, a profile, or a repo. Optional.',
+      placeholder: 'https://',
+      required: false,
+    },
+    {
+      key: 'timeline',
+      type: 'multiple_choice',
+      question: 'How soon do you need an answer?',
+      required: true,
+      options: [
+        { label: 'As soon as possible', value: 'asap', icon: '\u{26A1}' },
+        { label: 'Within a couple of weeks', value: 'weeks', icon: '\u{1F4C5}' },
+        { label: 'No rush', value: 'flexible', icon: '\u{1F60C}' },
+      ],
+    },
+  ],
+  ending: {
+    headline: 'Got it — thank you',
+    body: 'We read every submission and will come back to you at the address you gave us.',
+  },
+  partialSubmitAfterStep: 2,
+};

--- a/packages/db/src/templates/event-registration.ts
+++ b/packages/db/src/templates/event-registration.ts
@@ -1,0 +1,78 @@
+/**
+ * TEMPLATE — Event registration. Offered to whoever answers "register people for
+ * an event" in the onboarding wizard.
+ *
+ * Deliberately does NOT use a `scheduler` step. That step needs a real Calendly
+ * or HubSpot event-type URL to render anything, and a template cannot ship one —
+ * it would arrive broken, which is a worse first impression than not offering it.
+ * A registration form collects who is coming; picking a time slot is a different
+ * job the author can add once their own scheduling link exists.
+ *
+ * Scoring is OFF: an attendee list is a list, not a ranking, and a score column
+ * on it is noise the author would have to go and switch off.
+ */
+import type { FormConfig } from '@quill/types';
+
+export const EVENT_REGISTRATION_CONFIG: FormConfig = {
+  version: 1,
+  branding: { primaryColor: '#7c3aed' },
+  cover: {
+    enabled: true,
+    eyebrow: 'You are invited',
+    headline: 'Save your spot',
+    subheadline: 'Tell us who is coming and we will send the details straight to your inbox.',
+    ctaText: 'Register',
+    trustBadge: 'Free to attend — we will only email you about this event',
+  },
+  steps: [
+    {
+      key: 'name',
+      type: 'name',
+      question: 'Who should we put on the list?',
+      required: true,
+      flowGroup: 'lead_capture',
+    },
+    {
+      key: 'email',
+      type: 'email',
+      question: 'Where should we send your confirmation?',
+      placeholder: 'you@company.com',
+      required: true,
+      flowGroup: 'lead_capture',
+    },
+    {
+      key: 'attending',
+      type: 'multiple_choice',
+      question: 'How will you be joining us?',
+      required: true,
+      showIcons: true,
+      options: [
+        { label: 'In person', value: 'in_person', icon: '\u{1F3E2}' },
+        { label: 'Online', value: 'online', icon: '\u{1F4BB}' },
+      ],
+    },
+    {
+      key: 'guests',
+      type: 'slider',
+      question: 'Bringing anyone with you?',
+      helper: '0 means just you.',
+      min: 0,
+      max: 5,
+      step: 1,
+      default: 0,
+      sliderUnitLabel: 'guests',
+    },
+    {
+      key: 'notes',
+      type: 'textarea',
+      question: 'Anything we should know?',
+      placeholder: 'Dietary requirements, accessibility needs, or nothing at all.',
+      required: false,
+    },
+  ],
+  ending: {
+    headline: 'You are on the list',
+    body: 'Check your inbox for the details. See you there.',
+  },
+  partialSubmitAfterStep: 2,
+};

--- a/packages/db/src/templates/index.ts
+++ b/packages/db/src/templates/index.ts
@@ -1,0 +1,59 @@
+/**
+ * FORM TEMPLATES — the starting points the onboarding wizard offers for a
+ * workspace's first form.
+ *
+ * One entry per `FormTemplateId` (@quill/types), and the union is exhaustive by
+ * construction: `Record<FormTemplateId, …>` makes adding an id without a
+ * template a compile error rather than a runtime 404 on the one screen a new
+ * user cannot skip.
+ *
+ * `customer-feedback` IS the old auto-seeded demo form, reused rather than
+ * rewritten. Before the wizard it was pushed on everyone; now it is one of four
+ * things a person can choose, which is the same config doing an honester job.
+ *
+ * `blank` carries NO config on purpose — `config: null` means "let the API apply
+ * whatever a brand-new form gets", so the empty starting point can never drift
+ * away from what the dashboard's own "new form" button produces.
+ *
+ * The config never crosses the wire: the web posts a template ID and the API
+ * resolves it here, so a client cannot hand us an arbitrary form config through
+ * the onboarding path.
+ */
+import type { FormConfig, FormTemplateId } from '@quill/types';
+import { DEMO_FORM_CONFIG, DEMO_FORM_NAME } from '../demo-form';
+import { LEAD_QUALIFIER_CONFIG } from './lead-qualifier';
+import { EVENT_REGISTRATION_CONFIG } from './event-registration';
+import { APPLICATION_CONFIG } from './application';
+
+export { LEAD_QUALIFIER_CONFIG } from './lead-qualifier';
+export { EVENT_REGISTRATION_CONFIG } from './event-registration';
+export { APPLICATION_CONFIG } from './application';
+
+export interface FormTemplate {
+  /** The form's display name at creation; the person can rename it immediately. */
+  name: string;
+  /** The starting config, or null for the blank form (the API's own default). */
+  config: FormConfig | null;
+}
+
+export const FORM_TEMPLATES: Readonly<Record<FormTemplateId, FormTemplate>> = {
+  'lead-qualifier': { name: 'Lead qualifier', config: LEAD_QUALIFIER_CONFIG },
+  'customer-feedback': { name: DEMO_FORM_NAME, config: DEMO_FORM_CONFIG },
+  'event-registration': { name: 'Event registration', config: EVENT_REGISTRATION_CONFIG },
+  application: { name: 'Applications and requests', config: APPLICATION_CONFIG },
+  blank: { name: 'Untitled form', config: null },
+};
+
+/**
+ * Resolve a template id to its definition.
+ *
+ * Takes `string`, not `FormTemplateId`: the caller is an HTTP handler, and the
+ * value arrives from a request body. Returning `undefined` for anything
+ * unrecognized keeps the "is this a real template?" check in one place instead
+ * of scattering a cast at every call site.
+ */
+export function getFormTemplate(id: string): FormTemplate | undefined {
+  return Object.prototype.hasOwnProperty.call(FORM_TEMPLATES, id)
+    ? FORM_TEMPLATES[id as FormTemplateId]
+    : undefined;
+}

--- a/packages/db/src/templates/lead-qualifier.ts
+++ b/packages/db/src/templates/lead-qualifier.ts
@@ -1,0 +1,112 @@
+/**
+ * TEMPLATE — Lead qualifier. Offered to whoever answers "get more customers and
+ * leads" in the onboarding wizard.
+ *
+ * The one template that exercises SCORING end to end: every qualifying answer
+ * carries points, and two outcome buckets split the results. That is deliberate
+ * — scoring is the feature a lead-gen user came for, and a template that ships
+ * it switched off teaches them the product does not have it.
+ *
+ * Copy is English (the OSS default); Spanish parity lives beside it in
+ * `TEMPLATE_COPY_ES` (see ./copy-es.ts) for anyone localizing a fork.
+ */
+import type { FormConfig } from '@quill/types';
+
+export const LEAD_QUALIFIER_CONFIG: FormConfig = {
+  version: 1,
+  branding: { primaryColor: '#2563eb' },
+  cover: {
+    enabled: true,
+    eyebrow: 'Two minutes, tops',
+    headline: 'Let us see if we are a fit',
+    subheadline:
+      'A few quick questions so we can point you at the right thing instead of a generic demo.',
+    ctaText: 'Get started',
+    trustBadge: 'No credit card, no sales call unless you ask for one',
+  },
+  steps: [
+    {
+      key: 'role',
+      type: 'multiple_choice',
+      question: 'What best describes you?',
+      required: true,
+      showIcons: true,
+      flowGroup: 'qualification',
+      options: [
+        { label: 'Founder or owner', value: 'founder', icon: '\u{1F680}', points: 10 },
+        { label: 'Team lead or manager', value: 'lead', icon: '\u{1F9ED}', points: 7 },
+        { label: 'Individual contributor', value: 'individual', icon: '\u{1F464}', points: 3 },
+        { label: 'Just exploring', value: 'exploring', icon: '\u{1F440}', points: 1 },
+      ],
+    },
+    {
+      key: 'team_size',
+      type: 'slider',
+      question: 'How many people are on your team?',
+      helper: 'Drag to the closest number.',
+      flowGroup: 'qualification',
+      min: 1,
+      max: 100,
+      step: 1,
+      default: 5,
+      sliderUnitLabel: 'people',
+      sliderScoring: [
+        { min: 1, max: 4, points: 2 },
+        { min: 5, max: 24, points: 6 },
+        { min: 25, max: 100, points: 10 },
+      ],
+    },
+    {
+      key: 'timeline',
+      type: 'multiple_choice',
+      question: 'When are you looking to get started?',
+      required: true,
+      flowGroup: 'qualification',
+      options: [
+        { label: 'This month', value: 'now', icon: '\u{1F525}', points: 10 },
+        { label: 'This quarter', value: 'quarter', icon: '\u{1F4C5}', points: 6 },
+        { label: 'Sometime this year', value: 'year', icon: '\u{1F5D3}', points: 3 },
+        { label: 'Just researching', value: 'research', icon: '\u{1F4DA}', points: 0 },
+      ],
+    },
+    {
+      key: 'challenge',
+      type: 'textarea',
+      question: 'What are you trying to solve?',
+      placeholder: 'A sentence is plenty — it helps us skip the generic pitch.',
+      required: false,
+      flowGroup: 'qualification',
+    },
+    {
+      key: 'name',
+      type: 'name',
+      question: 'Last thing — who are we talking to?',
+      required: true,
+      flowGroup: 'lead_capture',
+    },
+    {
+      key: 'email',
+      type: 'email',
+      question: 'Where should we send the results?',
+      placeholder: 'you@company.com',
+      required: true,
+      flowGroup: 'lead_capture',
+    },
+  ],
+  scoring: { enabled: true },
+  outcomes: [
+    {
+      id: 'nurture',
+      label: 'Thanks — we will be in touch',
+      minScore: 0,
+      message: 'We will send over a few things worth reading while you decide.',
+    },
+    {
+      id: 'qualified',
+      label: 'You are exactly who we built this for',
+      minScore: 20,
+      message: 'Keep an eye on your inbox — someone from the team will reach out today.',
+    },
+  ],
+  partialSubmitAfterStep: 4,
+};

--- a/packages/db/src/templates/lead-qualifier.ts
+++ b/packages/db/src/templates/lead-qualifier.ts
@@ -108,5 +108,12 @@ export const LEAD_QUALIFIER_CONFIG: FormConfig = {
       message: 'Keep an eye on your inbox — someone from the team will reach out today.',
     },
   ],
-  partialSubmitAfterStep: 4,
+  // AFTER the email (step 6), not before it. `partialSubmitAfterStep` is 1-based
+  // over `steps`, and a partial submission exists to keep a lead who abandons
+  // mid-form. Firing it at step 4 — which this template did — saved the
+  // qualifying answers with no name and no email, i.e. a lead nobody can
+  // contact, on the one template whose entire job is producing contactable
+  // leads. Matches the customer-feedback template, which also fires on its
+  // contact step.
+  partialSubmitAfterStep: 6,
 };

--- a/packages/db/src/templates/templates.spec.ts
+++ b/packages/db/src/templates/templates.spec.ts
@@ -50,6 +50,30 @@ describe('FORM_TEMPLATES', () => {
     },
   );
 
+  it.each(FORM_TEMPLATE_IDS.filter((id) => id !== 'blank'))(
+    '%s only submits a partial once it can contact the person',
+    (id) => {
+      // `partialSubmitAfterStep` is 1-based over `steps`. A partial that fires
+      // BEFORE the email step saves a half-answered form with no way to reach
+      // whoever left it — which is the entire value a partial is supposed to
+      // capture. lead-qualifier shipped at step 4 with its email at step 6.
+      const config = FORM_TEMPLATES[id].config;
+      const after = config?.partialSubmitAfterStep;
+      if (after == null) return;
+
+      const steps = config?.steps ?? [];
+      const lastContact = steps.reduce(
+        (acc, s, i) => (s.type === 'email' || s.type === 'phone' ? i + 1 : acc),
+        0,
+      );
+      if (lastContact === 0) return; // no contact step to be early relative to
+      expect(after, `${id} submits its partial before collecting contact details`).toBeGreaterThanOrEqual(
+        lastContact,
+      );
+      expect(after, `${id} partialSubmitAfterStep is past the end`).toBeLessThanOrEqual(steps.length);
+    },
+  );
+
   it('only declares outcomes on the template that enables scoring', () => {
     // An outcome bucket without scoring never resolves past the first range, so
     // the author sees dead config they did not write.

--- a/packages/db/src/templates/templates.spec.ts
+++ b/packages/db/src/templates/templates.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * The templates are AUTHORED configs, not generated ones, so nothing else stops
+ * them drifting out of the v1 contract — a typo'd step type or a missing option
+ * value would ship and only fail on the one screen a new user cannot skip.
+ * Re-validating each of them here is what keeps that impossible.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formConfigSchema,
+  FORM_TEMPLATE_IDS,
+  USE_CASE_TEMPLATE,
+  ONBOARDING_USE_CASES,
+  type FormTemplateId,
+} from '@quill/types';
+import { FORM_TEMPLATES, getFormTemplate } from './index';
+
+describe('FORM_TEMPLATES', () => {
+  it('has an entry for every declared template id', () => {
+    expect(Object.keys(FORM_TEMPLATES).sort()).toEqual([...FORM_TEMPLATE_IDS].sort());
+  });
+
+  it.each(FORM_TEMPLATE_IDS.filter((id) => id !== 'blank'))(
+    '%s parses against the v1 config contract',
+    (id) => {
+      const result = formConfigSchema.safeParse(FORM_TEMPLATES[id].config);
+      // Surface zod's own message on failure — "false !== true" would send the
+      // next person hunting through a 90-line config by hand.
+      expect(result.success ? null : result.error.issues).toBeNull();
+    },
+  );
+
+  it('leaves `blank` without a config so it tracks the dashboard default', () => {
+    expect(FORM_TEMPLATES.blank.config).toBeNull();
+  });
+
+  it.each(FORM_TEMPLATE_IDS)('%s has a non-empty name', (id) => {
+    expect(FORM_TEMPLATES[id].name.trim().length).toBeGreaterThan(0);
+  });
+
+  it.each(FORM_TEMPLATE_IDS.filter((id) => id !== 'blank'))('%s asks at least one question', (id) => {
+    expect(FORM_TEMPLATES[id].config?.steps.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it.each(FORM_TEMPLATE_IDS.filter((id) => id !== 'blank'))(
+    '%s uses unique step keys',
+    (id) => {
+      // Duplicate keys silently collapse two questions into one answer.
+      const keys = (FORM_TEMPLATES[id].config?.steps ?? []).map((s) => s.key);
+      expect(new Set(keys).size).toBe(keys.length);
+    },
+  );
+
+  it('only declares outcomes on the template that enables scoring', () => {
+    // An outcome bucket without scoring never resolves past the first range, so
+    // the author sees dead config they did not write.
+    for (const id of FORM_TEMPLATE_IDS) {
+      const config = FORM_TEMPLATES[id].config;
+      if (!config?.outcomes?.length) continue;
+      expect(config.scoring?.enabled, `${id} declares outcomes`).toBe(true);
+    }
+  });
+});
+
+describe('USE_CASE_TEMPLATE', () => {
+  it('covers every use case', () => {
+    expect(Object.keys(USE_CASE_TEMPLATE).sort()).toEqual([...ONBOARDING_USE_CASES].sort());
+  });
+
+  it('maps every non-`other` use case to a real template', () => {
+    for (const useCase of ONBOARDING_USE_CASES) {
+      const mapped = USE_CASE_TEMPLATE[useCase];
+      if (useCase === 'other') {
+        // `other` pre-selects nothing on purpose: we do not know what they want,
+        // so guessing would put the wrong card under their cursor.
+        expect(mapped).toBeNull();
+        continue;
+      }
+      expect(mapped).not.toBeNull();
+      expect(getFormTemplate(mapped as FormTemplateId)).toBeDefined();
+    }
+  });
+
+  it('never pre-selects the blank form', () => {
+    // "Start from scratch" has to be chosen, never defaulted into — it is the
+    // one option that hands the person an empty screen.
+    expect(Object.values(USE_CASE_TEMPLATE)).not.toContain('blank');
+  });
+});
+
+describe('getFormTemplate', () => {
+  it('resolves a known id', () => {
+    expect(getFormTemplate('lead-qualifier')).toBe(FORM_TEMPLATES['lead-qualifier']);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getFormTemplate('not-a-template')).toBeUndefined();
+  });
+
+  it('returns undefined for an inherited Object property', () => {
+    // The id arrives in a request body, so `FORM_TEMPLATES[id]` alone would
+    // resolve 'constructor' or 'toString' to a function and crash the handler.
+    expect(getFormTemplate('constructor')).toBeUndefined();
+    expect(getFormTemplate('__proto__')).toBeUndefined();
+    expect(getFormTemplate('toString')).toBeUndefined();
+  });
+});

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1168,6 +1168,8 @@ export interface FormsMessages {
     onboarding: {
       /** The three stages, all visible from the first screen so the end is never a surprise. */
       stages: { account: string; profile: string; firstForm: string };
+      /** Accessible name for the language picker in the wizard's header. */
+      language: string;
       next: string;
       back: string;
       creating: string;
@@ -2330,6 +2332,7 @@ export const en: FormsMessages = {
     },
     onboarding: {
       stages: { account: 'Your account', profile: 'Get to know you', firstForm: 'Your first form' },
+      language: 'Language',
       next: 'Continue',
       back: 'Back',
       creating: 'Building your form…',
@@ -3514,6 +3517,7 @@ export const es: FormsMessages = {
     },
     onboarding: {
       stages: { account: 'Tu cuenta', profile: 'Conocerte', firstForm: 'Tu primer formulario' },
+      language: 'Idioma',
       next: 'Continuar',
       back: 'Atrás',
       creating: 'Creando tu formulario…',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1159,6 +1159,91 @@ export interface FormsMessages {
       unpublishedChanges: string;
       noChanges: string;
     };
+    /**
+     * First-run wizard: three questions, then the template the first form is
+     * built from. Keys are spelled out rather than derived from the @quill/types
+     * enums on purpose — this package is dependency-free by design, and the
+     * compiler still enforces EN/ES parity and a complete option set either way.
+     */
+    onboarding: {
+      /** The three stages, all visible from the first screen so the end is never a surprise. */
+      stages: { account: string; profile: string; firstForm: string };
+      next: string;
+      back: string;
+      creating: string;
+      /** Announced to assistive tech as the wizard advances. */
+      progress: string; // {current} {total}
+      role: {
+        question: string;
+        helper: string;
+        options: {
+          sales: string;
+          marketing: string;
+          support: string;
+          product: string;
+          founder: string;
+          engineering: string;
+          hr: string;
+          operations: string;
+          other: string;
+        };
+      };
+      industry: {
+        question: string;
+        helper: string;
+        placeholder: string;
+        search: string;
+        empty: string;
+        options: {
+          software: string;
+          ecommerce: string;
+          services: string;
+          agency: string;
+          health: string;
+          finance: string;
+          education: string;
+          realestate: string;
+          manufacturing: string;
+          nonprofit: string;
+          other: string;
+        };
+      };
+      useCase: {
+        question: string;
+        helper: string;
+        options: {
+          leads: string;
+          feedback: string;
+          event: string;
+          application: string;
+          other: string;
+        };
+      };
+      templates: {
+        question: string;
+        helper: string;
+        /** Badge on the card the previous answer pre-selected. */
+        recommended: string;
+        cta: string;
+        options: {
+          'lead-qualifier': { name: string; description: string };
+          'customer-feedback': { name: string; description: string };
+          'event-registration': { name: string; description: string };
+          application: { name: string; description: string };
+          blank: { name: string; description: string };
+        };
+      };
+      /** The three coach marks shown in the builder right after the form is made. */
+      tour: {
+        next: string;
+        done: string;
+        dismiss: string;
+        step: string; // {current} {total}
+        edit: { title: string; body: string };
+        preview: { title: string; body: string };
+        publish: { title: string; body: string };
+      };
+    };
   };
   /** Branded confirm dialog that replaces native browser confirm() prompts. */
   dialog: {
@@ -2242,6 +2327,105 @@ export const en: FormsMessages = {
       publishError: 'Could not publish — please try again.',
       unpublishedChanges: 'Unpublished changes',
       noChanges: 'All changes are published',
+    },
+    onboarding: {
+      stages: { account: 'Your account', profile: 'Get to know you', firstForm: 'Your first form' },
+      next: 'Continue',
+      back: 'Back',
+      creating: 'Building your form…',
+      progress: 'Question {current} of {total}',
+      role: {
+        question: 'What best describes your role?',
+        helper: 'Pick the closest one. It changes what we put in front of you first.',
+        options: {
+          sales: 'Sales',
+          marketing: 'Marketing',
+          support: 'Customer success or support',
+          product: 'Product, design or research',
+          founder: 'Founder or CEO',
+          engineering: 'Engineering or IT',
+          hr: 'People or HR',
+          operations: 'Operations',
+          other: 'Something else',
+        },
+      },
+      industry: {
+        question: 'What industry are you in?',
+        helper: 'Start typing to find yours.',
+        placeholder: 'Search industries',
+        search: 'Search',
+        empty: 'Nothing matches — pick Other.',
+        options: {
+          software: 'Software and technology',
+          ecommerce: 'Ecommerce and retail',
+          services: 'Professional services',
+          agency: 'Agency or marketing',
+          health: 'Healthcare',
+          finance: 'Finance and insurance',
+          education: 'Education',
+          realestate: 'Real estate',
+          manufacturing: 'Manufacturing and logistics',
+          nonprofit: 'Nonprofit',
+          other: 'Other',
+        },
+      },
+      useCase: {
+        question: 'What do you want to use Forms for?',
+        helper: 'We will set your first form up for exactly that.',
+        options: {
+          leads: 'Get more customers and leads',
+          feedback: 'Collect feedback',
+          event: 'Register people for an event',
+          application: 'Take applications or requests',
+          other: 'Something else',
+        },
+      },
+      templates: {
+        question: 'Here is your first form',
+        helper: 'Start from one of these — every question is yours to change.',
+        recommended: 'Recommended for you',
+        cta: 'Create my form',
+        options: {
+          'lead-qualifier': {
+            name: 'Lead qualifier',
+            description: 'Scores each answer and splits the results into hot and warm.',
+          },
+          'customer-feedback': {
+            name: 'Customer feedback',
+            description: 'A short satisfaction survey with an NPS question.',
+          },
+          'event-registration': {
+            name: 'Event registration',
+            description: 'Collect who is coming, how, and what they need.',
+          },
+          application: {
+            name: 'Applications and requests',
+            description: 'For job applications and inbound work requests alike.',
+          },
+          blank: {
+            name: 'Start from scratch',
+            description: 'An empty form. You write every question.',
+          },
+        },
+      },
+      tour: {
+        next: 'Next',
+        done: 'Got it',
+        dismiss: 'Dismiss',
+        step: '{current} of {total}',
+        edit: {
+          title: 'Edit any question',
+          body: 'Click a question to change its wording, its options, or what it asks for.',
+        },
+        preview: {
+          title: 'See what they see',
+          body: 'Preview opens the form exactly as the person answering it will find it.',
+        },
+        publish: {
+          title: 'Publish when you are ready',
+          body: 'Nothing is live until you publish. Then you get a link to share.',
+        },
+      },
     },
   },
   dialog: {
@@ -3327,6 +3511,105 @@ export const es: FormsMessages = {
       publishError: 'No se pudo publicar. Inténtalo de nuevo.',
       unpublishedChanges: 'Cambios sin publicar',
       noChanges: 'Todos los cambios están publicados',
+    },
+    onboarding: {
+      stages: { account: 'Tu cuenta', profile: 'Conocerte', firstForm: 'Tu primer formulario' },
+      next: 'Continuar',
+      back: 'Atrás',
+      creating: 'Creando tu formulario…',
+      progress: 'Pregunta {current} de {total}',
+      role: {
+        question: '¿Cuál es tu rol?',
+        helper: 'Elige el más cercano. Cambia lo que te mostramos primero.',
+        options: {
+          sales: 'Ventas',
+          marketing: 'Marketing',
+          support: 'Atención al cliente o soporte',
+          product: 'Producto, diseño o research',
+          founder: 'Fundador o CEO',
+          engineering: 'Tecnología o desarrollo',
+          hr: 'Recursos humanos',
+          operations: 'Operaciones',
+          other: 'Otro',
+        },
+      },
+      industry: {
+        question: '¿En qué industria estás?',
+        helper: 'Empieza a escribir para encontrar la tuya.',
+        placeholder: 'Buscar industrias',
+        search: 'Buscar',
+        empty: 'No hay coincidencias. Elige Otra.',
+        options: {
+          software: 'Software y tecnología',
+          ecommerce: 'Ecommerce y retail',
+          services: 'Servicios profesionales',
+          agency: 'Agencia o marketing',
+          health: 'Salud',
+          finance: 'Finanzas y seguros',
+          education: 'Educación',
+          realestate: 'Inmobiliaria',
+          manufacturing: 'Manufactura y logística',
+          nonprofit: 'ONG o sin fines de lucro',
+          other: 'Otra',
+        },
+      },
+      useCase: {
+        question: '¿Para qué quieres usar Forms?',
+        helper: 'Dejamos tu primer formulario listo para eso.',
+        options: {
+          leads: 'Captar clientes o leads',
+          feedback: 'Recibir feedback',
+          event: 'Registrar gente a un evento',
+          application: 'Recibir postulaciones o solicitudes',
+          other: 'Otra cosa',
+        },
+      },
+      templates: {
+        question: 'Aquí está tu primer formulario',
+        helper: 'Empieza con uno de estos. Cada pregunta es tuya para cambiarla.',
+        recommended: 'Recomendado para ti',
+        cta: 'Crear mi formulario',
+        options: {
+          'lead-qualifier': {
+            name: 'Calificador de leads',
+            description: 'Puntúa cada respuesta y separa los resultados en calientes y tibios.',
+          },
+          'customer-feedback': {
+            name: 'Opiniones de clientes',
+            description: 'Una encuesta corta de satisfacción con una pregunta NPS.',
+          },
+          'event-registration': {
+            name: 'Registro a evento',
+            description: 'Recoge quién viene, cómo y qué necesita.',
+          },
+          application: {
+            name: 'Postulaciones y solicitudes',
+            description: 'Sirve igual para vacantes que para pedidos de trabajo.',
+          },
+          blank: {
+            name: 'Empezar desde cero',
+            description: 'Un formulario vacío. Tú escribes cada pregunta.',
+          },
+        },
+      },
+      tour: {
+        next: 'Siguiente',
+        done: 'Entendido',
+        dismiss: 'Cerrar',
+        step: '{current} de {total}',
+        edit: {
+          title: 'Edita cualquier pregunta',
+          body: 'Haz clic en una pregunta para cambiar su texto, sus opciones o lo que pide.',
+        },
+        preview: {
+          title: 'Mira lo que ellos ven',
+          body: 'La vista previa abre el formulario tal como lo encontrará quien lo responda.',
+        },
+        publish: {
+          title: 'Publica cuando estés listo',
+          body: 'Nada está en línea hasta que publiques. Ahí obtienes el enlace para compartir.',
+        },
+      },
     },
   },
   dialog: {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1168,11 +1168,11 @@ export interface FormsMessages {
     onboarding: {
       /** The three stages, all visible from the first screen so the end is never a surprise. */
       stages: { account: string; profile: string; firstForm: string };
-      /** Accessible name for the language picker in the wizard's header. */
-      language: string;
       next: string;
       back: string;
+      /** Headline of the interstitial shown while the first form is created. */
       creating: string;
+      creatingSubtitle: string;
       /** Announced to assistive tech as the wizard advances. */
       progress: string; // {current} {total}
       role: {
@@ -2332,10 +2332,10 @@ export const en: FormsMessages = {
     },
     onboarding: {
       stages: { account: 'Your account', profile: 'Get to know you', firstForm: 'Your first form' },
-      language: 'Language',
       next: 'Continue',
       back: 'Back',
       creating: 'Building your form…',
+      creatingSubtitle: 'Setting up your questions. This only takes a second.',
       progress: 'Question {current} of {total}',
       role: {
         question: 'What best describes your role?',
@@ -3517,10 +3517,10 @@ export const es: FormsMessages = {
     },
     onboarding: {
       stages: { account: 'Tu cuenta', profile: 'Conocerte', firstForm: 'Tu primer formulario' },
-      language: 'Idioma',
       next: 'Continuar',
       back: 'Atrás',
       creating: 'Creando tu formulario…',
+      creatingSubtitle: 'Preparando tus preguntas. Solo toma un segundo.',
       progress: 'Pregunta {current} de {total}',
       role: {
         question: '¿Cuál es tu rol?',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1308,3 +1308,157 @@ export function attributionEventProps(attribution: Attribution): Record<string, 
   }
   return out;
 }
+
+/* ---------------------------------------------------------------------------
+ * ONBOARDING — the wizard a brand-new workspace sees before its dashboard.
+ *
+ * Three questions and a template pick. The answers describe WHO the workspace is
+ * for; the bookkeeping fields describe HOW FAR they got, which is the half that
+ * makes drop-off answerable at all.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Question 1 — "what best describes your role?".
+ *
+ * `other` is LAST on purpose. It is an escape hatch, not a peer of the real
+ * answers, and a list that buries it mid-way (as Typeform's does, at 7 of 8)
+ * makes people scan past their own role to find it.
+ */
+export const ONBOARDING_ROLES = [
+  'sales',
+  'marketing',
+  'support',
+  'product',
+  'founder',
+  'engineering',
+  'hr',
+  'operations',
+  'other',
+] as const;
+export type OnboardingRole = (typeof ONBOARDING_ROLES)[number];
+
+/**
+ * Question 2 — "what industry are you in?".
+ *
+ * Eleven buckets, not the 52 the Dapta IAM's `pre_signup` bank carries. Fifty-two
+ * options in a three-screen wizard is noise; these group the same space, and a
+ * 52 -> 11 mapping is a lookup table if the two ever need to be joined.
+ */
+export const ONBOARDING_INDUSTRIES = [
+  'software',
+  'ecommerce',
+  'services',
+  'agency',
+  'health',
+  'finance',
+  'education',
+  'realestate',
+  'manufacturing',
+  'nonprofit',
+  'other',
+] as const;
+export type OnboardingIndustry = (typeof ONBOARDING_INDUSTRIES)[number];
+
+/**
+ * Question 3 — "what do you want to use Forms for?".
+ *
+ * Deliberately 1:1 with the templates below (minus `other`): the question IS the
+ * template picker, answered a screen early. Answer `leads` and the lead
+ * qualifier is already selected on the next screen, so the momentum never breaks.
+ */
+export const ONBOARDING_USE_CASES = ['leads', 'feedback', 'event', 'application', 'other'] as const;
+export type OnboardingUseCase = (typeof ONBOARDING_USE_CASES)[number];
+
+/**
+ * The starting points offered at the end of the wizard.
+ *
+ * `blank` is not a template — it is the honest "start from scratch" choice, and
+ * it resolves to an empty form rather than to a config. Keeping it in the same
+ * union is what lets `template` record what the person actually picked instead
+ * of going NULL and being indistinguishable from an abandon.
+ */
+export const FORM_TEMPLATE_IDS = [
+  'lead-qualifier',
+  'customer-feedback',
+  'event-registration',
+  'application',
+  'blank',
+] as const;
+export type FormTemplateId = (typeof FORM_TEMPLATE_IDS)[number];
+
+/** Which use case pre-selects which template. `other` pre-selects nothing. */
+export const USE_CASE_TEMPLATE: Readonly<Record<OnboardingUseCase, FormTemplateId | null>> = {
+  leads: 'lead-qualifier',
+  feedback: 'customer-feedback',
+  event: 'event-registration',
+  application: 'application',
+  other: null,
+};
+
+/**
+ * The wizard's screens, in order. `lastStep` names the furthest one REACHED, so
+ * these are the buckets a drop-off report groups by.
+ */
+export const ONBOARDING_STEPS = ['role', 'industry', 'use_case', 'template'] as const;
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+
+/**
+ * `account.onboarding` (migration 0011) — the wizard's working state AND result.
+ *
+ * Every field is optional because this row is written on EVERY step advance, not
+ * only at the end. A half-filled blob is the normal, expected shape: it is the
+ * record of someone who is still mid-wizard, or who left. Requiring the answers
+ * would mean nothing is stored until completion, and an abandoned onboarding
+ * would leave no trace — which is precisely the thing this column exists to
+ * measure.
+ *
+ * Answers are stored RAW, with no score attached. Weighting them is a decision
+ * to make against real data later; baking a guess into the column now would make
+ * it unrecoverable.
+ *
+ * The API validates against this before writing, so an enum value the product
+ * does not offer can never reach the column even though the request body is
+ * client-supplied.
+ */
+export const accountOnboardingSchema = z.object({
+  version: z.literal(1),
+  role: z.enum(ONBOARDING_ROLES).nullable().optional(),
+  industry: z.enum(ONBOARDING_INDUSTRIES).nullable().optional(),
+  useCase: z.enum(ONBOARDING_USE_CASES).nullable().optional(),
+  template: z.enum(FORM_TEMPLATE_IDS).nullable().optional(),
+  /** The furthest screen REACHED — the drop-off bucket. */
+  lastStep: z.enum(ONBOARDING_STEPS).nullable().optional(),
+  /**
+   * Every screen reached, in order, deduped. `lastStep` alone cannot tell a
+   * straight run from one that went back and forth, and back-navigation is a
+   * usability signal worth keeping. Capped at the step count so a crafted body
+   * cannot grow the row.
+   */
+  stepsSeen: z.array(z.enum(ONBOARDING_STEPS)).max(ONBOARDING_STEPS.length).optional(),
+  /** Epoch-ms the wizard was first opened, for time-to-complete. */
+  startedAt: z.number().int().nonnegative().nullable().optional(),
+});
+export type AccountOnboarding = z.infer<typeof accountOnboardingSchema>;
+
+/**
+ * The PATCH body: a partial the client may send as it advances.
+ *
+ * `version` is deliberately NOT accepted — it is stamped server-side. A client
+ * that could set it could park a blob the reader will not understand.
+ * `stepsSeen` is likewise server-derived (appended from `lastStep`), so the
+ * ordering cannot be forged into a straight run that never happened.
+ */
+export const onboardingProgressSchema = z.object({
+  role: z.enum(ONBOARDING_ROLES).nullable().optional(),
+  industry: z.enum(ONBOARDING_INDUSTRIES).nullable().optional(),
+  useCase: z.enum(ONBOARDING_USE_CASES).nullable().optional(),
+  template: z.enum(FORM_TEMPLATE_IDS).nullable().optional(),
+  lastStep: z.enum(ONBOARDING_STEPS).nullable().optional(),
+});
+export type OnboardingProgressInput = z.infer<typeof onboardingProgressSchema>;
+
+/** The complete body: which starting point to create the first form from. */
+export const onboardingCompleteSchema = z.object({
+  template: z.enum(FORM_TEMPLATE_IDS),
+});
+export type OnboardingCompleteInput = z.infer<typeof onboardingCompleteSchema>;


### PR DESCRIPTION
## What

A first-run onboarding wizard behind the `ONBOARDING_WIZARD` flag (default **off**). New accounts land on `/onboarding`: three questions (role → industry → use case), then a template picker that creates their first form and drops them into the builder with the tour running.

## How it works

- **The wizard IS a Dapta form.** It renders through the public renderer's own shell and `StepInput` — the first screen a new user sees demonstrates the product, and it cannot drift from real forms because it shares their code.
- **Templates:** lead-qualifier, customer-feedback, event-registration, application, or blank. The use-case answer pre-selects the recommended card; the API resolves the template server-side.
- **Flag suppresses the demo auto-seed on purpose:** `seedDemoFormForAccount` only writes into accounts with zero forms, so a seeded demo would block the template form from ever being created. The rule lives inside `maybeSeedDemoForm`. Side effect wanted: with the wizard on, abandoners keep zero forms — abandonment becomes measurable.

## Tracking

- **PostHog:** `onboarding_started` / `step_viewed` / `step_answered` / `template_picked` (client) + `onboarding_completed` (server, from the completion claim's winner — counts accounts, not browsers). All filterable by UTM via the `forms_account` group.
- **DB:** `account.onboarding` JSON written on EVERY advance (`lastStep` = drop-off bucket) + `account.onboarding_completed_at` claim column, indexed. Same row as `account.attribution`, so drop-off per campaign is one GROUP BY.
- Migration 0011 is additive on both dialects and backfills `onboarding_completed_at = created_at` so existing accounts are never bounced into the wizard.

## UI

Desktop composes the wizard as the renderer's framed card, centred on the canvas (the wizard markup lacks `.pf__main`, so `.ob` takes over that centring job). Role question packs nine options into a two-column grid; every screen fits a 720px viewport with no scroll. Mobile keeps the renderer's full-bleed flow. All overrides scoped under `.ob` — real forms untouched.

## Rollout

The flag defaults **ON** — the deploy pipeline is the rollout gate, no configmap change needed anywhere:

1. Merge → dev auto-release picks it up, wizard live in dev
2. Watch the funnel a week
3. Promote to prd (manual gate) — wizard goes live there on promotion

`ONBOARDING_WIZARD=false` remains available as an emergency kill switch / fork opt-out. Existing accounts never see the wizard either way (migration 0011 backfills `onboarding_completed_at`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
