### PR TITLE
fix(onboarding): close the six blockers found in pre-merge review

### DIFF
--- a/.changeset/first-run-onboarding.md
+++ b/.changeset/first-run-onboarding.md
@@ -5,7 +5,7 @@
 '@quill/config': minor
 ---
 
-First-run onboarding wizard, behind `ONBOARDING_WIZARD` (default off).
+First-run onboarding wizard, behind `ONBOARDING_WIZARD` (**default on**).
 
 A brand-new workspace is asked three questions — role, industry, and what they
 want to use Forms for — and then picks the template its first form is built from,
@@ -13,6 +13,11 @@ replacing the demo form that used to be seeded for everyone. The two are mutuall
 exclusive by construction: the seed only writes into an account with zero forms,
 so `ONBOARDING_WIZARD` suppresses it rather than relying on operators to switch
 both correctly.
+
+> **Upgrading a self-hosted deployment:** because the flag defaults to on, this
+> release also turns `SEED_DEMO_FORM` inert — a new workspace gets the wizard and
+> the template it picks, not the seeded demo form. Set `ONBOARDING_WIZARD=false`
+> to keep the previous behaviour.
 
 - `@quill/types`: `accountOnboardingSchema` and the answer enums, the template id
   union, and the use-case → template mapping.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -8,25 +8,36 @@ up. This documents the wizard shipped behind `ONBOARDING_WIZARD` (default
 The short version:
 
 ```
-signup → /admin → (onboarding owed?) → /onboarding
-           ↑                               │
-           │            Q1 role → Q2 industry → Q3 use case → template picker
-           │                               │ (every advance PATCHes progress)
-           │                               ▼
-           └──────── redirect ←── POST complete (claim, once)
+signup → /admin → (owed AND admin/owner?) → /onboarding
+           ↑                                    │
+           │           Q1 role → Q2 industry → Q3 use case → template picker
+           │                                    │ (every advance PATCHes progress)
+           │                                    ▼
+           └──────── redirect ←── POST complete (claim, once; carries the answers)
                        to /admin/forms/<id>/edit?tour=1
 ```
 
 ## 1. The gate
 
-An account **owes onboarding** when both are true:
+A person **owes onboarding** when all three are true:
 
-- `ONBOARDING_WIZARD` is on (`packages/config/src/env.ts`), and
-- `account.onboarding_completed_at` is `NULL`.
+- `ONBOARDING_WIZARD` is on (`packages/config/src/env.ts`),
+- `account.onboarding_completed_at` is `NULL`, and
+- the caller is an **admin or owner** of that account.
 
-The API folds both into one field — `onboardingRequired` on `GET /v1/me`
+The API folds all three into one field — `onboardingRequired` on `GET /v1/me`
 (`apps/api/src/admin.service.ts`) — and the web app **never re-derives it**;
 there is exactly one copy of the rule.
+
+The role clause is not a nicety. Onboarding describes the **workspace**, so both
+its endpoints are admin-gated (`assertAdmin`) — an invited member must not be
+able to rewrite the owner's answers. Without the same clause on the gate, a
+plain member of an account whose owner abandoned the wizard was sent to
+`/onboarding`, silently 403'd on every step, 403'd on the completion, and
+bounced back by the same gate when the action fell through to `/admin`. The
+wizard renders no sidebar and no sign-out, so that loop had no exit. A member
+now lands on the dashboard of a workspace whose owner has not finished setting
+up, which is an ordinary state.
 
 Routing runs in both directions, which is what makes every URL safe to hit
 directly, bookmarked or back-buttoned:
@@ -45,6 +56,15 @@ exists.
 only genuinely new accounts are gated. (Using `created_at` rather than `now()`
 also keeps "completed before the feature shipped" legible in the data instead
 of inventing a spike of completions on deploy day.)
+
+**The seeded demo account is stamped by the seed itself**, not by that backfill.
+`db:setup` is `db:migrate && db:seed`, in that order, so the backfill sweeps the
+table before the demo row exists and can never reach it — which left the one
+account in a fresh database still owed a wizard. `pnpm dev` landed on
+`/onboarding` instead of the dashboard, the demo form was invisible behind the
+gate, and every Playwright spec that opens `/admin/...` followed the same
+redirect. `packages/db/src/seed.ts` writes the column directly; the demo account
+is onboarded by definition, since it ships with a form.
 
 ## 2. The wizard
 
@@ -96,13 +116,24 @@ template is a compile error).
 resolves it against this registry (`getFormTemplate`), so the onboarding path
 cannot be used to inject an arbitrary form config.
 
+**The form's NAME is localized, the QUESTIONS are not.** The completion request
+carries the locale the wizard rendered in, and the API resolves the name from
+`admin.onboarding.templates.options[id].formName` — the same catalog the card
+came from, so the form cannot be called something other than what was clicked.
+(`formName` is separate from the card's `name` because they are separate jobs:
+the blank card says "Start from scratch" and the form it makes is an "Untitled
+form".) The registry's own `name` is the English fallback for a caller that
+names no locale. The template **configs** are English only, so a Spanish signup
+gets a Spanish-named form asking English questions — a known gap, tracked
+separately.
+
 ## 4. Persistence — two writes, different jobs
 
 `packages/db/src/onboarding.ts`. Both live on the `account` row (migration
 `0011_onboarding.sql`, both dialects, additive):
 
 - `account.onboarding` (JSON) — `{ version, role, industry, useCase, template,
-  lastStep, stepsSeen[], startedAt }` (`accountOnboardingSchema`).
+  lastStep, stepsSeen[], startedAt, formId }` (`accountOnboardingSchema`).
 - `account.onboarding_completed_at` (epoch-ms) — the completion claim, indexed.
 
 **Write 1: `saveOnboardingProgress` — on EVERY advance.** This is what makes an
@@ -113,6 +144,24 @@ the role question and quit on industry. The wizard also claims the very first
 screen on arrival (`lastStep: 'role'`), otherwise "opened and quit immediately"
 is indistinguishable from "never arrived".
 
+The merge is **monotonic in every field**, and that is what makes two writes
+racing harmless:
+
+- an answer is never blanked — a patch field that is absent *or explicitly
+  `null`* is ignored (the schema is `.nullable()`, so `{"role": null}` is a
+  valid body, and an `!== undefined` guard used to let it erase a stored answer);
+- `lastStep` only ever **advances**. The wizard is pure client state, so a
+  refresh or a return visit remounts at question one and re-announces
+  `lastStep: 'role'`; letting that overwrite a stored `'template'` would file a
+  finisher as a first-question quitter and invert the metric this whole feature
+  exists to produce;
+- `stepsSeen` only grows, and `startedAt` keeps the earliest.
+
+The wizard also sends its **full accumulated answers** on every advance rather
+than a one-field delta — a patch that never landed is repaired by the next one —
+and **serializes** them, so its two writers (the arrival effect and each answer)
+cannot interleave on the row.
+
 The client action (`apps/web/app/onboarding/actions.ts`) **never throws into
 the wizard**: a failed save advances anyway. Losing one breadcrumb of telemetry
 beats trapping a person on question two because the network blipped.
@@ -120,16 +169,32 @@ beats trapping a person on question two because the network blipped.
 **Write 2: `claimOnboardingComplete` — once.** `UPDATE … WHERE
 onboarding_completed_at IS NULL`: exactly one caller wins, so the first form is
 created once and `forms_onboarding_completed` fires once even on a double-click or a
-second tab. A loser is handed the winner's form id and lands on the same form.
-Both writes guard on the claim, so a stale PATCH after completion can never
-rewrite a finished onboarding's answers.
+second tab. Both writes guard on the claim, so a stale PATCH after completion can
+never rewrite a finished onboarding's answers.
+
+The completion request **carries the answers** (`onboardingCompleteSchema`), not
+just the template. The template screen arms its CTA the moment question three is
+answered, so that answer's PATCH and this claim are routinely in flight
+together — and whichever read the row first would have written a blob missing
+the other's field. Carrying them means the winning statement writes the complete
+set and nothing has to arrive in time.
 
 After the claim wins, the API creates the form from the template
-(`apps/api/src/admin.service.ts#completeOnboarding`) and the web redirects to
+(`apps/api/src/admin.service.ts#completeOnboarding`), records its id on the blob
+(`recordOnboardingFormId`), and the web redirects to
 `/admin/forms/<id>/edit?tour=1` — the query param (never a cookie) arms the
-builder's coach marks exactly once. A failed form-create does **not** un-claim
-completion: the answers are stored, and the person lands on the dashboard where
-"New form" is the obvious next click.
+builder's coach marks exactly once. A **losing** claim reads that recorded id and
+lands on the same form. It used to guess with `ORDER BY created_at ASC LIMIT 1`,
+which on an account that already had a form handed the second tab an unrelated
+one with the first-run tour armed on it.
+
+A failed form-create does **not** un-claim completion: the answers are stored,
+and the person lands on the dashboard where "New form" is the obvious next click.
+A failed **completion** — a 500, a timeout, the API down — is different: the
+claim is unwritten, so `/admin` is not reachable (the gate reads the same NULL
+column and bounces them back into a wizard remounted at question one, with their
+answers gone). The action returns `{ ok: false }` and the wizard shows an error
+with a retry instead of navigating anywhere.
 
 ## 5. Interaction with the demo seed
 
@@ -180,6 +245,15 @@ source of a first form, so this is the whole cohort, not an edge case.
 The builder tour that follows emits `forms_onboarding_tour_step` (per coach
 mark) and `forms_onboarding_tour_finished`, so the funnel can run past the
 wizard into the first minute of the builder.
+
+`forms_onboarding_tour_step` fires only for a step whose **anchor actually
+resolved**, and `total_steps` counts only those. The tour probes for its three
+`[data-tour]` anchors once before it starts, because two of them can legitimately
+be absent: `edit` sits on a `hidden lg:block` aside inside the editor's
+`hasQuestions` branch, so it is missing under 1024px and missing for the `blank`
+template. Walking the list blind logged an impression for a card that never
+rendered and told the person "1 of 3" while showing two — and `blank` is both the
+template most in need of the tour and the one guaranteed to lose its first step.
 
 **The server event carries no `account_code`.** Client events are enriched by
 the browser SDK's registered identity (`account_code`, `account_id`,
@@ -234,7 +308,13 @@ as a string through node-postgres — the DB layer coerces at the read site.)
   answers stay on the row (`completed_at` stays NULL). If the flag comes back
   on later, those accounts resume being gated and the wizard restarts.
 - **Forks / self-hosters:** `ONBOARDING_WIZARD=false` + `SEED_DEMO_FORM=true`
-  restores the pre-wizard behaviour exactly.
+  restores the pre-wizard behaviour exactly. Note that `SEED_DEMO_FORM=true`
+  **alone** does nothing while the wizard is on — the wizard suppresses it, so
+  that the two can never both write a "first" form into the same account.
+- **A workspace stuck mid-wizard is not a support incident.** Only its
+  admins/owners are gated; everyone else works normally. An owner who wants out
+  can finish the wizard (any template, including blank), or an operator can
+  stamp `account.onboarding_completed_at` directly.
 
 ## 9. File map
 
@@ -250,7 +330,8 @@ as a string through node-postgres — the DB layer coerces at the read site.)
 | Persistence | `packages/db/src/onboarding.ts`, migration `0011_onboarding` (pg + sqlite) |
 | Templates | `packages/db/src/templates/` |
 | Seed suppression | `apps/api/src/auth.provider.ts` (`maybeSeedDemoForm`) |
+| Demo account's completion stamp | `packages/db/src/seed.ts` |
 | Enums + schemas | `packages/types/src/index.ts` (`ONBOARDING_*`, `accountOnboardingSchema`, `USE_CASE_TEMPLATE`) |
 | Copy (EN/ES) | `packages/shared/src/i18n/index.ts` (`admin.onboarding`) |
 | Builder tour | `apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx` (`?tour=1`) |
-| Tests | `packages/db/src/onboarding.spec.ts`, `packages/db/src/templates/templates.spec.ts`, `apps/api/src/onboarding.controller.spec.ts` |
+| Tests | `packages/db/src/onboarding.spec.ts`, `packages/db/src/seed.spec.ts`, `packages/db/src/templates/templates.spec.ts`, `apps/api/src/onboarding.controller.spec.ts`, `qa/e2e/v10-onboarding-gate.spec.ts` |

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -158,7 +158,15 @@ loud** on a bad value. Copy [`.env.example`](.env.example) to `.env` to override
 | `OUTBOX_WORKER_ENABLED` | `true` | set `false` only if a separate worker drains the outbox | no |
 | `OUTBOX_POLL_MS` | `5000` | — | no |
 | `OUTBOX_MAX_ATTEMPTS` | `5` | — | no |
-| `SEED_DEMO_FORM` | `true` | set `false` to ship empty new workspaces | no |
+| `ONBOARDING_WIZARD` | `true` | set `false` to skip the first-run wizard (and get `SEED_DEMO_FORM` back) | no |
+| `SEED_DEMO_FORM` | `true` | **inert while `ONBOARDING_WIZARD` is on**; set `false` to ship empty new workspaces | no |
+
+The two form-seeding knobs are mutually exclusive by construction. A new
+workspace gets exactly one of: the wizard's chosen template (`ONBOARDING_WIZARD`
+on, the default), the seeded demo form (`ONBOARDING_WIZARD=false` +
+`SEED_DEMO_FORM=true`), or nothing (both off). `SEED_DEMO_FORM=true` alone does
+**not** seed a form — the wizard suppresses it, so that the two can never both
+write a "first" form into the same account.
 
 ### Auth
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "@quill/destinations": "workspace:*",
     "@quill/engine": "workspace:*",
     "@quill/notifications": "workspace:*",
+    "@quill/shared": "workspace:*",
     "@quill/types": "workspace:*",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -247,7 +247,7 @@ export class AdminCrudController {
       throw new BadRequestException({ error: 'INVALID_TEMPLATE', message: 'Unknown template.' });
     }
 
-    const result = await this.admin.completeOnboarding(p, parsed.data.template);
+    const result = await this.admin.completeOnboarding(p, parsed.data);
     if (result.completed && this.productAnalytics?.enabled) {
       // Emitted server-side, from the CLAIM's winner, so the completion count is
       // the count of accounts that finished — not of browsers that reached the

--- a/apps/api/src/admin.service.ts
+++ b/apps/api/src/admin.service.ts
@@ -4,16 +4,24 @@ import {
   cacheEntitlement,
   claimOnboardingComplete,
   createForm,
+  getAccountOnboarding,
   getFormTemplate,
   getMe,
+  recordOnboardingFormId,
   saveOnboardingProgress,
   setVanitySlug,
   sql,
   type VanityOutcome,
 } from '@quill/db';
 import { canClaimVanitySlug } from '@quill/engine';
-import type { FormTemplateId, OnboardingProgressInput } from '@quill/types';
+import { getMessages } from '@quill/shared';
+import type {
+  FormTemplateId,
+  OnboardingCompleteInput,
+  OnboardingProgressInput,
+} from '@quill/types';
 import type { HostPrincipal } from './auth.service';
+import { isAdmin } from './permissions';
 import { DisabledEntitlementsProvider, type EntitlementsProvider } from './entitlements.provider';
 import { DB, ENTITLEMENTS, ONBOARDING_ENABLED, PREMIUM_MODE } from './tokens';
 
@@ -45,13 +53,23 @@ export class AdminService {
    * environment with the flag on in the web and off in the API would bounce
    * every user into a wizard whose endpoints refuse to serve it — a login loop
    * with no way out. One authority, one answer.
+   *
+   * ROLE is part of that answer, and leaving it out was a lockout. The wizard
+   * describes the WORKSPACE, so both its endpoints are admin-gated; an
+   * account-scoped flag would therefore send a plain `member` — a colleague who
+   * joined an org whose owner abandoned the wizard — to a screen where every
+   * write 403s, the completion 403s, and the fallback lands back under the gate
+   * that sent them. No sidebar, no sign-out, no way out. Answering `false` for
+   * anyone who cannot complete it puts them on the dashboard of a workspace
+   * whose owner has not finished setting up, which is a normal state.
    */
   async me(p: HostPrincipal) {
     const view = await getMe(this.db, p.accountId, p.memberId);
     if (!view) return view;
     return {
       ...view,
-      onboardingRequired: this.onboardingEnabled && view.onboardingCompletedAt == null,
+      onboardingRequired:
+        this.onboardingEnabled && view.onboardingCompletedAt == null && isAdmin(p.role),
     };
   }
 
@@ -81,38 +99,62 @@ export class AdminService {
    *
    * The template id is resolved to a config HERE, from a server-side registry, so
    * the request body can only ever name a starting point — never supply one.
+   *
+   * The NAME comes from the same i18n catalog the wizard rendered its cards
+   * from, so the form is called what the card said. The registry's own `name` is
+   * the fallback for a caller that names no locale — it is English, and having
+   * two places that both answer "what is this template called" is how a Spanish
+   * signup ended up clicking "Calificador de leads" and getting "Lead qualifier".
    */
   async completeOnboarding(
     p: HostPrincipal,
-    templateId: FormTemplateId,
+    input: OnboardingCompleteInput,
   ): Promise<{ completed: boolean; formId: string | null }> {
     if (!this.onboardingEnabled) return { completed: false, formId: null };
 
+    const templateId = input.template;
     const template = getFormTemplate(templateId);
     if (!template) return { completed: false, formId: null };
 
-    const won = await claimOnboardingComplete(this.db, p.accountId, templateId);
+    const won = await claimOnboardingComplete(this.db, p.accountId, templateId, {
+      role: input.role,
+      industry: input.industry,
+      useCase: input.useCase,
+    });
     if (!won) {
       // A loser must not create a second form. It still needs somewhere to send
-      // the person, so hand back the form the WINNER made (the account's first).
-      const existing = await this.db.get<{ id: string }>(
-        sql`SELECT id FROM form WHERE account_id = ${p.accountId}
-            ORDER BY created_at ASC LIMIT 1`,
-      );
-      return { completed: false, formId: existing?.id ?? null };
+      // the person, so hand back the form the WINNER made — read from the blob
+      // the winner recorded it in, never guessed from the account's oldest form.
+      // On an account that already had one (a re-gated workspace, a fork that
+      // toggled the flag) the oldest form is an unrelated one, and the loser
+      // would land in it with the first-run tour armed.
+      const state = await getAccountOnboarding(this.db, p.accountId);
+      return { completed: false, formId: state?.onboarding?.formId ?? null };
     }
 
     const created = await createForm(
       this.db,
       p.accountId,
-      { name: template.name, ...(template.config ? { config: template.config } : {}) },
+      {
+        name: this.templateFormName(templateId, template.name, input.locale),
+        ...(template.config ? { config: template.config } : {}),
+      },
       p.memberId,
     );
     // A failed create must NOT un-claim the completion: the person answered the
     // questions and those answers are stored. Sending them back through the
     // wizard to re-answer would lose the thing we actually wanted. They land on
     // an empty dashboard instead, where "New form" is the obvious next click.
-    return { completed: true, formId: created.ok ? created.value.id : null };
+    if (!created.ok) return { completed: true, formId: null };
+
+    await recordOnboardingFormId(this.db, p.accountId, created.value.id);
+    return { completed: true, formId: created.value.id };
+  }
+
+  /** The created form's name in the locale the wizard rendered its cards in. */
+  private templateFormName(id: FormTemplateId, fallback: string, locale?: 'en' | 'es'): string {
+    if (!locale) return fallback;
+    return getMessages(locale).admin.onboarding.templates.options[id].formName;
   }
 
   // --- Vanity slug (premium — included with the Dapta AI subscription) ------

--- a/apps/api/src/onboarding.controller.spec.ts
+++ b/apps/api/src/onboarding.controller.spec.ts
@@ -135,6 +135,30 @@ describe('/v1/me — the dashboard gate', () => {
     const me = await controllerWith(true).me(asOwner());
     expect(me?.onboardingRequired).toBe(false);
   });
+
+  /**
+   * The lockout. The gate is account-scoped, the endpoints are admin-scoped, and
+   * nothing used to reconcile the two.
+   *
+   * A colleague joining an org whose owner abandoned the wizard was sent to
+   * `/onboarding` by the dashboard layout, had every PATCH silently 403'd, had
+   * the completion 403'd outright, and was bounced back to `/onboarding` by the
+   * same gate when the action fell through to `/admin`. The wizard renders no
+   * sidebar and no sign-out, so that loop had no exit at all.
+   */
+  it('does NOT require it of a plain member — they cannot complete it', async () => {
+    const me = await controllerWith(true).me(asMember());
+    expect(me?.onboardingRequired).toBe(false);
+    // Still genuinely un-onboarded — the account state is unchanged, only who is
+    // asked to fix it.
+    expect(me?.onboardingCompletedAt).toBeNull();
+  });
+
+  it('still requires it of the owner of that same un-onboarded account', async () => {
+    const c = controllerWith(true);
+    expect((await c.me(asMember()))?.onboardingRequired).toBe(false);
+    expect((await c.me(asOwner()))?.onboardingRequired).toBe(true);
+  });
 });
 
 describe('PATCH /v1/account/onboarding', () => {
@@ -326,6 +350,74 @@ describe('POST /v1/account/onboarding/complete', () => {
       template: 'customer-feedback',
       lastStep: 'template',
     });
+  });
+
+  /**
+   * The template screen arms its CTA the moment question three is answered, so
+   * the completion can be sent before that answer's PATCH has landed. Carrying
+   * the answers ON the completion is what makes the record independent of which
+   * request wins.
+   */
+  it('stores answers that arrive WITH the completion, never having been PATCHed', async () => {
+    const c = controllerWith(true);
+    await c.completeOnboarding(asOwner(), {
+      template: 'lead-qualifier',
+      role: 'founder',
+      industry: 'software',
+      useCase: 'leads',
+    });
+
+    expect((await getAccountOnboarding(db, accountId))?.onboarding).toMatchObject({
+      role: 'founder',
+      industry: 'software',
+      useCase: 'leads',
+      template: 'lead-qualifier',
+    });
+  });
+
+  it('names the form in the locale the wizard rendered its cards in', async () => {
+    // The card said "Calificador de leads"; a form called "Lead qualifier" is a
+    // different answer to the same click.
+    const res = await controllerWith(true).completeOnboarding(asOwner(), {
+      template: 'lead-qualifier',
+      locale: 'es',
+    });
+    const form = await db.get<{ name: string }>(sql`SELECT name FROM form WHERE id = ${res.formId!}`);
+    expect(form?.name).toBe('Calificador de leads');
+  });
+
+  it('falls back to the registry name when no locale is named', async () => {
+    const res = await controllerWith(true).completeOnboarding(asOwner(), { template: 'blank' });
+    const form = await db.get<{ name: string }>(sql`SELECT name FROM form WHERE id = ${res.formId!}`);
+    expect(form?.name).toBe('Untitled form');
+  });
+
+  /**
+   * The losing claim used to be handed `ORDER BY created_at ASC LIMIT 1` — the
+   * account's OLDEST form. On an account that already had one, that is an
+   * unrelated form, and the loser lands in it with the first-run tour armed.
+   */
+  it('sends a losing claim to the form the WINNER made, not the oldest one', async () => {
+    // A form that predates the wizard entirely — a re-gated workspace, or a fork
+    // that toggled the flag off and on.
+    await db.run(
+      sql`INSERT INTO form (id, account_id, name, slug, config, created_at, updated_at)
+          VALUES (${'form_old'}, ${accountId}, ${'Older form'}, ${'older'},
+            ${'{"version":1,"steps":[]}'}, 100, 100)`,
+    );
+
+    const c = controllerWith(true);
+    const winner = await c.completeOnboarding(asOwner(), { template: 'lead-qualifier' });
+    const loser = await c.completeOnboarding(asOwner(), { template: 'lead-qualifier' });
+
+    expect(loser.completed).toBe(false);
+    expect(loser.formId).toBe(winner.formId);
+    expect(loser.formId).not.toBe('form_old');
+  });
+
+  it('records the created form id on the account, so the loser has something to read', async () => {
+    const res = await controllerWith(true).completeOnboarding(asOwner(), { template: 'blank' });
+    expect((await getAccountOnboarding(db, accountId))?.onboarding?.formId).toBe(res.formId);
   });
 });
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.css
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.css
@@ -9,7 +9,14 @@
 .bt {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  /* The app's scale (documented in components/ui/anchored-menu.tsx): 50 for
+     popovers and modals inside <main>, 55 for anchored menus, 60 for the toast
+     stack, 70 for the confirm dialog. The coach marks sit above the builder's
+     own chrome and BELOW the toasts — at a tie the later-painted element wins,
+     which made "Changes published" land underneath the card pointing at the
+     publish button. A toast answers something the person just did; a tip does
+     not. */
+  z-index: 58;
   /* The layer never eats clicks: the card and the ring opt back in below. The
      builder has to stay usable while the tip is on screen, or the tour becomes
      a series of modals. */

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx
@@ -30,6 +30,25 @@ type TourMessages = ReturnType<typeof getMessages>['admin']['onboarding']['tour'
 const STEPS = ['edit', 'preview', 'publish'] as const;
 type TourStep = (typeof STEPS)[number];
 
+/**
+ * The anchor for a step, or null when this screen does not have one.
+ *
+ * "Does not have one" is a real, ordinary state, not a bug to retry through.
+ * `data-tour="edit"` sits on the question spine, which is `hidden lg:block` AND
+ * inside the editor's `hasQuestions` branch — so it is absent below 1024px and
+ * absent for the `blank` template, which starts with no questions. A hidden
+ * element is still found by `querySelector` and still returns a rect, all zeros,
+ * so the presence check has to be the SIZE.
+ */
+function anchorFor(step: TourStep): Element | null {
+  const el = document.querySelector(`[data-tour="${step}"]`);
+  const r = el?.getBoundingClientRect();
+  return el && r && (r.width > 0 || r.height > 0) ? el : null;
+}
+
+/** ~2s at 60fps — long enough for the editor to stream in, short enough not to hang. */
+const PROBE_FRAMES = 120;
+
 interface Placement {
   top: number;
   left: number;
@@ -84,6 +103,26 @@ function place(el: Element, cardHeight: number): Placement {
   };
 }
 
+/**
+ * Do two placements describe the same pixels?
+ *
+ * `place()` builds a new object every call, so identity says nothing. Comparing
+ * the numbers is what lets a scroll that did not actually move the anchor —
+ * most of them, since the builder's panels scroll independently — cost nothing:
+ * no state write, no render, and no dependent effect re-running.
+ */
+function samePlacement(a: Placement | null, b: Placement): boolean {
+  return (
+    a != null &&
+    a.top === b.top &&
+    a.left === b.left &&
+    a.anchor.top === b.anchor.top &&
+    a.anchor.left === b.anchor.left &&
+    a.anchor.width === b.anchor.width &&
+    a.anchor.height === b.anchor.height
+  );
+}
+
 export function BuilderTour({ locale }: { locale: Locale }) {
   const router = useRouter();
   const params = useSearchParams();
@@ -97,7 +136,30 @@ export function BuilderTour({ locale }: { locale: Locale }) {
   // so a fixed estimate mis-places the tallest one against the bottom edge.
   const [cardHeight, setCardHeight] = useState(CARD_HEIGHT_ESTIMATE);
   const cardRef = useRef<HTMLDivElement>(null);
-  const step: TourStep | undefined = STEPS[index];
+  /**
+   * The steps this screen can actually show, resolved ONCE before the tour
+   * starts. Null while still probing.
+   *
+   * Deciding up front is what makes the count honest. Walking `STEPS` blind
+   * meant a step whose anchor never appears still emitted its `tour_step` event
+   * and still counted toward "of 3", so a `blank` template on a laptop reported
+   * a three-step tour, showed two, and logged a view of a card that never
+   * rendered. The irony was that `blank` is the template most in need of the
+   * tour and the one guaranteed to lose its first step.
+   */
+  const [steps, setSteps] = useState<readonly TourStep[] | null>(null);
+  const step: TourStep | undefined = steps?.[index];
+  const total = steps?.length ?? 0;
+  /**
+   * Which step the tour was on when it ended.
+   *
+   * A completed tour walks `index` one PAST the last step, which is how the
+   * finish effect below knows it is over — so `step` is undefined by then.
+   * Reporting `last_step: null` for every successful tour would make the one
+   * number that says how far people get unreadable, so fall back to the final
+   * step: "finished on publish", not "finished on nothing".
+   */
+  const reachedStep: TourStep | null = step ?? steps?.[steps.length - 1] ?? null;
 
   /**
    * Drop `?tour=1` from the URL once the tour is over.
@@ -116,92 +178,119 @@ export function BuilderTour({ locale }: { locale: Locale }) {
   const finish = useCallback(
     (reason: 'completed' | 'dismissed') => {
       setDone(true);
-      captureEvent('onboarding_tour_finished', { reason, last_step: step ?? null });
+      captureEvent('onboarding_tour_finished', { reason, last_step: reachedStep });
       clearParam();
     },
-    [clearParam, step],
+    [clearParam, reachedStep],
   );
 
-  const advance = useCallback(() => {
-    setIndex((i) => {
-      const next = i + 1;
-      if (next >= STEPS.length) {
-        // Deferred: calling `finish` inside the updater would set state during
-        // another component's render phase.
-        queueMicrotask(() => finish('completed'));
-        return i;
+  const advance = useCallback(() => setIndex((i) => i + 1), []);
+
+  /**
+   * Which steps this screen has anchors for. Runs once, before the first card.
+   *
+   * Bounded, and it stops early once all three have appeared: the editor streams
+   * in, so an anchor missing on frame one is normal, but an anchor missing at
+   * the end of the budget is genuinely not on this screen and no amount of
+   * waiting will conjure it.
+   */
+  useEffect(() => {
+    if (!armed || done || steps) return;
+    let frame = 0;
+    let tries = 0;
+    const probe = () => {
+      const found = STEPS.filter((s) => anchorFor(s) !== null);
+      if (found.length === STEPS.length || tries++ >= PROBE_FRAMES) {
+        setSteps(found);
+        return;
       }
-      return next;
-    });
-  }, [finish]);
+      frame = requestAnimationFrame(probe);
+    };
+    probe();
+    return () => cancelAnimationFrame(frame);
+  }, [armed, done, steps]);
+
+  /**
+   * Past the last step — or with no steps at all — the tour is over.
+   *
+   * An effect rather than a branch inside the `setIndex` updater: updaters must
+   * be pure, and StrictMode invokes them twice in development, which fired
+   * `tour_finished` twice for every completed tour.
+   */
+  useEffect(() => {
+    if (!armed || done || !steps) return;
+    if (index >= steps.length) finish(steps.length === 0 ? 'dismissed' : 'completed');
+  }, [armed, done, steps, index, finish]);
 
   /**
    * Measure the anchor. `useLayoutEffect` so the card is positioned before paint
    * — with a plain effect it flashes at the top-left corner for one frame.
    *
-   * Two ways an anchor is unusable, and they need opposite handling:
-   *
-   *  - NOT THERE YET. The editor streams in, so the element can be missing for a
-   *    few frames. Retry, bounded — an unbounded rAF loop would spin forever on
-   *    a step whose anchor was renamed.
-   *  - THERE BUT HIDDEN. The question spine is `hidden lg:block`, so below
-   *    1024px it is in the DOM with a 0×0 rect. `querySelector` finds it and
-   *    `getBoundingClientRect()` returns all zeros, which used to draw the ring
-   *    around nothing in the top-left corner. Retrying cannot help — the anchor
-   *    is genuinely not on this screen — so the step is SKIPPED.
+   * The anchor is known to exist by now (the probe above only keeps steps whose
+   * anchor rendered), so this places rather than retries.
    */
   useLayoutEffect(() => {
     if (!armed || done || !step) return;
-    let frame = 0;
-    let tries = 0;
-    const measure = () => {
-      const el = document.querySelector(`[data-tour="${step}"]`);
-      const rect = el?.getBoundingClientRect();
-      if (rect && (rect.width > 0 || rect.height > 0)) {
-        setPlacement(place(el as Element, cardHeight));
-        return;
-      }
-      // ~2s at 60fps. Past that, either the anchor does not exist or this
-      // viewport does not render it; move on rather than sit on a blank step.
-      if (tries++ < 120) {
-        frame = requestAnimationFrame(measure);
-        return;
-      }
-      setPlacement(null);
-      advance();
-    };
-    measure();
-    return () => cancelAnimationFrame(frame);
-  }, [armed, done, step, cardHeight, advance]);
+    const el = anchorFor(step);
+    setPlacement(el ? place(el, cardHeight) : null);
+  }, [armed, done, step, cardHeight]);
 
-  /** Keep the card glued to its anchor while the page moves under it. */
+  /**
+   * Keep the card glued to its anchor while the page moves under it.
+   *
+   * Registered with `capture: true`, so this fires for scrolls inside EVERY
+   * nested scroller in the builder — the question spine, the properties panel,
+   * the preview — not only the window. That volume is why both guards matter:
+   *
+   *  - One `requestAnimationFrame` per frame, coalesced. Unthrottled, each
+   *    event cost two forced reflows plus a React render, on the heaviest page
+   *    in the app.
+   *  - `setPlacement` only when the numbers actually changed. `place()` returns
+   *    a fresh object literal every call, so an unconditional set handed every
+   *    dependent effect a new identity on every scroll event — and one of those
+   *    effects moves focus to the card. The symptom was the caret jumping out of
+   *    a question input the moment the person scrolled, over and over, for the
+   *    whole tour.
+   */
   useEffect(() => {
     if (!armed || done || !step) return;
+    let frame = 0;
+    const apply = () => {
+      frame = 0;
+      const el = anchorFor(step);
+      // A resize can HIDE the anchor (dragging the window below the lg
+      // breakpoint). Re-placing against a 0×0 rect would snap the ring to the
+      // corner, so hold the last good position instead.
+      if (!el) return;
+      const next = place(el, cardHeight);
+      setPlacement((prev) => (samePlacement(prev, next) ? prev : next));
+    };
     const reposition = () => {
-      const el = document.querySelector(`[data-tour="${step}"]`);
-      const rect = el?.getBoundingClientRect();
-      // Same visibility guard: a resize can HIDE the anchor (dragging a window
-      // below the lg breakpoint), and re-placing against a 0×0 rect would snap
-      // the ring to the corner mid-tour.
-      if (el && rect && (rect.width > 0 || rect.height > 0)) {
-        setPlacement(place(el, cardHeight));
-      }
+      if (frame) return;
+      frame = requestAnimationFrame(apply);
     };
     window.addEventListener('resize', reposition);
     window.addEventListener('scroll', reposition, true);
     return () => {
+      if (frame) cancelAnimationFrame(frame);
       window.removeEventListener('resize', reposition);
       window.removeEventListener('scroll', reposition, true);
     };
   }, [armed, done, step, cardHeight]);
 
-  /** One `tour_step` event per step ARRIVAL, not per reposition. */
+  /**
+   * One `tour_step` event per step ARRIVAL, and only for a step that RENDERED.
+   *
+   * Gated on `placement` because the count and the events have to agree: a step
+   * with no resolved anchor draws nothing, so reporting a view of it would put
+   * impressions in the funnel for a card nobody saw.
+   */
   const seen = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (!armed || done || !step || seen.current.has(step)) return;
+    if (!armed || done || !step || !placement || seen.current.has(step)) return;
     seen.current.add(step);
-    captureEvent('onboarding_tour_step', { tour_step: step, step_index: index });
-  }, [armed, done, step, index]);
+    captureEvent('onboarding_tour_step', { tour_step: step, step_index: index, total_steps: total });
+  }, [armed, done, step, placement, index, total]);
 
   /** Escape closes it. The most direct way out should not need a mouse. */
   useEffect(() => {
@@ -223,15 +312,23 @@ export function BuilderTour({ locale }: { locale: Locale }) {
     if (h && Math.abs(h - cardHeight) > 1) setCardHeight(h);
   }, [cardHeight, placement, step]);
 
-  /** Move focus to the card so a keyboard user is not left behind it. */
+  /**
+   * Move focus to the card so a keyboard user is not left behind it.
+   *
+   * Keyed on the STEP, not on `placement`. The card only needs focus once per
+   * step, and depending on the placement object meant re-focusing on every
+   * scroll-driven reposition — stealing the caret out of whatever the person was
+   * typing in, which the tour's `pointer-events: none` explicitly invites them
+   * to keep doing.
+   */
   useEffect(() => {
-    if (placement && !done) cardRef.current?.focus();
-  }, [placement, done]);
+    if (step && !done) cardRef.current?.focus();
+  }, [step, done]);
 
   if (!armed || done || !step || !placement) return null;
 
   const copy = m[step];
-  const last = index === STEPS.length - 1;
+  const last = index === total - 1;
 
   return (
     <div className="bt" role="presentation">
@@ -260,7 +357,7 @@ export function BuilderTour({ locale }: { locale: Locale }) {
         // time and put the card outside the viewport.
         style={{ top: placement.top, left: placement.left, width: CARD_WIDTH }}
       >
-        <p className="bt__step">{fill(m.step, { current: index + 1, total: STEPS.length })}</p>
+        <p className="bt__step">{fill(m.step, { current: index + 1, total })}</p>
         <h2 className="bt__title" id="bt-title">
           {copy.title}
         </h2>

--- a/apps/web/app/onboarding/actions.ts
+++ b/apps/web/app/onboarding/actions.ts
@@ -1,30 +1,10 @@
 'use server';
 
-import { redirect } from 'next/navigation';
+import { redirect, unstable_rethrow } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
-import { adminApi, type OnboardingProgress } from '@/lib/admin-api';
-
-/**
- * Is this the control-flow exception `redirect()` throws?
- *
- * `adminApi` redirects to /login from inside the request helper when the API
- * answers 401, and it does that by THROWING — Next's redirect is an exception,
- * not a return. A bare `catch {}` around an api call therefore swallows the
- * sign-out and the person silently continues in a dead session. Every catch in
- * this file has to let it through.
- *
- * Identified by the `digest` string rather than an instanceof, because the error
- * class lives behind a `next/dist/...` internal path that is not part of the
- * public API and moves between releases.
- */
-function isRedirect(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    typeof (error as { digest?: unknown }).digest === 'string' &&
-    (error as { digest: string }).digest.startsWith('NEXT_REDIRECT')
-  );
-}
+import { cookies } from 'next/headers';
+import { adminApi, type OnboardingComplete, type OnboardingProgress } from '@/lib/admin-api';
+import { LOCALE_COOKIE } from '@/lib/locale';
 
 /**
  * Persist one screen's worth of answers.
@@ -34,15 +14,31 @@ function isRedirect(error: unknown): boolean {
  * regardless and the API simply never hears about that step. Losing one
  * breadcrumb of telemetry is strictly better than trapping someone on question
  * two because the network blipped.
+ *
+ * `unstable_rethrow` first, always. `adminApi` signs a dead session out by
+ * THROWING Next's redirect — the framework's control flow is an exception, not
+ * a return — and the same is true of `notFound()`, dynamic-usage bailouts and
+ * postpone errors. A catch that does not re-throw those swallows the sign-out
+ * and leaves the person clicking through a wizard nobody is authenticated for.
  */
 export async function saveOnboardingStepAction(patch: OnboardingProgress): Promise<void> {
   try {
     await adminApi.saveOnboarding(patch);
   } catch (e) {
-    // An expired session must still sign them out — see `isRedirect`.
-    if (isRedirect(e)) throw e;
+    unstable_rethrow(e);
     /* progress is an observer of the wizard, never a participant */
   }
+}
+
+/**
+ * What the wizard gets back when the completion did NOT go through.
+ *
+ * There is no success variant, and that is not an oversight: every path where
+ * the API answered ends in a `redirect`, which throws. The only way this
+ * function returns a value is a failure the wizard has to show.
+ */
+export interface CompleteOnboardingFailure {
+  ok: false;
 }
 
 /**
@@ -59,21 +55,48 @@ export async function saveOnboardingStepAction(patch: OnboardingProgress): Promi
  * When the claim was already spent (a double-submit, a second tab) the API hands
  * back the WINNER's form id and this still lands there — both tabs end up on the
  * same form instead of one of them on an error page.
+ *
+ * ONLY an answering API redirects. A thrown failure returns `{ ok: false }` and
+ * the wizard shows it, because `/admin` is not a reachable fallback while the
+ * claim is unwritten: the layout's first-run gate reads the same NULL column
+ * this request failed to set, so it would bounce them straight back here — into
+ * a wizard that remounts at question one with none of their answers, since the
+ * component's state died with the navigation. A redirect loop that silently
+ * erases the work is worse than an error with a retry button.
+ *
+ * `/admin` IS the right target when the API answers without a form id, which is
+ * a different case: the claim is written by then (by this caller or by the one
+ * that beat it), so the gate lets them through to an empty dashboard where "New
+ * form" is the obvious next click.
  */
-export async function completeOnboardingAction(template: string): Promise<void> {
-  let target = '/admin';
+export async function completeOnboardingAction(
+  input: OnboardingComplete,
+): Promise<CompleteOnboardingFailure> {
+  let target: string;
   try {
-    const result = await adminApi.completeOnboarding({ template });
-    if (result.formId) target = `/admin/forms/${result.formId}/edit?tour=1`;
+    const result = await adminApi.completeOnboarding(input);
+    target = result.formId ? `/admin/forms/${result.formId}/edit?tour=1` : '/admin';
   } catch (e) {
-    if (isRedirect(e)) throw e;
-    // The answers are already stored and the completion may well have been
-    // claimed. Sending them back through the wizard would ask them to redo work
-    // that is done; the dashboard is the honest fallback.
+    unstable_rethrow(e);
+    return { ok: false };
   }
+
+  // The wizard resolved its language from `Accept-Language`, because nobody
+  // arriving at it has ever seen the switcher — but everything past this
+  // redirect reads the COOKIE and answers English without one. Persisting it
+  // here is what stops a Spanish signup finishing the wizard in Spanish and
+  // landing in an English builder, with the three coach marks in English on top.
+  if (input.locale === 'es' || input.locale === 'en') {
+    (await cookies()).set(LOCALE_COOKIE, input.locale, {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 365,
+      sameSite: 'lax',
+    });
+  }
+
   revalidatePath('/admin', 'layout');
   // OUTSIDE the try: `redirect` throws, so calling it inside would hand the
-  // catch above its own control-flow exception and this action would fall
-  // through to no navigation at all.
+  // catch above its own control-flow exception. `unstable_rethrow` would let it
+  // back out correctly, but keeping it out here says the intent plainly.
   redirect(target);
 }

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -54,6 +54,8 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [template, setTemplate] = useState<string | null>(null);
   const [submitting, startSubmit] = useTransition();
+  /** Set when the completion could not be made — see `finish`. */
+  const [failed, setFailed] = useState(false);
 
   /** Past the last question is the template screen. */
   const onTemplates = index >= questions.length;
@@ -69,6 +71,31 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
     const useCase = answers.useCase as OnboardingUseCase | undefined;
     return useCase ? USE_CASE_TEMPLATE[useCase] : null;
   }, [answers.useCase]);
+
+  /**
+   * The progress patches, one at a time and in order.
+   *
+   * The wizard has two writers — the arrival effect below and every answer — and
+   * they both patch the SAME JSON column by read-modify-write. Left unchained
+   * they overlap: the arrival patch, fired un-awaited on mount, can still be in
+   * flight when the first answer's patch reads the row, and whichever writes
+   * second overwrites the other's field with a snapshot taken before it existed.
+   * Serializing costs nothing here — nothing in the UI waits on these — and it
+   * removes the only interleaving this screen can actually produce.
+   *
+   * The chain swallows rejections rather than propagating them. It has to: a
+   * rejected link would leave `queue.current` permanently rejected, so every
+   * later patch would be skipped and the progress column would stop at whatever
+   * the last success wrote. The action already treats a failed save as a
+   * non-event by design, and the next advance re-sends every answer anyway.
+   */
+  const queue = useRef<Promise<unknown>>(Promise.resolve());
+  const save = useCallback((patch: Parameters<typeof saveOnboardingStepAction>[0]) => {
+    queue.current = queue.current
+      .catch(() => undefined)
+      .then(() => saveOnboardingStepAction(patch))
+      .catch(() => undefined);
+  }, []);
 
   /**
    * Emit `step_viewed` once per screen ARRIVAL, not once per render.
@@ -96,16 +123,18 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
     // all. Those are opposite problems: one is a wizard failing, the other is a
     // signup that never arrived.
     //
-    // Safe to fire alongside `answer`'s patch because it only ever runs for
-    // index 0, which no answer patch targets — the two never race on the row.
-    void saveOnboardingStepAction({ lastStep: 'role' });
-  }, [stepKey, index, questions.length, locale]);
+    // Harmless on a RETURN visit even though it re-announces step one: the
+    // server only ever advances `lastStep`, so it cannot drag a stored
+    // `template` back to `role` and misfile a finisher as a first-question quit.
+    save({ lastStep: 'role' });
+  }, [stepKey, index, questions.length, locale, save]);
 
   /** Answer the current question and advance. Choosing IS continuing — one tap. */
   const answer = useCallback(
     (value: string) => {
       if (!current) return;
-      setAnswers((a) => ({ ...a, [current.field]: value }));
+      const next = { ...answers, [current.field]: value };
+      setAnswers(next);
       // Changing the use case invalidates an explicit template pick made on a
       // later screen. Without this, going back and choosing a different purpose
       // leaves the OLD card selected while the "Recommended for you" badge moves
@@ -121,10 +150,14 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
       // `lastStep` names the screen being REACHED, which is what makes the
       // stored value a drop-off bucket rather than a record of the last answer.
       const reached = questions[advancing]?.key ?? 'template';
-      void saveOnboardingStepAction({ [current.field]: value, lastStep: reached });
+      // Every answer so far, not just this one. A patch that never landed — the
+      // action swallows its failures by design — is repaired by the next advance
+      // instead of leaving a permanent hole in the column, and the merge ignores
+      // fields it already has, so re-sending them costs nothing.
+      save({ ...next, lastStep: reached });
       setIndex(advancing);
     },
-    [current, index, questions],
+    [answers, current, index, questions, save],
   );
 
   const back = useCallback(() => setIndex((i) => Math.max(0, i - 1)), []);
@@ -136,9 +169,31 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
         recommended: id === recommended,
         use_case: answers.useCase ?? null,
       });
-      startSubmit(() => void completeOnboardingAction(id));
+      setFailed(false);
+      // `async` so the scope returns a PROMISE. A non-thenable body ends the
+      // transition in the same tick: `submitting` would flip straight back to
+      // false, the interstitial below would never paint, the CTA would stay live
+      // for the whole round trip, and a rejection would have nobody to catch it.
+      startSubmit(async () => {
+        // The answers travel WITH the completion, so the claim writes them in
+        // its own single statement and cannot lose the last one to a PATCH still
+        // in flight. `locale` so the created form is named like the card.
+        const result = await completeOnboardingAction({
+          template: id,
+          role: answers.role ?? null,
+          industry: answers.industry ?? null,
+          useCase: answers.useCase ?? null,
+          locale,
+        });
+        // Only a FAILURE returns: every path where the API answered ends in a
+        // redirect, which throws. `/admin` is not a fallback while the claim is
+        // unwritten — the first-run gate reads the same column this request
+        // failed to set and would bounce them back into a wizard remounted at
+        // question one, with their answers gone. Say so, and offer a retry.
+        if (result && !result.ok) setFailed(true);
+      });
     },
-    [answers.useCase, recommended],
+    [answers, locale, recommended],
   );
 
   const stage = onTemplates ? TEMPLATE_STAGE : QUESTION_STAGE;
@@ -148,6 +203,12 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
   // disabled copy of itself — a frozen page with a greyed-out button reads as a
   // hang, and this is the last thing before a screen they have never seen.
   if (submitting) return <CreatingScreen m={m} />;
+  // The completion did not go through. The template pick is still in state, so
+  // retrying is one button and nothing has to be re-answered.
+  if (failed) {
+    const pick = template ?? recommended;
+    return <FailedScreen m={m} onRetry={pick ? () => finish(pick) : undefined} />;
+  }
 
   return (
     <div className="pf ob">
@@ -290,6 +351,33 @@ function CreatingScreen({ m }: { m: Messages }) {
         <div className="ob__creating-track" role="progressbar" aria-label={m.creating}>
           <div className="ob__creating-fill" />
         </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The completion failed and there is nowhere safe to send them.
+ *
+ * The dashboard is not that place: the claim is unwritten, so the first-run gate
+ * would read the same NULL column and redirect them back into a wizard that
+ * remounts with none of their answers. Standing still and saying so keeps the
+ * template pick alive in state, which makes the retry one click.
+ *
+ * Same shell as the interstitial it replaces, so nothing jumps between the two.
+ */
+function FailedScreen({ m, onRetry }: { m: Messages; onRetry?: () => void }) {
+  return (
+    <div className="pf ob ob--creating">
+      <div className="ob__creating" role="alert">
+        <FormsMark className="ob__creating-mark" title="Dapta Forms" />
+        <h1 className="ob__creating-headline">{m.error.headline}</h1>
+        <p className="ob__creating-sub">{m.error.body}</p>
+        {onRetry ? (
+          <button type="button" className="pf__btn ob__cta" onClick={onRetry}>
+            {m.error.retry}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -154,6 +154,20 @@ export interface OnboardingProgress {
   lastStep?: string | null;
 }
 
+/**
+ * The completion body. The answers ride along with the template rather than
+ * being left to the last PATCH to deliver in time — see `onboardingCompleteSchema`
+ * in @quill/types, which is the contract this mirrors.
+ */
+export interface OnboardingComplete {
+  template: string;
+  role?: string | null;
+  industry?: string | null;
+  useCase?: string | null;
+  /** What the wizard rendered in, so the created form is named to match. */
+  locale?: string;
+}
+
 export interface FormSummary {
   id: string;
   name: string;
@@ -379,7 +393,7 @@ export const adminApi = {
       '/v1/account/onboarding',
       b,
     ),
-  completeOnboarding: (b: { template: string }) =>
+  completeOnboarding: (b: OnboardingComplete) =>
     req<{ completed: boolean; formId: string | null }>(
       'POST',
       '/v1/account/onboarding/complete',

--- a/packages/db/src/onboarding.spec.ts
+++ b/packages/db/src/onboarding.spec.ts
@@ -9,6 +9,7 @@ import {
   getAccountOnboarding,
   saveOnboardingProgress,
   claimOnboardingComplete,
+  recordOnboardingFormId,
 } from './onboarding';
 
 let db: Db;
@@ -97,6 +98,46 @@ describe('saveOnboardingProgress', () => {
     expect(saved?.role).toBe('founder');
   });
 
+  it('does NOT blank an earlier answer when a later patch sends an explicit null', async () => {
+    // `onboardingProgressSchema` declares every answer `.nullable()`, so
+    // `{"role": null}` is a VALID body — and an `!== undefined` guard lets it
+    // through and erases an answer already given. Nothing in the product ever
+    // un-answers a question, so absent and null have to mean the same thing.
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'founder', lastStep: 'role' }, 5000);
+    const saved = await saveOnboardingProgress(
+      db,
+      ACCOUNT,
+      { role: null, industry: 'software', lastStep: 'industry' },
+      6000,
+    );
+    expect(saved?.role).toBe('founder');
+    expect(saved?.industry).toBe('software');
+  });
+
+  it('never moves lastStep BACKWARDS', async () => {
+    // The wizard is pure client state, so a refresh or a return visit remounts
+    // at index 0 and re-announces step one. `lastStep` documents itself as the
+    // furthest screen REACHED — the drop-off bucket — so letting it regress
+    // files someone who got to the template picker as a question-one quitter,
+    // and inverts the metric the whole feature exists to produce.
+    await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'template' }, 5000);
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'role' }, 6000);
+    expect(saved?.lastStep).toBe('template');
+    // The visit is still recorded — only the bucket is protected.
+    expect(saved?.stepsSeen).toEqual(['template', 'role']);
+  });
+
+  it('settles on the same answers whichever order two patches land in', async () => {
+    // The wizard has two writers — the arrival patch and every answer — and they
+    // can overlap on the wire. The merge is monotonic in every field, so the
+    // order the network happens to pick cannot change the result.
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'industry' }, 5000);
+    await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'role' }, 5001);
+
+    const state = await getAccountOnboarding(db, ACCOUNT);
+    expect(state?.onboarding).toMatchObject({ role: 'sales', lastStep: 'industry' });
+  });
+
   it('accumulates the step trail in order, without repeats', async () => {
     await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'role' }, 1);
     await saveOnboardingProgress(db, ACCOUNT, { lastStep: 'industry' }, 2);
@@ -122,7 +163,7 @@ describe('saveOnboardingProgress', () => {
   it('refuses to write once onboarding is COMPLETE', async () => {
     // A stale tab or a retried request must not rewrite the answers of a
     // finished onboarding — the record of what was actually chosen is the point.
-    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 7000);
     expect(await saveOnboardingProgress(db, ACCOUNT, { role: 'hr', lastStep: 'role' }, 8000)).toBeNull();
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding?.template).toBe('lead-qualifier');
@@ -136,20 +177,20 @@ describe('saveOnboardingProgress', () => {
 
 describe('claimOnboardingComplete — exactly once, ever', () => {
   it('the first caller wins', async () => {
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', 7000)).toBe(true);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, 7000)).toBe(true);
   });
 
   it('every later caller loses', async () => {
-    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', 7000);
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', 8000)).toBe(false);
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', 9000)).toBe(false);
+    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, 7000);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 8000)).toBe(false);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 9000)).toBe(false);
   });
 
   it('the LOSER does not overwrite the winner’s template', async () => {
     // Losing must be inert. If the second call still wrote, the account would
     // report a template it never created a form from.
-    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', 7000);
-    await claimOnboardingComplete(db, ACCOUNT, 'blank', 8000);
+    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 8000);
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding?.template).toBe('customer-feedback');
     expect(state?.completedAt).toBe(7000);
@@ -160,8 +201,8 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
     // so the two calls serialize there regardless. It is the guarded UPDATE, not
     // the read before it, that makes this single-winner.
     const results = await Promise.all([
-      claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', 7000),
-      claimOnboardingComplete(db, ACCOUNT, 'application', 7000),
+      claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 7000),
+      claimOnboardingComplete(db, ACCOUNT, 'application', {}, 7000),
     ]);
     expect(results.filter(Boolean)).toHaveLength(1);
   });
@@ -170,7 +211,7 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
     await saveOnboardingProgress(db, ACCOUNT, { role: 'founder', lastStep: 'role' }, 1000);
     await saveOnboardingProgress(db, ACCOUNT, { industry: 'ecommerce', lastStep: 'industry' }, 2000);
     await saveOnboardingProgress(db, ACCOUNT, { useCase: 'leads', lastStep: 'use_case' }, 3000);
-    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', 4000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 4000);
 
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding).toMatchObject({
@@ -189,13 +230,75 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
   it('completes even when the wizard was never patched', async () => {
     // Someone who lands on the last screen via a restored session still has to
     // be able to finish; a missing blob is not an error state.
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', 7000)).toBe(true);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 7000)).toBe(true);
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding).toMatchObject({ version: 1, template: 'blank', startedAt: 7000 });
   });
 
   it('returns false for an account that does not exist', async () => {
-    expect(await claimOnboardingComplete(db, 'acc_nope', 'blank', 1)).toBe(false);
+    expect(await claimOnboardingComplete(db, 'acc_nope', 'blank', {}, 1)).toBe(false);
+  });
+
+  /**
+   * The template screen arms its CTA the moment question three is answered, so
+   * the completion can be sent ~300ms behind that answer's PATCH — and both used
+   * to write the same JSON column by read-modify-write. If the claim's read won,
+   * `useCase` was written by nobody. Carrying the answers on the claim is what
+   * makes the final record independent of who reads the row first.
+   */
+  it('writes answers handed to it, even with nothing patched before', async () => {
+    await claimOnboardingComplete(
+      db,
+      ACCOUNT,
+      'lead-qualifier',
+      { role: 'founder', industry: 'software', useCase: 'leads' },
+      7000,
+    );
+    expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding).toMatchObject({
+      role: 'founder',
+      industry: 'software',
+      useCase: 'leads',
+      template: 'lead-qualifier',
+    });
+  });
+
+  it('keeps a PATCHed answer the completion did not carry', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'marketing', lastStep: 'role' }, 1000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', { useCase: 'other' }, 7000);
+    expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding).toMatchObject({
+      role: 'marketing',
+      useCase: 'other',
+    });
+  });
+});
+
+describe('recordOnboardingFormId', () => {
+  it('records the form the winner built', async () => {
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 7000);
+    await recordOnboardingFormId(db, ACCOUNT, 'form_created_by_winner');
+    expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding?.formId).toBe(
+      'form_created_by_winner',
+    );
+  });
+
+  it('is write-once — a retry cannot repoint it at a form built later', async () => {
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 7000);
+    await recordOnboardingFormId(db, ACCOUNT, 'form_first');
+    await recordOnboardingFormId(db, ACCOUNT, 'form_second');
+    expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding?.formId).toBe('form_first');
+  });
+
+  it('leaves the rest of the blob alone', async () => {
+    await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 1000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 7000);
+    await recordOnboardingFormId(db, ACCOUNT, 'form_x');
+    expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding).toMatchObject({
+      role: 'sales',
+      template: 'lead-qualifier',
+      lastStep: 'template',
+      startedAt: 1000,
+      formId: 'form_x',
+    });
   });
 });
 

--- a/packages/db/src/onboarding.ts
+++ b/packages/db/src/onboarding.ts
@@ -23,6 +23,7 @@ import type { Db } from './client';
 import { jsonParam, parseJsonColumn } from './forms';
 import {
   accountOnboardingSchema,
+  ONBOARDING_STEPS,
   type AccountOnboarding,
   type FormTemplateId,
   type OnboardingProgressInput,
@@ -62,6 +63,48 @@ function withStepSeen(seen: readonly OnboardingStep[], step: OnboardingStep | nu
   return [...seen, step];
 }
 
+/**
+ * The furthest of two steps, in wizard order.
+ *
+ * `lastStep` documents itself as "the furthest screen REACHED — the drop-off
+ * bucket", and a bucket that can move BACKWARDS is not a bucket. The wizard is
+ * pure client state, so a refresh or a return visit remounts at index 0 and its
+ * arrival patch would write `role` over a stored `template` — recording someone
+ * who reached the template picker as having quit on question one. That does not
+ * lose a breadcrumb, it inverts the metric the whole feature was built to
+ * produce, and it does it hardest for the people who came back to try again.
+ *
+ * Advancing only is also what makes an out-of-order PATCH harmless: two writes
+ * racing can no longer disagree about which is later.
+ */
+function furthestStep(
+  a: OnboardingStep | null | undefined,
+  b: OnboardingStep | null | undefined,
+): OnboardingStep | null | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return ONBOARDING_STEPS.indexOf(b) > ONBOARDING_STEPS.indexOf(a) ? b : a;
+}
+
+/**
+ * Merge one patch of answers into a blob.
+ *
+ * `!= null`, not `!== undefined`. Every answer field is `.nullable().optional()`
+ * in `onboardingProgressSchema`, so `{"role": null}` is a VALID body that used to
+ * pass an `undefined` check and blank an answer already given. Nothing in the
+ * product ever needs to un-answer a question — the wizard has no clear button —
+ * so "absent" and "explicitly null" mean the same thing here: do not write.
+ */
+function mergeAnswers(base: AccountOnboarding, patch: OnboardingProgressInput): AccountOnboarding {
+  return {
+    ...base,
+    ...(patch.role != null ? { role: patch.role } : {}),
+    ...(patch.industry != null ? { industry: patch.industry } : {}),
+    ...(patch.useCase != null ? { useCase: patch.useCase } : {}),
+    ...(patch.template != null ? { template: patch.template } : {}),
+  };
+}
+
 /** The onboarding state for one account, or null when the account does not exist. */
 export async function getAccountOnboarding(
   db: Db,
@@ -89,11 +132,17 @@ export async function getAccountOnboarding(
  *
  * Read-modify-write rather than a SQL-side merge, because there is no jsonb
  * concatenation SQLite also understands and the dual-dialect rule is not
- * negotiable. The lost-update window is real but bounded to a SINGLE person
- * advancing their OWN wizard one screen at a time: two overlapping PATCHes can
- * drop one entry from `stepsSeen`. The answers themselves survive — each screen
- * patches a different field — and `lastStep` self-heals on the next advance. A
- * missing breadcrumb is an acceptable price; a non-portable write is not.
+ * negotiable. What makes that safe is that the merge is MONOTONIC in every
+ * field: an answer is never blanked (see `mergeAnswers`), `lastStep` only ever
+ * advances (see `furthestStep`), `stepsSeen` only grows, and `startedAt` keeps
+ * the earliest. Two writes can therefore arrive in either order and settle on
+ * the same result, so the ordering the network happens to pick stops mattering.
+ *
+ * The callers close the rest: the wizard sends its FULL accumulated answers on
+ * every advance rather than a one-field delta — so a patch that never landed is
+ * repaired by the next one — and it serializes them, so its own two writers
+ * cannot interleave. The final answers do not depend on any of this at all:
+ * `claimOnboardingComplete` writes them itself, in one statement.
  */
 export async function saveOnboardingProgress(
   db: Db,
@@ -105,17 +154,11 @@ export async function saveOnboardingProgress(
   if (!current || current.completedAt != null) return null;
 
   const base = current.onboarding ?? emptyOnboarding(now);
+  const lastStep = furthestStep(base.lastStep, patch.lastStep);
   const next: AccountOnboarding = {
-    ...base,
+    ...mergeAnswers(base, patch),
     version: 1,
-    // Only fields the client actually sent overwrite. Spreading `patch` wholesale
-    // would let an omitted key arrive as `undefined` and blank an earlier answer,
-    // so a back-navigation that re-patches only `lastStep` would erase the role.
-    ...(patch.role !== undefined ? { role: patch.role } : {}),
-    ...(patch.industry !== undefined ? { industry: patch.industry } : {}),
-    ...(patch.useCase !== undefined ? { useCase: patch.useCase } : {}),
-    ...(patch.template !== undefined ? { template: patch.template } : {}),
-    ...(patch.lastStep !== undefined ? { lastStep: patch.lastStep } : {}),
+    ...(lastStep != null ? { lastStep } : {}),
     stepsSeen: withStepSeen(base.stepsSeen ?? [], patch.lastStep),
     startedAt: base.startedAt ?? now,
   };
@@ -140,11 +183,20 @@ export async function saveOnboardingProgress(
  * Writes the answers and the timestamp in ONE statement so the two can never
  * disagree: an account is never left marked complete with no record of what was
  * chosen, nor with a template recorded and no completion.
+ *
+ * `answers` comes from the wizard's own state, not from what happened to reach
+ * the database first. The template screen arms its CTA as soon as question three
+ * is answered, so that answer's PATCH and this claim are routinely in flight
+ * together — and whichever read the row first would have written a blob without
+ * the other's field. Taking the answers here removes the dependency: the winning
+ * statement writes the complete set, and a PATCH that lands afterwards is
+ * correctly refused by the `IS NULL` guard.
  */
 export async function claimOnboardingComplete(
   db: Db,
   accountId: string,
   template: FormTemplateId,
+  answers: OnboardingProgressInput = {},
   now: number = Date.now(),
 ): Promise<boolean> {
   const current = await getAccountOnboarding(db, accountId);
@@ -152,7 +204,7 @@ export async function claimOnboardingComplete(
 
   const base = current.onboarding ?? emptyOnboarding(now);
   const next: AccountOnboarding = {
-    ...base,
+    ...mergeAnswers(base, answers),
     version: 1,
     template,
     lastStep: 'template',
@@ -170,4 +222,30 @@ export async function claimOnboardingComplete(
         RETURNING id`,
   );
   return Boolean(claimed);
+}
+
+/**
+ * Record the form the winning claim created, so a LOSING claim can be sent to
+ * that exact form.
+ *
+ * A second write rather than part of the claim, because the ordering is not
+ * negotiable: only the claim's winner may create anything, so the form does not
+ * exist yet when the claim is made. It is uncontended all the same —
+ * `onboarding_completed_at` is set by the time this runs, which is precisely the
+ * condition under which `saveOnboardingProgress` refuses to write.
+ *
+ * Guarded on the field still being empty so a retry cannot repoint a workspace's
+ * recorded first form at something built later.
+ */
+export async function recordOnboardingFormId(
+  db: Db,
+  accountId: string,
+  formId: string,
+): Promise<void> {
+  const current = await getAccountOnboarding(db, accountId);
+  if (!current?.onboarding || current.onboarding.formId) return;
+  const next: AccountOnboarding = { ...current.onboarding, formId };
+  await db.run(
+    sql`UPDATE account SET onboarding = ${jsonParam(next)} WHERE id = ${accountId}`,
+  );
 }

--- a/packages/db/src/seed.spec.ts
+++ b/packages/db/src/seed.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * The demo seed's contract with the first-run gate.
+ *
+ * `db:setup` is `db:migrate && db:seed`, in that order, so migration 0011's
+ * backfill sweeps the table BEFORE this row exists and can never reach it. That
+ * left the seeded account as the one account in a fresh database still owed a
+ * wizard — and with `ONBOARDING_WIZARD` on by default, that is not a cosmetic
+ * detail:
+ *
+ *   - `pnpm dev` lands on `/onboarding` instead of the dashboard, contradicting
+ *     the zero-infra path CLAUDE.md documents.
+ *   - The demo form the seed just wrote is invisible behind the gate, and
+ *     finishing the wizard adds a SECOND "first" form to the same account.
+ *   - `qa/dev-sqlite.sh` seeds the same row, so every Playwright spec that
+ *     navigates to `/admin/...` redirects into the wizard. That is most of the
+ *     suite, and it fails in a way that looks like a routing bug.
+ *
+ * The account is onboarded by definition: it ships with a form.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createDb, type Db } from './client';
+import { migrate } from './migrate';
+import { seed } from './seed';
+
+let db: Db;
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+});
+
+afterEach(async () => {
+  await db.close?.();
+});
+
+describe('seed — the demo account and the first-run gate', () => {
+  it('stamps onboarding_completed_at, so a fresh clone lands on the dashboard', async () => {
+    const { accountCode } = await seed(db);
+    const row = await db.get<{ onboarding_completed_at: number | string | null }>(
+      sql`SELECT onboarding_completed_at FROM account WHERE code = ${accountCode}`,
+    );
+    expect(row?.onboarding_completed_at).not.toBeNull();
+    expect(Number(row?.onboarding_completed_at)).toBeGreaterThan(0);
+  });
+
+  it('reseeds to the same state — the stamp is not a one-time accident', async () => {
+    await seed(db);
+    const { accountCode } = await seed(db);
+    const row = await db.get<{ onboarding_completed_at: number | string | null }>(
+      sql`SELECT onboarding_completed_at FROM account WHERE code = ${accountCode}`,
+    );
+    expect(Number(row?.onboarding_completed_at)).toBeGreaterThan(0);
+  });
+});

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -96,8 +96,21 @@ export async function seed(db: Db): Promise<SeedResult> {
   }
 
   const accountId = randomUUID();
+  // `onboarding_completed_at` is stamped, not left NULL, and that is what keeps
+  // the zero-infra path in CLAUDE.md true. Migration 0011 backfills every
+  // pre-existing account, but `db:setup` runs migrate BEFORE seed, so this row
+  // does not exist yet when the backfill sweeps — it would be the one account in
+  // the database still owed a wizard. With `ONBOARDING_WIZARD` on by default
+  // that means `pnpm dev` lands on `/onboarding` instead of the dashboard, the
+  // demo form the seed just wrote is invisible behind the gate, and finishing
+  // the wizard adds a SECOND "first" form. Every Playwright spec that navigates
+  // to `/admin/...` redirects into the wizard too.
+  //
+  // The demo account has already been onboarded by definition: it ships with a
+  // form.
   await db.run(
-    sql`INSERT INTO account (id, code, name, created_at) VALUES (${accountId}, ${accountCode}, ${'Acme Inc.'}, ${now})`,
+    sql`INSERT INTO account (id, code, name, created_at, onboarding_completed_at)
+        VALUES (${accountId}, ${accountCode}, ${'Acme Inc.'}, ${now}, ${now})`,
   );
   await db.run(
     sql`INSERT INTO member (id, account_id, handle, display_name, email, role, status, created_at)

--- a/packages/db/src/templates/application.ts
+++ b/packages/db/src/templates/application.ts
@@ -21,7 +21,7 @@ export const APPLICATION_CONFIG: FormConfig = {
     enabled: true,
     eyebrow: 'We are reading every one',
     headline: 'Tell us what you need',
-    subheadline: 'Five questions. No account, no login — just the details so we can get moving.',
+    subheadline: 'Six questions. No account, no login — just the details so we can get moving.',
     ctaText: 'Start my request',
   },
   steps: [

--- a/packages/db/src/templates/lead-qualifier.ts
+++ b/packages/db/src/templates/lead-qualifier.ts
@@ -7,8 +7,11 @@
  * — scoring is the feature a lead-gen user came for, and a template that ships
  * it switched off teaches them the product does not have it.
  *
- * Copy is English (the OSS default); Spanish parity lives beside it in
- * `TEMPLATE_COPY_ES` (see ./copy-es.ts) for anyone localizing a fork.
+ * The QUESTIONS are English only. The form's NAME is localized — the API
+ * resolves it from `admin.onboarding.templates.options` so it matches the card
+ * that was clicked — but the config below is not, so a Spanish signup gets a
+ * Spanish-named form asking English questions. That is a known gap, not a
+ * design: translating the four template configs is tracked separately.
  */
 import type { FormConfig } from '@quill/types';
 

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1173,6 +1173,8 @@ export interface FormsMessages {
       /** Headline of the interstitial shown while the first form is created. */
       creating: string;
       creatingSubtitle: string;
+      /** Shown in place of the interstitial when the form could not be created. */
+      error: { headline: string; body: string; retry: string };
       /** Announced to assistive tech as the wizard advances. */
       progress: string; // {current} {total}
       role: {
@@ -1227,12 +1229,19 @@ export interface FormsMessages {
         /** Badge on the card the previous answer pre-selected. */
         recommended: string;
         cta: string;
+        /**
+         * `name`/`description` are the CARD; `formName` is what the created form
+         * is actually called. They are two strings because they are two jobs —
+         * the blank card invites you to "Start from scratch" and the form it
+         * makes is an "Untitled form" — and they live together so the name the
+         * API writes cannot drift from the card that was clicked.
+         */
         options: {
-          'lead-qualifier': { name: string; description: string };
-          'customer-feedback': { name: string; description: string };
-          'event-registration': { name: string; description: string };
-          application: { name: string; description: string };
-          blank: { name: string; description: string };
+          'lead-qualifier': { name: string; description: string; formName: string };
+          'customer-feedback': { name: string; description: string; formName: string };
+          'event-registration': { name: string; description: string; formName: string };
+          application: { name: string; description: string; formName: string };
+          blank: { name: string; description: string; formName: string };
         };
       };
       /** The three coach marks shown in the builder right after the form is made. */
@@ -2336,6 +2345,11 @@ export const en: FormsMessages = {
       back: 'Back',
       creating: 'Building your form…',
       creatingSubtitle: 'Setting up your questions. This only takes a second.',
+      error: {
+        headline: 'We could not create your form',
+        body: 'Your answers are saved. Try again — it is usually a passing connection problem.',
+        retry: 'Try again',
+      },
       progress: 'Question {current} of {total}',
       role: {
         question: 'What best describes your role?',
@@ -2392,22 +2406,27 @@ export const en: FormsMessages = {
           'lead-qualifier': {
             name: 'Lead qualifier',
             description: 'Scores each answer and splits the results into hot and warm.',
+            formName: 'Lead qualifier',
           },
           'customer-feedback': {
             name: 'Customer feedback',
             description: 'A short satisfaction survey with an NPS question.',
+            formName: 'Customer feedback',
           },
           'event-registration': {
             name: 'Event registration',
             description: 'Collect who is coming, how, and what they need.',
+            formName: 'Event registration',
           },
           application: {
             name: 'Applications and requests',
             description: 'For job applications and inbound work requests alike.',
+            formName: 'Applications and requests',
           },
           blank: {
             name: 'Start from scratch',
             description: 'An empty form. You write every question.',
+            formName: 'Untitled form',
           },
         },
       },
@@ -3521,6 +3540,11 @@ export const es: FormsMessages = {
       back: 'Atrás',
       creating: 'Creando tu formulario…',
       creatingSubtitle: 'Preparando tus preguntas. Solo toma un segundo.',
+      error: {
+        headline: 'No pudimos crear tu formulario',
+        body: 'Tus respuestas están guardadas. Inténtalo de nuevo: casi siempre es la conexión.',
+        retry: 'Reintentar',
+      },
       progress: 'Pregunta {current} de {total}',
       role: {
         question: '¿Cuál es tu rol?',
@@ -3577,22 +3601,27 @@ export const es: FormsMessages = {
           'lead-qualifier': {
             name: 'Calificador de leads',
             description: 'Puntúa cada respuesta y separa los resultados en calientes y tibios.',
+            formName: 'Calificador de leads',
           },
           'customer-feedback': {
             name: 'Opiniones de clientes',
             description: 'Una encuesta corta de satisfacción con una pregunta NPS.',
+            formName: 'Opiniones de clientes',
           },
           'event-registration': {
             name: 'Registro a evento',
             description: 'Recoge quién viene, cómo y qué necesita.',
+            formName: 'Registro a evento',
           },
           application: {
             name: 'Postulaciones y solicitudes',
             description: 'Sirve igual para vacantes que para pedidos de trabajo.',
+            formName: 'Postulaciones y solicitudes',
           },
           blank: {
             name: 'Empezar desde cero',
             description: 'Un formulario vacío. Tú escribes cada pregunta.',
+            formName: 'Formulario sin título',
           },
         },
       },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1437,6 +1437,16 @@ export const accountOnboardingSchema = z.object({
   stepsSeen: z.array(z.enum(ONBOARDING_STEPS)).max(ONBOARDING_STEPS.length).optional(),
   /** Epoch-ms the wizard was first opened, for time-to-complete. */
   startedAt: z.number().int().nonnegative().nullable().optional(),
+  /**
+   * The form the winning claim created, recorded so a LOSING claim (a
+   * double-submit, a second tab) can be sent to that exact form.
+   *
+   * Written after the create, because the claim has to run first — only its
+   * winner may create anything. Guessing instead, by taking the account's
+   * oldest form, sends the loser to an unrelated pre-existing form with the
+   * first-run tour armed on it.
+   */
+  formId: z.string().nullable().optional(),
 });
 export type AccountOnboarding = z.infer<typeof accountOnboardingSchema>;
 
@@ -1457,8 +1467,29 @@ export const onboardingProgressSchema = z.object({
 });
 export type OnboardingProgressInput = z.infer<typeof onboardingProgressSchema>;
 
-/** The complete body: which starting point to create the first form from. */
+/**
+ * The complete body: which starting point to create the first form from, plus
+ * the answers the wizard is holding.
+ *
+ * The answers ride along rather than being left to the last PATCH, and that is
+ * what closes the race between them. The template screen arms its CTA the moment
+ * question three is answered, so the completion can be in flight ~300ms behind
+ * that answer's PATCH — and both write the same JSON column by
+ * read-modify-write. If the claim's read wins, `useCase` is written by nobody:
+ * the exact field the template recommendation and every "why this template"
+ * query are built on. Carrying it here means the claim's single guarded
+ * statement writes the complete answer set itself, and nothing is left to
+ * arrive in time.
+ *
+ * `locale` is what the wizard rendered in, so the form gets the same name as the
+ * card that was clicked. Optional: a caller that omits it gets the registry's
+ * English default rather than a 400.
+ */
 export const onboardingCompleteSchema = z.object({
   template: z.enum(FORM_TEMPLATE_IDS),
+  role: z.enum(ONBOARDING_ROLES).nullable().optional(),
+  industry: z.enum(ONBOARDING_INDUSTRIES).nullable().optional(),
+  useCase: z.enum(ONBOARDING_USE_CASES).nullable().optional(),
+  locale: z.enum(['en', 'es']).optional(),
 });
 export type OnboardingCompleteInput = z.infer<typeof onboardingCompleteSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@quill/notifications':
         specifier: workspace:*
         version: link:../../packages/notifications
+      '@quill/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@quill/types':
         specifier: workspace:*
         version: link:../../packages/types

--- a/qa/e2e/v10-onboarding-gate.spec.ts
+++ b/qa/e2e/v10-onboarding-gate.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+/**
+ * The first-run gate, from the outside.
+ *
+ * Four things this suite could not see before, each of which the unit tests
+ * cannot reach because they are about what the BROWSER ends up looking at:
+ *
+ *  1. The seeded demo account lands on the DASHBOARD. `db:setup` runs migrate
+ *     before seed, so migration 0011's backfill sweeps the table before the demo
+ *     row exists and never stamps it — leaving the one account in a fresh
+ *     database still owed a wizard. With the flag on by default that redirected
+ *     `pnpm dev` into `/onboarding` and took most of this suite with it, since
+ *     every spec that opens `/admin/...` would have followed the same redirect.
+ *
+ *  2. A plain MEMBER of an un-onboarded workspace reaches a real page. The gate
+ *     was account-scoped and the wizard's endpoints are admin-scoped, so a
+ *     colleague of an owner who abandoned the wizard was sent to `/onboarding`,
+ *     403'd on every write, 403'd on the completion, and bounced back by the
+ *     same gate. The wizard renders no sidebar and no sign-out: that loop had no
+ *     exit.
+ *
+ *  3. The "Creating your form" interstitial actually PAINTS while the request is
+ *     in flight, and the CTA stops being clickable. `startSubmit(() => void
+ *     action())` returns undefined rather than a thenable, so React ended the
+ *     transition in the same tick and the last screen before the builder read as
+ *     a frozen page with a live button.
+ *
+ *  4. Scrolling the builder during the coach-mark tour does not steal the caret.
+ *     `place()` returns a fresh object every call and the focus effect depended
+ *     on it, so every scroll event — captured from every nested scroller in the
+ *     builder — re-focused the tour card out of whatever was being typed in.
+ *
+ * Under test: apps/api/src/admin.service.ts (`me`), apps/web/app/admin/layout.tsx,
+ * apps/web/app/onboarding/{wizard,actions}.tsx, packages/db/src/seed.ts,
+ * apps/web/app/admin/forms/[id]/edit/_components/builder-tour.tsx.
+ */
+
+const API = 'http://localhost:4400';
+
+/** A brand-new dev identity. The API's local stub JIT-creates its account. */
+function freshEmail(tag: string): string {
+  return `qa-${tag}-${Date.now()}-${Math.floor(Math.random() * 1e6)}@onboarding.test`;
+}
+
+/** Sign the browser in as `email` through the real local-dev login screen. */
+async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', email);
+  await Promise.all([page.waitForURL(/\/(admin|onboarding)/), page.click('button[type="submit"]')]);
+}
+
+/**
+ * Answer whichever of the three questions is on screen and advance.
+ *
+ * Two shapes, because the wizard renders through the PUBLIC renderer's own
+ * components rather than a bespoke set: role and use case are choice cards
+ * (`multiple_choice`), industry is a searchable dropdown (`combobox`) whose
+ * options only exist once it is open. Choosing IS continuing on both — there is
+ * no Next button to click.
+ */
+async function answerCurrentQuestion(page: Page): Promise<void> {
+  const combobox = page.locator('.pf__fields [role="combobox"]');
+  if (await combobox.count()) {
+    await combobox.click();
+    const option = page.locator('.pf-dropdown__list button').first();
+    await expect(option).toBeVisible();
+    await option.click();
+    return;
+  }
+  const choice = page.locator('.pf__fields button').first();
+  await expect(choice).toBeVisible();
+  await choice.click();
+}
+
+/** Walk the three questions and stop on the template picker. */
+async function walkQuestions(page: Page): Promise<void> {
+  for (const label of ['1 of 3', '2 of 3', '3 of 3']) {
+    await expect(page.locator('.ob__eyebrow'), `never reached question ${label}`).toBeVisible();
+    await answerCurrentQuestion(page);
+  }
+}
+
+test.describe('the first-run gate', () => {
+  test('the seeded demo account lands on the dashboard, not the wizard', async ({ page }) => {
+    // No dev-login cookie at all: the local stub falls back to the FIRST seeded
+    // account, which is the demo one. This is the exact path `pnpm dev` takes.
+    await page.context().clearCookies();
+    await page.goto('/admin');
+    await expect(page).toHaveURL(/\/admin$/);
+    // The sidebar, which the wizard deliberately does not render — there is
+    // nowhere to wander off to before a first form exists. Its presence is what
+    // says this is the dashboard and not a wizard that happens to sit at /admin.
+    const nav = page.getByRole('navigation', { name: 'Primary' });
+    await expect(nav).toBeVisible();
+    await expect(nav.getByRole('link', { name: 'Forms', exact: true })).toBeVisible();
+  });
+
+  test('a plain member of an un-onboarded workspace is NOT trapped in the wizard', async ({
+    page,
+    request,
+  }) => {
+    const ownerEmail = freshEmail('owner');
+    const colleagueEmail = freshEmail('colleague');
+
+    // The owner signs in and ABANDONS the wizard: a JIT account whose
+    // `onboarding_completed_at` is still NULL.
+    const me = await asUser(request, ownerEmail).get(`${API}/v1/me`);
+    expect(me.ok()).toBeTruthy();
+    expect((await me.json()).onboardingRequired).toBe(true);
+
+    // A colleague joins that same workspace, as a plain member.
+    const invited = await asUser(request, ownerEmail).post(`${API}/v1/members`, {
+      data: { email: colleagueEmail, role: 'member' },
+    });
+    expect(invited.status()).toBe(201);
+
+    // The colleague signs in. Before the fix this landed on /onboarding and
+    // every route back out returned to it.
+    await signIn(page, colleagueEmail);
+    await page.goto('/admin');
+    await expect(page).not.toHaveURL(/\/onboarding/);
+
+    // And the owner of that same workspace still owes the wizard — the account
+    // is genuinely un-onboarded, only the question of who is asked changed.
+    const ownerMe = await asUser(request, ownerEmail).get(`${API}/v1/me`);
+    expect((await ownerMe.json()).onboardingRequired).toBe(true);
+  });
+});
+
+test.describe('the wizard, end to end', () => {
+  test('answers three questions, shows the interstitial, and lands in the builder', async ({
+    page,
+  }) => {
+    await signIn(page, freshEmail('wizard'));
+    await expect(page).toHaveURL(/\/onboarding/);
+
+    await walkQuestions(page);
+
+    // The template screen arms its recommended card, so the CTA is live.
+    const cta = page.locator('.ob__cta');
+    await expect(cta).toBeEnabled();
+    await cta.click();
+
+    // The interstitial has to be on screen while the round trip runs. Without
+    // the awaited transition the transition ended in the same tick, so this
+    // never rendered at all and the CTA stayed live for the whole request.
+    await expect(page.locator('.ob__creating-track')).toBeVisible();
+    await expect(cta).toHaveCount(0);
+
+    await page.waitForURL(/\/admin\/forms\/[^/]+\/edit/, { timeout: 20_000 });
+    expect(page.url()).toContain('tour=1');
+  });
+
+  test('the coach marks do not steal the caret when the builder scrolls', async ({ page }) => {
+    await signIn(page, freshEmail('tour'));
+    await expect(page).toHaveURL(/\/onboarding/);
+    await walkQuestions(page);
+    await page.locator('.ob__cta').click();
+    await page.waitForURL(/\/admin\/forms\/[^/]+\/edit/, { timeout: 20_000 });
+
+    // The tour is up and the builder underneath is usable — that is the whole
+    // reason the overlay is `pointer-events: none`.
+    await expect(page.locator('.bt__card')).toBeVisible();
+
+    const input = page.locator('main input[type="text"], main textarea').first();
+    await expect(input).toBeVisible();
+    await input.click();
+    await expect(input).toBeFocused();
+
+    // Scroll the way a person reading the tip would. Every one of these used to
+    // re-place the card, hand the focus effect a new object identity, and pull
+    // the caret out of this field.
+    for (let i = 0; i < 5; i++) await page.mouse.wheel(0, 120);
+    await page.waitForTimeout(300);
+
+    await expect(input).toBeFocused();
+  });
+});
+
+/**
+ * An API context that authenticates as one dev identity.
+ *
+ * The local auth stub reads `x-quill-email` and resolves — or JIT-creates — the
+ * member behind it, which is the same path the web app takes for a local
+ * session. Dev/test only; `loadServerEnv` refuses this provider in production.
+ */
+function asUser(request: APIRequestContext, email: string) {
+  const headers = { 'x-quill-email': email, 'content-type': 'application/json' };
+  return {
+    get: (url: string) => request.get(url, { headers }),
+    post: (url: string, opts: { data: unknown }) => request.post(url, { headers, ...opts }),
+  };
+}


### PR DESCRIPTION
Fixes the six blockers and eight follow-ups a pre-merge review found in the
onboarding wizard (#67, #68), all of which are already on `develop`.

Every one of them passed lint, typecheck and 251 unit tests on `78d8aba`, because
every one of them lives in a seam no single test crosses: between the layer that
authorizes and the layer that routes, between `migrate` and `seed`, between two
writers of the same JSON column.

## Blockers

**B1 — a plain `member` was locked out of the product, permanently.** The gate is
account-scoped, the wizard's endpoints are admin-scoped, and nothing reconciled
the two. A colleague joining an org whose owner abandoned the wizard was
redirected to `/onboarding`, silently 403'd on every step (the action swallows it
by design, so the wizard advanced as if saving), 403'd outright on "Create my
form", and bounced back by the same gate when the action fell through to
`/admin`. The wizard renders no sidebar and no sign-out — the loop had no exit.

`onboardingRequired` now folds in `isAdmin(p.role)`. `assertAdmin` stays on both
endpoints: onboarding describes the WORKSPACE, so an invited member must not be
able to rewrite the owner's answers.

**B2 — the seeded demo account was gated, and took the e2e suite with it.**
`db:setup` is `db:migrate && db:seed`, in that order, so migration 0011's
backfill sweeps the table before the demo row exists and can never reach it. That
left the one account in a fresh database still owed a wizard: `pnpm dev` landed
on `/onboarding`, the demo form was invisible behind the gate, finishing the
wizard added a second "first" form, and every Playwright spec that opens
`/admin/...` followed the same redirect. Fixed in the seed rather than in
`qa/dev-sqlite.sh`, which would have fixed QA and left `pnpm dev` broken.

**B3 — concurrent writes erased saved answers.** Both `saveOnboardingProgress`
and `claimOnboardingComplete` read-modify-write the whole `account.onboarding`
blob. The template screen arms its CTA the moment question three is answered, so
that answer's PATCH and the claim are routinely in flight together, and the
loser's field was written by nobody — `useCase` being the one the template
recommendation and every "why this template" query are built on.

Three changes, no migration:
- the completion request **carries the answers**, so the claim's single guarded
  statement writes the complete set;
- the merge is monotonic in every field — an answer is never blanked (`!= null`,
  not `!== undefined`: the schema is `.nullable()`, so `{"role": null}` was a
  valid body that erased a stored answer), `lastStep` only ever advances,
  `stepsSeen` only grows;
- the wizard sends its full accumulated answers on every advance and serializes
  them, so its own two writers cannot interleave.

**B4 — the interstitial never painted.** `startSubmit(() => void action())`
returns `undefined`, not a thenable, so React ended the transition in the same
tick: the "Creating your form" screen never rendered, the CTA stayed live for the
whole round trip, and a rejection had nobody to catch it.

**B5 — the tour stole keyboard focus on every scroll.** `reposition` is
registered with `capture: true`, so it fires for every nested scroller in the
builder; `place()` returns a fresh object each call and the focus effect depended
on it. Click into a question input, scroll to read the tip, lose the caret —
repeatedly, for the whole tour. Focus now keys on `step`, and reposition
coalesces into one rAF and skips the state write when the anchor has not moved.

**B6 — the changeset published the wrong default.** It said `default off`; the
code has been `boolish.default('true')` since `aacba2a`, and changeset bodies are
copied verbatim into `CHANGELOG.md` — the one artifact a fork reads before
upgrading. Since `auth.provider.ts` is `if (!env.SEED_DEMO_FORM ||
env.ONBOARDING_WIZARD) return;`, an operator who believed the feature was inert
would upgrade, get the wizard for every new account, and silently lose the demo
seed they were relying on.

## Also fixed (S1–S8)

- The wizard resolved its locale from `Accept-Language` but never persisted it,
  so a Spanish signup finished in Spanish and landed in an English builder.
- A tour step whose anchor never resolves no longer emits `tour_step` or counts
  toward "of 3". `data-tour="edit"` is absent below 1024px and absent for the
  `blank` template — the template most in need of the tour.
- `.bt` moved off `z-index: 60`, which tied with the toast stack, so "Changes
  published" landed under the card pointing at the publish button.
- Hand-rolled `isRedirect()` replaced by `unstable_rethrow` (repo convention) —
  the digest sniff only matched `NEXT_REDIRECT`, so `notFound()`, dynamic-usage
  bailouts and postpone errors were swallowed.
- The created form is named from the same i18n catalog the card came from, via a
  `formName` key kept beside the card copy. The template **configs** stay
  English-only — a known gap, now stated in the code rather than promised to a
  `./copy-es.ts` that has never existed.
- `lastStep` never regresses. The wizard is pure client state, so a refresh
  remounted at question one and overwrote a stored `template` — filing someone
  who reached the picker as a question-one quitter, hardest for the people who
  came back to try again.
- A losing claim reads the winner's recorded `formId` instead of
  `ORDER BY created_at ASC LIMIT 1`, which on an account that already had a form
  handed the second tab an unrelated one with the first-run tour armed.
- The application template's cover promised five questions and defines six.

`/admin` is also no longer used as a fallback when the completion **throws**: the
claim is unwritten then, so the gate reads the same NULL column and bounces the
person back into a wizard remounted at question one with their answers gone. The
action returns `{ ok: false }` and the wizard shows an error with a retry, the
template pick still in state.

## Verification

- **869 unit tests**, `typecheck` 16/16, `lint` 16/16, `pnpm build` — all green.
- **Postgres parity 152/152** (`packages/db` changed).
- **10 new unit/integration tests, each verified to fail with its fix reverted.**
  Reverting each change by hand and confirming the failure was the check — a test
  that passes before and after proves nothing.
- **New `qa/e2e/v10-onboarding-gate.spec.ts`, 4/4**: the member is not trapped,
  the seeded account lands on the dashboard, the interstitial paints while the
  request is in flight, and the caret survives scrolling during the tour.
- The API gained `@quill/shared` as a dependency, so the pruned production bundle
  (`pnpm --filter @quill/api deploy --legacy --prod`) was loaded under the
  container's exact `tsx --tsconfig tsconfig.runtime.json` entry to confirm it
  resolves.

### Not verified

**The full Playwright suite was not run to completion.** It was stopped partway.
At that point it showed 37 distinct failures, from two confirmed environmental
causes: `suite-regression` needs the pilot form that `qa/import-pilot-form.ts`
imports (`dev-sqlite.sh` does not run it), and the HubSpot/booking specs need CRM
tokens. `v10-onboarding-gate.spec.ts` is the only spec in the repo that passes
`?tour=1`, so `BuilderTour` returns null in every other spec exactly as it did
before — but no baseline was taken on `develop`, so that is reasoning, not
evidence. CI runs from a clean checkout and is the authority here.

## Not in scope

The review's follow-up list (React `cache` on `adminApi.me()`, the duplicated
`fill()`/`t()` helpers, the `admin.onboarding` catalog reaching the public form
bundle, the unused `account(onboarding_completed_at)` index, a `FormsService`
seam so `form_created` cannot be skipped again) is untouched and still worth
issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
