### PR TITLE
fix(web): send the growth badge to the landing, not to the app login

### DIFF
--- a/.changeset/growth-badge-landing.md
+++ b/.changeset/growth-badge-landing.md
@@ -1,0 +1,9 @@
+---
+'@quill/shared': minor
+---
+
+Split "is the growth loop on?" from "where does it point?". `growthTarget` gates
+on `NEXT_PUBLIC_SIGNUP_URL` exactly as before — unset still renders no badge and
+no CTA — but the destination now prefers `NEXT_PUBLIC_LANDING_URL` when the
+deployment sets one. Both surfaces address a stranger, so a landing page suits
+them better than a login screen.

--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,14 @@
 # upstream cloud deployment sets its own signup URL.
 # NEXT_PUBLIC_SIGNUP_URL=https://app.your-cloud.example
 #
+# Where those links POINT, when it should not be the signup URL itself. Both
+# surfaces greet a stranger — the badge says "Made with …", the CTA asks "Want
+# your own form?" — so a landing page usually reads better than a login screen.
+# Defaults to the upstream product's landing in the published image; unset here
+# (and in a plain `pnpm build`) it falls back to NEXT_PUBLIC_SIGNUP_URL. It
+# never turns anything ON by itself: with no signup URL, nothing renders.
+# NEXT_PUBLIC_LANDING_URL=https://www.your-product.example
+#
 # Every badge/CTA link carries the UTM scheme
 #   utm_source=dapta-forms
 #   utm_medium=badge | confirmation        (which surface was clicked)

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -110,9 +110,9 @@ docker build -f apps/web/Dockerfile -t dapta-forms-web \
   - `NEXT_PUBLIC_API_URL` (default `http://localhost:4000`) — where the browser and
     SSR reach the API. **Set this to your public API URL at build time.**
   - `NEXT_PUBLIC_PRODUCT_NAME` (default `Forms`) — UI product name.
-  - `NEXT_PUBLIC_PLATFORM_URL`, `NEXT_PUBLIC_SIGNUP_URL`, `NEXT_PUBLIC_HIDE_BADGE`,
-    `NEXT_PUBLIC_CALENDARS_URL` — optional branding / growth-loop links (empty =
-    nothing rendered).
+  - `NEXT_PUBLIC_PLATFORM_URL`, `NEXT_PUBLIC_SIGNUP_URL`, `NEXT_PUBLIC_LANDING_URL`,
+    `NEXT_PUBLIC_HIDE_BADGE`, `NEXT_PUBLIC_CALENDARS_URL` — optional branding /
+    growth-loop links (no signup URL = nothing rendered).
 
 ## Database
 
@@ -224,7 +224,8 @@ are runtime server env for the web container.
 | `NEXT_PUBLIC_API_URL` | `http://localhost:4000` | any real deploy (build arg) | no |
 | `NEXT_PUBLIC_PRODUCT_NAME` | `Forms` | branding (build arg) | no |
 | `NEXT_PUBLIC_PLATFORM_URL` | _(empty)_ | app-switcher link (build arg) | no |
-| `NEXT_PUBLIC_SIGNUP_URL` | _(empty)_ | growth-loop badge target (build arg) | no |
+| `NEXT_PUBLIC_SIGNUP_URL` | _(empty)_ | growth-loop opt-in — unset renders no badge/CTA (build arg) | no |
+| `NEXT_PUBLIC_LANDING_URL` | product landing | where the badge/CTA point; falls back to the signup URL (build arg) | no |
 | `NEXT_PUBLIC_HIDE_BADGE` | _(empty)_ | set truthy to hide the badge (build arg) | no |
 | `NEXT_PUBLIC_CALENDARS_URL` | _(empty)_ | app-switcher link (build arg) | no |
 | `AUTH_PROVIDER` | `local` | mirror the API value so the web picks the right login UX | no |

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -35,6 +35,15 @@ ARG NEXT_PUBLIC_PLATFORM_URL=
 ENV NEXT_PUBLIC_PLATFORM_URL=$NEXT_PUBLIC_PLATFORM_URL
 ARG NEXT_PUBLIC_SIGNUP_URL=
 ENV NEXT_PUBLIC_SIGNUP_URL=$NEXT_PUBLIC_SIGNUP_URL
+# Where the badge and the post-submission CTA point. Unlike the two above this
+# one carries a real default, because it is a fact about the PRODUCT rather than
+# about a deployment: the badge reads "Made with Dapta Forms", so the page it
+# opens is Dapta Forms' own. Nothing changes for a fork — the loop stays gated on
+# NEXT_PUBLIC_SIGNUP_URL, so with that unset neither surface renders at all.
+# The `www.` is load-bearing: the apex 301s and DROPS the query string, which
+# would strip the very UTM tags the loop is built to carry.
+ARG NEXT_PUBLIC_LANDING_URL=https://www.daptaforms.ai
+ENV NEXT_PUBLIC_LANDING_URL=$NEXT_PUBLIC_LANDING_URL
 ARG NEXT_PUBLIC_HIDE_BADGE=
 ENV NEXT_PUBLIC_HIDE_BADGE=$NEXT_PUBLIC_HIDE_BADGE
 # Deployment's OWN product telemetry (PostHog) — also NEXT_PUBLIC (inlined at
@@ -64,6 +73,8 @@ ARG NEXT_PUBLIC_PLATFORM_URL=
 ENV NEXT_PUBLIC_PLATFORM_URL=$NEXT_PUBLIC_PLATFORM_URL
 ARG NEXT_PUBLIC_SIGNUP_URL=
 ENV NEXT_PUBLIC_SIGNUP_URL=$NEXT_PUBLIC_SIGNUP_URL
+ARG NEXT_PUBLIC_LANDING_URL=https://www.daptaforms.ai
+ENV NEXT_PUBLIC_LANDING_URL=$NEXT_PUBLIC_LANDING_URL
 ARG NEXT_PUBLIC_HIDE_BADGE=
 ENV NEXT_PUBLIC_HIDE_BADGE=$NEXT_PUBLIC_HIDE_BADGE
 ARG NEXT_PUBLIC_PRODUCT_ANALYTICS_KEY=

--- a/apps/web/lib/growth.ts
+++ b/apps/web/lib/growth.ts
@@ -11,10 +11,22 @@
  * inline them into the client bundle too (the confirmation CTA lives in the
  * FormRenderer client island).
  */
-import { badgeHidden, buildSignupUrl, type SignupMedium } from '@quill/shared';
+import { badgeHidden, buildSignupUrl, growthTarget, type SignupMedium } from '@quill/shared';
 
-/** Signup destination + UTM tags, or null when the growth loop is off. */
+/**
+ * Growth destination + UTM tags, or null when the loop is off.
+ *
+ * NEXT_PUBLIC_SIGNUP_URL still decides WHETHER the surfaces render (the
+ * open-core opt-in), while NEXT_PUBLIC_LANDING_URL decides WHERE they go — see
+ * `growthTarget`. Both are read as full static property accesses so Next can
+ * inline them into the client bundle: the badge and the confirmation CTA both
+ * live inside the renderer's client island.
+ */
 export function signupHref(medium: SignupMedium, accountCode?: string | null): string | null {
   if (badgeHidden(process.env.NEXT_PUBLIC_HIDE_BADGE)) return null;
-  return buildSignupUrl({ baseUrl: process.env.NEXT_PUBLIC_SIGNUP_URL, medium, accountCode });
+  const baseUrl = growthTarget({
+    signupUrl: process.env.NEXT_PUBLIC_SIGNUP_URL,
+    landingUrl: process.env.NEXT_PUBLIC_LANDING_URL,
+  });
+  return buildSignupUrl({ baseUrl, medium, accountCode });
 }

--- a/packages/shared/src/growth.spec.ts
+++ b/packages/shared/src/growth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildSignupUrl, badgeHidden, UTM_SOURCE, UTM_CAMPAIGN } from './growth';
+import { buildSignupUrl, badgeHidden, growthTarget, UTM_SOURCE, UTM_CAMPAIGN } from './growth';
 
 describe('growth attribution', () => {
   it('tags signup URLs with the forms UTM source', () => {
@@ -23,5 +23,44 @@ describe('growth attribution', () => {
     expect(badgeHidden('true')).toBe(true);
     expect(badgeHidden('0')).toBe(false);
     expect(badgeHidden(undefined)).toBe(false);
+  });
+});
+
+describe('growthTarget — the loop is gated on signup, but points at the landing', () => {
+  it('prefers the landing when both are configured', () => {
+    expect(growthTarget({ signupUrl: 'https://app.example.com', landingUrl: 'https://www.example.ai' }))
+      .toBe('https://www.example.ai');
+  });
+
+  it('falls back to the signup URL when no landing is configured', () => {
+    expect(growthTarget({ signupUrl: 'https://app.example.com', landingUrl: '' })).toBe('https://app.example.com');
+    expect(growthTarget({ signupUrl: 'https://app.example.com' })).toBe('https://app.example.com');
+  });
+
+  it('a landing alone turns NOTHING on — signup is the opt-in', () => {
+    // The open-core contract: a fork that configures no signup destination
+    // renders no badge and no CTA, whatever else is set. The landing default
+    // ships in the image, so this is the case that keeps a fork clean.
+    expect(growthTarget({ signupUrl: null, landingUrl: 'https://www.example.ai' })).toBeNull();
+    expect(growthTarget({ signupUrl: '', landingUrl: 'https://www.example.ai' })).toBeNull();
+    expect(growthTarget({})).toBeNull();
+  });
+
+  it('ignores a non-http(s) value on either side', () => {
+    expect(growthTarget({ signupUrl: 'ftp://x', landingUrl: 'https://www.example.ai' })).toBeNull();
+    expect(growthTarget({ signupUrl: 'https://app.example.com', landingUrl: 'javascript:alert(1)' }))
+      .toBe('https://app.example.com');
+  });
+
+  it('the built URL still carries every UTM tag', () => {
+    const built = buildSignupUrl({
+      baseUrl: growthTarget({ signupUrl: 'https://app.example.com', landingUrl: 'https://www.example.ai' }),
+      medium: 'badge',
+      accountCode: 'acme',
+    });
+    const url = new URL(built!);
+    expect(url.origin).toBe('https://www.example.ai');
+    expect(url.searchParams.get('utm_source')).toBe(UTM_SOURCE);
+    expect(url.searchParams.get('utm_content')).toBe('acme');
   });
 });

--- a/packages/shared/src/growth.ts
+++ b/packages/shared/src/growth.ts
@@ -45,6 +45,32 @@ export function buildSignupUrl(opts: {
 }
 
 /**
+ * Where the growth loop actually sends someone, given both configured URLs.
+ *
+ * Two different questions, deliberately kept apart:
+ *  - **Is the loop on?** Answered by `signupUrl` alone. Unset → null → no badge
+ *    and no CTA. That is the open-core opt-in and it does not move: a bare fork
+ *    still carries no Dapta branding and no dead link.
+ *  - **Where does it point?** `landingUrl` when the deployment has one,
+ *    `signupUrl` otherwise.
+ *
+ * They were the same value once, and that was the bug: both surfaces greet a
+ * STRANGER — the badge says "Made with Dapta Forms", the CTA asks "Want your
+ * own form?" — and both were dropping that person on the app's login screen for
+ * a product they had never heard of. A landing page is written for exactly that
+ * reader; a login screen is written for someone who already decided.
+ */
+export function growthTarget(opts: {
+  signupUrl?: string | null;
+  landingUrl?: string | null;
+}): string | null {
+  const signup = (opts.signupUrl ?? '').trim();
+  if (!/^https?:\/\/\S+$/i.test(signup)) return null;
+  const landing = (opts.landingUrl ?? '').trim();
+  return /^https?:\/\/\S+$/i.test(landing) ? landing : signup;
+}
+
+/**
  * Parse the badge kill-switch (NEXT_PUBLIC_HIDE_BADGE). Truthy spellings
  * ("1", "true", "yes", any case) hide it; everything else keeps it on —
  * shown-by-default is the open-core contract.


### PR DESCRIPTION
The "Made with Dapta Forms" badge on every public form opened **app.dapta.ai** — a login screen. It should open the product's landing page.

## Why it lives here and not in the deploy pipeline

The destination came from `NEXT_PUBLIC_SIGNUP_URL`, which the release pipeline passes as an explicit `--build-arg`, so no default in this repo could win. But the pipeline passes exactly six build args, and **any `ARG` it does not pass keeps its Dockerfile default** — so a separate variable puts this back in the repo that owns the button, shipping through the normal release flow.

## The two questions were one variable

That is why the destination could not move without the deployment moving with it. They are now separate:

| | decides | unset |
|---|---|---|
| `NEXT_PUBLIC_SIGNUP_URL` | **whether** the badge/CTA render (open-core opt-in) | nothing renders — unchanged |
| `NEXT_PUBLIC_LANDING_URL` | **where** they point | falls back to the signup URL |

A landing URL alone turns nothing on, which is the case that guards the open-core contract and has its own test: a bare fork still carries no upstream branding and no dead link, and a self-hoster who configured only a signup URL sees no change whatsoever.

Unlike the other brand vars this one ships a real Dockerfile default (`https://www.daptaforms.ai`), because it is a fact about the **product** rather than about a deployment: the badge names Dapta Forms, so the page it opens is Dapta Forms' own. `publish-gate` passes — the landing is a different domain from the `*.dapta.ai` hosts the scan blocks.

## The `www.` is load-bearing

The apex 301s to www **and drops the query string**. Measured:

```
https://daptaforms.ai/?utm_source=dapta-forms&…   → https://www.daptaforms.ai/           (all tags gone)
https://www.daptaforms.ai?utm_source=dapta-forms&… → …/?utm_source=…&utm_content=mkxus7  (0 redirects, intact)
```

The loop appends `utm_source=dapta-forms`, `utm_medium=badge|confirmation`, `utm_campaign=made-with-dapta` and `utm_content=<accountCode>`. The landing reads those on load and forwards them to its signup CTA, but falls back to `utm_source=landing` when it sees none — so with the apex, every badge-driven signup would have credited the landing for its own traffic, silently.

## Verification

- `growthTarget` is pure and tested in `@quill/shared` — 8 tests covering preference, fallback, the fork gate, and non-http values on either side
- The three deployments that actually exist, asserted end to end: Dapta's image → `www.daptaforms.ai?utm_…`; bare fork → `null`; signup-only self-hoster → byte-identical to today
- `pnpm typecheck` 16/16 · `pnpm test` 16/16 · `pnpm lint` 16/16 · publish-gate PASSED
- Changeset included (`@quill/shared` minor)

Both stages of the Dockerfile declare it — `build` for the client-bundle inlining, `run` because server components read `NEXT_PUBLIC_*` from the runtime env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
