### PR TITLE
feat(forms): an authorable banner, a reveal screen with a look, and client logos that can leave the cover

### DIFF
--- a/.changeset/banner-reveal-and-logo-scope.md
+++ b/.changeset/banner-reveal-and-logo-scope.md
@@ -1,0 +1,38 @@
+---
+'@quill/types': minor
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+An authorable promo banner, a reveal screen with a look, and client logos that
+can leave the cover.
+
+`cover.bannerColor`, `cover.bannerTextColor` and `cover.bannerSize` give the
+promo strip a fill, a text colour and one of three heights. Absent on any axis
+keeps the derived tint and padding the stylesheet has always applied.
+
+`formRevealSchema` gains a presentation: `loader` picks the animation
+(`spinner` — the default and the existing look — `bar`, `versus`, or `none`),
+`loaderSize` and `textSize` scale the mark and the copy across four steps,
+`accentBackground` floods the screen with the form's accent, and
+`versusYouLabel` / `versusMatchLabel` / `versusStatusLabel` name the two sides
+of the `versus` layout and the live status under the match. The new pure helper
+`resolveRevealPresentation` owns the defaults so the builder canvas and the
+public renderer cannot disagree about them. The `md` mark is pinned to the size
+this screen has always drawn, so an unconfigured reveal — and every form's
+submitting screen, which shares the same spinner — is unchanged.
+
+`cover.clientLogosScope` chooses where the "trusted by" marquee renders: the
+cover (absent — every existing config, and the only place it has ever shown),
+the reveal interstitial, or both. Resolved by the new pure helper
+`showClientLogosOn`, which keeps the existing `showClientLogos` master switch
+deciding first.
+
+**Behaviour change:** the one-page (`vertical`) layout now honours
+`cover.showClientLogos`. It previously ignored the toggle entirely, so a stored
+config with `layout: 'vertical'` and `showClientLogos: false` was still showing
+its marquee; after this it is hidden, as the slides layout already did.
+
+`@quill/shared` also exports `blendHex`, the TS twin of CSS `color-mix`, so the
+editor can run a contrast readout against a surface the stylesheet derives
+rather than stores.

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -107,6 +107,7 @@ export function FormRenderer({
     subtitle: m.revealSubtitle,
     versusYou: m.revealVersusYou,
     versusMatch: m.revealVersusMatch,
+    versusStatus: m.revealVersusStatus,
   };
 
   // `startAt` feeds the INITIALIZERS only — no effect reacts to it changing

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -23,7 +23,7 @@ import {
   nameFields,
   isMultiSelect,
   isSafeHttpUrl,
-  showClientLogos,
+  showClientLogosOn,
   resolveFormLogos,
   type Answers,
   type AnswerValue,
@@ -38,7 +38,7 @@ import { FormProgress } from '@/components/public/form-progress';
 import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
 import { StepInput } from '@/components/public/step-input';
 import { BookingScreen } from '@/components/public/booking-screen';
-import { RevealScreen } from '@/components/public/reveal-screen';
+import { RevealScreen, revealShellProps } from '@/components/public/reveal-screen';
 import { MadeWithBadge } from '@/components/made-with-badge';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
@@ -93,6 +93,21 @@ export function FormRenderer({
   // even though `showBanner` handles that case, and it disagreed with the
   // builder preview (which reads `config.cover` directly).
   const chrome = config.cover ?? null;
+  // The marquee's logos, and the two surfaces that may show them. Resolved off
+  // `chrome` rather than the gated cover for the same reason the banner is: a
+  // form with no cover screen can still scope its logos to the reveal, and
+  // reading the gated value would silently drop them there.
+  const marqueeLogos = chrome?.clientLogos ?? config.branding?.clientLogos ?? [];
+  const coverLogos = showClientLogosOn(chrome, 'cover') ? marqueeLogos : [];
+  const revealLogos = showClientLogosOn(chrome, 'reveal') ? marqueeLogos : [];
+  // The interstitial's copy fallbacks, identical at both call sites below — the
+  // legacy form-level reveal and a `reveal` STEP render the same screen.
+  const revealMessages = {
+    headline: m.revealHeadline,
+    subtitle: m.revealSubtitle,
+    versusYou: m.revealVersusYou,
+    versusMatch: m.revealVersusMatch,
+  };
 
   // `startAt` feeds the INITIALIZERS only — no effect reacts to it changing
   // (the preview remounts by key instead). An out-of-range index is caught by
@@ -538,13 +553,16 @@ export function FormRenderer({
         role="status"
         aria-live="polite"
         cover={chrome}
+        {...revealShellProps(config.reveal)}
       >
         <RevealScreen
           reveal={config.reveal}
           answers={answers}
-          messages={{ headline: m.revealHeadline, subtitle: m.revealSubtitle }}
+          messages={revealMessages}
           onComplete={onRevealComplete}
-        />
+        >
+          <ClientLogosMarquee logos={revealLogos} label={m.trustedBy} />
+        </RevealScreen>
       </PhaseShell>
     );
   }
@@ -567,9 +585,6 @@ export function FormRenderer({
   }
 
   if (phase === 'cover' && coverScreen) {
-    const clientLogos = showClientLogos(coverScreen)
-      ? (coverScreen.clientLogos ?? config.branding?.clientLogos ?? [])
-      : [];
     return (
       <PhaseShell
         className="pf pf--cover"
@@ -591,7 +606,7 @@ export function FormRenderer({
             {coverScreen.subheadline ? <p className="pf__subheadline">{coverScreen.subheadline}</p> : null}
             {coverScreen.trustBadge ? <p className="pf__trust">{coverScreen.trustBadge}</p> : null}
           </div>
-          <ClientLogosMarquee logos={clientLogos} label={m.trustedBy} />
+          <ClientLogosMarquee logos={coverLogos} label={m.trustedBy} />
         </div>
         <div className="pf__cover-footer">
           <button type="button" className="pf__btn" onClick={start}>
@@ -629,18 +644,21 @@ export function FormRenderer({
         role="status"
         aria-live="polite"
         cover={chrome}
+        {...revealShellProps(step.reveal)}
       >
         <RevealScreen
           reveal={step.reveal ?? { enabled: true }}
           answers={answers}
-          messages={{ headline: m.revealHeadline, subtitle: m.revealSubtitle }}
+          messages={revealMessages}
           onComplete={() => {
             // Completing an interstitial is completing a step: reuse `advance`
             // so the partial-submit threshold, forward jumps and the finalize
             // path all behave exactly as they do after a real question.
             void advance(answersRef.current, step);
           }}
-        />
+        >
+          <ClientLogosMarquee logos={revealLogos} label={m.trustedBy} />
+        </RevealScreen>
       </PhaseShell>
     );
   }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -81,18 +81,42 @@
    illegible here, so text uses the form foreground and the accent shows only as
    the tint + hairline bottom border. Mixes against `--background` (the `.pf`
    ground), so it stays correct in both the dark and light themes. */
+/* The promo strip. Every axis is a variable with the pre-feature value as its
+   own fallback, so a config that sets none of them renders byte-identical: the
+   fill is still 12% of the accent over the ground, and the padding/type still
+   come from `--pf-banner-pad` / `--pf-banner-size`, which only the size
+   attribute below ever changes. An authored `--pf-banner-bg` also takes over
+   the border, because a saturated strip with a 45%-accent hairline under it
+   reads as two competing bands rather than one. */
 .pf__banner {
   position: sticky;
   top: 0;
   z-index: 30;
-  background: color-mix(in srgb, var(--pf-primary) 12%, var(--background));
-  color: var(--foreground);
-  border-bottom: 1px solid color-mix(in srgb, var(--pf-primary) 45%, transparent);
-  font-size: 14px;
+  --pf-banner-pad: 12px 20px;
+  --pf-banner-size: 14px;
+  background: var(--pf-banner-bg, color-mix(in srgb, var(--pf-primary) 12%, var(--background)));
+  color: var(--pf-banner-fg, var(--foreground));
+  border-bottom: 1px solid
+    var(--pf-banner-bg, color-mix(in srgb, var(--pf-primary) 45%, transparent));
+  font-size: var(--pf-banner-size);
   font-weight: 600;
   text-align: center;
-  padding: 12px 20px;
+  padding: var(--pf-banner-pad);
   flex-shrink: 0;
+}
+/* Height presets. `md` is the default the rule above already sets, so it is
+   named here only to keep the three legible together. */
+.pf__banner[data-pf-banner-size='sm'] {
+  --pf-banner-pad: 7px 20px;
+  --pf-banner-size: 13px;
+}
+.pf__banner[data-pf-banner-size='md'] {
+  --pf-banner-pad: 12px 20px;
+  --pf-banner-size: 14px;
+}
+.pf__banner[data-pf-banner-size='lg'] {
+  --pf-banner-pad: 18px 24px;
+  --pf-banner-size: 17px;
 }
 
 /* ── Main area — everything below the banner ── */
@@ -1037,7 +1061,11 @@
   }
 }
 
-/* ── Reveal / processing interstitial (generic, templated) ── */
+/* ── Reveal / processing interstitial (generic, templated) ──
+   Sized off two variables so the three scales below move the mark and the copy
+   without any rule needing to know which scale is active. The values declared
+   here are the `md` ones — i.e. exactly what this screen has always rendered —
+   so a reveal with no presentation configured is unchanged. */
 .pf--reveal {
   text-align: center;
 }
@@ -1051,10 +1079,33 @@
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
+  --pf-reveal-mark: 52px;
+  --pf-reveal-headline: clamp(22px, 5vw, 28px);
+  --pf-reveal-subtitle: 15px;
+}
+.pf-reveal__inner[data-pf-reveal-mark='sm'] {
+  --pf-reveal-mark: 36px;
+}
+.pf-reveal__inner[data-pf-reveal-mark='lg'] {
+  --pf-reveal-mark: 76px;
+}
+.pf-reveal__inner[data-pf-reveal-text='sm'] {
+  --pf-reveal-headline: clamp(18px, 4vw, 22px);
+  --pf-reveal-subtitle: 14px;
+}
+.pf-reveal__inner[data-pf-reveal-text='lg'] {
+  --pf-reveal-headline: clamp(28px, 6.4vw, 40px);
+  --pf-reveal-subtitle: 18px;
+}
+/* The copy carries the screen on its own once there is no mark, so it gets the
+   width the loader would have taken. */
+.pf-reveal__inner[data-pf-reveal-loader='versus'],
+.pf-reveal__inner[data-pf-reveal-loader='none'] {
+  max-width: 560px;
 }
 .pf-reveal__spinner {
-  width: 52px;
-  height: 52px;
+  width: var(--pf-reveal-mark);
+  height: var(--pf-reveal-mark);
   border-radius: 50%;
   border: 4px solid var(--muted);
   border-top-color: var(--pf-primary);
@@ -1067,7 +1118,7 @@
   }
 }
 .pf-reveal__headline {
-  font-size: clamp(22px, 5vw, 28px);
+  font-size: var(--pf-reveal-headline);
   font-weight: 800;
   line-height: 1.2;
   letter-spacing: -0.02em;
@@ -1076,7 +1127,7 @@
   text-wrap: balance;
 }
 .pf-reveal__subtitle {
-  font-size: 15px;
+  font-size: var(--pf-reveal-subtitle);
   color: var(--muted-foreground);
   margin: 0 0 24px;
   line-height: 1.5;
@@ -1095,6 +1146,136 @@
   background: var(--pf-primary);
   border-radius: var(--pf-radius-pill);
   transition: width 0.08s linear;
+}
+
+/* ── Reveal: `versus` loader ──
+   The respondent on one side, the thing being matched on the other, progress
+   between them. Its own track is narrower than the standalone one because it
+   shares the row with two marks. */
+.pf-reveal__versus {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: clamp(12px, 4vw, 28px);
+  width: 100%;
+  margin-top: 4px;
+}
+.pf-reveal__mark {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  flex-shrink: 0;
+}
+.pf-reveal__mark-dot {
+  width: var(--pf-reveal-mark);
+  height: var(--pf-reveal-mark);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(var(--pf-reveal-mark) * 0.42);
+  font-weight: 700;
+  line-height: 1;
+}
+.pf-reveal__mark-dot--you {
+  background: var(--foreground);
+  color: var(--background);
+}
+/* The unknown side reads as an outline, not a second filled mark — the point of
+   the layout is that one of the two is not resolved yet. */
+.pf-reveal__mark-dot--match {
+  background: var(--background);
+  color: var(--foreground);
+  border: 2px solid color-mix(in srgb, var(--foreground) 35%, transparent);
+}
+.pf-reveal__mark-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--foreground);
+  max-width: 12ch;
+  text-wrap: balance;
+}
+.pf-reveal__versus-mid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  /* Centred against the marks' DOTS, not their captions: the labels wrap to
+     different heights, and a percentage that drifts with the longer label
+     looks like a layout bug. */
+  min-width: 0;
+  flex: 1;
+  max-width: 200px;
+  padding-top: calc(var(--pf-reveal-mark) * 0.22);
+}
+.pf-reveal__pct {
+  font-size: calc(var(--pf-reveal-headline) * 0.72);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--foreground);
+}
+.pf-reveal__versus .pf-reveal__track {
+  width: 100%;
+}
+
+/* ── Reveal: accent flood ──
+   `accentBackground` paints the whole screen, so the copy has to flip to the
+   accent's contrast colour with it — otherwise a dark headline lands on a dark
+   brand colour and the screen is unreadable. `--pf-primary-contrast` is the
+   token the solid button already uses for exactly this pairing. */
+.pf--reveal[data-pf-reveal-bg='accent'] {
+  background: var(--pf-primary);
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__headline,
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__subtitle,
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__pct,
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__mark-label {
+  color: var(--pf-primary-contrast);
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__track {
+  background: color-mix(in srgb, var(--pf-primary-contrast) 22%, transparent);
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__fill,
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__mark-dot--you {
+  background: var(--pf-primary-contrast);
+  color: var(--pf-primary);
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__spinner {
+  border-color: color-mix(in srgb, var(--pf-primary-contrast) 25%, transparent);
+  border-top-color: var(--pf-primary-contrast);
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__mark-dot--match {
+  background: transparent;
+  color: var(--pf-primary-contrast);
+  border-color: color-mix(in srgb, var(--pf-primary-contrast) 45%, transparent);
+}
+
+/* The bar is a real progress signal, so it keeps moving; only the decorative
+   infinite spin stops. */
+@media (prefers-reduced-motion: reduce) {
+  .pf-reveal__spinner {
+    animation: none;
+  }
+}
+
+@media (max-width: 480px) {
+  /* Two marks plus a percentage do not fit a phone at the large scale, and
+     shrinking the type to force it would defeat picking `lg` in the first
+     place. The row wraps into a column instead: marks side by side, progress
+     under them. */
+  .pf-reveal__versus {
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+  .pf-reveal__versus-mid {
+    order: 3;
+    flex-basis: 100%;
+    max-width: 100%;
+    padding-top: 0;
+  }
 }
 
 /* ── Thank-you / outcome screen ── */
@@ -1255,9 +1436,26 @@
 }
 
 @media (max-width: 480px) {
+  /* Narrow shrinks the strip by re-declaring the VARIABLES, not the properties.
+     Setting `font-size`/`padding` directly here would out-specify nothing and
+     be out-specified by the `[data-pf-banner-size]` presets above — so `md`
+     (the value the default silently is) would shrink on a phone while an
+     explicitly-chosen `md` would not. Same knob, same layer, three sizes. */
   .pf__banner {
-    font-size: 12px;
-    padding: 10px 14px;
+    --pf-banner-pad: 10px 14px;
+    --pf-banner-size: 12px;
+  }
+  .pf__banner[data-pf-banner-size='sm'] {
+    --pf-banner-pad: 6px 14px;
+    --pf-banner-size: 11px;
+  }
+  .pf__banner[data-pf-banner-size='md'] {
+    --pf-banner-pad: 10px 14px;
+    --pf-banner-size: 12px;
+  }
+  .pf__banner[data-pf-banner-size='lg'] {
+    --pf-banner-pad: 14px 16px;
+    --pf-banner-size: 15px;
   }
   .pf__body {
     padding: 24px 16px;

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1150,24 +1150,36 @@
 
 /* ── Reveal: `versus` loader ──
    The respondent on one side, the thing being matched on the other, progress
-   between them. Its own track is narrower than the standalone one because it
-   shares the row with two marks. */
+   between them.
+
+   The two marks are deliberately the same INK/PAPER poles whatever the form's
+   colours are — a known person against an unresolved one only reads if the pair
+   is maximally opposed. Both poles are mixed out of the accent rather than
+   hardcoded, so they stay faintly branded and, crucially, stay a near-black and
+   a near-white on ANY accent: under a lime flood the paper mark must not come
+   out lime, or the "unknown" side disappears into the background. */
 .pf-reveal__versus {
+  --pf-mark-ink: color-mix(in srgb, var(--pf-primary) 12%, #05070a);
+  --pf-mark-paper: color-mix(in srgb, var(--pf-primary) 8%, #ffffff);
+  --pf-mark-halo: color-mix(in srgb, var(--pf-mark-paper) 55%, transparent);
   display: flex;
   align-items: flex-start;
   justify-content: center;
   gap: clamp(12px, 4vw, 28px);
   width: 100%;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 .pf-reveal__mark {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   margin: 0;
   flex-shrink: 0;
 }
+/* The halo is two shadows: a tight ring hugging the circle, then a wide soft
+   bloom. One shadow cannot do both — a single large spread reads as a blur, and
+   a single tight one as a plain border. */
 .pf-reveal__mark-dot {
   width: var(--pf-reveal-mark);
   height: var(--pf-reveal-mark);
@@ -1175,50 +1187,99 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(var(--pf-reveal-mark) * 0.42);
+  font-size: calc(var(--pf-reveal-mark) * 0.44);
   font-weight: 700;
   line-height: 1;
+  box-shadow:
+    0 0 0 calc(var(--pf-reveal-mark) * 0.075) var(--pf-mark-halo),
+    0 0 calc(var(--pf-reveal-mark) * 0.5) calc(var(--pf-reveal-mark) * 0.1)
+      color-mix(in srgb, var(--pf-mark-paper) 30%, transparent);
+}
+.pf-reveal__mark-dot svg {
+  width: 62%;
+  height: 62%;
 }
 .pf-reveal__mark-dot--you {
-  background: var(--foreground);
-  color: var(--background);
+  background: var(--pf-mark-ink);
+  color: var(--pf-mark-paper);
 }
-/* The unknown side reads as an outline, not a second filled mark — the point of
-   the layout is that one of the two is not resolved yet. */
 .pf-reveal__mark-dot--match {
-  background: var(--background);
-  color: var(--foreground);
-  border: 2px solid color-mix(in srgb, var(--foreground) 35%, transparent);
+  background: var(--pf-mark-paper);
+  color: var(--pf-mark-ink);
 }
 .pf-reveal__mark-label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
   color: var(--foreground);
   max-width: 12ch;
   text-wrap: balance;
+}
+.pf-reveal__mark-status {
+  margin: -6px 0 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: color-mix(in srgb, var(--foreground) 55%, transparent);
+  max-width: 14ch;
+  text-wrap: balance;
+  animation: pf-reveal-breathe 1.6s ease-in-out infinite;
 }
 .pf-reveal__versus-mid {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   /* Centred against the marks' DOTS, not their captions: the labels wrap to
      different heights, and a percentage that drifts with the longer label
      looks like a layout bug. */
   min-width: 0;
   flex: 1;
   max-width: 200px;
-  padding-top: calc(var(--pf-reveal-mark) * 0.22);
+  padding-top: calc(var(--pf-reveal-mark) * 0.24);
 }
 .pf-reveal__pct {
+  position: relative;
+  margin: 0;
   font-size: calc(var(--pf-reveal-headline) * 0.72);
   font-weight: 800;
   letter-spacing: -0.02em;
   line-height: 1;
   color: var(--foreground);
 }
+/* The sign is set smaller and raised: at the headline's weight a full-size `%`
+   competes with the number it is qualifying. */
+.pf-reveal__pct-sign {
+  font-size: 0.55em;
+  font-weight: 700;
+  vertical-align: 0.12em;
+  margin-left: 0.06em;
+}
+.pf-reveal__pulse {
+  display: inline-block;
+  width: 0.17em;
+  height: 0.17em;
+  border-radius: 50%;
+  margin-left: 0.5em;
+  vertical-align: 0.35em;
+  background: currentColor;
+  animation: pf-reveal-breathe 1.2s ease-in-out infinite;
+}
+@keyframes pf-reveal-breathe {
+  50% {
+    opacity: 0.35;
+  }
+}
 .pf-reveal__versus .pf-reveal__track {
   width: 100%;
+  height: 10px;
+  background: color-mix(in srgb, var(--pf-mark-ink) 22%, transparent);
+}
+/* A flat fill made the bar read as a second progress bar rather than the meter
+   BETWEEN the two marks. The gradient runs from the ink mark's colour to the
+   paper one's, so the bar is literally travelling from the respondent toward
+   the match — and it lands on the same two values the marks do, in every
+   colour mode, which is why the flood below does not need to restate it. */
+.pf-reveal__versus .pf-reveal__fill {
+  background: linear-gradient(90deg, var(--pf-mark-ink), var(--pf-mark-paper));
 }
 
 /* ── Reveal: accent flood ──
@@ -1238,25 +1299,44 @@
 .pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__track {
   background: color-mix(in srgb, var(--pf-primary-contrast) 22%, transparent);
 }
-.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__fill,
-.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__mark-dot--you {
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__fill {
   background: var(--pf-primary-contrast);
-  color: var(--pf-primary);
 }
 .pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__spinner {
   border-color: color-mix(in srgb, var(--pf-primary-contrast) 25%, transparent);
   border-top-color: var(--pf-primary-contrast);
 }
-.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__mark-dot--match {
-  background: transparent;
-  color: var(--pf-primary-contrast);
-  border-color: color-mix(in srgb, var(--pf-primary-contrast) 45%, transparent);
+/* The MARKS are deliberately NOT re-coloured here. They are an ink/paper pair
+   mixed out of the accent already (see `.pf-reveal__versus`), and that pair is
+   what the flood needs: over a lime page the known side stays near-black and
+   the unknown side stays near-white. Repainting them in the accent's own
+   contrast colour — which the rest of this block does to the copy — would
+   collapse the two marks onto the same value. Only their status line and the
+   meter follow the flood. */
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__mark-status {
+  color: color-mix(in srgb, var(--pf-primary-contrast) 55%, transparent);
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__versus .pf-reveal__track {
+  background: color-mix(in srgb, var(--pf-mark-ink) 18%, transparent);
+}
+/* The marquee chips take the paper tone here too. Their default `--card` fill is
+   a near-black panel meant to sit on the form's own dark ground; left alone on a
+   flooded page it reads as a row of holes punched in the colour. */
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-logos__chip {
+  background: color-mix(in srgb, var(--pf-primary) 8%, #ffffff);
+  color: color-mix(in srgb, var(--pf-primary) 12%, #05070a);
+  border-color: transparent;
+}
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-logos__label {
+  color: color-mix(in srgb, var(--pf-primary-contrast) 65%, transparent);
 }
 
-/* The bar is a real progress signal, so it keeps moving; only the decorative
-   infinite spin stops. */
+/* The bar is a real progress signal, so it keeps moving; the decorative
+   infinite loops — the spin, and the two things that only breathe — stop. */
 @media (prefers-reduced-motion: reduce) {
-  .pf-reveal__spinner {
+  .pf-reveal__spinner,
+  .pf-reveal__pulse,
+  .pf-reveal__mark-status {
     animation: none;
   }
 }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1079,15 +1079,22 @@
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
-  --pf-reveal-mark: 52px;
+  /* Every size is a RANGE, not a number. A fixed px mark that looks right on a
+     laptop is either lost on a wide screen or colliding with its twin on a
+     phone — and this row has to hold two marks AND the meter between them at
+     375px. The `md` values here are the default an unconfigured reveal gets. */
+  --pf-reveal-mark: clamp(56px, 11vw, 88px);
   --pf-reveal-headline: clamp(22px, 5vw, 28px);
   --pf-reveal-subtitle: 15px;
 }
 .pf-reveal__inner[data-pf-reveal-mark='sm'] {
-  --pf-reveal-mark: 36px;
+  --pf-reveal-mark: clamp(44px, 8vw, 64px);
 }
 .pf-reveal__inner[data-pf-reveal-mark='lg'] {
-  --pf-reveal-mark: 76px;
+  --pf-reveal-mark: clamp(72px, 15vw, 128px);
+}
+.pf-reveal__inner[data-pf-reveal-mark='xl'] {
+  --pf-reveal-mark: clamp(88px, 20vw, 176px);
 }
 .pf-reveal__inner[data-pf-reveal-text='sm'] {
   --pf-reveal-headline: clamp(18px, 4vw, 22px);
@@ -1096,6 +1103,10 @@
 .pf-reveal__inner[data-pf-reveal-text='lg'] {
   --pf-reveal-headline: clamp(28px, 6.4vw, 40px);
   --pf-reveal-subtitle: 18px;
+}
+.pf-reveal__inner[data-pf-reveal-text='xl'] {
+  --pf-reveal-headline: clamp(34px, 8vw, 54px);
+  --pf-reveal-subtitle: 20px;
 }
 /* The copy carries the screen on its own once there is no mark, so it gets the
    width the loader would have taken. */
@@ -1165,7 +1176,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  gap: clamp(12px, 4vw, 28px);
+  gap: clamp(14px, 4vw, 32px);
   width: 100%;
   margin-top: 8px;
 }
@@ -1190,9 +1201,13 @@
   font-size: calc(var(--pf-reveal-mark) * 0.44);
   font-weight: 700;
   line-height: 1;
+  /* The ring is a HAIRLINE that separates the disc from the page, not a second
+     shape competing with it — at the largest sizes a proportional stroke read
+     as a grey donut around the mark. The bloom is capped for the same reason:
+     left proportional the two marks' glows met in the middle of the meter. */
   box-shadow:
-    0 0 0 calc(var(--pf-reveal-mark) * 0.075) var(--pf-mark-halo),
-    0 0 calc(var(--pf-reveal-mark) * 0.5) calc(var(--pf-reveal-mark) * 0.1)
+    0 0 0 clamp(1.5px, calc(var(--pf-reveal-mark) * 0.025), 4px) var(--pf-mark-halo),
+    0 0 clamp(14px, calc(var(--pf-reveal-mark) * 0.4), 40px) 0
       color-mix(in srgb, var(--pf-mark-paper) 30%, transparent);
 }
 .pf-reveal__mark-dot svg {
@@ -1231,7 +1246,10 @@
   /* Centred against the marks' DOTS, not their captions: the labels wrap to
      different heights, and a percentage that drifts with the longer label
      looks like a layout bug. */
-  min-width: 0;
+  /* `min-width` over `min-width: 0`: this column has to keep a readable meter
+     between two marks that never shrink, so it claims its floor first and the
+     row's `gap` gives way instead. */
+  min-width: 76px;
   flex: 1;
   max-width: 200px;
   padding-top: calc(var(--pf-reveal-mark) * 0.24);
@@ -1252,16 +1270,6 @@
   font-weight: 700;
   vertical-align: 0.12em;
   margin-left: 0.06em;
-}
-.pf-reveal__pulse {
-  display: inline-block;
-  width: 0.17em;
-  height: 0.17em;
-  border-radius: 50%;
-  margin-left: 0.5em;
-  vertical-align: 0.35em;
-  background: currentColor;
-  animation: pf-reveal-breathe 1.2s ease-in-out infinite;
 }
 @keyframes pf-reveal-breathe {
   50% {
@@ -1335,26 +1343,23 @@
    infinite loops — the spin, and the two things that only breathe — stop. */
 @media (prefers-reduced-motion: reduce) {
   .pf-reveal__spinner,
-  .pf-reveal__pulse,
   .pf-reveal__mark-status {
     animation: none;
   }
 }
 
 @media (max-width: 480px) {
-  /* Two marks plus a percentage do not fit a phone at the large scale, and
-     shrinking the type to force it would defeat picking `lg` in the first
-     place. The row wraps into a column instead: marks side by side, progress
-     under them. */
+  /* The row does NOT wrap. It used to, which dropped the meter to its own line
+     and left the two marks sitting against each other — the pairing reads as
+     "you versus the match" only while something separates them, and two
+     touching discs read as one blob. The marks shrink instead (their `clamp()`
+     minimums are sized for exactly this width) and the meter keeps its place
+     between them. */
   .pf-reveal__versus {
-    flex-wrap: wrap;
-    gap: 16px;
+    gap: 14px;
   }
   .pf-reveal__versus-mid {
-    order: 3;
-    flex-basis: 100%;
-    max-width: 100%;
-    padding-top: 0;
+    max-width: none;
   }
 }
 

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1079,22 +1079,34 @@
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
-  /* Every size is a RANGE, not a number. A fixed px mark that looks right on a
-     laptop is either lost on a wide screen or colliding with its twin on a
-     phone — and this row has to hold two marks AND the meter between them at
-     375px. The `md` values here are the default an unconfigured reveal gets. */
-  --pf-reveal-mark: clamp(56px, 11vw, 88px);
+  /* The larger sizes are RANGES, not numbers: a fixed px mark that looks right
+     on a laptop is either lost on a wide screen or colliding with its twin on a
+     phone, and the versus row has to hold two marks AND the meter between them
+     at 375px.
+     `md` is the exception and is deliberately the flat, historical 52px. It is
+     the value an ABSENT `loaderSize` resolves to, so anything else here would
+     resize the mark on every reveal already published — and, worse, on every
+     form's `submitting` screen, which renders this same spinner with no reveal
+     config at all and so has no way to opt out. Growing the default is a real
+     product decision; it does not get to happen as a side effect of adding a
+     scale. */
+  --pf-reveal-mark: 52px;
   --pf-reveal-headline: clamp(22px, 5vw, 28px);
   --pf-reveal-subtitle: 15px;
 }
+/* Spread around the pinned `md`. `sm` has to sit clearly BELOW 52px or the two
+   smallest steps are 4px apart on a laptop and read as the same choice. */
 .pf-reveal__inner[data-pf-reveal-mark='sm'] {
-  --pf-reveal-mark: clamp(44px, 8vw, 64px);
+  --pf-reveal-mark: clamp(34px, 6vw, 40px);
+}
+.pf-reveal__inner[data-pf-reveal-mark='md'] {
+  --pf-reveal-mark: 52px;
 }
 .pf-reveal__inner[data-pf-reveal-mark='lg'] {
-  --pf-reveal-mark: clamp(72px, 15vw, 128px);
+  --pf-reveal-mark: clamp(64px, 13vw, 104px);
 }
 .pf-reveal__inner[data-pf-reveal-mark='xl'] {
-  --pf-reveal-mark: clamp(88px, 20vw, 176px);
+  --pf-reveal-mark: clamp(84px, 19vw, 168px);
 }
 .pf-reveal__inner[data-pf-reveal-text='sm'] {
   --pf-reveal-headline: clamp(18px, 4vw, 22px);
@@ -1326,6 +1338,13 @@
 }
 .pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__versus .pf-reveal__track {
   background: color-mix(in srgb, var(--pf-mark-ink) 18%, transparent);
+}
+/* The versus meter keeps its ink -> paper gradient under the flood. It has to be
+   restated: the flood's generic `.pf-reveal__fill` rule above is 0,3,0 and sits
+   later in the file, so it out-specified the 0,2,0 versus rule and flattened the
+   gradient to a solid — while the builder canvas went on drawing it. */
+.pf--reveal[data-pf-reveal-bg='accent'] .pf-reveal__versus .pf-reveal__fill {
+  background: linear-gradient(90deg, var(--pf-mark-ink), var(--pf-mark-paper));
 }
 /* The marquee chips take the paper tone here too. Their default `--card` fill is
    a near-black panel meant to sit on the form's own dark ground; left alone on a

--- a/apps/web/app/[accountCode]/[handle]/[slug]/renderer-shared.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/renderer-shared.tsx
@@ -127,6 +127,31 @@ export function schedulerToBooking(
 }
 
 /**
+ * The banner strip's authored look, as inline custom properties.
+ *
+ * Exported and pure so BOTH renderers and the builder preview stamp identical
+ * markup — a banner that reads as loud in the builder and washed out on the
+ * public page is the exact bug this feature exists to fix.
+ *
+ * An unset axis emits NO variable, which is what keeps every stored config
+ * pixel-identical: the stylesheet's own `var(…, <legacy fallback>)` answers
+ * instead. The size is a `data-` attribute rather than a variable because it
+ * moves two values (padding and type) that the CSS should keep together.
+ */
+export function bannerChromeProps(cover: FormCover | null | undefined): {
+  style: React.CSSProperties;
+  'data-pf-banner-size'?: string;
+} {
+  const vars: Record<string, string> = {};
+  if (cover?.bannerColor) vars['--pf-banner-bg'] = cover.bannerColor;
+  if (cover?.bannerTextColor) vars['--pf-banner-fg'] = cover.bannerTextColor;
+  return {
+    style: vars as React.CSSProperties,
+    ...(cover?.bannerSize ? { 'data-pf-banner-size': cover.bannerSize } : {}),
+  };
+}
+
+/**
  * Per-phase page shell. The promo banner (`cover.bannerText`) renders ONCE here
  * as the first child of `.pf`, so it is a full-width strip pinned to the top of
  * the viewport; everything else lives in `.pf__main`, which owns the remaining
@@ -136,6 +161,7 @@ export function schedulerToBooking(
  *
  * WHICH phases show it is `cover.bannerScope` (see `showBanner`): every phase by
  * default, or the cover alone — hence `isCover`, set only by the cover phase.
+ * WHAT it looks like is `bannerChromeProps`.
  */
 export function PhaseShell({
   cover,
@@ -165,7 +191,11 @@ export function PhaseShell({
       {/* An author-supplied face has to be declared in the document; there is no
           build step that could have hoisted it into the stylesheet. */}
       {design?.fontFace ? <style>{design.fontFace}</style> : null}
-      {banner ? <div className="pf__banner">{banner}</div> : null}
+      {banner ? (
+        <div className="pf__banner" {...bannerChromeProps(cover)}>
+          {banner}
+        </div>
+      ) : null}
       <div className="pf__main">{children}</div>
     </div>
   );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -183,6 +183,7 @@ export function VerticalFormRenderer({
     subtitle: m.revealSubtitle,
     versusYou: m.revealVersusYou,
     versusMatch: m.revealVersusMatch,
+    versusStatus: m.revealVersusStatus,
   };
 
   const [phase, setPhase] = useState<Phase>('form');

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -37,6 +37,7 @@ import {
   nameFields,
   isSafeHttpUrl,
   showBanner,
+  showClientLogosOn,
   resolveFormLogos,
   type Answers,
   type AnswerValue,
@@ -50,7 +51,7 @@ import { FormLogo } from '@/components/public/form-logo';
 import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
 import { StepInput } from '@/components/public/step-input';
 import { BookingScreen } from '@/components/public/booking-screen';
-import { RevealScreen } from '@/components/public/reveal-screen';
+import { RevealScreen, revealShellProps } from '@/components/public/reveal-screen';
 import { MadeWithBadge } from '@/components/made-with-badge';
 import { formDesignProps } from '@/lib/form-design';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
@@ -62,6 +63,7 @@ import {
   captureDefaults,
   capturePrefill,
   schedulerToBooking,
+  bannerChromeProps,
   PhaseShell,
   DoneScreen,
 } from './renderer-shared';
@@ -168,6 +170,20 @@ export function VerticalFormRenderer({
   // `form-renderer.tsx`. `showBanner` already handles a disabled cover; reading
   // it off the gated value above is what made it unreachable.
   const chrome = config.cover ?? null;
+  // The marquee, scoped exactly as in the slides layout. This used to read the
+  // logos with no regard for `showClientLogos`, so switching the marquee OFF hid
+  // it on slides and did nothing at all on a one-page form — one toggle, two
+  // answers. Read off `chrome`, not the gated cover, so a form with the hero
+  // switched off can still show its logos on the interstitial.
+  const marqueeLogos = chrome?.clientLogos ?? config.branding?.clientLogos ?? [];
+  const heroLogos = showClientLogosOn(chrome, 'cover') ? marqueeLogos : [];
+  const revealLogos = showClientLogosOn(chrome, 'reveal') ? marqueeLogos : [];
+  const revealMessages = {
+    headline: m.revealHeadline,
+    subtitle: m.revealSubtitle,
+    versusYou: m.revealVersusYou,
+    versusMatch: m.revealVersusMatch,
+  };
 
   const [phase, setPhase] = useState<Phase>('form');
   const [answers, setAnswers] = useState<Answers>({});
@@ -534,13 +550,16 @@ export function VerticalFormRenderer({
         role="status"
         aria-live="polite"
         cover={chrome}
+        {...revealShellProps(pendingReveal)}
       >
         <RevealScreen
           reveal={pendingReveal ?? { enabled: true }}
           answers={answers}
-          messages={{ headline: m.revealHeadline, subtitle: m.revealSubtitle }}
+          messages={revealMessages}
           onComplete={onRevealComplete}
-        />
+        >
+          <ClientLogosMarquee logos={revealLogos} label={m.trustedBy} />
+        </RevealScreen>
       </PhaseShell>
     );
   }
@@ -567,7 +586,6 @@ export function VerticalFormRenderer({
   // when the cover is off. Either can be cleared to nothing independently.
   const logos = resolveFormLogos(config);
   const headerLogo = coverScreen ? logos.cover : logos.form;
-  const clientLogos = coverScreen?.clientLogos ?? config.branding?.clientLogos ?? [];
   const total = answerable.length;
 
   return (
@@ -585,7 +603,9 @@ export function VerticalFormRenderer({
             shows, exactly as in the slides layout. The post-submit phases defer
             to the scope via the shared shell. */}
         {showBanner(chrome, coverScreen != null) ? (
-          <div className="pf__banner">{chrome?.bannerText}</div>
+          <div className="pf__banner" {...bannerChromeProps(chrome)}>
+            {chrome?.bannerText}
+          </div>
         ) : null}
         {total > 0 ? (
           <div className="pf-v__progressbar">
@@ -618,7 +638,7 @@ export function VerticalFormRenderer({
               <h1 className="pf__title">{coverScreen.headline ?? name}</h1>
               {coverScreen.subheadline ? <p className="pf__subheadline">{coverScreen.subheadline}</p> : null}
               {coverScreen.trustBadge ? <p className="pf__trust">{coverScreen.trustBadge}</p> : null}
-              <ClientLogosMarquee logos={clientLogos} label={m.trustedBy} />
+              <ClientLogosMarquee logos={heroLogos} label={m.trustedBy} />
             </section>
           ) : null}
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -219,6 +219,8 @@ export interface BuilderMessages {
     revealAccentBackgroundHint: string;
     revealVersusYou: string;
     revealVersusMatch: string;
+    revealVersusStatus: string;
+    revealVersusStatusHint: string;
     revealVersusHint: string;
     /** V6 — the scheduler STEP picks a Calendly event type here. */
     schedulerSection: string;
@@ -623,6 +625,8 @@ const en: BuilderMessages = {
       'Paints the whole screen in the form’s accent color, so the interstitial reads as a moment of its own.',
     revealVersusYou: 'Your side’s label',
     revealVersusMatch: 'The match’s label',
+    revealVersusStatus: 'Status line',
+    revealVersusStatusHint: 'Shown under the match while it plays. Clear it to drop the line.',
     revealVersusHint: 'Both accept [field] tokens. Empty uses the default wording.',
     schedulerSection: 'Scheduler',
     schedulerHint: 'Pick a Calendly event type. When someone books, it counts as their answer.',
@@ -994,6 +998,8 @@ const es: BuilderMessages = {
       'Pinta toda la pantalla con el color de acento del formulario, para que la espera se sienta como un momento aparte.',
     revealVersusYou: 'Etiqueta de tu lado',
     revealVersusMatch: 'Etiqueta del match',
+    revealVersusStatus: 'Línea de estado',
+    revealVersusStatusHint: 'Se muestra bajo el match mientras corre. Vacíala para quitar la línea.',
     revealVersusHint: 'Ambas aceptan tokens [campo]. Vacías usan el texto por defecto.',
     schedulerSection: 'Agendador',
     schedulerHint: 'Elige un tipo de evento de Calendly. Cuando alguien agenda, cuenta como su respuesta.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -222,6 +222,7 @@ export interface BuilderMessages {
     revealVersusMatch: string;
     revealVersusStatus: string;
     revealVersusStatusHint: string;
+    revealVersusStatusReset: string;
     revealVersusHint: string;
     /** V6 — the scheduler STEP picks a Calendly event type here. */
     schedulerSection: string;
@@ -629,6 +630,7 @@ const en: BuilderMessages = {
     revealVersusMatch: 'The match’s label',
     revealVersusStatus: 'Status line',
     revealVersusStatusHint: 'Shown under the match while it plays. Clear it to drop the line.',
+    revealVersusStatusReset: 'Use the default wording',
     revealVersusHint: 'Both accept [field] tokens. Empty uses the default wording.',
     schedulerSection: 'Scheduler',
     schedulerHint: 'Pick a Calendly event type. When someone books, it counts as their answer.',
@@ -1003,6 +1005,7 @@ const es: BuilderMessages = {
     revealVersusMatch: 'Etiqueta del match',
     revealVersusStatus: 'Línea de estado',
     revealVersusStatusHint: 'Se muestra bajo el match mientras corre. Vacíala para quitar la línea.',
+    revealVersusStatusReset: 'Usar el texto por defecto',
     revealVersusHint: 'Ambas aceptan tokens [campo]. Vacías usan el texto por defecto.',
     schedulerSection: 'Agendador',
     schedulerHint: 'Elige un tipo de evento de Calendly. Cuando alguien agenda, cuenta como su respuesta.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -215,6 +215,7 @@ export interface BuilderMessages {
     revealSizeSm: string;
     revealSizeMd: string;
     revealSizeLg: string;
+    revealSizeXl: string;
     revealAccentBackground: string;
     revealAccentBackgroundHint: string;
     revealVersusYou: string;
@@ -620,6 +621,7 @@ const en: BuilderMessages = {
     revealSizeSm: 'Small',
     revealSizeMd: 'Medium',
     revealSizeLg: 'Large',
+    revealSizeXl: 'Huge',
     revealAccentBackground: 'Flood with the accent',
     revealAccentBackgroundHint:
       'Paints the whole screen in the form’s accent color, so the interstitial reads as a moment of its own.',
@@ -993,6 +995,7 @@ const es: BuilderMessages = {
     revealSizeSm: 'Pequeño',
     revealSizeMd: 'Mediano',
     revealSizeLg: 'Grande',
+    revealSizeXl: 'Enorme',
     revealAccentBackground: 'Fondo con el color de acento',
     revealAccentBackgroundHint:
       'Pinta toda la pantalla con el color de acento del formulario, para que la espera se sienta como un momento aparte.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -202,6 +202,24 @@ export interface BuilderMessages {
     revealHint: string;
     revealPrewarm: string;
     revealPrewarmHint: string;
+    /** How the interstitial is drawn — loader style, scales, accent flood. */
+    revealLook: string;
+    revealLoader: string;
+    revealLoaderHint: string;
+    revealLoaderSpinner: string;
+    revealLoaderBar: string;
+    revealLoaderVersus: string;
+    revealLoaderNone: string;
+    revealLoaderSize: string;
+    revealTextSize: string;
+    revealSizeSm: string;
+    revealSizeMd: string;
+    revealSizeLg: string;
+    revealAccentBackground: string;
+    revealAccentBackgroundHint: string;
+    revealVersusYou: string;
+    revealVersusMatch: string;
+    revealVersusHint: string;
     /** V6 — the scheduler STEP picks a Calendly event type here. */
     schedulerSection: string;
     schedulerHint: string;
@@ -588,6 +606,24 @@ const en: BuilderMessages = {
       'Plays here, then the form continues on its own. Drag the card in the list to move it. Both lines accept [field] tokens.',
     revealPrewarm: 'Pre-warm the booking embed',
     revealPrewarmHint: 'Loads the outcome’s booking calendar while this screen plays.',
+    revealLook: 'Look',
+    revealLoader: 'Loader',
+    revealLoaderHint: 'What animates while the screen plays.',
+    revealLoaderSpinner: 'Spinner',
+    revealLoaderBar: 'Bar only',
+    revealLoaderVersus: 'You vs. match',
+    revealLoaderNone: 'No animation',
+    revealLoaderSize: 'Loader size',
+    revealTextSize: 'Text size',
+    revealSizeSm: 'Small',
+    revealSizeMd: 'Medium',
+    revealSizeLg: 'Large',
+    revealAccentBackground: 'Flood with the accent',
+    revealAccentBackgroundHint:
+      'Paints the whole screen in the form’s accent color, so the interstitial reads as a moment of its own.',
+    revealVersusYou: 'Your side’s label',
+    revealVersusMatch: 'The match’s label',
+    revealVersusHint: 'Both accept [field] tokens. Empty uses the default wording.',
     schedulerSection: 'Scheduler',
     schedulerHint: 'Pick a Calendly event type. When someone books, it counts as their answer.',
     schedulerEventType: 'Event type',
@@ -941,6 +977,24 @@ const es: BuilderMessages = {
       'Se muestra aquí y el formulario continúa solo. Arrastra la tarjeta en la lista para moverla. Ambas líneas aceptan tokens [campo].',
     revealPrewarm: 'Precargar el calendario',
     revealPrewarmHint: 'Carga el calendario de agendamiento del resultado mientras se muestra esta pantalla.',
+    revealLook: 'Aspecto',
+    revealLoader: 'Cargador',
+    revealLoaderHint: 'Qué se anima mientras se muestra la pantalla.',
+    revealLoaderSpinner: 'Ruedita',
+    revealLoaderBar: 'Solo la barra',
+    revealLoaderVersus: 'Tú vs. el match',
+    revealLoaderNone: 'Sin animación',
+    revealLoaderSize: 'Tamaño del cargador',
+    revealTextSize: 'Tamaño del texto',
+    revealSizeSm: 'Pequeño',
+    revealSizeMd: 'Mediano',
+    revealSizeLg: 'Grande',
+    revealAccentBackground: 'Fondo con el color de acento',
+    revealAccentBackgroundHint:
+      'Pinta toda la pantalla con el color de acento del formulario, para que la espera se sienta como un momento aparte.',
+    revealVersusYou: 'Etiqueta de tu lado',
+    revealVersusMatch: 'Etiqueta del match',
+    revealVersusHint: 'Ambas aceptan tokens [campo]. Vacías usan el texto por defecto.',
     schedulerSection: 'Agendador',
     schedulerHint: 'Elige un tipo de evento de Calendly. Cuando alguien agenda, cuenta como su respuesta.',
     schedulerEventType: 'Tipo de evento',

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -9,8 +9,10 @@ import {
   resolveOptionLayout,
   resolveOptionIcon,
   resolveDesign,
+  resolveRevealPresentation,
 } from '@quill/engine';
-import { onAccent, DEFAULT_ACCENT } from '@quill/shared';
+import { onAccent, DEFAULT_ACCENT, getMessages } from '@quill/shared';
+import { clientLocale } from '@/lib/client-locale';
 import { cn } from '@/lib/cn';
 import { iconForStep, hasOptions } from './question-types';
 import { maxStepPoints } from './scoring-util';
@@ -28,6 +30,7 @@ function AutoTextarea({
   onChange,
   placeholder,
   className,
+  style,
   ariaLabel,
   autoFocus,
   rows = 1,
@@ -36,17 +39,23 @@ function AutoTextarea({
   onChange: (v: string) => void;
   placeholder: string;
   className?: string;
+  /** Inline overrides for values the canvas computes — the reveal's type scale. */
+  style?: React.CSSProperties;
   ariaLabel: string;
   autoFocus?: boolean;
   rows?: number;
 }) {
   const ref = useRef<HTMLTextAreaElement>(null);
+  // Re-measure on the TYPE SCALE too, not just the text. The box is
+  // `overflow-hidden`, so a font-size change with a stale height silently clips
+  // the line — which is exactly what picking the reveal's "Large" text size did
+  // to its headline.
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
     el.style.height = 'auto';
     el.style.height = `${el.scrollHeight}px`;
-  }, [value]);
+  }, [value, style?.fontSize, style?.lineHeight]);
   useEffect(() => {
     if (autoFocus && ref.current) {
       const el = ref.current;
@@ -62,6 +71,7 @@ function AutoTextarea({
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
       aria-label={ariaLabel}
+      style={style}
       className={cn(
         'w-full resize-none overflow-hidden bg-transparent outline-none placeholder:text-muted-foreground/50',
         className,
@@ -613,16 +623,28 @@ function RevealPageBlock({
   );
 }
 
+/** The canvas mirror of the public `--pf-reveal-mark` scale. */
+const REVEAL_MARK_PX = { sm: 36, md: 52, lg: 76 } as const;
+/** The canvas mirror of the public `--pf-reveal-headline` / `-subtitle` scales. */
+const REVEAL_TEXT_PX = {
+  sm: { headline: 22, subtitle: 14 },
+  md: { headline: 26, subtitle: 15 },
+  lg: { headline: 36, subtitle: 18 },
+} as const;
+
 /**
- * The reveal card, rendered as the respondent will see it: the accent spinner,
- * the headline and subtitle, and the progress bar filling over the configured
- * duration — looping, so the author can feel how long `durationMs` actually is.
+ * The reveal card, rendered as the respondent will see it: the configured
+ * loader, the headline and subtitle at their configured scale, and the progress
+ * bar filling over the configured duration — looping, so the author can feel how
+ * long `durationMs` actually is.
  *
  * The copy is edited IN PLACE (same inline-textarea idiom as a question title),
  * which is why this mirrors the public `.pf-reveal__*` markup by hand instead of
  * mounting `<RevealScreen>`: that component owns its own timer and renders the
  * copy as static text, so it could preview the screen or let you edit it, not
- * both. Duration and pre-warm stay in the settings panel.
+ * both. The cost of that choice is this file having to track the public scales —
+ * hence the two tables above, which mirror `public-form.css` value for value.
+ * Duration and pre-warm stay in the settings panel.
  */
 function RevealCanvas({
   step,
@@ -638,27 +660,47 @@ function RevealCanvas({
   m: BuilderMessages;
 }) {
   const durationMs = step.reveal?.durationMs ?? DEFAULT_REVEAL_MS;
+  const { loader, loaderSize, textSize, accentBackground } = resolveRevealPresentation(step.reveal);
+  // The RESPONDENT's fallbacks, not the editor's field labels. The canvas is a
+  // preview of the published screen, so an unnamed side has to read the way it
+  // will publish ("You"), never the way the input beside it is captioned
+  // ("Your side's label") — that is the preview lying about the page.
+  const r = getMessages(clientLocale()).renderer;
+  const mark = REVEAL_MARK_PX[loaderSize];
+  const text = REVEAL_TEXT_PX[textSize];
+  // The accent flood makes the card its own surface, so the copy has to flip
+  // with it — the same pairing the public stylesheet makes with
+  // `--pf-primary-contrast`.
+  const onAccentColor = onAccent(accent);
+  const bar = accentBackground ? onAccentColor : accent;
+  const bodyColor = accentBackground ? onAccentColor : undefined;
   return (
     <div className="flex justify-center">
       <div
         data-testid="canvas-reveal-preview"
+        data-pf-reveal-loader={loader}
         className={cn(
-          'flex w-full flex-col items-center rounded-2xl border border-border bg-card px-6 py-14 shadow-xl sm:px-8',
+          'flex w-full flex-col items-center rounded-2xl border border-border px-6 py-14 shadow-xl sm:px-8',
+          accentBackground ? '' : 'bg-card',
           device === 'mobile' ? 'max-w-[380px]' : 'max-w-[640px]',
         )}
+        style={accentBackground ? { background: accent, color: onAccentColor } : undefined}
       >
-        <div
-          aria-hidden
-          data-testid="canvas-reveal-spinner"
-          className="qb-reveal__spinner mb-7 h-[52px] w-[52px] rounded-full border-4 border-muted"
-          style={{ borderTopColor: accent }}
-        />
+        {loader === 'spinner' ? (
+          <div
+            aria-hidden
+            data-testid="canvas-reveal-spinner"
+            className="qb-reveal__spinner mb-7 rounded-full border-4 border-muted"
+            style={{ width: mark, height: mark, borderTopColor: bar }}
+          />
+        ) : null}
         <AutoTextarea
           value={step.reveal?.headline ?? ''}
           onChange={(v) => onUpdate({ reveal: { ...step.reveal, headline: v || null } })}
           placeholder={m.canvas.revealHeadlinePlaceholder}
           ariaLabel={m.canvas.revealHeadlinePlaceholder}
-          className="canvas-title max-w-[420px] text-center text-[26px] font-extrabold leading-tight tracking-tight text-foreground"
+          className="canvas-title max-w-[420px] text-center font-extrabold leading-tight tracking-tight text-foreground"
+          style={{ fontSize: text.headline, color: bodyColor }}
         />
         <div className="mt-2 w-full max-w-[420px]">
           <AutoTextarea
@@ -667,16 +709,65 @@ function RevealCanvas({
             placeholder={m.canvas.revealSubtitlePlaceholder}
             ariaLabel={m.canvas.revealSubtitlePlaceholder}
             rows={2}
-            className="text-center text-[15px] leading-relaxed text-muted-foreground"
+            className="text-center leading-relaxed text-muted-foreground"
+            style={{ fontSize: text.subtitle, color: bodyColor }}
           />
         </div>
-        <div className="mt-6 h-2 w-[260px] max-w-full overflow-hidden rounded-full bg-muted">
+        {loader === 'spinner' || loader === 'bar' ? (
+          <div className="mt-6 h-2 w-[260px] max-w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="qb-reveal__fill h-full rounded-full"
+              style={{ background: bar, animationDuration: `${durationMs}ms` }}
+            />
+          </div>
+        ) : null}
+        {loader === 'versus' ? (
           <div
-            className="qb-reveal__fill h-full rounded-full"
-            style={{ background: accent, animationDuration: `${durationMs}ms` }}
-          />
-        </div>
-        <p className="mt-5 text-xs text-muted-foreground">
+            aria-hidden
+            data-testid="canvas-reveal-versus"
+            className="mt-6 flex w-full items-start justify-center gap-5"
+          >
+            <div className="flex flex-col items-center gap-2.5">
+              <div
+                className="rounded-full"
+                style={{
+                  width: mark,
+                  height: mark,
+                  background: accentBackground ? onAccentColor : 'var(--foreground)',
+                }}
+              />
+              <span className="max-w-[12ch] text-center text-[13px] font-semibold">
+                {step.reveal?.versusYouLabel || r.revealVersusYou}
+              </span>
+            </div>
+            <div className="flex max-w-[200px] flex-1 flex-col items-center gap-2 pt-3">
+              <span className="text-[19px] font-extrabold leading-none tracking-tight">100%</span>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="qb-reveal__fill h-full rounded-full"
+                  style={{ background: bar, animationDuration: `${durationMs}ms` }}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col items-center gap-2.5">
+              <div
+                className="flex items-center justify-center rounded-full border-2 font-bold"
+                style={{
+                  width: mark,
+                  height: mark,
+                  fontSize: mark * 0.42,
+                  borderColor: 'color-mix(in srgb, currentColor 35%, transparent)',
+                }}
+              >
+                ?
+              </div>
+              <span className="max-w-[12ch] text-center text-[13px] font-semibold">
+                {step.reveal?.versusMatchLabel || r.revealVersusMatch}
+              </span>
+            </div>
+          </div>
+        ) : null}
+        <p className="mt-5 text-xs text-muted-foreground" style={{ color: bodyColor }}>
           {tb(m.canvas.revealPlays, { ms: durationMs })}
         </p>
       </div>

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -623,13 +623,26 @@ function RevealPageBlock({
   );
 }
 
-/** The canvas mirror of the public `--pf-reveal-mark` scale. */
-const REVEAL_MARK_PX = { sm: 36, md: 52, lg: 76 } as const;
-/** The canvas mirror of the public `--pf-reveal-headline` / `-subtitle` scales. */
+/**
+ * The canvas mirror of the public `--pf-reveal-*` scales.
+ *
+ * Those are `clamp()` ranges keyed off the VIEWPORT, which is the one thing the
+ * canvas cannot reuse: this card is ~640px wide inside a much wider admin
+ * window, so a `vw` unit here would resolve against the browser rather than the
+ * form. Each step is therefore stored as its two ends, and the preview picks the
+ * one matching the device toggle — the desktop ceiling, or the phone floor.
+ */
+const REVEAL_MARK_PX = {
+  sm: { desktop: 64, mobile: 44 },
+  md: { desktop: 88, mobile: 56 },
+  lg: { desktop: 128, mobile: 72 },
+  xl: { desktop: 176, mobile: 88 },
+} as const;
 const REVEAL_TEXT_PX = {
   sm: { headline: 22, subtitle: 14 },
-  md: { headline: 26, subtitle: 15 },
-  lg: { headline: 36, subtitle: 18 },
+  md: { headline: 28, subtitle: 15 },
+  lg: { headline: 40, subtitle: 18 },
+  xl: { headline: 54, subtitle: 20 },
 } as const;
 
 /**
@@ -670,7 +683,10 @@ function RevealCanvas({
   // clearing the field previews the line actually disappearing.
   const versusStatus =
     step.reveal?.versusStatusLabel == null ? r.revealVersusStatus : step.reveal.versusStatusLabel;
-  const mark = REVEAL_MARK_PX[loaderSize];
+  const mark = REVEAL_MARK_PX[loaderSize][device];
+  // Clamped exactly as the stylesheet clamps it, so the biggest marks do not
+  // preview with a halo the published page will not draw.
+  const ring = Math.min(4, Math.max(1.5, mark * 0.025));
   const text = REVEAL_TEXT_PX[textSize];
   // The accent flood makes the card its own surface, so the copy has to flip
   // with it — the same pairing the public stylesheet makes with
@@ -748,7 +764,7 @@ function RevealCanvas({
                   height: mark,
                   background: 'var(--pf-mark-ink)',
                   color: 'var(--pf-mark-paper)',
-                  boxShadow: `0 0 0 ${mark * 0.075}px color-mix(in srgb, var(--pf-mark-paper) 55%, transparent)`,
+                  boxShadow: `0 0 0 ${ring}px color-mix(in srgb, var(--pf-mark-paper) 55%, transparent)`,
                 }}
               >
                 <svg
@@ -794,7 +810,7 @@ function RevealCanvas({
                   fontSize: mark * 0.44,
                   background: 'var(--pf-mark-paper)',
                   color: 'var(--pf-mark-ink)',
-                  boxShadow: `0 0 0 ${mark * 0.075}px color-mix(in srgb, var(--pf-mark-paper) 55%, transparent)`,
+                  boxShadow: `0 0 0 ${ring}px color-mix(in srgb, var(--pf-mark-paper) 55%, transparent)`,
                 }}
               >
                 ?

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -666,6 +666,10 @@ function RevealCanvas({
   // will publish ("You"), never the way the input beside it is captioned
   // ("Your side's label") — that is the preview lying about the page.
   const r = getMessages(clientLocale()).renderer;
+  // Same precedence as `resolveRevealCopy`: only an ABSENT value falls back, so
+  // clearing the field previews the line actually disappearing.
+  const versusStatus =
+    step.reveal?.versusStatusLabel == null ? r.revealVersusStatus : step.reveal.versusStatusLabel;
   const mark = REVEAL_MARK_PX[loaderSize];
   const text = REVEAL_TEXT_PX[textSize];
   // The accent flood makes the card its own surface, so the copy has to flip
@@ -726,44 +730,86 @@ function RevealCanvas({
             aria-hidden
             data-testid="canvas-reveal-versus"
             className="mt-6 flex w-full items-start justify-center gap-5"
+            // The same ink/paper poles the public stylesheet derives, so the
+            // card previews the pairing that will publish rather than a
+            // grey-on-grey approximation of it.
+            style={
+              {
+                '--pf-mark-ink': `color-mix(in srgb, ${accent} 12%, #05070a)`,
+                '--pf-mark-paper': `color-mix(in srgb, ${accent} 8%, #ffffff)`,
+              } as React.CSSProperties
+            }
           >
-            <div className="flex flex-col items-center gap-2.5">
+            <div className="flex flex-col items-center gap-3">
               <div
-                className="rounded-full"
+                className="flex items-center justify-center rounded-full"
                 style={{
                   width: mark,
                   height: mark,
-                  background: accentBackground ? onAccentColor : 'var(--foreground)',
+                  background: 'var(--pf-mark-ink)',
+                  color: 'var(--pf-mark-paper)',
+                  boxShadow: `0 0 0 ${mark * 0.075}px color-mix(in srgb, var(--pf-mark-paper) 55%, transparent)`,
                 }}
-              />
-              <span className="max-w-[12ch] text-center text-[13px] font-semibold">
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  style={{ width: '62%', height: '62%' }}
+                  aria-hidden
+                >
+                  <circle cx="12" cy="8" r="3.6" />
+                  <path d="M12 13.2c-3.6 0-6.4 2.1-6.4 4.7v1.3h12.8v-1.3c0-2.6-2.8-4.7-6.4-4.7Z" />
+                </svg>
+              </div>
+              <span className="max-w-[12ch] text-center text-[14px] font-bold">
                 {step.reveal?.versusYouLabel || r.revealVersusYou}
               </span>
             </div>
-            <div className="flex max-w-[200px] flex-1 flex-col items-center gap-2 pt-3">
-              <span className="text-[19px] font-extrabold leading-none tracking-tight">100%</span>
-              <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="flex max-w-[200px] flex-1 flex-col items-center gap-2.5"
+              style={{ paddingTop: mark * 0.24 }}
+            >
+              <span className="text-[19px] font-extrabold leading-none tracking-tight">
+                100<span className="align-[0.12em] text-[0.55em] font-bold">%</span>
+              </span>
+              <div
+                className="h-2.5 w-full overflow-hidden rounded-full"
+                style={{ background: 'color-mix(in srgb, var(--pf-mark-ink) 22%, transparent)' }}
+              >
                 <div
                   className="qb-reveal__fill h-full rounded-full"
-                  style={{ background: bar, animationDuration: `${durationMs}ms` }}
+                  style={{
+                    background: `linear-gradient(90deg, var(--pf-mark-ink), ${bar})`,
+                    animationDuration: `${durationMs}ms`,
+                  }}
                 />
               </div>
             </div>
-            <div className="flex flex-col items-center gap-2.5">
+            <div className="flex flex-col items-center gap-3">
               <div
-                className="flex items-center justify-center rounded-full border-2 font-bold"
+                className="flex items-center justify-center rounded-full font-bold"
                 style={{
                   width: mark,
                   height: mark,
-                  fontSize: mark * 0.42,
-                  borderColor: 'color-mix(in srgb, currentColor 35%, transparent)',
+                  fontSize: mark * 0.44,
+                  background: 'var(--pf-mark-paper)',
+                  color: 'var(--pf-mark-ink)',
+                  boxShadow: `0 0 0 ${mark * 0.075}px color-mix(in srgb, var(--pf-mark-paper) 55%, transparent)`,
                 }}
               >
                 ?
               </div>
-              <span className="max-w-[12ch] text-center text-[13px] font-semibold">
+              <span className="max-w-[12ch] text-center text-[14px] font-bold">
                 {step.reveal?.versusMatchLabel || r.revealVersusMatch}
               </span>
+              {versusStatus ? (
+                <span
+                  className="-mt-1.5 max-w-[14ch] text-center text-[13px]"
+                  style={{ color: 'color-mix(in srgb, currentColor 55%, transparent)' }}
+                >
+                  {versusStatus}
+                </span>
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -633,16 +633,17 @@ function RevealPageBlock({
  * one matching the device toggle — the desktop ceiling, or the phone floor.
  */
 const REVEAL_MARK_PX = {
-  sm: { desktop: 64, mobile: 44 },
-  md: { desktop: 88, mobile: 56 },
-  lg: { desktop: 128, mobile: 72 },
-  xl: { desktop: 176, mobile: 88 },
+  sm: { desktop: 40, mobile: 34 },
+  // Flat in the stylesheet — the pinned historical default — so both ends match.
+  md: { desktop: 52, mobile: 52 },
+  lg: { desktop: 104, mobile: 64 },
+  xl: { desktop: 168, mobile: 84 },
 } as const;
 const REVEAL_TEXT_PX = {
-  sm: { headline: 22, subtitle: 14 },
-  md: { headline: 28, subtitle: 15 },
-  lg: { headline: 40, subtitle: 18 },
-  xl: { headline: 54, subtitle: 20 },
+  sm: { desktop: { headline: 22, subtitle: 14 }, mobile: { headline: 18, subtitle: 14 } },
+  md: { desktop: { headline: 28, subtitle: 15 }, mobile: { headline: 22, subtitle: 15 } },
+  lg: { desktop: { headline: 40, subtitle: 18 }, mobile: { headline: 28, subtitle: 18 } },
+  xl: { desktop: { headline: 54, subtitle: 20 }, mobile: { headline: 34, subtitle: 20 } },
 } as const;
 
 /**
@@ -687,7 +688,10 @@ function RevealCanvas({
   // Clamped exactly as the stylesheet clamps it, so the biggest marks do not
   // preview with a halo the published page will not draw.
   const ring = Math.min(4, Math.max(1.5, mark * 0.025));
-  const text = REVEAL_TEXT_PX[textSize];
+  const text = REVEAL_TEXT_PX[textSize][device];
+  // `.pf-reveal__pct` is `calc(headline * 0.72)`; hardcoding it drifted from the
+  // headline the moment the type scale gained a step.
+  const pctPx = Math.round(text.headline * 0.72);
   // The accent flood makes the card its own surface, so the copy has to flip
   // with it — the same pairing the public stylesheet makes with
   // `--pf-primary-contrast`.
@@ -698,7 +702,6 @@ function RevealCanvas({
     <div className="flex justify-center">
       <div
         data-testid="canvas-reveal-preview"
-        data-pf-reveal-loader={loader}
         className={cn(
           'flex w-full flex-col items-center rounded-2xl border border-border px-6 py-14 shadow-xl sm:px-8',
           accentBackground ? '' : 'bg-card',
@@ -785,7 +788,10 @@ function RevealCanvas({
               className="flex max-w-[200px] flex-1 flex-col items-center gap-2.5"
               style={{ paddingTop: mark * 0.24 }}
             >
-              <span className="text-[19px] font-extrabold leading-none tracking-tight">
+              <span
+                className="font-extrabold leading-none tracking-tight"
+                style={{ fontSize: pctPx }}
+              >
                 100<span className="align-[0.12em] text-[0.55em] font-bold">%</span>
               </span>
               <div

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -14,6 +14,7 @@ import {
   AA_CONTRAST,
   DEFAULT_ACCENT,
   DEFAULT_CANVAS,
+  blendHex,
   DEFAULT_CANVAS_FOREGROUND,
   contrastGrade,
   contrastRatio,
@@ -619,6 +620,16 @@ function CoverSection({
   m: EditorMessages;
 }) {
   const cover = config.cover ?? {};
+  // What the strip renders when `bannerColor` is unset — `.pf__banner`'s own
+  // fallback, 12% of the accent over the form ground. Resolved here so the text
+  // colour's contrast readout has a real surface to judge against. The two
+  // inputs fall back exactly as the section above resolves them.
+  const branding = config.branding ?? {};
+  const bannerTint = blendHex(
+    branding.background?.trim() || DEFAULT_CANVAS,
+    branding.primaryColor?.trim() || DEFAULT_ACCENT,
+    0.12,
+  );
   return (
     <PanelSection title={m.cover.title} subtitle={m.cover.subtitle}>
       <InlineField label={m.cover.enabled}>
@@ -662,12 +673,17 @@ function CoverSection({
           <Field label={m.cover.bannerTextColor}>
             {/* `against` is the strip's own fill, so the contrast readout judges
                 the pair that actually renders — not the text against the form
-                ground, which is a different surface entirely. */}
+                ground, which is a different surface entirely.
+                It falls back to the DERIVED tint rather than to `undefined`,
+                which switches the badge off: the likeliest bad pair is pale text
+                on the default 12%-accent wash, so leaving the colour unset was
+                exactly the case that got no warning. Mirrors the stylesheet's
+                own fallback in `.pf__banner`. */}
             <ColorPicker
               value={cover.bannerTextColor}
               onChange={(bannerTextColor) => onCoverChange({ bannerTextColor })}
               label={m.cover.bannerTextColor}
-              against={cover.bannerColor ?? undefined}
+              against={cover.bannerColor ?? bannerTint}
               againstLabel={m.cover.bannerColor}
               allowEmpty
               m={m.design}

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -634,18 +634,58 @@ function CoverSection({
           onChange={(e) => onCoverChange({ bannerText: e.target.value || null })}
         />
       </Field>
+      {/* Everything about the strip's look hangs off there BEING a strip. With
+          no text there is no banner on the page, so a color picker for it would
+          be a control with nothing to change. */}
       {cover.bannerText ? (
-        <InlineField label={m.cover.bannerScope}>
-          <SegmentedToggle
-            value={cover.bannerScope ?? 'form'}
-            onChange={(bannerScope) => onCoverChange({ bannerScope })}
-            options={[
-              { value: 'form' as const, label: m.cover.bannerScopeForm },
-              { value: 'cover' as const, label: m.cover.bannerScopeCover },
-            ]}
-            ariaLabel={m.cover.bannerScope}
-          />
-        </InlineField>
+        <>
+          <InlineField label={m.cover.bannerScope}>
+            <SegmentedToggle
+              value={cover.bannerScope ?? 'form'}
+              onChange={(bannerScope) => onCoverChange({ bannerScope })}
+              options={[
+                { value: 'form' as const, label: m.cover.bannerScopeForm },
+                { value: 'cover' as const, label: m.cover.bannerScopeCover },
+              ]}
+              ariaLabel={m.cover.bannerScope}
+            />
+          </InlineField>
+          <Field label={m.cover.bannerColor} hint={m.cover.bannerColorHint}>
+            <ColorPicker
+              value={cover.bannerColor}
+              onChange={(bannerColor) => onCoverChange({ bannerColor })}
+              label={m.cover.bannerColor}
+              allowEmpty
+              m={m.design}
+            />
+          </Field>
+          <Field label={m.cover.bannerTextColor}>
+            {/* `against` is the strip's own fill, so the contrast readout judges
+                the pair that actually renders — not the text against the form
+                ground, which is a different surface entirely. */}
+            <ColorPicker
+              value={cover.bannerTextColor}
+              onChange={(bannerTextColor) => onCoverChange({ bannerTextColor })}
+              label={m.cover.bannerTextColor}
+              against={cover.bannerColor ?? undefined}
+              againstLabel={m.cover.bannerColor}
+              allowEmpty
+              m={m.design}
+            />
+          </Field>
+          <InlineField label={m.cover.bannerSize}>
+            <SegmentedToggle
+              value={cover.bannerSize ?? 'md'}
+              onChange={(bannerSize) => onCoverChange({ bannerSize })}
+              options={[
+                { value: 'sm' as const, label: m.cover.bannerSizeSm },
+                { value: 'md' as const, label: m.cover.bannerSizeMd },
+                { value: 'lg' as const, label: m.cover.bannerSizeLg },
+              ]}
+              ariaLabel={m.cover.bannerSize}
+            />
+          </InlineField>
+        </>
       ) : null}
       <Field label={m.cover.eyebrow}>
         <TextField value={cover.eyebrow ?? ''} onChange={(e) => onCoverChange({ eyebrow: e.target.value || null })} />
@@ -708,6 +748,22 @@ function ClientLogosSection({
           aria-label={m.cover.showClientLogos}
         />
       </InlineField>
+      {/* Only reachable while the marquee is on: picking WHERE something shows
+          is meaningless once it shows nowhere. */}
+      {cover.showClientLogos !== false ? (
+        <InlineField label={m.cover.clientLogosScope}>
+          <SegmentedToggle
+            value={cover.clientLogosScope ?? 'cover'}
+            onChange={(clientLogosScope) => onCoverChange({ clientLogosScope })}
+            options={[
+              { value: 'cover' as const, label: m.cover.clientLogosScopeCover },
+              { value: 'reveal' as const, label: m.cover.clientLogosScopeReveal },
+              { value: 'both' as const, label: m.cover.clientLogosScopeBoth },
+            ]}
+            ariaLabel={m.cover.clientLogosScope}
+          />
+        </InlineField>
+      ) : null}
       <div className="flex flex-col gap-2">
         {logos.length === 0 ? (
           <p className="text-xs text-muted-foreground">{m.cover.clientLogosEmpty}</p>

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import type { FormStep, FormLayout } from '@quill/engine';
+import type { FormStep, FormLayout, FormRevealSize } from '@quill/engine';
 import {
+  FORM_REVEAL_SIZES,
   clampSliderValue,
   defaultFlowGroup,
   nameFields,
@@ -47,6 +48,20 @@ const ALL_ITEMS: GalleryItem[] = GALLERY_GROUPS.flatMap((g) => GALLERY[g]);
 const DEFAULT_REVEAL_MS = 2200;
 const MIN_REVEAL_MS = 500;
 const MAX_REVEAL_MS = 30_000;
+
+/**
+ * The reveal's size scale, built from the engine's enum so a step added there
+ * cannot go missing from one of the two rows that use it (the loader mark and
+ * the copy). Labels stay hand-written — "Huge" is a product word, not `xl`.
+ */
+const REVEAL_SIZE_LABELS: Record<FormRevealSize, keyof BuilderMessages['settings']> = {
+  sm: 'revealSizeSm',
+  md: 'revealSizeMd',
+  lg: 'revealSizeLg',
+  xl: 'revealSizeXl',
+};
+const REVEAL_SIZE_OPTIONS = (bm: BuilderMessages) =>
+  FORM_REVEAL_SIZES.map((value) => ({ value, label: bm.settings[REVEAL_SIZE_LABELS[value]] }));
 
 /** Shared look for the inline slider-bounds warnings (V5-A2). */
 const sliderWarnClass =
@@ -342,32 +357,26 @@ export function QuestionSettings({
           {/* `none` draws no mark, so a size for it would be a control with
               nothing to scale — the combination is unreachable rather than
               merely ignored. */}
+          {/* Stacked like the loader row above, and for the same reason: at four
+              options a side-by-side label column is one word wide. */}
           {(step.reveal?.loader ?? 'spinner') !== 'none' ? (
-            <InlineField label={bm.settings.revealLoaderSize}>
+            <Field label={bm.settings.revealLoaderSize}>
               <SegmentedToggle
                 value={step.reveal?.loaderSize ?? 'md'}
                 onChange={(loaderSize) => onUpdate({ reveal: { ...step.reveal, loaderSize } })}
-                options={[
-                  { value: 'sm' as const, label: bm.settings.revealSizeSm },
-                  { value: 'md' as const, label: bm.settings.revealSizeMd },
-                  { value: 'lg' as const, label: bm.settings.revealSizeLg },
-                ]}
+                options={REVEAL_SIZE_OPTIONS(bm)}
                 ariaLabel={bm.settings.revealLoaderSize}
               />
-            </InlineField>
+            </Field>
           ) : null}
-          <InlineField label={bm.settings.revealTextSize}>
+          <Field label={bm.settings.revealTextSize}>
             <SegmentedToggle
               value={step.reveal?.textSize ?? 'md'}
               onChange={(textSize) => onUpdate({ reveal: { ...step.reveal, textSize } })}
-              options={[
-                { value: 'sm' as const, label: bm.settings.revealSizeSm },
-                { value: 'md' as const, label: bm.settings.revealSizeMd },
-                { value: 'lg' as const, label: bm.settings.revealSizeLg },
-              ]}
+              options={REVEAL_SIZE_OPTIONS(bm)}
               ariaLabel={bm.settings.revealTextSize}
             />
-          </InlineField>
+          </Field>
           <InlineField
             label={bm.settings.revealAccentBackground}
             hint={bm.settings.revealAccentBackgroundHint}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -414,23 +414,42 @@ export function QuestionSettings({
                   }
                 />
               </Field>
-              {/* Unlike the two labels above, an EMPTY status is meaningful —
-                  it removes the line — so it is stored as `''`, not as the
-                  `null` that means "use the localized default". */}
+              {/* Three reachable states, unlike the two labels above:
+                    null -> the localized default (empty field, shown as the
+                            placeholder — so a Spanish respondent still reads
+                            "Buscando…" even though the author edits in English);
+                    ''   -> no status line at all;
+                    text -> the author's line.
+                  Seeding the INPUT with the localized default would collapse two
+                  of those: the first keystroke freezes the admin's locale into
+                  the config, and `null` becomes unreachable forever after. */}
               <Field
                 label={bm.settings.revealVersusStatus}
                 hint={bm.settings.revealVersusStatusHint}
               >
-                <TextField
-                  value={
-                    step.reveal?.versusStatusLabel ??
-                    getMessages(clientLocale()).renderer.revealVersusStatus
-                  }
-                  data-testid="step-reveal-versus-status"
-                  onChange={(e) =>
-                    onUpdate({ reveal: { ...step.reveal, versusStatusLabel: e.target.value } })
-                  }
-                />
+                <div className="flex items-center gap-2">
+                  <TextField
+                    value={step.reveal?.versusStatusLabel ?? ''}
+                    placeholder={getMessages(clientLocale()).renderer.revealVersusStatus}
+                    data-testid="step-reveal-versus-status"
+                    onChange={(e) =>
+                      onUpdate({ reveal: { ...step.reveal, versusStatusLabel: e.target.value } })
+                    }
+                  />
+                  {step.reveal?.versusStatusLabel != null ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onUpdate({ reveal: { ...step.reveal, versusStatusLabel: null } })
+                      }
+                      className="shrink-0 rounded-sm p-1.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      aria-label={bm.settings.revealVersusStatusReset}
+                      title={bm.settings.revealVersusStatusReset}
+                    >
+                      <i aria-hidden className="pi pi-refresh" style={{ fontSize: 12 }} />
+                    </button>
+                  ) : null}
+                </div>
               </Field>
             </>
           ) : null}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -405,6 +405,24 @@ export function QuestionSettings({
                   }
                 />
               </Field>
+              {/* Unlike the two labels above, an EMPTY status is meaningful —
+                  it removes the line — so it is stored as `''`, not as the
+                  `null` that means "use the localized default". */}
+              <Field
+                label={bm.settings.revealVersusStatus}
+                hint={bm.settings.revealVersusStatusHint}
+              >
+                <TextField
+                  value={
+                    step.reveal?.versusStatusLabel ??
+                    getMessages(clientLocale()).renderer.revealVersusStatus
+                  }
+                  data-testid="step-reveal-versus-status"
+                  onChange={(e) =>
+                    onUpdate({ reveal: { ...step.reveal, versusStatusLabel: e.target.value } })
+                  }
+                />
+              </Field>
             </>
           ) : null}
         </section>

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -319,6 +319,94 @@ export function QuestionSettings({
               aria-label={bm.settings.revealPrewarm}
             />
           </InlineField>
+
+          <p className="text-2xs font-semibold uppercase tracking-wide text-faint">
+            {bm.settings.revealLook}
+          </p>
+          {/* A stacked Field, not an InlineField: four options leave the label
+              column about one word wide, so a side-by-side row wraps the hint to
+              a single word per line. The three-option rows below still fit. */}
+          <Field label={bm.settings.revealLoader} hint={bm.settings.revealLoaderHint}>
+            <SegmentedToggle
+              value={step.reveal?.loader ?? 'spinner'}
+              onChange={(loader) => onUpdate({ reveal: { ...step.reveal, loader } })}
+              options={[
+                { value: 'spinner' as const, label: bm.settings.revealLoaderSpinner },
+                { value: 'bar' as const, label: bm.settings.revealLoaderBar },
+                { value: 'versus' as const, label: bm.settings.revealLoaderVersus },
+                { value: 'none' as const, label: bm.settings.revealLoaderNone },
+              ]}
+              ariaLabel={bm.settings.revealLoader}
+            />
+          </Field>
+          {/* `none` draws no mark, so a size for it would be a control with
+              nothing to scale — the combination is unreachable rather than
+              merely ignored. */}
+          {(step.reveal?.loader ?? 'spinner') !== 'none' ? (
+            <InlineField label={bm.settings.revealLoaderSize}>
+              <SegmentedToggle
+                value={step.reveal?.loaderSize ?? 'md'}
+                onChange={(loaderSize) => onUpdate({ reveal: { ...step.reveal, loaderSize } })}
+                options={[
+                  { value: 'sm' as const, label: bm.settings.revealSizeSm },
+                  { value: 'md' as const, label: bm.settings.revealSizeMd },
+                  { value: 'lg' as const, label: bm.settings.revealSizeLg },
+                ]}
+                ariaLabel={bm.settings.revealLoaderSize}
+              />
+            </InlineField>
+          ) : null}
+          <InlineField label={bm.settings.revealTextSize}>
+            <SegmentedToggle
+              value={step.reveal?.textSize ?? 'md'}
+              onChange={(textSize) => onUpdate({ reveal: { ...step.reveal, textSize } })}
+              options={[
+                { value: 'sm' as const, label: bm.settings.revealSizeSm },
+                { value: 'md' as const, label: bm.settings.revealSizeMd },
+                { value: 'lg' as const, label: bm.settings.revealSizeLg },
+              ]}
+              ariaLabel={bm.settings.revealTextSize}
+            />
+          </InlineField>
+          <InlineField
+            label={bm.settings.revealAccentBackground}
+            hint={bm.settings.revealAccentBackgroundHint}
+          >
+            <Switch
+              checked={!!step.reveal?.accentBackground}
+              onCheckedChange={(v) =>
+                onUpdate({ reveal: { ...step.reveal, accentBackground: v || undefined } })
+              }
+              aria-label={bm.settings.revealAccentBackground}
+            />
+          </InlineField>
+          {/* Only the versus layout has two sides to name. */}
+          {step.reveal?.loader === 'versus' ? (
+            <>
+              <Field label={bm.settings.revealVersusYou} hint={bm.settings.revealVersusHint}>
+                <TextField
+                  value={step.reveal?.versusYouLabel ?? ''}
+                  data-testid="step-reveal-versus-you"
+                  onChange={(e) =>
+                    onUpdate({
+                      reveal: { ...step.reveal, versusYouLabel: e.target.value || null },
+                    })
+                  }
+                />
+              </Field>
+              <Field label={bm.settings.revealVersusMatch}>
+                <TextField
+                  value={step.reveal?.versusMatchLabel ?? ''}
+                  data-testid="step-reveal-versus-match"
+                  onChange={(e) =>
+                    onUpdate({
+                      reveal: { ...step.reveal, versusMatchLabel: e.target.value || null },
+                    })
+                  }
+                />
+              </Field>
+            </>
+          ) : null}
         </section>
       ) : null}
 

--- a/apps/web/components/public/reveal-screen.spec.tsx
+++ b/apps/web/components/public/reveal-screen.spec.tsx
@@ -6,7 +6,12 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_REVEAL_MS, resolveRevealCopy } from './reveal-screen';
 
-const messages = { headline: 'Reviewing your answers…', subtitle: 'One moment.' };
+const messages = {
+  headline: 'Reviewing your answers…',
+  subtitle: 'One moment.',
+  versusYou: 'You',
+  versusMatch: 'Your match',
+};
 
 describe('resolveRevealCopy', () => {
   it('falls back to the localized messages when the config has no copy', () => {
@@ -14,8 +19,20 @@ describe('resolveRevealCopy', () => {
       headline: messages.headline,
       subtitle: messages.subtitle,
       durationMs: DEFAULT_REVEAL_MS,
+      versusYou: messages.versusYou,
+      versusMatch: messages.versusMatch,
     });
     expect(resolveRevealCopy({}, {}, messages).headline).toBe(messages.headline);
+  });
+
+  it('uses the configured versus labels and interpolates them', () => {
+    const out = resolveRevealCopy(
+      { versusYouLabel: '[firstname]', versusMatchLabel: 'Your [role]' },
+      { firstname: 'Ana', role: 'advisor' },
+      messages,
+    );
+    expect(out.versusYou).toBe('Ana');
+    expect(out.versusMatch).toBe('Your advisor');
   });
 
   it('uses the configured headline/subtitle when present', () => {

--- a/apps/web/components/public/reveal-screen.spec.tsx
+++ b/apps/web/components/public/reveal-screen.spec.tsx
@@ -11,6 +11,7 @@ const messages = {
   subtitle: 'One moment.',
   versusYou: 'You',
   versusMatch: 'Your match',
+  versusStatus: 'Searching…',
 };
 
 describe('resolveRevealCopy', () => {
@@ -21,8 +22,29 @@ describe('resolveRevealCopy', () => {
       durationMs: DEFAULT_REVEAL_MS,
       versusYou: messages.versusYou,
       versusMatch: messages.versusMatch,
+      versusStatus: messages.versusStatus,
     });
     expect(resolveRevealCopy({}, {}, messages).headline).toBe(messages.headline);
+  });
+
+  it('an EMPTY status survives, because clearing it means "no status line"', () => {
+    // The two labels fall back on any falsy value — a blank label is just an
+    // unnamed side. The status is different: the line exists or it does not, so
+    // only an ABSENT value may take the localized default.
+    expect(resolveRevealCopy({ versusStatusLabel: '' }, {}, messages).versusStatus).toBe('');
+    expect(resolveRevealCopy({ versusStatusLabel: null }, {}, messages).versusStatus).toBe(
+      messages.versusStatus,
+    );
+    expect(resolveRevealCopy({}, {}, messages).versusStatus).toBe(messages.versusStatus);
+  });
+
+  it('interpolates the status line', () => {
+    const out = resolveRevealCopy(
+      { versusStatusLabel: 'Searching in [industry]…' },
+      { industry: 'fintech' },
+      messages,
+    );
+    expect(out.versusStatus).toBe('Searching in fintech…');
   });
 
   it('uses the configured versus labels and interpolates them', () => {

--- a/apps/web/components/public/reveal-screen.tsx
+++ b/apps/web/components/public/reveal-screen.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { interpolate, type Answers, type FormReveal } from '@quill/engine';
+import {
+  interpolate,
+  resolveRevealPresentation,
+  type Answers,
+  type FormReveal,
+} from '@quill/engine';
 
 /** The interstitial's default play time when the config sets none. */
 export const DEFAULT_REVEAL_MS = 2200;
@@ -10,6 +15,9 @@ export const DEFAULT_REVEAL_MS = 2200;
 export interface RevealScreenMessages {
   headline: string;
   subtitle: string;
+  /** `versus` loader: the two marks' labels when the config names neither. */
+  versusYou: string;
+  versusMatch: string;
 }
 
 /**
@@ -22,11 +30,19 @@ export function resolveRevealCopy(
   reveal: FormReveal | null | undefined,
   answers: Answers,
   messages: RevealScreenMessages,
-): { headline: string; subtitle: string; durationMs: number } {
+): {
+  headline: string;
+  subtitle: string;
+  durationMs: number;
+  versusYou: string;
+  versusMatch: string;
+} {
   const template = reveal?.subtitleTemplate;
   // Every configured line interpolates. `subtitleTemplate` always did, but the
   // headline and the plain subtitle did not — so "Matching [firstname]…" reached
   // the respondent as literal text on the very screen meant to feel personal.
+  // The versus labels join that rule: they are authored copy on the same screen,
+  // so "[company]" in one of them has to resolve too.
   return {
     headline: reveal?.headline ? interpolate(reveal.headline, answers) : messages.headline,
     subtitle: template
@@ -35,7 +51,66 @@ export function resolveRevealCopy(
         ? interpolate(reveal.subtitle, answers)
         : messages.subtitle,
     durationMs: reveal?.durationMs ?? DEFAULT_REVEAL_MS,
+    versusYou: reveal?.versusYouLabel
+      ? interpolate(reveal.versusYouLabel, answers)
+      : messages.versusYou,
+    versusMatch: reveal?.versusMatchLabel
+      ? interpolate(reveal.versusMatchLabel, answers)
+      : messages.versusMatch,
   };
+}
+
+/**
+ * What the `.pf` ROOT needs for this interstitial, spread by the caller.
+ *
+ * `accentBackground` floods the whole screen, not the content column, so it
+ * cannot be a class on `.pf-reveal__inner` — it has to reach the element that
+ * owns the page. Returning it from here keeps the decision in one place: the
+ * three call sites spread it and never re-derive the rule.
+ */
+export function revealShellProps(
+  reveal: FormReveal | null | undefined,
+): { 'data-pf-reveal-bg'?: 'accent' } {
+  return resolveRevealPresentation(reveal).accentBackground ? { 'data-pf-reveal-bg': 'accent' } : {};
+}
+
+/**
+ * The two marks of the `versus` layout — the respondent on one side, whatever
+ * they are being matched with on the other, the progress between them.
+ *
+ * `aria-hidden` on the whole group is deliberate. The interstitial's shell is an
+ * `aria-live="polite"` region (it is a status), and the percentage re-renders
+ * every 60ms — announcing it would read a new number to a screen-reader user
+ * dozens of times for a screen that lasts two seconds and says nothing the
+ * headline above has not already said.
+ */
+function VersusMarks({
+  pct,
+  youLabel,
+  matchLabel,
+}: {
+  pct: number;
+  youLabel: string;
+  matchLabel: string;
+}) {
+  return (
+    <div className="pf-reveal__versus" aria-hidden="true">
+      <figure className="pf-reveal__mark">
+        <div className="pf-reveal__mark-dot pf-reveal__mark-dot--you" />
+        <figcaption className="pf-reveal__mark-label">{youLabel}</figcaption>
+      </figure>
+      <div className="pf-reveal__versus-mid">
+        <span className="pf-reveal__pct">{pct}%</span>
+        <div className="pf-reveal__track">
+          <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <figure className="pf-reveal__mark">
+        <div className="pf-reveal__mark-dot pf-reveal__mark-dot--match">?</div>
+        <figcaption className="pf-reveal__mark-label">{matchLabel}</figcaption>
+      </figure>
+    </div>
+  );
 }
 
 /**
@@ -43,23 +118,38 @@ export function resolveRevealCopy(
  * plays for `reveal.durationMs` (default 2200ms), renders the configured
  * headline + subtitle — `subtitleTemplate` wins over `subtitle` and gets its
  * `[key]` tokens interpolated from the answers via the engine's `interpolate`,
- * so e.g. "Finding the best advisor for [industry]…" personalizes live — above
- * an animated determinate progress bar (existing `.pf-reveal__*` styles).
- * Fires `onComplete` exactly once when the bar fills; the caller owns the
- * page chrome (accent vars, banner) and what happens next.
+ * so e.g. "Finding the best advisor for [industry]…" personalizes live.
+ *
+ * HOW it animates is `reveal.loader` (see `resolveRevealPresentation`), and the
+ * order of the parts follows from it: the `spinner` mark sits above the copy the
+ * way it always has, while `bar` and `versus` put the copy first and the
+ * progress under it. `none` is copy alone — the honest choice when the wait is
+ * not really a computation. Every variant runs the SAME timer, so the screen's
+ * duration never depends on how it is drawn.
+ *
+ * Fires `onComplete` exactly once when the bar fills; the caller owns the page
+ * chrome (accent vars, banner, `revealShellProps`) and what happens next.
  */
 export function RevealScreen({
   reveal,
   answers,
   messages,
+  children,
   onComplete,
 }: {
   reveal?: FormReveal | null;
   answers: Answers;
   messages: RevealScreenMessages;
+  /** Rendered under the interstitial — the "trusted by" marquee, when scoped here. */
+  children?: React.ReactNode;
   onComplete?: () => void;
 }) {
-  const { headline, subtitle, durationMs } = resolveRevealCopy(reveal, answers, messages);
+  const { headline, subtitle, durationMs, versusYou, versusMatch } = resolveRevealCopy(
+    reveal,
+    answers,
+    messages,
+  );
+  const { loader, loaderSize, textSize } = resolveRevealPresentation(reveal);
 
   const [pct, setPct] = useState(4);
   const completedRef = useRef(false);
@@ -85,13 +175,24 @@ export function RevealScreen({
   }, [durationMs]);
 
   return (
-    <div className="pf-reveal__inner">
-      <div className="pf-reveal__spinner" aria-hidden="true" />
+    <div
+      className="pf-reveal__inner"
+      data-pf-reveal-loader={loader}
+      data-pf-reveal-mark={loaderSize}
+      data-pf-reveal-text={textSize}
+    >
+      {loader === 'spinner' ? <div className="pf-reveal__spinner" aria-hidden="true" /> : null}
       <h1 className="pf-reveal__headline">{headline}</h1>
       <p className="pf-reveal__subtitle">{subtitle}</p>
-      <div className="pf-reveal__track">
-        <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />
-      </div>
+      {loader === 'spinner' || loader === 'bar' ? (
+        <div className="pf-reveal__track" aria-hidden="true">
+          <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />
+        </div>
+      ) : null}
+      {loader === 'versus' ? (
+        <VersusMarks pct={pct} youLabel={versusYou} matchLabel={versusMatch} />
+      ) : null}
+      {children}
     </div>
   );
 }

--- a/apps/web/components/public/reveal-screen.tsx
+++ b/apps/web/components/public/reveal-screen.tsx
@@ -18,6 +18,8 @@ export interface RevealScreenMessages {
   /** `versus` loader: the two marks' labels when the config names neither. */
   versusYou: string;
   versusMatch: string;
+  /** The live status under the match's label. */
+  versusStatus: string;
 }
 
 /**
@@ -36,6 +38,7 @@ export function resolveRevealCopy(
   durationMs: number;
   versusYou: string;
   versusMatch: string;
+  versusStatus: string;
 } {
   const template = reveal?.subtitleTemplate;
   // Every configured line interpolates. `subtitleTemplate` always did, but the
@@ -57,6 +60,13 @@ export function resolveRevealCopy(
     versusMatch: reveal?.versusMatchLabel
       ? interpolate(reveal.versusMatchLabel, answers)
       : messages.versusMatch,
+    // `?? messages` rather than the truthiness the labels use: an author who
+    // clears this line means "no status line", and that empty string has to
+    // survive instead of falling back to the localized default.
+    versusStatus:
+      reveal?.versusStatusLabel == null
+        ? messages.versusStatus
+        : interpolate(reveal.versusStatusLabel, answers),
   };
 }
 
@@ -88,19 +98,34 @@ function VersusMarks({
   pct,
   youLabel,
   matchLabel,
+  statusLabel,
 }: {
   pct: number;
   youLabel: string;
   matchLabel: string;
+  statusLabel: string;
 }) {
   return (
     <div className="pf-reveal__versus" aria-hidden="true">
       <figure className="pf-reveal__mark">
-        <div className="pf-reveal__mark-dot pf-reveal__mark-dot--you" />
+        <div className="pf-reveal__mark-dot pf-reveal__mark-dot--you">
+          {/* The respondent is a KNOWN person and the match is not — the whole
+              point of the pairing — so this side gets a figure and the other
+              side a question mark. Inline because the renderer ships no icon
+              set and a lone glyph is not worth a font. */}
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <circle cx="12" cy="8" r="3.6" />
+            <path d="M12 13.2c-3.6 0-6.4 2.1-6.4 4.7v1.3h12.8v-1.3c0-2.6-2.8-4.7-6.4-4.7Z" />
+          </svg>
+        </div>
         <figcaption className="pf-reveal__mark-label">{youLabel}</figcaption>
       </figure>
       <div className="pf-reveal__versus-mid">
-        <span className="pf-reveal__pct">{pct}%</span>
+        <p className="pf-reveal__pct">
+          {pct}
+          <span className="pf-reveal__pct-sign">%</span>
+          <span className="pf-reveal__pulse" />
+        </p>
         <div className="pf-reveal__track">
           <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />
         </div>
@@ -108,6 +133,7 @@ function VersusMarks({
       <figure className="pf-reveal__mark">
         <div className="pf-reveal__mark-dot pf-reveal__mark-dot--match">?</div>
         <figcaption className="pf-reveal__mark-label">{matchLabel}</figcaption>
+        {statusLabel ? <p className="pf-reveal__mark-status">{statusLabel}</p> : null}
       </figure>
     </div>
   );
@@ -144,11 +170,8 @@ export function RevealScreen({
   children?: React.ReactNode;
   onComplete?: () => void;
 }) {
-  const { headline, subtitle, durationMs, versusYou, versusMatch } = resolveRevealCopy(
-    reveal,
-    answers,
-    messages,
-  );
+  const { headline, subtitle, durationMs, versusYou, versusMatch, versusStatus } =
+    resolveRevealCopy(reveal, answers, messages);
   const { loader, loaderSize, textSize } = resolveRevealPresentation(reveal);
 
   const [pct, setPct] = useState(4);
@@ -190,7 +213,12 @@ export function RevealScreen({
         </div>
       ) : null}
       {loader === 'versus' ? (
-        <VersusMarks pct={pct} youLabel={versusYou} matchLabel={versusMatch} />
+        <VersusMarks
+          pct={pct}
+          youLabel={versusYou}
+          matchLabel={versusMatch}
+          statusLabel={versusStatus}
+        />
       ) : null}
       {children}
     </div>

--- a/apps/web/components/public/reveal-screen.tsx
+++ b/apps/web/components/public/reveal-screen.tsx
@@ -165,7 +165,10 @@ export function RevealScreen({
   reveal?: FormReveal | null;
   answers: Answers;
   messages: RevealScreenMessages;
-  /** Rendered under the interstitial — the "trusted by" marquee, when scoped here. */
+  /**
+   * Rendered under the interstitial — the "trusted by" marquee, when scoped
+   * here. Presented to assistive tech as decoration; see the wrapper below.
+   */
   children?: React.ReactNode;
   onComplete?: () => void;
 }) {
@@ -219,7 +222,12 @@ export function RevealScreen({
           statusLabel={versusStatus}
         />
       ) : null}
-      {children}
+      {/* The caller's slot is decoration — the client-logo marquee. Hidden from
+          assistive tech because this whole screen is an `aria-live="polite"`
+          status: without it the announcement of "we are working on it" ends by
+          reciting the trusted-by label and every logo name, which the cover
+          already announced and which says nothing about the wait. */}
+      {children ? <div aria-hidden="true">{children}</div> : null}
     </div>
   );
 }

--- a/apps/web/components/public/reveal-screen.tsx
+++ b/apps/web/components/public/reveal-screen.tsx
@@ -124,7 +124,6 @@ function VersusMarks({
         <p className="pf-reveal__pct">
           {pct}
           <span className="pf-reveal__pct-sign">%</span>
-          <span className="pf-reveal__pulse" />
         </p>
         <div className="pf-reveal__track">
           <div className="pf-reveal__fill" style={{ width: `${pct}%` }} />

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -24,6 +24,9 @@ import {
   resolveOptionLayout,
   showBanner,
   showClientLogos,
+  showClientLogosOn,
+  resolveRevealPresentation,
+  type FormClientLogoScope,
   resolveFormLogos,
   operatorsForFieldType,
   conditionsContradict,
@@ -797,6 +800,61 @@ describe('cover presentation toggles', () => {
     const cover = { clientLogos: [{ name: 'Acme' }], showClientLogos: false };
     expect(showClientLogos(cover)).toBe(false);
     expect(cover.clientLogos).toHaveLength(1);
+  });
+
+  it('showClientLogosOn defaults to the cover — a legacy config never moves its logos', () => {
+    const legacy = { clientLogos: [{ name: 'Acme' }] };
+    expect(showClientLogosOn(legacy, 'cover')).toBe(true);
+    expect(showClientLogosOn(legacy, 'reveal')).toBe(false);
+    expect(showClientLogosOn(undefined, 'cover')).toBe(true);
+    expect(showClientLogosOn(null, 'reveal')).toBe(false);
+  });
+
+  it('showClientLogosOn honors each scope', () => {
+    const at = (clientLogosScope: FormClientLogoScope) => ({ clientLogosScope });
+    expect(showClientLogosOn(at('cover'), 'cover')).toBe(true);
+    expect(showClientLogosOn(at('cover'), 'reveal')).toBe(false);
+    expect(showClientLogosOn(at('reveal'), 'cover')).toBe(false);
+    expect(showClientLogosOn(at('reveal'), 'reveal')).toBe(true);
+    expect(showClientLogosOn(at('both'), 'cover')).toBe(true);
+    expect(showClientLogosOn(at('both'), 'reveal')).toBe(true);
+  });
+
+  it('the master switch beats the scope — off means off on every surface', () => {
+    const off = { showClientLogos: false, clientLogosScope: 'both' as const };
+    expect(showClientLogosOn(off, 'cover')).toBe(false);
+    expect(showClientLogosOn(off, 'reveal')).toBe(false);
+  });
+});
+
+describe('resolveRevealPresentation', () => {
+  it('an unconfigured reveal resolves to the historical spinner look', () => {
+    for (const reveal of [undefined, null, {}, { headline: 'Hold on' }]) {
+      expect(resolveRevealPresentation(reveal)).toEqual({
+        loader: 'spinner',
+        loaderSize: 'md',
+        textSize: 'md',
+        accentBackground: false,
+      });
+    }
+  });
+
+  it('carries every configured axis through', () => {
+    expect(
+      resolveRevealPresentation({
+        loader: 'versus',
+        loaderSize: 'lg',
+        textSize: 'sm',
+        accentBackground: true,
+      }),
+    ).toEqual({ loader: 'versus', loaderSize: 'lg', textSize: 'sm', accentBackground: true });
+  });
+
+  it('only an explicit true floods the screen', () => {
+    // `accentBackground` paints over the form's own ground, so anything short of
+    // the author saying yes has to resolve to the ground they already chose.
+    expect(resolveRevealPresentation({ accentBackground: false }).accentBackground).toBe(false);
+    expect(resolveRevealPresentation({}).accentBackground).toBe(false);
   });
 });
 

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -473,9 +473,13 @@ export type FormRevealLoader = (typeof FORM_REVEAL_LOADERS)[number];
  * Four steps rather than three because this screen is a full-page moment, not a
  * component: the top of a three-step scale landed around what a normal `md`
  * should be, so the sizes an author actually reached for were all at the
- * ceiling. Each step resolves to a `clamp()` in the stylesheet, so a size is a
- * RANGE across viewports, not one number — that is what keeps the largest marks
- * from colliding on a phone.
+ * ceiling. The larger steps resolve to a `clamp()` in the stylesheet, so a size
+ * is a RANGE across viewports rather than one number — that is what keeps the
+ * biggest marks from colliding on a phone.
+ *
+ * `md` is the value an absent `loaderSize` resolves to, and it is pinned to the
+ * mark this screen has always drawn. Growing the DEFAULT would resize every
+ * published reveal, so the new headroom lives on `lg`/`xl` only.
  */
 export const FORM_REVEAL_SIZES = ['sm', 'md', 'lg', 'xl'] as const;
 export type FormRevealSize = (typeof FORM_REVEAL_SIZES)[number];

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -310,6 +310,25 @@ export interface FormClientLogo {
 export const FORM_BANNER_SCOPES = ['form', 'cover'] as const;
 export type FormBannerScope = (typeof FORM_BANNER_SCOPES)[number];
 
+/**
+ * How loud the promo banner strip is. Absent is the legacy look, which the
+ * stylesheet still owns — the sizes only scale padding and type off it, so a
+ * config saved before this existed renders byte-identical.
+ */
+export const FORM_BANNER_SIZES = ['sm', 'md', 'lg'] as const;
+export type FormBannerSize = (typeof FORM_BANNER_SIZES)[number];
+
+/**
+ * Which surfaces the "trusted by" marquee is allowed to render on. Absent means
+ * `'cover'` — where it has always rendered — so no stored config moves its
+ * logos by upgrading.
+ */
+export const FORM_CLIENT_LOGO_SCOPES = ['cover', 'reveal', 'both'] as const;
+export type FormClientLogoScope = (typeof FORM_CLIENT_LOGO_SCOPES)[number];
+
+/** A surface the marquee can be asked about. */
+export type ClientLogoSurface = 'cover' | 'reveal';
+
 export interface FormCover {
   enabled?: boolean;
   /** A sticky banner line (promo strip) shown above the form — see `bannerScope`. */
@@ -319,6 +338,16 @@ export interface FormCover {
    * behaviour, and the default when absent), `'cover'` limits it to the cover.
    */
   bannerScope?: FormBannerScope;
+  /**
+   * The banner strip's own fill. Absent keeps the derived tint the stylesheet
+   * has always used (12% of the accent over the form ground) — deliberately
+   * soft, which is exactly why an author needs to be able to override it.
+   */
+  bannerColor?: string | null;
+  /** The banner's text color. Absent inherits the form's foreground. */
+  bannerTextColor?: string | null;
+  /** The banner's height/type scale. Absent = the legacy `md` strip. */
+  bannerSize?: FormBannerSize;
   eyebrow?: string | null;
   /** Alias for eyebrow (pilot `badge`); eyebrow wins when both are set. */
   badge?: string | null;
@@ -331,13 +360,18 @@ export interface FormCover {
    * absent inherits the form's own (`branding.logo`).
    */
   logo?: string | null;
-  /** Optional "trusted by" marquee shown on the cover. */
+  /** Optional "trusted by" marquee — see `clientLogosScope` for where it shows. */
   clientLogos?: FormClientLogo[];
   /**
    * Whether the "trusted by" marquee renders. Absent means shown (the legacy
    * behaviour), so the logos can be switched off without deleting them.
    */
   showClientLogos?: boolean;
+  /**
+   * WHICH surfaces the marquee renders on. Absent means `'cover'` — the only
+   * place it has ever rendered — so upgrading never moves an author's logos.
+   */
+  clientLogosScope?: FormClientLogoScope;
 }
 
 /** Per-form branding — the accent color threads the banner/CTA/selected states. */
@@ -421,6 +455,22 @@ export interface FormScheduler {
 }
 
 /** Optional processing/result-reveal interstitial (generic, templated copy). */
+/**
+ * How the interstitial animates while it plays.
+ *
+ * `spinner` is the historical look (a ring above a determinate bar) and stays
+ * the default for every stored config. `bar` drops the ring for the bar alone;
+ * `versus` is the "you vs. the match" layout — two marks with the percentage
+ * between them — and `none` shows the copy with no motion at all, which is the
+ * honest option for an author who does not want a fake progress signal.
+ */
+export const FORM_REVEAL_LOADERS = ['spinner', 'bar', 'versus', 'none'] as const;
+export type FormRevealLoader = (typeof FORM_REVEAL_LOADERS)[number];
+
+/** The scale shared by the interstitial's loader mark and its copy. */
+export const FORM_REVEAL_SIZES = ['sm', 'md', 'lg'] as const;
+export type FormRevealSize = (typeof FORM_REVEAL_SIZES)[number];
+
 export interface FormReveal {
   enabled?: boolean;
   headline?: string | null;
@@ -431,6 +481,19 @@ export interface FormReveal {
   subtitleTemplate?: string | null;
   /** Pre-warm the booking embed while the interstitial plays. */
   prewarm?: boolean;
+  // --- Presentation (all optional; absent = the historical spinner look) -----
+  /** Which animation plays. Absent = `'spinner'`. */
+  loader?: FormRevealLoader;
+  /** The loader mark's scale. Absent = `'md'`. */
+  loaderSize?: FormRevealSize;
+  /** The headline/subtitle scale. Absent = `'md'`. */
+  textSize?: FormRevealSize;
+  /** Flood the screen with the form's accent instead of its ground. */
+  accentBackground?: boolean;
+  /** `versus` only — the label under the respondent's mark. */
+  versusYouLabel?: string | null;
+  /** `versus` only — the label under the match's mark. */
+  versusMatchLabel?: string | null;
 }
 
 /**
@@ -1936,6 +1999,40 @@ export function showBanner(cover: FormCover | null | undefined, isCover: boolean
  */
 export function showClientLogos(cover: FormCover | null | undefined): boolean {
   return cover?.showClientLogos !== false;
+}
+
+/**
+ * Whether the marquee renders on a GIVEN surface. The master switch above still
+ * decides first — off means off everywhere — and then `clientLogosScope` picks
+ * the surfaces. Absent scope answers `true` for the cover and `false` for the
+ * reveal, which is where every config saved before this existed already stood.
+ */
+export function showClientLogosOn(
+  cover: FormCover | null | undefined,
+  surface: ClientLogoSurface,
+): boolean {
+  if (!showClientLogos(cover)) return false;
+  const scope = cover?.clientLogosScope ?? 'cover';
+  return scope === 'both' || scope === surface;
+}
+
+/**
+ * The interstitial's resolved presentation. Split out from the component so the
+ * defaults are one tested decision rather than a chain of `??` in JSX — and so
+ * the builder preview and the public renderer can never disagree about them.
+ */
+export function resolveRevealPresentation(reveal: FormReveal | null | undefined): {
+  loader: FormRevealLoader;
+  loaderSize: FormRevealSize;
+  textSize: FormRevealSize;
+  accentBackground: boolean;
+} {
+  return {
+    loader: reveal?.loader ?? 'spinner',
+    loaderSize: reveal?.loaderSize ?? 'md',
+    textSize: reveal?.textSize ?? 'md',
+    accentBackground: reveal?.accentBackground === true,
+  };
 }
 
 /** The logo each surface of a form shows. `null` on either axis means "none". */

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -467,8 +467,17 @@ export interface FormScheduler {
 export const FORM_REVEAL_LOADERS = ['spinner', 'bar', 'versus', 'none'] as const;
 export type FormRevealLoader = (typeof FORM_REVEAL_LOADERS)[number];
 
-/** The scale shared by the interstitial's loader mark and its copy. */
-export const FORM_REVEAL_SIZES = ['sm', 'md', 'lg'] as const;
+/**
+ * The scale shared by the interstitial's loader mark and its copy.
+ *
+ * Four steps rather than three because this screen is a full-page moment, not a
+ * component: the top of a three-step scale landed around what a normal `md`
+ * should be, so the sizes an author actually reached for were all at the
+ * ceiling. Each step resolves to a `clamp()` in the stylesheet, so a size is a
+ * RANGE across viewports, not one number — that is what keeps the largest marks
+ * from colliding on a phone.
+ */
+export const FORM_REVEAL_SIZES = ['sm', 'md', 'lg', 'xl'] as const;
 export type FormRevealSize = (typeof FORM_REVEAL_SIZES)[number];
 
 export interface FormReveal {

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -494,6 +494,11 @@ export interface FormReveal {
   versusYouLabel?: string | null;
   /** `versus` only — the label under the match's mark. */
   versusMatchLabel?: string | null;
+  /**
+   * `versus` only — the live status under the match's label ("Searching…").
+   * Absent falls back to localized copy; an empty string removes the line.
+   */
+  versusStatusLabel?: string | null;
 }
 
 /**

--- a/packages/shared/src/branding.ts
+++ b/packages/shared/src/branding.ts
@@ -91,6 +91,24 @@ function mix(rgb: Rgb, target: Rgb, amount: number): Rgb {
 const WHITE: Rgb = { r: 255, g: 255, b: 255 };
 const BLACK: Rgb = { r: 0, g: 0, b: 0 };
 
+/**
+ * `amount` of `target` blended over `base`, both hex — the TS twin of CSS's
+ * `color-mix(in srgb, target <amount>%, base)`.
+ *
+ * Exists so the editor can judge a surface the stylesheet DERIVES rather than
+ * stores. The promo banner's default fill is 12% of the accent over the form
+ * ground and lives only in CSS, so a contrast readout for the text sitting on it
+ * had nothing to measure against and silently switched itself off — in exactly
+ * the case most likely to be unreadable. Returns `base` unchanged if either
+ * color fails to parse.
+ */
+export function blendHex(base: string, target: string, amount: number): string {
+  const a = parseHex(base);
+  const b = parseHex(target);
+  if (!a || !b) return base;
+  return toHex(mix(a, b, Math.max(0, Math.min(1, amount))));
+}
+
 /** True when a color is light enough that dark text belongs on top of it. */
 export function isLightColor(hex: string): boolean {
   const rgb = parseHex(hex);

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -40,6 +40,9 @@ export interface FormsMessages {
     verticalErrors: string;
     revealHeadline: string;
     revealSubtitle: string;
+    /** `versus` interstitial: the two marks' labels when the config sets none. */
+    revealVersusYou: string;
+    revealVersusMatch: string;
     noSteps: string;
     dropdownPlaceholder: string;
     dropdownEmpty: string;
@@ -710,6 +713,13 @@ export interface FormsMessages {
         bannerScope: string;
         bannerScopeForm: string;
         bannerScopeCover: string;
+        bannerColor: string;
+        bannerColorHint: string;
+        bannerTextColor: string;
+        bannerSize: string;
+        bannerSizeSm: string;
+        bannerSizeMd: string;
+        bannerSizeLg: string;
         eyebrow: string;
         badge: string;
         headline: string;
@@ -725,6 +735,10 @@ export interface FormsMessages {
         clientLogos: string;
         clientLogosHint: string;
         showClientLogos: string;
+        clientLogosScope: string;
+        clientLogosScopeCover: string;
+        clientLogosScopeReveal: string;
+        clientLogosScopeBoth: string;
         clientLogoName: string;
         clientLogoSrc: string;
         addClientLogo: string;
@@ -1313,6 +1327,8 @@ export const en: FormsMessages = {
     verticalErrors: 'Check the highlighted questions above.',
     revealHeadline: 'Reviewing your answers…',
     revealSubtitle: 'One moment while we match you with the best next step.',
+    revealVersusYou: 'You',
+    revealVersusMatch: 'Your match',
     noSteps: 'This form has no steps yet.',
     dropdownPlaceholder: 'Type to search…',
     dropdownEmpty: 'No results found',
@@ -1916,6 +1932,13 @@ export const en: FormsMessages = {
         bannerScope: 'Show the banner on',
         bannerScopeForm: 'Every screen',
         bannerScopeCover: 'Cover only',
+        bannerColor: 'Banner color',
+        bannerColorHint: 'Empty uses a soft tint of the accent — set a color to make the strip carry.',
+        bannerTextColor: 'Banner text color',
+        bannerSize: 'Banner height',
+        bannerSizeSm: 'Slim',
+        bannerSizeMd: 'Standard',
+        bannerSizeLg: 'Tall',
         eyebrow: 'Eyebrow',
         badge: 'Badge',
         headline: 'Headline',
@@ -1929,8 +1952,12 @@ export const en: FormsMessages = {
         logoHint: 'Shown on the cover screen only. Leave empty for no logo there.',
         logoInvalid: 'This URL protocol is not allowed for images.',
         clientLogos: 'Client logos',
-        clientLogosHint: 'A “trusted by” marquee on the cover. The name shows when no image is set.',
+        clientLogosHint: 'A “trusted by” marquee. The name shows when no image is set.',
         showClientLogos: 'Show the marquee',
+        clientLogosScope: 'Show the marquee on',
+        clientLogosScopeCover: 'Cover',
+        clientLogosScopeReveal: 'Reveal screen',
+        clientLogosScopeBoth: 'Both',
         clientLogoName: 'Name',
         clientLogoSrc: 'Image URL',
         addClientLogo: 'Add logo',
@@ -2519,6 +2546,8 @@ export const es: FormsMessages = {
     verticalErrors: 'Revisa las preguntas marcadas arriba.',
     revealHeadline: 'Revisando tus respuestas…',
     revealSubtitle: 'Un momento mientras encontramos el mejor siguiente paso para ti.',
+    revealVersusYou: 'Tú',
+    revealVersusMatch: 'Tu match',
     noSteps: 'Este formulario aún no tiene pasos.',
     dropdownPlaceholder: 'Escribe para buscar…',
     dropdownEmpty: 'No se encontraron resultados',
@@ -3124,6 +3153,13 @@ export const es: FormsMessages = {
         bannerScope: 'Mostrar el banner en',
         bannerScopeForm: 'Todas las pantallas',
         bannerScopeCover: 'Solo la portada',
+        bannerColor: 'Color del banner',
+        bannerColorHint: 'Vacío usa un tinte suave del acento; elegí un color para que la franja se note.',
+        bannerTextColor: 'Color del texto del banner',
+        bannerSize: 'Alto del banner',
+        bannerSizeSm: 'Fina',
+        bannerSizeMd: 'Normal',
+        bannerSizeLg: 'Alta',
         eyebrow: 'Antetítulo',
         badge: 'Insignia',
         headline: 'Titular',
@@ -3137,8 +3173,12 @@ export const es: FormsMessages = {
         logoHint: 'Solo en la portada. Vacío = sin logo ahí.',
         logoInvalid: 'Este protocolo de URL no está permitido para imágenes.',
         clientLogos: 'Logos de clientes',
-        clientLogosHint: 'Una marquesina de «confían en nosotros» en la portada. El nombre se muestra si no hay imagen.',
+        clientLogosHint: 'Una marquesina de «confían en nosotros». El nombre se muestra si no hay imagen.',
         showClientLogos: 'Mostrar la marquesina',
+        clientLogosScope: 'Mostrar la marquesina en',
+        clientLogosScopeCover: 'Portada',
+        clientLogosScopeReveal: 'Pantalla de carga',
+        clientLogosScopeBoth: 'Ambas',
         clientLogoName: 'Nombre',
         clientLogoSrc: 'URL de la imagen',
         addClientLogo: 'Añadir logo',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -43,6 +43,8 @@ export interface FormsMessages {
     /** `versus` interstitial: the two marks' labels when the config sets none. */
     revealVersusYou: string;
     revealVersusMatch: string;
+    /** The live status under the match's label while the screen plays. */
+    revealVersusStatus: string;
     noSteps: string;
     dropdownPlaceholder: string;
     dropdownEmpty: string;
@@ -1329,6 +1331,7 @@ export const en: FormsMessages = {
     revealSubtitle: 'One moment while we match you with the best next step.',
     revealVersusYou: 'You',
     revealVersusMatch: 'Your match',
+    revealVersusStatus: 'Searching…',
     noSteps: 'This form has no steps yet.',
     dropdownPlaceholder: 'Type to search…',
     dropdownEmpty: 'No results found',
@@ -2548,6 +2551,7 @@ export const es: FormsMessages = {
     revealSubtitle: 'Un momento mientras encontramos el mejor siguiente paso para ti.',
     revealVersusYou: 'Tú',
     revealVersusMatch: 'Tu match',
+    revealVersusStatus: 'Buscando…',
     noSteps: 'Este formulario aún no tiene pasos.',
     dropdownPlaceholder: 'Escribe para buscar…',
     dropdownEmpty: 'No se encontraron resultados',

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src",
-    "test": "echo \"(types) no tests\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@quill/config": "workspace:*",
     "eslint": "^9.17.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Contract tests for `formConfigSchema` — architecture invariant #4: the form
+ * config is a versioned schema that gets EXTENDED, never broken. Every field
+ * added here is optional, so the assertions that matter are the ones about what
+ * a config saved before the field existed still does.
+ *
+ * The presentation axes added alongside the banner/reveal/marquee work are the
+ * first ones to be pinned this way; the file exists so the next additive field
+ * has somewhere obvious to prove the same thing.
+ */
+import { describe, expect, it } from 'vitest';
+import { formConfigSchema } from './index';
+
+/** The smallest config the schema accepts — one step, nothing configured. */
+function baseConfig() {
+  return {
+    version: 1 as const,
+    steps: [{ key: 'q1', type: 'text' as const, question: 'Your name?' }],
+  };
+}
+
+describe('formConfigSchema — banner presentation (additive)', () => {
+  it('a config with a banner and no look still parses, and sets no look', () => {
+    const parsed = formConfigSchema.parse({
+      ...baseConfig(),
+      cover: { bannerText: 'Free credits when you book' },
+    });
+    expect(parsed.cover?.bannerText).toBe('Free credits when you book');
+    // Absent, not defaulted: the renderer's CSS fallback owns the legacy look,
+    // so writing a default in here would be the one way to change it.
+    expect(parsed.cover?.bannerColor).toBeUndefined();
+    expect(parsed.cover?.bannerSize).toBeUndefined();
+  });
+
+  it('accepts the authored banner look', () => {
+    const parsed = formConfigSchema.parse({
+      ...baseConfig(),
+      cover: {
+        bannerText: 'Free credits',
+        bannerColor: '#c6f24e',
+        bannerTextColor: '#0b0b0b',
+        bannerSize: 'lg',
+      },
+    });
+    expect(parsed.cover?.bannerColor).toBe('#c6f24e');
+    expect(parsed.cover?.bannerTextColor).toBe('#0b0b0b');
+    expect(parsed.cover?.bannerSize).toBe('lg');
+  });
+
+  it('rejects a banner color that could break out of the CSS color context', () => {
+    const bad = { ...baseConfig(), cover: { bannerColor: 'red;} body{display:none' } };
+    expect(formConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects an unknown banner size rather than silently ignoring it', () => {
+    const bad = { ...baseConfig(), cover: { bannerSize: 'huge' } };
+    expect(formConfigSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('formConfigSchema — client-logo scope (additive)', () => {
+  it('a legacy marquee parses with no scope — the renderer reads that as the cover', () => {
+    const parsed = formConfigSchema.parse({
+      ...baseConfig(),
+      cover: { clientLogos: [{ name: 'Acme' }] },
+    });
+    expect(parsed.cover?.clientLogos).toHaveLength(1);
+    expect(parsed.cover?.clientLogosScope).toBeUndefined();
+  });
+
+  it('accepts each scope', () => {
+    for (const clientLogosScope of ['cover', 'reveal', 'both'] as const) {
+      const parsed = formConfigSchema.parse({ ...baseConfig(), cover: { clientLogosScope } });
+      expect(parsed.cover?.clientLogosScope).toBe(clientLogosScope);
+    }
+  });
+});
+
+describe('formConfigSchema — reveal presentation (additive)', () => {
+  it('a legacy reveal parses with no presentation set', () => {
+    const parsed = formConfigSchema.parse({
+      ...baseConfig(),
+      reveal: { headline: 'Matching you…', durationMs: 5000 },
+    });
+    expect(parsed.reveal?.durationMs).toBe(5000);
+    expect(parsed.reveal?.loader).toBeUndefined();
+    expect(parsed.reveal?.accentBackground).toBeUndefined();
+  });
+
+  it('accepts the full presentation on a reveal STEP as well as the form-level one', () => {
+    const reveal = {
+      loader: 'versus' as const,
+      loaderSize: 'lg' as const,
+      textSize: 'sm' as const,
+      accentBackground: true,
+      versusYouLabel: 'You',
+      versusMatchLabel: 'Your [role]',
+    };
+    const parsed = formConfigSchema.parse({
+      version: 1 as const,
+      steps: [{ key: 'r1', type: 'reveal' as const, question: '', reveal }],
+      reveal,
+    });
+    expect(parsed.steps[0]?.reveal?.loader).toBe('versus');
+    expect(parsed.steps[0]?.reveal?.versusMatchLabel).toBe('Your [role]');
+    expect(parsed.reveal?.accentBackground).toBe(true);
+  });
+
+  it('rejects an unknown loader', () => {
+    const bad = { ...baseConfig(), reveal: { loader: 'fireworks' } };
+    expect(formConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('keeps the existing duration bounds', () => {
+    expect(formConfigSchema.safeParse({ ...baseConfig(), reveal: { durationMs: 400 } }).success).toBe(
+      false,
+    );
+    expect(
+      formConfigSchema.safeParse({ ...baseConfig(), reveal: { durationMs: 30_001 } }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,9 @@ import {
   CONDITION_OPS,
   FORM_BACKGROUND_STYLES,
   FORM_BANNER_SCOPES,
+  FORM_BANNER_SIZES,
   FORM_BUTTON_STYLES,
+  FORM_CLIENT_LOGO_SCOPES,
   FORM_CONTENT_ALIGNS,
   FORM_CONTENT_WIDTHS,
   FORM_FIELD_TYPES,
@@ -20,6 +22,8 @@ import {
   FORM_OPTION_LAYOUTS,
   FORM_PROGRESS_STYLES,
   FORM_RADII,
+  FORM_REVEAL_LOADERS,
+  FORM_REVEAL_SIZES,
   FORM_TRANSITIONS,
   isImageIcon,
   isSafeHttpUrl,
@@ -127,6 +131,28 @@ const clientLogoSchema = z.object({
   src: safeImageUrl.nullable().optional(),
 });
 
+/**
+ * A CSS color value flowing into an inline custom property (`--pf-primary`,
+ * `--pf-banner-bg`, …) on the public renderer. Constrain the format (hex /
+ * rgb(a) / hsl(a) / named) so a value like `red;} body{...` can't break out of
+ * the color context — CSS-injection defense-in-depth on top of the 32-char cap
+ * (L2).
+ *
+ * Declared here, above the first schema that uses it: these are plain `const`
+ * bindings evaluated top-to-bottom at module load, so a schema built before
+ * this line would hit the temporal dead zone.
+ */
+const cssColor = z
+  .string()
+  .max(32)
+  .refine(
+    (v) =>
+      /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(v) ||
+      /^(?:rgb|rgba|hsl|hsla)\([0-9.,%\s/-]+\)$/.test(v) ||
+      /^[a-zA-Z]+$/.test(v),
+    { message: 'Color must be a hex, rgb(a)/hsl(a), or named CSS color.' },
+  );
+
 export const formRevealSchema = z.object({
   enabled: z.boolean().optional(),
   headline: z.string().max(300).nullable().optional(),
@@ -138,6 +164,18 @@ export const formRevealSchema = z.object({
   subtitleTemplate: z.string().max(200).nullable().optional(),
   /** Pre-warm the booking embed while the interstitial plays. */
   prewarm: z.boolean().optional(),
+  /**
+   * Presentation (ADDITIVE — all optional). Absent on every axis resolves to
+   * the historical spinner-over-a-bar look, so a stored reveal keeps rendering
+   * exactly as it does today. See `resolveRevealPresentation` in @quill/engine.
+   */
+  loader: z.enum(FORM_REVEAL_LOADERS).optional(),
+  loaderSize: z.enum(FORM_REVEAL_SIZES).optional(),
+  textSize: z.enum(FORM_REVEAL_SIZES).optional(),
+  accentBackground: z.boolean().optional(),
+  /** `versus` only — the two marks' labels. Absent falls back to localized copy. */
+  versusYouLabel: z.string().max(40).nullable().optional(),
+  versusMatchLabel: z.string().max(40).nullable().optional(),
 });
 
 /**
@@ -261,6 +299,14 @@ export const formCoverSchema = z.object({
    * screen; absent — every legacy config — keeps it above every screen.
    */
   bannerScope: z.enum(FORM_BANNER_SCOPES).optional(),
+  /**
+   * The banner strip's own look (ADDITIVE). Absent on any axis keeps the
+   * derived tint + padding the stylesheet has always applied, so no published
+   * form's banner changes by upgrading.
+   */
+  bannerColor: cssColor.nullable().optional(),
+  bannerTextColor: cssColor.nullable().optional(),
+  bannerSize: z.enum(FORM_BANNER_SIZES).optional(),
   eyebrow: z.string().max(200).nullable().optional(),
   badge: z.string().max(200).nullable().optional(),
   headline: z.string().max(300).nullable().optional(),
@@ -274,24 +320,13 @@ export const formCoverSchema = z.object({
    * config — means shown, so switching it off never deletes the logos.
    */
   showClientLogos: z.boolean().optional(),
+  /**
+   * WHICH surfaces the marquee renders on (ADDITIVE): the cover alone (absent —
+   * every legacy config, and where it has always rendered), the reveal
+   * interstitial alone, or both.
+   */
+  clientLogosScope: z.enum(FORM_CLIENT_LOGO_SCOPES).optional(),
 });
-
-/**
- * A CSS color value flowing into an inline custom property (`--pf-primary`) on
- * the public renderer. Constrain the format (hex / rgb(a) / hsl(a) / named) so a
- * value like `red;} body{...` can't break out of the color context — CSS-
- * injection defense-in-depth on top of the 32-char cap (L2).
- */
-const cssColor = z
-  .string()
-  .max(32)
-  .refine(
-    (v) =>
-      /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(v) ||
-      /^(?:rgb|rgba|hsl|hsla)\([0-9.,%\s/-]+\)$/.test(v) ||
-      /^[a-zA-Z]+$/.test(v),
-    { message: 'primaryColor must be a hex, rgb(a)/hsl(a), or named CSS color.' },
-  );
 
 /**
  * An author-supplied typeface. This repo has no asset storage, so the source is

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -176,6 +176,8 @@ export const formRevealSchema = z.object({
   /** `versus` only — the two marks' labels. Absent falls back to localized copy. */
   versusYouLabel: z.string().max(40).nullable().optional(),
   versusMatchLabel: z.string().max(40).nullable().optional(),
+  /** `versus` only — the live status line under the match. `''` removes it. */
+  versusStatusLabel: z.string().max(40).nullable().optional(),
 });
 
 /**

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -6,5 +6,5 @@
     "types": []
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["**/*.spec.ts", "dist", "node_modules"]
 }

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@26.1.1)(lightningcss@1.32.0)
 
 packages:
 


### PR DESCRIPTION
Recreates three things the pilot at `bookings.dapta.ai` has and a Dapta Form could not express. All additive on `formConfig` v1 — every new field is optional, and absent resolves to today's rendering.

## What changes

**Banner.** `cover.bannerColor` / `bannerTextColor` / `bannerSize` reach the strip as inline custom properties; `public-form.css` consumes them with the old values as its own `var()` fallbacks. The narrow-viewport override now re-declares those *variables* rather than the properties — otherwise it out-specified the size presets, and an implicit `md` shrank on a phone while an explicitly chosen `md` did not.

**Reveal.** `reveal.loader` picks the animation — `spinner` (the default, unchanged), `bar`, `versus`, `none` — with `loaderSize`, `textSize`, `accentBackground`, and the `versus` layout's two labels plus its status line. `resolveRevealPresentation` in `@quill/engine` owns the defaults so the builder canvas and the public renderer cannot disagree about them.

The `versus` layout is an ink/paper pair mixed out of the accent rather than the form's own foreground/background. That is what makes it survive the accent flood: over a lime page the "unknown" mark has to stay near-white, and painting it in the accent's contrast colour collapsed both marks onto one value.

**Marquee.** `cover.clientLogosScope` puts the "trusted by" logos on the cover (absent — where they have always been), the reveal, or both.

## Behaviour change worth calling out

The one-page (`vertical`) layout now honours `cover.showClientLogos`. It previously ignored the toggle entirely, so the switch worked on slides and did nothing on a one-page form. A stored config with `layout: 'vertical'` + `showClientLogos: false` renders differently after this merges. Recorded in the changeset.

## Back-compat

`md` is pinned flat to the 52px mark this screen has always drawn. It is what an absent `loaderSize` resolves to, and the `submitting` screen renders the same spinner with **no** reveal config at all — so anything else there would have resized every published reveal and every form's submitting screen with no way to opt out. The new headroom lives on `lg`/`xl`.

`packages/types` gains a vitest harness (it carried invariant #4 with no tests) and `src/form-config.spec.ts` pins the back-compat cases for all three axes.

## Fixed in passing

- The vertical renderer ignored `showClientLogos` (above).
- `AutoTextarea` only re-measured on text changes, so raising the reveal's text size clipped its headline against `overflow-hidden`.
- The builder canvas previewed unnamed `versus` sides with the *editor's* field captions instead of the respondent's copy.

## Verification

`pnpm typecheck` 16/16 · `pnpm lint` 16/16 · `pnpm test` 16/16 (uncached) · `pnpm build` 9/9. DCO on all four commits; commitlint clean.

`packages/db` is untouched — no schema, migration or repository change — so the Postgres parity test does not apply.

publish-gate: git-history scan clean across 302 commits. The working-tree gitleaks findings are all under `apps/web/.next/`, each confirmed gitignored, with 0 tracked `.next` files; the only FAIL is trufflehog not being installed locally, which CI provides.

Reviewed against the repo invariants with the `forms-reviewer` agent before opening; its two blockers (the `md` default regression above, and a missing changeset) and its should-fixes are addressed in `bb7077e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)