### PR TITLE
feat: cohort-aware onboarding + dapta_sync (IAM responses + HubSpot flow)

### DIFF
--- a/.changeset/onboarding-cohorts-dapta-sync.md
+++ b/.changeset/onboarding-cohorts-dapta-sync.md
@@ -1,0 +1,18 @@
+---
+'@quill/types': minor
+'@quill/db': minor
+'@quill/shared': minor
+'@quill/config': minor
+---
+
+Cohort-aware onboarding wizard + Dapta-estate sync.
+
+- `@quill/types`: the onboarding blob and steps grow `phone`, `crm`,
+  `lead_volume`, `lead_source`, a `cohort` (`cold`/`dapta`) and per-answer
+  `sources`; the industry enum becomes the IAM's 52-value bank.
+- `@quill/db`: migration 0012 rewrites stored industry answers to the new
+  bank (a stale enum value would otherwise take the whole blob down on read);
+  new outbox kind `dapta_sync`.
+- `@quill/shared`: EN/ES copy for the new questions.
+- `@quill/config`: optional `IAM_BASE_URL`, `IAM_API_KEY`,
+  `DAPTA_SYNC_FLOW_URL`, `DAPTA_SYNC_FLOW_KEY` (all unset = feature off).

--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,19 @@ MAIL_FROM_NAME=Forms
 # ENTITLEMENTS_API_URL=
 # ENTITLEMENTS_API_KEY=
 
+# --- Dapta pipeline (optional; cloud only) ----------------------------------
+# Pushes a new account's onboarding into the rest of the Dapta estate: the
+# wizard's mappable answers to the IAM's onboarding endpoints, then a call to
+# the FlowStudio contact-sync flow (HubSpot upsert by email). All four unset
+# (the default, and every bare fork) = the feature does not exist — nothing is
+# enqueued, no third-party request is made. IAM_API_KEY is read by BOTH apps:
+# the API (sync) and the web (the cohort probe's x-api-key). IAM_BASE_URL was
+# already a web var (login/logout hand-off); the API now reads it too.
+# IAM_BASE_URL=https://iam.example.com/iam
+# IAM_API_KEY=
+# DAPTA_SYNC_FLOW_URL=https://flows.example.com/api/WORKSPACE/sync_contact
+# DAPTA_SYNC_FLOW_KEY=
+
 # --- Outbox worker (durable submission emails + destination deliveries) -----
 # OUTBOX_WORKER_ENABLED=true
 # OUTBOX_POLL_MS=5000

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -213,6 +213,19 @@ HMAC secret) — no environment variable.
 | `ENTITLEMENTS_API_URL` | _(unset)_ | when `PREMIUM_FEATURES=locked` | no |
 | `ENTITLEMENTS_API_KEY` | _(unset)_ | when `PREMIUM_FEATURES=locked` | yes |
 
+### Dapta pipeline (optional; cloud only)
+
+Pushes a new account's onboarding into the Dapta estate (IAM answers + the
+HubSpot contact-sync flow) via the `dapta_sync` outbox kind. All four unset —
+the fork default — disables the feature entirely: nothing is enqueued.
+
+| Var | Default | Required when | Secret |
+|---|---|---|---|
+| `IAM_BASE_URL` | _(unset)_ | syncing onboarding answers to the IAM (API; the web already uses it for login) | no |
+| `IAM_API_KEY` | _(unset)_ | same — also read by the **web** for the cohort probe | yes |
+| `DAPTA_SYNC_FLOW_URL` | _(unset)_ | calling the contact-sync flow | no |
+| `DAPTA_SYNC_FLOW_KEY` | _(unset)_ | calling the contact-sync flow | yes |
+
 ### Web app
 
 `NEXT_PUBLIC_*` are **build-time** (inlined into the client bundle — pass as
@@ -231,6 +244,7 @@ are runtime server env for the web container.
 | `AUTH_PROVIDER` | `local` | mirror the API value so the web picks the right login UX | no |
 | `WEB_SESSION_SECRET` | _(empty)_ | **required** unless `AUTH_PROVIDER=local` — signs the httpOnly session cookie | yes |
 | `IAM_BASE_URL` | _(unset)_ | **required** when `AUTH_PROVIDER=workos` — upstream identity service the web calls for the login URL / logout | no |
+| `IAM_API_KEY` | _(unset)_ | the onboarding cohort probe (key-gated IAM status endpoint); unset probes fail closed to the short wizard | yes |
 | `PUBLIC_APP_URL` | _(empty)_ | trusted origin for OAuth redirects (same as API) | no |
 
 ## Reverse proxy + TLS

--- a/apps/api/src/admin.service.ts
+++ b/apps/api/src/admin.service.ts
@@ -16,6 +16,7 @@ import {
 import { canClaimVanitySlug } from '@quill/engine';
 import { getMessages } from '@quill/shared';
 import type {
+  AccountOnboarding,
   FormTemplateId,
   OnboardingCompleteInput,
   OnboardingProgressInput,
@@ -23,10 +24,30 @@ import type {
 import type { HostPrincipal } from './auth.service';
 import { isAdmin } from './permissions';
 import { DisabledEntitlementsProvider, type EntitlementsProvider } from './entitlements.provider';
+import { DaptaSyncEffects } from './dapta-sync-effects';
 import { DB, ENTITLEMENTS, ONBOARDING_ENABLED, PREMIUM_MODE } from './tokens';
 
 /** How long a cached Dapta AI entitlement verdict stays fresh before re-asking upstream. */
 const ENTITLEMENT_TTL_MS = 6 * 3600_000;
+
+/**
+ * The wizard's answer fields, for the early-sync trigger. `role` is absent on
+ * purpose — it is no longer asked, and counting a legacy blob's role would
+ * stop the first NEW answer from reading as first.
+ */
+const ANSWER_FIELDS = [
+  'phone',
+  'industry',
+  'crm',
+  'leadVolume',
+  'leadSource',
+  'useCase',
+] as const satisfies ReadonlyArray<keyof AccountOnboarding>;
+
+/** How many wizard questions this blob has a stored answer for. */
+function answerCount(blob: AccountOnboarding): number {
+  return ANSWER_FIELDS.reduce((n, field) => (blob[field] != null ? n + 1 : n), 0);
+}
 
 /** Authed host/dashboard operations. All are scoped to the caller's account. */
 @Injectable()
@@ -43,6 +64,9 @@ export class AdminService {
     // + default false so every direct construction (tests, forks) behaves as it
     // did before the feature existed.
     @Optional() @Inject(ONBOARDING_ENABLED) private readonly onboardingEnabled: boolean = false,
+    // Explicit class token (esbuild elides type-only imports); optional so a
+    // deployment without the Dapta pipeline — every fork — simply has no sync.
+    @Optional() @Inject(DaptaSyncEffects) private readonly daptaSync?: DaptaSyncEffects,
   ) {}
 
   /**
@@ -85,7 +109,18 @@ export class AdminService {
    */
   async saveOnboarding(p: HostPrincipal, patch: OnboardingProgressInput) {
     if (!this.onboardingEnabled) return null;
-    return saveOnboardingProgress(this.db, p.accountId, patch);
+    const merged = await saveOnboardingProgress(this.db, p.accountId, patch);
+    // The FIRST answer just landed → make the person exist in the CRM now,
+    // not only if they finish. Exactly-one on the MERGED blob: deterministic
+    // without knowing the cohort (the PATCH does not carry it), no extra
+    // query, and a repeat — a refresh re-sending the same answer — at worst
+    // re-enqueues a call that upserts by email anyway. Awaited, not voided:
+    // the enqueue is a LOCAL outbox insert that never rejects, so this costs
+    // one write — the network delivery stays in the worker (invariant 5).
+    if (merged && answerCount(merged) === 1) {
+      await this.daptaSync?.enqueueEarly(p.accountId, p.memberId);
+    }
+    return merged;
   }
 
   /**
@@ -116,11 +151,24 @@ export class AdminService {
     const template = getFormTemplate(templateId);
     if (!template) return { completed: false, formId: null };
 
-    const won = await claimOnboardingComplete(this.db, p.accountId, templateId, {
-      role: input.role,
-      industry: input.industry,
-      useCase: input.useCase,
-    });
+    const won = await claimOnboardingComplete(
+      this.db,
+      p.accountId,
+      templateId,
+      {
+        role: input.role,
+        industry: input.industry,
+        useCase: input.useCase,
+        crm: input.crm,
+        leadVolume: input.leadVolume,
+        leadSource: input.leadSource,
+        phone: input.phone,
+      },
+      // The cohort comes from the WIZARD, which is where the IAM probe runs —
+      // the API has no `IAM_BASE_URL` and giving it one would mean a configmap
+      // owned by another team, for a lookup the web already made.
+      input.cohort,
+    );
     if (!won) {
       // A loser must not create a second form. It still needs somewhere to send
       // the person, so hand back the form the WINNER made — read from the blob
@@ -131,6 +179,12 @@ export class AdminService {
       const state = await getAccountOnboarding(this.db, p.accountId);
       return { completed: false, formId: state?.onboarding?.formId ?? null };
     }
+
+    // The claim is won — the answers are stored — so the estate sync fires
+    // HERE, not after form creation: a failed create keeps the completion
+    // (see below), and it must keep the sync too. Awaited for the same reason
+    // as the early hook: a local never-rejecting insert, not a network call.
+    await this.daptaSync?.enqueueComplete(p.accountId, p.memberId);
 
     // Not guarded by `hasExtraHubspotDestination`, unlike POST /v1/forms: the
     // config here is a static server-authored template from the registry, never

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,8 @@ import { BookingEffects } from './booking-effects';
 import { BookingSyncEffects } from './booking-sync';
 import { AnalyticsEffects } from './analytics-effects';
 import { AnalyticsCapture } from './analytics-capture';
+import { DaptaSyncEffects } from './dapta-sync-effects';
+import { DaptaSyncDelivery } from './dapta-sync';
 import { OutboxWorker } from './outbox.worker';
 import { RateLimitGuard, createRateLimiter } from './rate-limit';
 import { resolveEntitlementsProvider } from './entitlements.provider';
@@ -145,6 +147,12 @@ import {
     // enqueue is a no-op and nothing is ever sent.
     AnalyticsEffects,
     AnalyticsCapture,
+    // Dapta-estate onboarding sync: the enqueue side (used by AdminService)
+    // and its worker-side executor (outbox kind `dapta_sync` — IAM responses
+    // + the HubSpot contact-sync flow). With DAPTA_SYNC_FLOW_URL/KEY unset —
+    // the default, and every bare fork — the enqueue is a no-op.
+    DaptaSyncEffects,
+    DaptaSyncDelivery,
     // Server-side HubSpot property lookup for the mapping UI (5-min cache, clear
     // disabled state without a token). Resolves the per-account token (else the
     // env fallback), so it needs the DB. Factory so `fetch` isn't DI-reflected.

--- a/apps/api/src/dapta-sync-effects.ts
+++ b/apps/api/src/dapta-sync-effects.ts
@@ -1,0 +1,86 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { enqueueOutbox, type Db } from '@quill/db';
+import type { ServerEnv } from '@quill/config/env';
+import { DB, ENV } from './tokens';
+
+/**
+ * The durable payload a `dapta_sync` outbox row carries. Deliberately just the
+ * two principal ids: everything else — the member's email and external id, the
+ * onboarding answers, the account's attribution — is read FRESH at delivery
+ * time. A row can sit through minutes of retries, and during that window the
+ * person may answer more questions; serializing answers here would deliver a
+ * stale snapshot when the whole point is that the CRM reflects what was
+ * actually answered.
+ */
+export interface DaptaSyncPayload {
+  accountId: string;
+  memberId: string;
+}
+
+/** The two moments Forms pushes into the Dapta estate. */
+export type DaptaSyncAction = 'early' | 'complete';
+
+/**
+ * Durable enqueue of the Dapta-estate sync (mirrors AnalyticsEffects).
+ *
+ * `early` fires when the wizard's FIRST answer lands, so the person exists in
+ * HubSpot (email + phone + campaign tags) even if they abandon the wizard —
+ * the same reason Dapta's own admin panel calls the sync flow from its first
+ * onboarding screen. `complete` fires when the completion claim is won: the
+ * delivery writes the mappable answers to the IAM and then calls the flow,
+ * which pulls them (plus the computed lead score) into the HubSpot contact.
+ *
+ * Never called inline (invariant 5): both deliveries are network calls into
+ * another team's infrastructure, and neither a wizard PATCH nor the completion
+ * request may fail or slow down because that infrastructure is down. When the
+ * flow env is unset (any OSS fork, and any environment where the feature is
+ * not configured yet) this enqueues NOTHING — not a row that fails later.
+ */
+@Injectable()
+export class DaptaSyncEffects {
+  private readonly log = new Logger('DaptaSyncEffects');
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Optional() @Inject(ENV) private readonly env?: ServerEnv,
+  ) {}
+
+  /** True when this deployment can reach the Dapta contact-sync flow at all. */
+  get enabled(): boolean {
+    return Boolean(this.env?.DAPTA_SYNC_FLOW_URL && this.env?.DAPTA_SYNC_FLOW_KEY);
+  }
+
+  /**
+   * Enqueue one sync moment. NEVER REJECTS — the sync is an observer of
+   * onboarding, not a participant, so callers `void` this safely.
+   */
+  private async enqueue(
+    action: DaptaSyncAction,
+    accountId: string,
+    memberId: string,
+  ): Promise<void> {
+    if (!this.enabled) return;
+    try {
+      const payload: DaptaSyncPayload = { accountId, memberId };
+      await enqueueOutbox(this.db, {
+        kind: 'dapta_sync',
+        action,
+        subjectUid: accountId,
+        accountId,
+        payload: JSON.stringify(payload),
+      });
+    } catch (err) {
+      this.log.error(`failed to enqueue dapta_sync ${action}: ${String(err)}`);
+    }
+  }
+
+  /** The wizard's first answer just landed — make the contact exist. */
+  async enqueueEarly(accountId: string, memberId: string): Promise<void> {
+    await this.enqueue('early', accountId, memberId);
+  }
+
+  /** The completion claim was won — push answers + score to the estate. */
+  async enqueueComplete(accountId: string, memberId: string): Promise<void> {
+    await this.enqueue('complete', accountId, memberId);
+  }
+}

--- a/apps/api/src/dapta-sync.spec.ts
+++ b/apps/api/src/dapta-sync.spec.ts
@@ -1,0 +1,442 @@
+/**
+ * The Dapta-estate onboarding sync, end to end on in-memory SQLite: the
+ * wizard's first answer and its completion are ENQUEUED as durable
+ * `dapta_sync` outbox rows (never inline HTTP), and the worker-side delivery
+ * pushes mappable answers to the IAM BEFORE calling the contact-sync flow —
+ * the order the flow depends on, because it reads the answers back from the
+ * IAM rather than from the webhook body.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  claimOnboardingComplete,
+  createDb,
+  listOutbox,
+  migrate,
+  saveOnboardingProgress,
+  sql,
+  type Db,
+} from '@quill/db';
+import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
+import type { AccountOnboarding } from '@quill/types';
+import { DaptaSyncEffects } from './dapta-sync-effects';
+import { DaptaSyncDelivery, buildFlowPayload, buildIamResponses } from './dapta-sync';
+import { AdminService } from './admin.service';
+import { EmailEffects } from './email-effects';
+import { DestinationEffects } from './destination-effects';
+import { OutboxWorker } from './outbox.worker';
+
+const FLOW_URL = 'https://flows.example.com/api/ws1/sync_contact';
+const IAM_URL = 'https://iam.example.com/iam';
+
+/** The three mappable questions, in the live bank's verified shape. */
+const BANK = [
+  {
+    id: 'q-industry',
+    question_key: 'industry',
+    options: [
+      { id: 'o-software', option_value: 'computer_software' },
+      { id: 'o-retail', option_value: 'retail' },
+    ],
+  },
+  {
+    id: 'q-crm',
+    question_key: 'crm_usage',
+    options: [
+      { id: 'o-hubspot', option_value: 'hubspot' },
+      { id: 'o-none', option_value: 'none' },
+    ],
+  },
+  {
+    id: 'q-volume',
+    question_key: 'contacts_per_month',
+    options: [{ id: 'o-mid', option_value: '201_500' }],
+  },
+];
+
+let db: Db;
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** Env with the pipeline ON. Cast: the suite only touches these fields. */
+function envWith(overrides: Record<string, string | undefined> = {}) {
+  return {
+    DAPTA_SYNC_FLOW_URL: FLOW_URL,
+    DAPTA_SYNC_FLOW_KEY: 'flow-key',
+    IAM_BASE_URL: IAM_URL,
+    IAM_API_KEY: 'iam-key',
+    ...overrides,
+  } as never;
+}
+
+/**
+ * A delivery whose fetch routes by URL: the question bank, the status probe,
+ * the responses POST and the flow webhook each answer in the live shape.
+ */
+function newDelivery(
+  env: unknown,
+  calls: RecordedCall[],
+  opts: { hasCompleted?: boolean; flowStatus?: number } = {},
+): DaptaSyncDelivery {
+  const delivery = new DaptaSyncDelivery(db, env as never);
+  delivery.fetchImpl = (async (url: string, init?: RequestInit) => {
+    calls.push({
+      url,
+      method: init?.method ?? 'GET',
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.includes('/onboarding/questions')) {
+      return new Response(JSON.stringify(BANK), { status: 200 });
+    }
+    if (url.includes('/onboarding/status/')) {
+      return new Response(
+        JSON.stringify({ has_completed_onboarding: opts.hasCompleted ?? false }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/onboarding/responses')) {
+      return new Response(JSON.stringify({ message: 'ok', total_score: 4 }), { status: 201 });
+    }
+    return new Response('{}', { status: opts.flowStatus ?? 200 });
+  }) as unknown as typeof fetch;
+  return delivery;
+}
+
+function newWorker(daptaSync?: DaptaSyncDelivery) {
+  const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
+  const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
+  return new OutboxWorker(
+    db,
+    env,
+    email,
+    new DestinationEffects(db),
+    undefined,
+    undefined,
+    daptaSync,
+  );
+}
+
+async function seedAccount(input: {
+  memberExternalId?: string | null;
+  email?: string | null;
+  attribution?: Record<string, string> | null;
+}): Promise<{ accountId: string; memberId: string }> {
+  const now = Date.now();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, external_id, attribution, created_at)
+        VALUES (${'acc_1'}, ${'t1'}, ${'Test Co'}, ${'org-ext-1'},
+                ${input.attribution ? JSON.stringify(input.attribution) : null}, ${now})`,
+  );
+  await db.run(
+    sql`INSERT INTO member (id, account_id, external_id, email, display_name, role, status, created_at)
+        VALUES (${'mem_1'}, ${'acc_1'},
+                ${input.memberExternalId === undefined ? 'user-ext-1' : input.memberExternalId},
+                ${input.email === undefined ? 'a@b.com' : input.email}, ${'Ada Test'},
+                ${'owner'}, ${'active'}, ${now})`,
+  );
+  return { accountId: 'acc_1', memberId: 'mem_1' };
+}
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+});
+
+afterEach(() => {
+  db.close?.();
+});
+
+describe('buildIamResponses — pure mapping', () => {
+  it('maps the three mappable answers by question_key + option_value', () => {
+    const blob = {
+      version: 1,
+      industry: 'computer_software',
+      crm: 'hubspot',
+      leadVolume: '201_500',
+    } as AccountOnboarding;
+
+    const { responses, unmapped } = buildIamResponses(blob, BANK);
+
+    expect(unmapped).toEqual([]);
+    expect(responses).toEqual([
+      { question_id: 'q-industry', selected_option_ids: ['o-software'] },
+      { question_id: 'q-crm', selected_option_ids: ['o-hubspot'] },
+      { question_id: 'q-volume', selected_option_ids: ['o-mid'] },
+    ]);
+  });
+
+  it('reports an answer whose option left the bank instead of dropping it silently', () => {
+    const blob = { version: 1, industry: 'computer_software', crm: 'hubspot' } as AccountOnboarding;
+    const bankWithoutHubspot = BANK.map((q) =>
+      q.question_key === 'crm_usage' ? { ...q, options: [] } : q,
+    );
+
+    const { responses, unmapped } = buildIamResponses(blob, bankWithoutHubspot);
+
+    expect(responses).toEqual([{ question_id: 'q-industry', selected_option_ids: ['o-software'] }]);
+    expect(unmapped).toEqual(['crm']);
+  });
+
+  it('returns nothing for a dapta-cohort blob — its answers have no IAM home', () => {
+    const blob = { version: 1, leadSource: 'outbound', useCase: 'leads' } as AccountOnboarding;
+
+    const { responses, unmapped } = buildIamResponses(blob, BANK);
+
+    // Not "unmapped" either: leadSource/useCase are not in the mapping table at
+    // all, so nothing is attempted and nothing is worth warning about.
+    expect(responses).toEqual([]);
+    expect(unmapped).toEqual([]);
+  });
+});
+
+describe('buildFlowPayload — pure mapping', () => {
+  it('carries the three utm_* keys the flow reads, snake_cased, dropping the rest', () => {
+    const body = buildFlowPayload({
+      email: 'a@b.com',
+      userId: 'user-ext-1',
+      accountExternalId: 'org-ext-1',
+      displayName: 'Ada Test',
+      blob: { version: 1, phone: '3001234567' } as AccountOnboarding,
+      attribution: {
+        utmSource: 'landing',
+        utmMedium: 'banner',
+        utmCampaign: 'launch',
+        // Verified against the flow's code: it reads ONLY the three utm_* keys.
+        gclid: 'g-123',
+        referrer: 'https://example.com',
+      },
+    });
+
+    expect(body).toEqual({
+      email: 'a@b.com',
+      user_id: 'user-ext-1',
+      account_id: 'org-ext-1',
+      name: 'Ada Test',
+      phone: '3001234567',
+      params: { utm_source: 'landing', utm_medium: 'banner', utm_campaign: 'launch' },
+    });
+  });
+
+  it('omits params entirely when there is no attribution, and junk-length phones', () => {
+    const body = buildFlowPayload({
+      email: 'a@b.com',
+      userId: 'user-ext-1',
+      accountExternalId: null,
+      displayName: null,
+      // Below the flow's own isValidPhone floor — sending it would plant junk
+      // in the contact's primary phone field.
+      blob: { version: 1, phone: '123' } as AccountOnboarding,
+      attribution: null,
+    });
+
+    expect(body).toEqual({ email: 'a@b.com', user_id: 'user-ext-1' });
+  });
+});
+
+describe('DaptaSyncEffects — enqueue', () => {
+  it('enqueues NOTHING when the flow env is unset (a bare fork stays silent)', async () => {
+    const effects = new DaptaSyncEffects(db, undefined);
+    expect(effects.enabled).toBe(false);
+
+    await effects.enqueueEarly('acc_1', 'mem_1');
+
+    expect(await listOutbox(db, { kind: 'dapta_sync' })).toHaveLength(0);
+  });
+
+  it('enqueues a durable row carrying only the principal ids', async () => {
+    const effects = new DaptaSyncEffects(db, envWith());
+
+    await effects.enqueueComplete('acc_1', 'mem_1');
+
+    const rows = await listOutbox(db, { kind: 'dapta_sync' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.action).toBe('complete');
+    expect(rows[0]!.accountId).toBe('acc_1');
+    // Ids only: answers are read FRESH at delivery time, never snapshotted.
+    expect(JSON.parse(String(rows[0]!.payload))).toEqual({
+      accountId: 'acc_1',
+      memberId: 'mem_1',
+    });
+  });
+});
+
+describe('DaptaSyncDelivery — worker-side', () => {
+  it('early: calls the flow once with email+phone+params and touches no IAM endpoint', async () => {
+    const { accountId, memberId } = await seedAccount({
+      attribution: { utmSource: 'landing' },
+    });
+    // The wizard's first answer — the moment the early sync fires.
+    await saveOnboardingProgress(db, accountId, { phone: '3001234567', lastStep: 'industry' });
+    await new DaptaSyncEffects(db, envWith()).enqueueEarly(accountId, memberId);
+
+    const calls: RecordedCall[] = [];
+    await newWorker(newDelivery(envWith(), calls)).drainOnce();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(FLOW_URL);
+    expect(calls[0]!.headers['x-api-key']).toBe('flow-key');
+    expect(calls[0]!.body).toMatchObject({
+      email: 'a@b.com',
+      user_id: 'user-ext-1',
+      account_id: 'org-ext-1',
+      phone: '3001234567',
+      params: { utm_source: 'landing' },
+    });
+    expect((await listOutbox(db, { kind: 'dapta_sync' }))[0]!.status).toBe('done');
+  });
+
+  it('complete: writes the IAM responses BEFORE calling the flow', async () => {
+    const { accountId, memberId } = await seedAccount({ attribution: null });
+    await claimOnboardingComplete(
+      db,
+      accountId,
+      'blank',
+      { industry: 'computer_software', crm: 'hubspot', leadVolume: '201_500' },
+      'cold',
+    );
+    await new DaptaSyncEffects(db, envWith()).enqueueComplete(accountId, memberId);
+
+    const calls: RecordedCall[] = [];
+    await newWorker(newDelivery(envWith(), calls)).drainOnce();
+
+    // The order IS the contract: the flow reads the answers back from the IAM,
+    // so the responses POST must land before the webhook fires.
+    expect(calls.map((c) => c.url)).toEqual([
+      `${IAM_URL}/onboarding/questions?stage=pre_signup`,
+      `${IAM_URL}/onboarding/status/user-ext-1`,
+      `${IAM_URL}/onboarding/responses`,
+      FLOW_URL,
+    ]);
+    expect(calls[2]!.headers['x-api-key']).toBe('iam-key');
+    expect(calls[2]!.body).toEqual({
+      user_id: 'user-ext-1',
+      responses: [
+        { question_id: 'q-industry', selected_option_ids: ['o-software'] },
+        { question_id: 'q-crm', selected_option_ids: ['o-hubspot'] },
+        { question_id: 'q-volume', selected_option_ids: ['o-mid'] },
+      ],
+    });
+    expect((await listOutbox(db, { kind: 'dapta_sync' }))[0]!.status).toBe('done');
+  });
+
+  it('complete: an already-completed IAM status skips the POST but still syncs the contact', async () => {
+    const { accountId, memberId } = await seedAccount({});
+    await claimOnboardingComplete(db, accountId, 'blank', { industry: 'retail' }, 'cold');
+    await new DaptaSyncEffects(db, envWith()).enqueueComplete(accountId, memberId);
+
+    const calls: RecordedCall[] = [];
+    // A retried row after a first success, or a user who completed on Dapta's
+    // side meanwhile: double-posting semantics are unspecified upstream, so
+    // the status guard is what makes the retry safe.
+    await newWorker(newDelivery(envWith(), calls, { hasCompleted: true })).drainOnce();
+
+    const urls = calls.map((c) => c.url);
+    expect(urls).not.toContain(`${IAM_URL}/onboarding/responses`);
+    expect(urls[urls.length - 1]).toBe(FLOW_URL);
+    expect((await listOutbox(db, { kind: 'dapta_sync' }))[0]!.status).toBe('done');
+  });
+
+  it('complete: a dapta-cohort blob makes no IAM call at all', async () => {
+    const { accountId, memberId } = await seedAccount({});
+    // Their industry/CRM/volume live in Dapta already; Forms only asked the
+    // two questions the bank does not have.
+    await claimOnboardingComplete(
+      db,
+      accountId,
+      'blank',
+      { leadSource: 'outbound', useCase: 'leads' },
+      'dapta',
+    );
+    await new DaptaSyncEffects(db, envWith()).enqueueComplete(accountId, memberId);
+
+    const calls: RecordedCall[] = [];
+    await newWorker(newDelivery(envWith(), calls)).drainOnce();
+
+    expect(calls.map((c) => c.url)).toEqual([FLOW_URL]);
+  });
+
+  it('skips a member with no external identity — the flow dies silently on unknown ids', async () => {
+    const { accountId, memberId } = await seedAccount({ memberExternalId: null });
+    await new DaptaSyncEffects(db, envWith()).enqueueEarly(accountId, memberId);
+
+    const calls: RecordedCall[] = [];
+    await newWorker(newDelivery(envWith(), calls)).drainOnce();
+
+    expect(calls).toHaveLength(0);
+    const row = (await listOutbox(db, { kind: 'dapta_sync' }))[0]!;
+    expect(row.status).toBe('skipped');
+    expect(row.lastError).toMatch(/external identity/);
+  });
+
+  it('retries on a flow 5xx with backoff instead of losing the sync', async () => {
+    const { accountId, memberId } = await seedAccount({});
+    await saveOnboardingProgress(db, accountId, { phone: '3001234567', lastStep: 'industry' });
+    await new DaptaSyncEffects(db, envWith()).enqueueEarly(accountId, memberId);
+
+    await newWorker(newDelivery(envWith(), [], { flowStatus: 503 })).drainOnce();
+
+    const row = (await listOutbox(db, { kind: 'dapta_sync' }))[0]!;
+    expect(row.status).toBe('pending');
+    expect(row.attempts).toBe(1);
+    expect(row.lastError).toMatch(/HTTP 503/);
+  });
+
+  it('skips rows drained after the env was removed', async () => {
+    const { accountId, memberId } = await seedAccount({});
+    await new DaptaSyncEffects(db, envWith()).enqueueEarly(accountId, memberId);
+
+    const calls: RecordedCall[] = [];
+    await newWorker(newDelivery(undefined, calls)).drainOnce();
+
+    expect(calls).toHaveLength(0);
+    expect((await listOutbox(db, { kind: 'dapta_sync' }))[0]!.status).toBe('skipped');
+  });
+});
+
+describe('AdminService — enqueue triggers', () => {
+  function newAdmin(effects: DaptaSyncEffects) {
+    return new AdminService(db, undefined, undefined, true, effects);
+  }
+
+  it('fires the early sync on the FIRST answer and never again', async () => {
+    const { accountId, memberId } = await seedAccount({});
+    const effects = new DaptaSyncEffects(db, envWith());
+    const admin = newAdmin(effects);
+    const p = { accountId, memberId, role: 'owner' as const };
+
+    // Arrival patch: a step was SEEN, nothing was answered.
+    await admin.saveOnboarding(p, { lastStep: 'phone' });
+    expect(await listOutbox(db, { kind: 'dapta_sync' })).toHaveLength(0);
+
+    // First answer → the person should exist in the CRM from here on.
+    await admin.saveOnboarding(p, { phone: '3001234567', lastStep: 'industry' });
+    expect(await listOutbox(db, { kind: 'dapta_sync' })).toHaveLength(1);
+
+    // Second answer → the early moment already happened.
+    await admin.saveOnboarding(p, { industry: 'retail', lastStep: 'crm' });
+    expect(await listOutbox(db, { kind: 'dapta_sync' })).toHaveLength(1);
+  });
+
+  it('fires the complete sync for the claim WINNER only', async () => {
+    const { accountId, memberId } = await seedAccount({});
+    const effects = new DaptaSyncEffects(db, envWith());
+    const admin = newAdmin(effects);
+    const p = { accountId, memberId, role: 'owner' as const };
+
+    const first = await admin.completeOnboarding(p, { template: 'blank', cohort: 'cold' });
+    expect(first.completed).toBe(true);
+    const afterWin = await listOutbox(db, { kind: 'dapta_sync' });
+    expect(afterWin.filter((r) => r.action === 'complete')).toHaveLength(1);
+
+    // The double-submit loser must not sync twice.
+    const second = await admin.completeOnboarding(p, { template: 'blank', cohort: 'cold' });
+    expect(second.completed).toBe(false);
+    const afterLoss = await listOutbox(db, { kind: 'dapta_sync' });
+    expect(afterLoss.filter((r) => r.action === 'complete')).toHaveLength(1);
+  });
+});

--- a/apps/api/src/dapta-sync.ts
+++ b/apps/api/src/dapta-sync.ts
@@ -1,0 +1,307 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { getAccountOnboarding, getMe, getMemberIdentity, sql, type Db } from '@quill/db';
+import type { ServerEnv } from '@quill/config/env';
+import type { AccountOnboarding, Attribution } from '@quill/types';
+import { DB, ENV } from './tokens';
+import { OutboxSkipError } from './email-effects';
+import type { DaptaSyncPayload } from './dapta-sync-effects';
+
+/**
+ * Worker-side delivery of a `dapta_sync` outbox row: push a new account's
+ * onboarding into the Dapta estate.
+ *
+ * Two external systems, called in a load-bearing order:
+ *
+ *   1. IAM `POST /onboarding/responses` — stores the answers that exist in
+ *      Dapta's own question bank and computes the lead score. Only on the
+ *      `complete` action, and only when there is at least one mappable answer.
+ *   2. The FlowStudio contact-sync flow — upserts the HubSpot contact by
+ *      email. The flow itself reads the answers back FROM the IAM (they do not
+ *      travel in the webhook body), which is why the IAM write must land
+ *      first: called in the other order, the flow would sync a contact with no
+ *      answers and nothing would ever retry it.
+ *
+ * Failure policy mirrors AnalyticsCapture, because the outbox reads it the
+ * same way: network/timeout/429/5xx → throw (retry with backoff); a 4xx from
+ * the flow → OutboxSkipError (permanent, recorded once). One deliberate
+ * exception: a permanent IAM rejection LOGS and falls through to the flow
+ * call instead of skipping the row — the contact sync is independently
+ * valuable, and the answers remain safe in our own database either way.
+ */
+@Injectable()
+export class DaptaSyncDelivery {
+  private readonly log = new Logger('DaptaSyncDelivery');
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl: typeof fetch = fetch;
+  /** Question-bank cache — one GET per burst of signups, not one per row. */
+  private bank: { fetchedAt: number; questions: IamQuestion[] } | null = null;
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Optional() @Inject(ENV) private readonly env?: ServerEnv,
+  ) {}
+
+  /** The worker's executor for a `dapta_sync` outbox row. */
+  async deliver(action: string, payloadJson: string): Promise<void> {
+    const flowUrl = this.env?.DAPTA_SYNC_FLOW_URL;
+    const flowKey = this.env?.DAPTA_SYNC_FLOW_KEY;
+    if (!flowUrl || !flowKey) {
+      // A row enqueued before the env was removed. A decision, not a failure.
+      throw new OutboxSkipError('dapta_sync: flow URL/key not configured');
+    }
+
+    const payload = JSON.parse(payloadJson) as DaptaSyncPayload;
+
+    // Everything below is read fresh — see DaptaSyncPayload for why.
+    const identity = await getMemberIdentity(this.db, payload.accountId, payload.memberId);
+    if (!identity?.externalId) {
+      // Local-auth accounts have no Dapta identity — and the flow's own code
+      // dies silently on an unknown user_id, so refusing here is the only
+      // place this failure is ever visible.
+      throw new OutboxSkipError('dapta_sync: member has no external identity');
+    }
+    if (!identity.email) {
+      // Email is the flow's upsert key; without it the call can do nothing.
+      throw new OutboxSkipError('dapta_sync: member has no email');
+    }
+    const me = await getMe(this.db, payload.accountId, payload.memberId);
+    const state = await getAccountOnboarding(this.db, payload.accountId);
+    const blob = state?.onboarding ?? null;
+    const account = await this.db.get<{ external_id: string | null }>(
+      sql`SELECT external_id FROM account WHERE id = ${payload.accountId} LIMIT 1`,
+    );
+
+    if (action === 'complete' && blob) {
+      await this.pushIamResponses(identity.externalId, blob);
+    }
+
+    const body = buildFlowPayload({
+      email: identity.email,
+      userId: identity.externalId,
+      accountExternalId: account?.external_id ?? null,
+      displayName: me?.displayName ?? null,
+      blob,
+      attribution: me?.attribution ?? null,
+    });
+
+    let res: Response;
+    try {
+      res = await this.fetchImpl(flowUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': flowKey },
+        body: JSON.stringify(body),
+        // The flow holds a fixed 2s Wait node inside; observed end-to-end run
+        // is ~3.5s, so the analytics default of 10s would sit too close to the
+        // healthy path.
+        signal: AbortSignal.timeout(FLOW_TIMEOUT_MS),
+      });
+    } catch (err) {
+      // Network-level: unreachable, DNS, TLS, timeout. All transient.
+      throw new Error(`dapta_sync flow call failed: ${String(err)}`);
+    }
+    if (!res.ok) {
+      if (res.status === 429 || res.status >= 500) {
+        throw new Error(`dapta_sync flow call failed: HTTP ${res.status}`);
+      }
+      throw new OutboxSkipError(`dapta_sync: flow rejected ${action} with HTTP ${res.status}`);
+    }
+  }
+
+  /**
+   * Write the mappable answers to the IAM, guarded by its own status endpoint.
+   *
+   * The guard is what makes a retried row safe: `POST /onboarding/responses`
+   * flips `has_completed_onboarding` on first success, so a retry that finds
+   * it already flipped must not post again (double-posting semantics are
+   * unspecified upstream). It also covers the `dapta` cohort for free — those
+   * users completed Dapta's own onboarding, the status reads completed, and
+   * nothing is posted on their behalf.
+   */
+  private async pushIamResponses(externalId: string, blob: AccountOnboarding): Promise<void> {
+    const base = this.env?.IAM_BASE_URL?.replace(/\/+$/, '');
+    const key = this.env?.IAM_API_KEY;
+    // No IAM configured is a deployment shape, not an error: the flow call
+    // still runs and the answers stay in our own database.
+    if (!base || !key) return;
+    // Nothing mappable — the whole `dapta` cohort — makes NO IAM request at
+    // all, not even the bank fetch.
+    if (!hasMappableAnswer(blob)) return;
+
+    const { responses, unmapped } = buildIamResponses(blob, await this.questionBank(base, key));
+    if (unmapped.length > 0) {
+      // Keys only, never values — an answer is a person's data.
+      this.log.warn(`dapta_sync: no IAM home for answer(s): ${unmapped.join(', ')}`);
+    }
+    if (responses.length === 0) return;
+
+    const status = await this.iamGet<{ has_completed_onboarding?: boolean }>(
+      `${base}/onboarding/status/${encodeURIComponent(externalId)}`,
+      key,
+    );
+    if (status.has_completed_onboarding) return;
+
+    let res: Response;
+    try {
+      res = await this.fetchImpl(`${base}/onboarding/responses`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': key },
+        body: JSON.stringify({ user_id: externalId, responses }),
+        signal: AbortSignal.timeout(IAM_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw new Error(`dapta_sync IAM responses failed: ${String(err)}`);
+    }
+    if (res.ok) return;
+    if (res.status === 429 || res.status >= 500) {
+      throw new Error(`dapta_sync IAM responses failed: HTTP ${res.status}`);
+    }
+    // Permanent rejection: log and fall through to the flow call — see the
+    // class docblock for why this is not a row-level skip.
+    this.log.warn(`dapta_sync: IAM rejected responses with HTTP ${res.status}`);
+  }
+
+  /** GET against the IAM where any failure is transient (throw → retry). */
+  private async iamGet<T>(url: string, key: string): Promise<T> {
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        headers: { 'x-api-key': key },
+        signal: AbortSignal.timeout(IAM_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw new Error(`dapta_sync IAM GET failed: ${String(err)}`);
+    }
+    if (!res.ok) throw new Error(`dapta_sync IAM GET failed: HTTP ${res.status}`);
+    return (await res.json()) as T;
+  }
+
+  /**
+   * The IAM's pre-signup question bank, cached briefly. The bank changes on
+   * the order of months; the TTL exists so a burst of signups shares one GET,
+   * not so the cache is ever meaningfully stale.
+   */
+  private async questionBank(base: string, key: string): Promise<IamQuestion[]> {
+    const now = Date.now();
+    if (this.bank && now - this.bank.fetchedAt < BANK_TTL_MS) return this.bank.questions;
+    const questions = await this.iamGet<IamQuestion[]>(
+      `${base}/onboarding/questions?stage=pre_signup`,
+      key,
+    );
+    this.bank = { fetchedAt: now, questions };
+    return questions;
+  }
+}
+
+/** Observed live run ~3.5s (the flow holds a fixed 2s Wait node inside). */
+const FLOW_TIMEOUT_MS = 15_000;
+const IAM_TIMEOUT_MS = 10_000;
+const BANK_TTL_MS = 5 * 60_000;
+
+/** The subset of the IAM question shape this mapper reads. */
+export interface IamQuestion {
+  id: string;
+  question_key?: string;
+  options?: Array<{ id: string; option_value?: string }>;
+}
+
+/**
+ * Which of our answers map into Dapta's bank, by the bank's own stable
+ * `question_key` — NEVER by hardcoded question UUIDs, which belong to another
+ * team's database. Our option values are a verified subset of the bank's
+ * `option_value`s (the industry list, CRM list and volume buckets were copied
+ * from it verbatim), so the option lookup is an identity match.
+ *
+ * `leadSource` and `useCase` are deliberately absent: the bank has no such
+ * questions, so they live only in our own database until Dapta adds them.
+ */
+const IAM_QUESTION_FIELDS = [
+  ['industry', 'industry'],
+  ['crm', 'crm_usage'],
+  ['leadVolume', 'contacts_per_month'],
+] as const satisfies ReadonlyArray<readonly [keyof AccountOnboarding, string]>;
+
+/** Does this blob hold at least one answer the IAM bank has a home for? */
+export function hasMappableAnswer(blob: AccountOnboarding): boolean {
+  return IAM_QUESTION_FIELDS.some(([field]) => {
+    const value = blob[field];
+    return typeof value === 'string' && value.length > 0;
+  });
+}
+
+/**
+ * Build the IAM responses payload from the stored blob. Pure — unit-testable
+ * without a database or network. An answer whose question or option is missing
+ * from the bank is returned in `unmapped` (by key) rather than dropped
+ * silently, so the caller can log that the bank drifted.
+ */
+export function buildIamResponses(
+  blob: AccountOnboarding,
+  bank: IamQuestion[],
+): {
+  responses: Array<{ question_id: string; selected_option_ids: string[] }>;
+  unmapped: string[];
+} {
+  const responses: Array<{ question_id: string; selected_option_ids: string[] }> = [];
+  const unmapped: string[] = [];
+  for (const [field, questionKey] of IAM_QUESTION_FIELDS) {
+    const value = blob[field];
+    if (typeof value !== 'string' || !value) continue;
+    const question = bank.find((q) => q.question_key === questionKey);
+    const option = question?.options?.find((o) => o.option_value === value);
+    if (!question || !option) {
+      unmapped.push(field);
+      continue;
+    }
+    responses.push({ question_id: question.id, selected_option_ids: [option.id] });
+  }
+  return { responses, unmapped };
+}
+
+/** What the contact-sync flow's trigger accepts. */
+export interface FlowPayload {
+  email: string;
+  user_id: string;
+  account_id?: string;
+  phone?: string;
+  name?: string;
+  params?: Record<string, string>;
+}
+
+/**
+ * The flow's `isValidPhone` floor, mirrored so we never send a value the flow
+ * would classify as junk (it stores phone into the contact's primary field).
+ */
+const MIN_PHONE_LENGTH = 7;
+
+/**
+ * Build the flow webhook body. Pure — unit-testable.
+ *
+ * `params` is FLAT and carries only the three utm_* keys the flow's code
+ * actually reads (`utm_source`, `utm_medium`, `utm_campaign`) — verified
+ * against the flow's own JSON. gclid/fbclid have no vehicle and are dropped.
+ * Empty values are omitted entirely; an empty `params` omits the field.
+ */
+export function buildFlowPayload(input: {
+  email: string;
+  userId: string;
+  accountExternalId: string | null;
+  displayName: string | null;
+  blob: AccountOnboarding | null;
+  attribution: Attribution | null;
+}): FlowPayload {
+  const body: FlowPayload = { email: input.email, user_id: input.userId };
+  if (input.accountExternalId) body.account_id = input.accountExternalId;
+  if (input.displayName) body.name = input.displayName;
+
+  const phone = input.blob?.phone?.trim();
+  if (phone && phone.length >= MIN_PHONE_LENGTH) body.phone = phone;
+
+  const params: Record<string, string> = {};
+  const a = input.attribution;
+  if (a?.utmSource) params.utm_source = a.utmSource;
+  if (a?.utmMedium) params.utm_medium = a.utmMedium;
+  if (a?.utmCampaign) params.utm_campaign = a.utmCampaign;
+  if (Object.keys(params).length > 0) body.params = params;
+
+  return body;
+}

--- a/apps/api/src/onboarding.controller.spec.ts
+++ b/apps/api/src/onboarding.controller.spec.ts
@@ -339,13 +339,13 @@ describe('POST /v1/account/onboarding/complete', () => {
   it('preserves the answers gathered on the way', async () => {
     const c = controllerWith(true);
     await c.saveOnboarding(asOwner(), { role: 'marketing', lastStep: 'role' });
-    await c.saveOnboarding(asOwner(), { industry: 'agency', lastStep: 'industry' });
+    await c.saveOnboarding(asOwner(), { industry: 'marketing_advertising', lastStep: 'industry' });
     await c.saveOnboarding(asOwner(), { useCase: 'feedback', lastStep: 'use_case' });
     await c.completeOnboarding(asOwner(), { template: 'customer-feedback' });
 
     expect((await getAccountOnboarding(db, accountId))?.onboarding).toMatchObject({
       role: 'marketing',
-      industry: 'agency',
+      industry: 'marketing_advertising',
       useCase: 'feedback',
       template: 'customer-feedback',
       lastStep: 'template',
@@ -363,13 +363,13 @@ describe('POST /v1/account/onboarding/complete', () => {
     await c.completeOnboarding(asOwner(), {
       template: 'lead-qualifier',
       role: 'founder',
-      industry: 'software',
+      industry: 'computer_software',
       useCase: 'leads',
     });
 
     expect((await getAccountOnboarding(db, accountId))?.onboarding).toMatchObject({
       role: 'founder',
-      industry: 'software',
+      industry: 'computer_software',
       useCase: 'leads',
       template: 'lead-qualifier',
     });

--- a/apps/api/src/outbox.worker.ts
+++ b/apps/api/src/outbox.worker.ts
@@ -22,6 +22,7 @@ import { EmailEffects, OutboxSkipError } from './email-effects';
 import { DestinationEffects } from './destination-effects';
 import { BookingSyncEffects } from './booking-sync';
 import { AnalyticsCapture } from './analytics-capture';
+import { DaptaSyncDelivery } from './dapta-sync';
 import { DB, ENV } from './tokens';
 
 /**
@@ -61,6 +62,7 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
     // Optional so existing direct constructions (tests) keep working.
     @Optional() @Inject(BookingSyncEffects) private readonly bookingSync?: BookingSyncEffects,
     @Optional() @Inject(AnalyticsCapture) private readonly analytics?: AnalyticsCapture,
+    @Optional() @Inject(DaptaSyncDelivery) private readonly daptaSync?: DaptaSyncDelivery,
   ) {}
 
   onModuleInit(): void {
@@ -156,6 +158,14 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       // failures in a queue shared with emails and CRM deliveries.
       if (!this.analytics) throw new OutboxSkipError('analytics handler not wired');
       await this.analytics.deliver(row.action, row.payload);
+      return;
+    }
+    if (row.kind === 'dapta_sync') {
+      if (row.payload == null) throw new Error('dapta_sync outbox row missing payload');
+      // Same reasoning as analytics: an unwired handler is a deployment that
+      // does not sync into the Dapta estate, never a delivery failure.
+      if (!this.daptaSync) throw new OutboxSkipError('dapta_sync handler not wired');
+      await this.daptaSync.deliver(row.action, row.payload);
       return;
     }
     throw new Error(`unknown outbox kind: ${String(row.kind)}`);

--- a/apps/web/app/onboarding/onboarding.css
+++ b/apps/web/app/onboarding/onboarding.css
@@ -179,6 +179,47 @@
   letter-spacing: 0.1em;
 }
 
+/* --- The phone screen ------------------------------------------------------
+ *
+ * The only screen with buttons. Every other question advances on the choice
+ * itself, but a number is typed a digit at a time and cannot know when the
+ * person is finished.
+ *
+ * The label sits ABOVE the input rather than inside the question, because that
+ * is how Dapta's own signup words it: the heading asks nothing ("Tell us about
+ * you") and the field is labelled plainly. A phrasing with a verb in it —
+ * "what number should we call you on?" — announces a sales call, and the honest
+ * answer to that is no.
+ */
+.ob__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-foreground);
+  margin: 0 0 8px;
+}
+
+/* Quiet by design: a skip that competes with the CTA turns a considered choice
+   into a coin flip, and one that hides is a dark pattern. This reads as an
+   available option and not as the recommended one. */
+.ob__skip {
+  display: block;
+  width: 100%;
+  margin-top: 12px;
+  padding: 10px;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 14px;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  border-radius: var(--pf-radius-sm);
+  transition: color 0.12s;
+}
+
+.ob__skip:hover {
+  color: var(--foreground);
+}
+
 /* --- The question screens, packed to one viewport --------------------------
  *
  * The renderer stacks single-select options as full-width rows — right for a

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
 import { preferredLocale } from '@/lib/locale';
+import { currentOnboardingCohort } from '@/lib/dapta-onboarding';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
 import { ProductAnalytics } from '@/components/analytics/product-analytics';
 import { OnboardingWizard } from './wizard';
@@ -37,6 +38,14 @@ export default async function OnboardingPage() {
   const locale = await preferredLocale();
   const messages = getMessages(locale).admin.onboarding;
 
+  // Which questions this person gets. Resolved HERE, before the first paint,
+  // because it decides the FIRST screen — a client-side probe would render the
+  // cold wizard and then yank three screens out from under someone who came
+  // from Dapta. Bounded and failure-tolerant by construction: see
+  // `resolveOnboardingCohort`, which answers "dapta" (the shorter path) for any
+  // failure rather than asking a Dapta customer what Dapta already knows.
+  const cohort = await currentOnboardingCohort();
+
   return (
     <>
       <ProductAnalytics
@@ -50,7 +59,7 @@ export default async function OnboardingPage() {
           attribution: me.attribution,
         }}
       />
-      <OnboardingWizard messages={messages} locale={locale} />
+      <OnboardingWizard messages={messages} locale={locale} cohort={cohort} />
     </>
   );
 }

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * The first-run wizard: three questions, then the template the first form is
+ * The first-run wizard: a few questions, then the template the first form is
  * built from.
  *
  * It IS a Dapta form, not a page that resembles one. The chrome is the public
@@ -16,10 +16,16 @@
  * are named from the first paint — seeing that there are three is what stops
  * the second question feeling like the fifth.
  *
- * There is NO skip on the questions. They are three taps, and an answer that can
- * be skipped is an answer most people skip, which would leave the column this
- * whole feature exists to fill mostly empty. The template screen offers "start
- * from scratch" instead, which is an honest choice rather than a way out.
+ * ONE question can be skipped, and only one: the phone number. The rest are a
+ * tap each, and an answer that can be skipped is an answer most people skip,
+ * which would leave the column this whole feature exists to fill mostly empty.
+ * A phone number is the single real keyboard in the flow, so refusing it has to
+ * stay possible — and "asked and declined" is itself a fact worth storing.
+ *
+ * HOW MANY questions there are depends on who is asking. Someone arriving from
+ * Dapta AI already gave Dapta their industry, CRM, lead volume and phone number,
+ * so they see two screens where a cold signup sees six. Nothing here hardcodes a
+ * count — see `cohort`.
  *
  * Every advance patches the server. That is deliberate and is the difference
  * between a funnel and a completion count: the person who quits on question two
@@ -32,7 +38,11 @@ import { StepInput } from '@/components/public/step-input';
 import { FormsLockup, FormsMark } from '@/components/brand/forms-logo';
 import { captureEvent } from '@/lib/product-analytics';
 import { fill, wizardQuestions, wizardTemplates } from '@/lib/onboarding';
-import { USE_CASE_TEMPLATE, type OnboardingUseCase } from '@quill/types';
+import {
+  USE_CASE_TEMPLATE,
+  type OnboardingCohort,
+  type OnboardingUseCase,
+} from '@quill/types';
 import { saveOnboardingStepAction, completeOnboardingAction } from './actions';
 // The renderer's own stylesheet. Every rule in it is scoped under `.pf`, so
 // importing it here cannot leak into the dashboard — and it is what makes this
@@ -46,8 +56,21 @@ type Messages = FormsMessages['admin']['onboarding'];
 const QUESTION_STAGE = 2;
 const TEMPLATE_STAGE = 3;
 
-export function OnboardingWizard({ messages: m, locale }: { messages: Messages; locale: Locale }) {
-  const questions = useMemo(() => wizardQuestions(m), [m]);
+export function OnboardingWizard({
+  messages: m,
+  locale,
+  cohort,
+}: {
+  messages: Messages;
+  locale: Locale;
+  /**
+   * Which set of screens this person gets, resolved server-side against the
+   * Dapta IAM. Passed in rather than fetched here: it decides the FIRST screen,
+   * so it has to be known before the first paint.
+   */
+  cohort: OnboardingCohort;
+}) {
+  const questions = useMemo(() => wizardQuestions(m, cohort), [m, cohort]);
   const templates = useMemo(() => wizardTemplates(m), [m]);
 
   const [index, setIndex] = useState(0);
@@ -56,11 +79,26 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
   const [submitting, startSubmit] = useTransition();
   /** Set when the completion could not be made — see `finish`. */
   const [failed, setFailed] = useState(false);
+  /**
+   * The phone field as it is being typed.
+   *
+   * Kept apart from `answers` on purpose: `answers` is what gets PATCHed, and
+   * every other screen writes to it once, at the moment of a decision. A phone
+   * number arrives a digit at a time, so writing it there would send a patch per
+   * keystroke and store half-typed numbers.
+   */
+  const [draft, setDraft] = useState('');
+  /**
+   * Enough digits to be a number at all. Not validation — the input already
+   * builds E.164 and refuses letters — just a guard so the button cannot submit
+   * a bare country code.
+   */
+  const phoneUsable = draft.replace(/\D/g, '').length >= 8;
 
   /** Past the last question is the template screen. */
   const onTemplates = index >= questions.length;
   const current = onTemplates ? null : questions[index];
-  const stepKey = onTemplates ? 'template' : (current?.key ?? 'role');
+  const stepKey = onTemplates ? 'template' : (current?.key ?? questions[0]?.key ?? 'role');
 
   /**
    * The card the previous answer pre-selects. Recomputed rather than stored so
@@ -112,10 +150,14 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
     captureEvent('onboarding_step_viewed', {
       step_key: stepKey,
       step_index: index,
+      // The real length, not a constant. The two cohorts run different-length
+      // wizards, so a fixed total would count one against the other's
+      // denominator and make both drop-off rates meaningless.
       total_steps: questions.length + 1,
+      cohort,
     });
     if (index !== 0) return;
-    captureEvent('onboarding_started', { locale });
+    captureEvent('onboarding_started', { locale, cohort });
     // Claim the FIRST screen on arrival. Every later screen has its `lastStep`
     // written by the answer that led to it, but nothing precedes this one — so
     // without this patch, someone who opens the wizard and quits on question one
@@ -125,9 +167,46 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
     //
     // Harmless on a RETURN visit even though it re-announces step one: the
     // server only ever advances `lastStep`, so it cannot drag a stored
-    // `template` back to `role` and misfile a finisher as a first-question quit.
-    save({ lastStep: 'role' });
-  }, [stepKey, index, questions.length, locale, save]);
+    // `template` back and misfile a finisher as a first-question quit.
+    //
+    // Names the cohort's OWN first screen, which is `phone` for a cold signup
+    // and `role` for someone from Dapta — hardcoding `role` would have recorded
+    // every cold arrival as having already cleared the phone question.
+    const first = questions[0]?.key;
+    if (first) save({ lastStep: first });
+  }, [stepKey, index, questions, locale, cohort, save]);
+
+  /**
+   * Move to the screen after `from`, recording the one being REACHED.
+   *
+   * Shared by answering and by skipping, so the two can never disagree about
+   * what `lastStep` should say — the bug that would follow is silent and only
+   * shows up as a drop-off bucket that does not add up.
+   */
+  const advanceTo = useCallback(
+    (from: number, patch: Record<string, string | null>) => {
+      const advancing = from + 1;
+      // `lastStep` names the screen being REACHED, which is what makes the
+      // stored value a drop-off bucket rather than a record of the last answer.
+      const reached = questions[advancing]?.key ?? 'template';
+      save({ ...patch, lastStep: reached });
+      setIndex(advancing);
+    },
+    [questions, save],
+  );
+
+  /**
+   * Pass over a question that allows it — the phone screen, and only it.
+   *
+   * The skip is recorded as `null` rather than left absent, because "asked and
+   * declined" and "never asked" are different facts about a person and only one
+   * of them says anything about the question.
+   */
+  const skip = useCallback(() => {
+    if (!current?.skippable) return;
+    captureEvent('onboarding_step_skipped', { step_key: current.key, step_index: index, cohort });
+    advanceTo(index, { ...answers, [current.field]: null });
+  }, [advanceTo, answers, cohort, current, index]);
 
   /** Answer the current question and advance. Choosing IS continuing — one tap. */
   const answer = useCallback(
@@ -144,20 +223,19 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
       captureEvent('onboarding_step_answered', {
         step_key: current.key,
         step_index: index,
-        value,
+        // A phone number is PII and this event goes to a shared analytics
+        // project. Every other answer is an enum from a fixed list, so the value
+        // is the whole point; this one says only that it was given.
+        value: current.field === 'phone' ? '<provided>' : value,
+        cohort,
       });
-      const advancing = index + 1;
-      // `lastStep` names the screen being REACHED, which is what makes the
-      // stored value a drop-off bucket rather than a record of the last answer.
-      const reached = questions[advancing]?.key ?? 'template';
       // Every answer so far, not just this one. A patch that never landed — the
       // action swallows its failures by design — is repaired by the next advance
       // instead of leaving a permanent hole in the column, and the merge ignores
       // fields it already has, so re-sending them costs nothing.
-      save({ ...next, lastStep: reached });
-      setIndex(advancing);
+      advanceTo(index, next);
     },
-    [answers, current, index, questions, save],
+    [advanceTo, answers, cohort, current, index],
   );
 
   const back = useCallback(() => setIndex((i) => Math.max(0, i - 1)), []);
@@ -168,6 +246,7 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
         template: id,
         recommended: id === recommended,
         use_case: answers.useCase ?? null,
+        cohort,
       });
       setFailed(false);
       // `async` so the scope returns a PROMISE. A non-thenable body ends the
@@ -183,6 +262,14 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
           role: answers.role ?? null,
           industry: answers.industry ?? null,
           useCase: answers.useCase ?? null,
+          crm: answers.crm ?? null,
+          leadVolume: answers.leadVolume ?? null,
+          leadSource: answers.leadSource ?? null,
+          phone: answers.phone ?? null,
+          // The cohort travels too, so the server can record WHY the questions
+          // this person never saw are empty. Without it a Dapta account's null
+          // industry is indistinguishable from a gap in our own data.
+          cohort,
           locale,
         });
         // Only a FAILURE returns: every path where the API answered ends in a
@@ -193,7 +280,7 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
         if (result && !result.ok) setFailed(true);
       });
     },
-    [answers, locale, recommended],
+    [answers, cohort, locale, recommended],
   );
 
   const stage = onTemplates ? TEMPLATE_STAGE : QUESTION_STAGE;
@@ -247,23 +334,44 @@ export function OnboardingWizard({ messages: m, locale }: { messages: Messages; 
               </div>
 
               <div className="pf__fields">
+                {current.step.type === 'phone' ? <p className="ob__label">{m.phone.label}</p> : null}
                 <StepInput
                   step={current.step}
-                  value={answers[current.field] ?? ''}
+                  value={
+                    current.step.type === 'phone' ? draft : (answers[current.field] ?? '')
+                  }
                   answers={answers}
-                  // Only single-select choices and the dropdown are used here,
-                  // and both report through `onSelect`. The other two are
-                  // required by the shared component's contract and are wired to
-                  // no-ops rather than to `answer`: routing them there would
-                  // make a future step type (a slider, a text field) advance the
-                  // wizard on every keystroke.
+                  // Choices and the dropdown report through `onSelect`, and for
+                  // them choosing IS continuing. `onChange` is wired ONLY for the
+                  // phone step, which cannot auto-advance: a number is typed a
+                  // digit at a time, so advancing on change would leave on the
+                  // first keystroke. `onFieldChange` stays a no-op — no step type
+                  // here is multi-field.
                   onSelect={answer}
-                  onChange={() => {}}
+                  onChange={(v) => setDraft(String(v ?? ''))}
                   onFieldChange={() => {}}
                   dropdownPlaceholder={m.industry.placeholder}
                   dropdownEmpty={m.industry.empty}
                   locale={locale}
                 />
+
+                {/* The phone screen is the only one with buttons, because it is
+                    the only one that cannot know when the person is done. */}
+                {current.step.type === 'phone' ? (
+                  <>
+                    <button
+                      type="button"
+                      className="pf__btn ob__cta"
+                      disabled={!phoneUsable}
+                      onClick={() => answer(draft.trim())}
+                    >
+                      {m.next}
+                    </button>
+                    <button type="button" className="ob__skip" onClick={skip}>
+                      {m.phone.skip}
+                    </button>
+                  </>
+                ) : null}
               </div>
             </div>
           ) : (

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -150,6 +150,10 @@ export interface OnboardingProgress {
   role?: string | null;
   industry?: string | null;
   useCase?: string | null;
+  crm?: string | null;
+  leadVolume?: string | null;
+  leadSource?: string | null;
+  phone?: string | null;
   template?: string | null;
   lastStep?: string | null;
 }
@@ -164,6 +168,16 @@ export interface OnboardingComplete {
   role?: string | null;
   industry?: string | null;
   useCase?: string | null;
+  crm?: string | null;
+  leadVolume?: string | null;
+  leadSource?: string | null;
+  phone?: string | null;
+  /**
+   * Which screens this person was shown. The server needs it to record WHY the
+   * unasked ones are empty — a Dapta account's null industry is a pointer at
+   * Dapta, not a gap in our data.
+   */
+  cohort?: string;
   /** What the wizard rendered in, so the created form is named to match. */
   locale?: string;
 }

--- a/apps/web/lib/dapta-onboarding.ts
+++ b/apps/web/lib/dapta-onboarding.ts
@@ -1,0 +1,120 @@
+import 'server-only';
+import type { OnboardingCohort } from '@quill/types';
+import { getSession } from './auth-session';
+
+/**
+ * Did this person already answer Dapta AI's onboarding?
+ *
+ * Forms and Dapta AI share an identity: `member.external_id` is the `sub` of the
+ * IAM-minted JWT, and the IAM translates WorkOS ids before signing — so that
+ * value IS the Dapta `user.id`. Which means Forms can ask "do we already know
+ * this person?" with an id it already stores, and no integration to build.
+ *
+ * This runs in the WEB, not the API, and that is deliberate rather than
+ * incidental: `IAM_BASE_URL` is already in the web's environment (the login and
+ * logout routes read it), while the API has never needed it. Probing from the
+ * API would mean a configmap change owned by another team, for a lookup the web
+ * can do on the request it is already serving.
+ */
+
+/** The shape the IAM answers with. Everything past the two flags is unused here. */
+interface DaptaOnboardingStatus {
+  has_completed_onboarding?: boolean;
+  is_migrated_user?: boolean;
+}
+
+/**
+ * How long to wait before giving up.
+ *
+ * This sits in front of the wizard's FIRST paint, so the budget is a UX number,
+ * not a network one. Past this the answer stops being worth its latency and the
+ * fallback below takes over.
+ */
+const PROBE_TIMEOUT_MS = 800;
+
+/**
+ * The Dapta `user.id` behind the current session, or null.
+ *
+ * Read from the `sub` of the IAM-minted access token the session already holds,
+ * rather than from a new field on `/v1/me`. The claim is the same value either
+ * way — the API's own WorkOS adapter stores that `sub` as `member.external_id` —
+ * and taking it from the cookie keeps the Dapta user id off the API contract
+ * entirely.
+ *
+ * Decoded, NOT verified, and that is safe for exactly this use: the token comes
+ * out of our own httpOnly, HMAC-signed session cookie, and the only thing this
+ * value decides is WHICH QUESTIONS TO SHOW. It grants nothing. Every request
+ * that actually reads or writes data still carries the token to the API, which
+ * verifies it properly — that authority is not moved here.
+ */
+async function daptaUserId(): Promise<string | null> {
+  const session = await getSession();
+  if (session?.provider !== 'workos') return null;
+  const payload = session.accessToken.split('.')[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
+      sub?: unknown;
+    };
+    return typeof claims.sub === 'string' && claims.sub ? claims.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The cohort for whoever is signed in right now. */
+export async function currentOnboardingCohort(): Promise<OnboardingCohort> {
+  return resolveOnboardingCohort(await daptaUserId());
+}
+
+/**
+ * Which set of questions this person gets.
+ *
+ * Answers `'dapta'` — the SHORT path — for anyone who completed Dapta's
+ * onboarding or was migrated into it. `is_migrated_user` matters as much as the
+ * completion flag: a migrated customer is a customer, whether or not they ever
+ * walked through `pre_signup`.
+ *
+ * FAILS CLOSED on a FAILURE. A timeout, a 500, a DNS blip, a member with no
+ * external id — every one of those resolves to `'dapta'`, the cohort that gets
+ * asked LESS. The asymmetry is the point: guessing "cold" on a failure would let
+ * a few seconds of IAM latency ask Dapta's entire customer base for a phone
+ * number they already gave, which is the exact experience this probe exists to
+ * prevent. Guessing "dapta" costs three unasked questions.
+ *
+ * NO IAM CONFIGURED IS NOT A FAILURE. A self-hosting fork, or `pnpm dev`, has no
+ * Dapta behind it at all — nobody there can be arriving from a product the
+ * deployment does not know about, so everyone is cold and gets the full wizard.
+ * Folding that into the failure case would give a bare clone the short path and
+ * make three of the five screens unreachable in local development.
+ */
+export async function resolveOnboardingCohort(
+  externalId: string | null | undefined,
+): Promise<OnboardingCohort> {
+  const base = process.env.IAM_BASE_URL?.replace(/\/$/, '');
+  // No upstream identity service → no cross-sell cohort to protect.
+  if (!base) return 'cold';
+  // Configured, but this member has no id to look up. Anomalous in a deployment
+  // that has an IAM, so treat it as the failure it probably is.
+  if (!externalId) return 'dapta';
+
+  try {
+    const res = await fetch(`${base}/onboarding/status/${encodeURIComponent(externalId)}`, {
+      // The endpoint is key-gated. Sent only when configured: without the key
+      // the IAM answers 401, `!res.ok` fails closed to 'dapta', and nothing
+      // leaks — the header line just isn't worth a conditional shape.
+      headers: process.env.IAM_API_KEY ? { 'x-api-key': process.env.IAM_API_KEY } : undefined,
+      // `no-store`: the answer is per-person and changes the screen they see.
+      // A cached verdict would hand the next signup the previous one's cohort.
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      cache: 'no-store',
+    });
+    if (!res.ok) return 'dapta';
+    const status = (await res.json()) as DaptaOnboardingStatus;
+    return status.has_completed_onboarding || status.is_migrated_user ? 'dapta' : 'cold';
+  } catch {
+    // Includes the timeout. Nothing here is worth failing a page load over — the
+    // wizard still works, it just asks less.
+    return 'dapta';
+  }
+}

--- a/apps/web/lib/onboarding.spec.ts
+++ b/apps/web/lib/onboarding.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * The wizard's question bank, per cohort.
+ *
+ * What is actually worth pinning here is not that the lists are right — a diff
+ * shows that — but that everything downstream DERIVES from them. The counter,
+ * `lastStep`, and the drop-off buckets all read the selected list, so a cohort
+ * whose length disagrees with what is rendered silently counts one group against
+ * the other's denominator.
+ */
+import { describe, it, expect } from 'vitest';
+import { getMessages } from '@quill/shared';
+import { ONBOARDING_CRMS, ONBOARDING_INDUSTRIES, ONBOARDING_STEPS } from '@quill/types';
+import { skippedQuestions, wizardQuestions } from './onboarding';
+
+const m = getMessages('en').admin.onboarding;
+const keys = (cohort: 'cold' | 'dapta') => wizardQuestions(m, cohort).map((q) => q.key);
+
+describe('wizardQuestions — who is asked what', () => {
+  it('asks a cold signup everything, phone first', () => {
+    expect(keys('cold')).toEqual([
+      'phone',
+      'industry',
+      'crm',
+      'lead_volume',
+      'lead_source',
+      'use_case',
+    ]);
+  });
+
+  it('asks someone from Dapta only what Dapta CANNOT answer for them', () => {
+    // Industry, CRM, lead volume and a phone number are all in Dapta's own
+    // signup. Re-asking is the plainest way to tell a customer the two products
+    // do not talk to each other.
+    //
+    // The two that survive do so for opposite reasons: `lead_source` has no
+    // equivalent anywhere in the IAM, and `use_case` is what preselects a
+    // template on the next screen.
+    expect(keys('dapta')).toEqual(['lead_source', 'use_case']);
+  });
+
+  it('never asks for a role — the field lives on only so old blobs still parse', () => {
+    expect(keys('cold')).not.toContain('role');
+    expect(keys('dapta')).not.toContain('role');
+    // Still a legal step value: accounts onboarded before this release carry
+    // `lastStep: 'role'`, and the blob is validated in one pass — dropping it
+    // from the union would make those rows unreadable and take `industry` and
+    // `useCase` down with it.
+    expect(ONBOARDING_STEPS).toContain('role');
+  });
+
+  it('keeps both cohorts in canonical step order', () => {
+    // `lastStep` is only ever allowed to ADVANCE along ONBOARDING_STEPS, so a
+    // cohort that asked out of order would produce a bucket that can never be
+    // reached — the wizard would appear to stall on one screen forever.
+    for (const cohort of ['cold', 'dapta'] as const) {
+      const positions = keys(cohort).map((k) => ONBOARDING_STEPS.indexOf(k));
+      expect([...positions].sort((a, b) => a - b), cohort).toEqual(positions);
+    }
+  });
+
+  it('lets ONLY the phone screen be skipped', () => {
+    const skippable = wizardQuestions(m, 'cold')
+      .filter((q) => q.skippable)
+      .map((q) => q.key);
+    expect(skippable).toEqual(['phone']);
+  });
+
+  it('names the steps a cohort never sees, so the blob can say why they are empty', () => {
+    expect(skippedQuestions('dapta').sort()).toEqual([
+      'crm',
+      'industry',
+      'lead_volume',
+      'phone',
+    ]);
+    // A cold signup is shown every question there is.
+    expect(skippedQuestions('cold')).toEqual([]);
+    // `role` is not "skipped" for anyone — it is no longer a question at all, so
+    // it never gets a reason recorded beside it.
+    expect(skippedQuestions('dapta')).not.toContain('role');
+  });
+
+  it('labels every option from the catalog — no value renders as its own key', () => {
+    const industry = wizardQuestions(m, 'cold').find((q) => q.key === 'industry');
+    const crm = wizardQuestions(m, 'cold').find((q) => q.key === 'crm');
+    expect(industry?.step.options).toHaveLength(ONBOARDING_INDUSTRIES.length);
+    expect(crm?.step.options).toHaveLength(ONBOARDING_CRMS.length);
+    for (const opt of [...(industry?.step.options ?? []), ...(crm?.step.options ?? [])]) {
+      expect(opt.label, opt.value).toBeTruthy();
+      expect(opt.label, opt.value).not.toBe(opt.value);
+    }
+  });
+
+  it('carries the IAM bank verbatim, so the two products join', () => {
+    // Spot-checks rather than the whole list: these are the values that used to
+    // be Forms-only inventions (`software`, `agency`, `realestate`).
+    for (const v of ['computer_software', 'marketing_advertising', 'real_estate', 'hubspot']) {
+      expect([...ONBOARDING_INDUSTRIES, ...ONBOARDING_CRMS]).toContain(v);
+    }
+    // The bank ships `none` AND `no_crm` for the same answer. Offering both would
+    // split the one segment that matters most across two values.
+    expect(ONBOARDING_CRMS).not.toContain('no_crm');
+  });
+});

--- a/apps/web/lib/onboarding.ts
+++ b/apps/web/lib/onboarding.ts
@@ -15,39 +15,52 @@
 import type { FormsMessages } from '@quill/shared';
 import type { FormStep } from '@quill/engine';
 import {
+  ONBOARDING_COHORTS,
+  ONBOARDING_CRMS,
   ONBOARDING_INDUSTRIES,
-  ONBOARDING_ROLES,
+  ONBOARDING_LEAD_SOURCES,
+  ONBOARDING_LEAD_VOLUMES,
+  ONBOARDING_STEPS,
   ONBOARDING_USE_CASES,
   FORM_TEMPLATE_IDS,
   type FormTemplateId,
+  type OnboardingCohort,
   type OnboardingStep,
 } from '@quill/types';
 
 type OnboardingMessages = FormsMessages['admin']['onboarding'];
 
+/** Every step that is a QUESTION — `template` is the picker, not one of these. */
+export type WizardQuestionKey = Exclude<OnboardingStep, 'template'>;
+
 export interface WizardQuestion {
-  key: Extract<OnboardingStep, 'role' | 'industry' | 'use_case'>;
+  key: WizardQuestionKey;
   /** Which `OnboardingProgress` field this question's answer patches. */
-  field: 'role' | 'industry' | 'useCase';
+  field: 'role' | 'industry' | 'useCase' | 'crm' | 'phone' | 'leadVolume' | 'leadSource';
   /** The step `StepInput` renders — a real form question, not a lookalike. */
   step: FormStep;
+  /**
+   * May this one be passed over? Only the phone screen can be. Every other
+   * question is three taps, and an answer that can be skipped is an answer most
+   * people skip — which would leave the column this whole feature exists to fill
+   * mostly empty. A phone number is the one real keyboard in the flow, so
+   * refusing it has to stay an option, and "asked and declined" is itself a fact
+   * worth storing.
+   */
+  skippable?: boolean;
 }
 
 /**
- * Per-role glyphs, keyed by the enum so a new role cannot ship without one.
- * Icons are here rather than in the i18n catalog because they are the same in
- * every language — duplicating them per locale would only create a way for the
- * two to disagree.
+ * One glyph per lead source, keyed by the enum so a new source cannot ship
+ * without one. `none` gets the empty-state mark rather than a channel logo —
+ * "no leads yet" is an answer, not a channel.
  */
-const ROLE_ICONS: Readonly<Record<(typeof ONBOARDING_ROLES)[number], string>> = {
-  sales: '\u{1F4B0}',
-  marketing: '\u{1F4E3}',
-  support: '\u{1F4AC}',
-  product: '\u{1F9ED}',
-  founder: '\u{1F680}',
-  engineering: '\u{1F4BB}',
-  hr: '\u{1F91D}',
-  operations: '\u{2699}',
+const LEAD_SOURCE_ICONS: Readonly<Record<(typeof ONBOARDING_LEAD_SOURCES)[number], string>> = {
+  none: '\u{1F331}',
+  facebook_ads: '\u{1F4D8}',
+  google_ads: '\u{1F50E}',
+  outbound: '\u{1F4E4}',
+  internal_lists: '\u{1F4C7}',
   other: '\u{2728}',
 };
 
@@ -59,26 +72,32 @@ const USE_CASE_ICONS: Readonly<Record<(typeof ONBOARDING_USE_CASES)[number], str
   other: '\u{2728}',
 };
 
-/** The three questions, in the order they are asked. */
-export function wizardQuestions(m: OnboardingMessages): WizardQuestion[] {
+/**
+ * Every question the wizard knows how to ask, in canonical order.
+ *
+ * `wizardQuestions` selects from this by cohort — nobody is shown all of it.
+ * Order matches `ONBOARDING_STEPS`, which is what keeps `lastStep` monotonic and
+ * both cohorts subsequences of one another.
+ */
+function allQuestions(m: OnboardingMessages): WizardQuestion[] {
   return [
     {
-      key: 'role',
-      field: 'role',
+      // FIRST, and only for a cold signup. The wording is Dapta's own, verbatim:
+      // a neutral field label under "tell us about you", never a verb. "What
+      // number should we call you on?" announces a sales call, and the honest
+      // answer to that is no — so it is not what either product asks.
+      key: 'phone',
+      field: 'phone',
+      skippable: true,
+      // The field LABEL ("Your phone number") is not on the step: `FormStep` has
+      // no such field, and inventing one would put a wizard-only concept into
+      // the form config contract. The wizard renders it beside the input.
       step: {
-        key: 'role',
-        type: 'multiple_choice',
-        question: m.role.question,
-        helper: m.role.helper,
-        // LIST, not cards. Nine roles as tiles read as a wall next to the
-        // five-tile use-case screen two questions later; rows scan in one pass
-        // and keep the card treatment meaningful where it is actually used.
-        optionLayout: 'list',
-        options: ONBOARDING_ROLES.map((value) => ({
-          value,
-          label: m.role.options[value],
-          icon: ROLE_ICONS[value],
-        })),
+        key: 'phone',
+        type: 'phone',
+        question: m.phone.question,
+        helper: m.phone.helper,
+        placeholder: m.phone.placeholder,
       },
     },
     {
@@ -95,6 +114,62 @@ export function wizardQuestions(m: OnboardingMessages): WizardQuestion[] {
         options: ONBOARDING_INDUSTRIES.map((value) => ({
           value,
           label: m.industry.options[value],
+        })),
+      },
+    },
+    {
+      // Cold cohort only — someone arriving from Dapta answered this in the
+      // IAM's own `crm_usage` question. It is also the one answer here that is
+      // an ACTION rather than a segment: Forms already syncs to HubSpot, so
+      // "hubspot" is a connection to offer on day one.
+      key: 'crm',
+      field: 'crm',
+      step: {
+        key: 'crm',
+        type: 'dropdown',
+        question: m.crm.question,
+        helper: m.crm.helper,
+        placeholder: m.industry.placeholder,
+        options: ONBOARDING_CRMS.map((value) => ({
+          value,
+          label: m.crm.options[value],
+        })),
+      },
+    },
+    {
+      // Cold cohort only — someone arriving from Dapta answered this in the
+      // IAM's own `contacts_per_month` question, and the buckets here are that
+      // question's, verbatim, so the two products' answers can be added up.
+      key: 'lead_volume',
+      field: 'leadVolume',
+      step: {
+        key: 'lead_volume',
+        type: 'multiple_choice',
+        question: m.leadVolume.question,
+        helper: m.leadVolume.helper,
+        optionLayout: 'list',
+        options: ONBOARDING_LEAD_VOLUMES.map((value) => ({
+          value,
+          label: m.leadVolume.options[value],
+        })),
+      },
+    },
+    {
+      // Asked of EVERYONE, including people from Dapta — the IAM has no
+      // equivalent, so it is the only thing here nobody can answer on their
+      // behalf, and the only genuinely new signal Forms sends back.
+      key: 'lead_source',
+      field: 'leadSource',
+      step: {
+        key: 'lead_source',
+        type: 'multiple_choice',
+        question: m.leadSource.question,
+        helper: m.leadSource.helper,
+        optionLayout: 'list',
+        options: ONBOARDING_LEAD_SOURCES.map((value) => ({
+          value,
+          label: m.leadSource.options[value],
+          icon: LEAD_SOURCE_ICONS[value],
         })),
       },
     },
@@ -118,6 +193,44 @@ export function wizardQuestions(m: OnboardingMessages): WizardQuestion[] {
       },
     },
   ];
+}
+
+/**
+ * The questions THIS person is asked, in order.
+ *
+ * A cold signup answers all five; someone arriving from Dapta AI answers two.
+ * The difference is not a shortcut — Dapta's `pre_signup` bank already holds
+ * their industry, their CRM and a phone number, and re-asking is the plainest
+ * way to tell a customer that the two products do not talk to each other.
+ *
+ * Role and use case survive for both, because Dapta asks neither: it collects no
+ * role at all, and its `dapta_goals` question is about voice and text agents,
+ * not about what someone wants a FORM for.
+ *
+ * Everything downstream — the counter, `lastStep`, the drop-off buckets — reads
+ * the length of THIS list rather than a constant, so the two cohorts cannot end
+ * up counted against each other's denominator.
+ */
+export function wizardQuestions(m: OnboardingMessages, cohort: OnboardingCohort): WizardQuestion[] {
+  const wanted: readonly OnboardingStep[] = ONBOARDING_COHORTS[cohort];
+  return allQuestions(m).filter((q) => wanted.includes(q.key));
+}
+
+/**
+ * The steps this cohort never sees but ANOTHER cohort does — so the blob can
+ * record why each is empty.
+ *
+ * Derived from the union of the cohorts rather than from `ONBOARDING_STEPS`,
+ * which still carries `role`. Role is not skipped for anyone; it is simply no
+ * longer a question, and calling that "skipped" would put a reason next to a
+ * field nobody was ever going to be asked about.
+ */
+export function skippedQuestions(cohort: OnboardingCohort): WizardQuestionKey[] {
+  const wanted: readonly OnboardingStep[] = ONBOARDING_COHORTS[cohort];
+  const askable = new Set<OnboardingStep>(Object.values(ONBOARDING_COHORTS).flat());
+  return ONBOARDING_STEPS.filter(
+    (s): s is WizardQuestionKey => askable.has(s) && !wanted.includes(s),
+  );
 }
 
 export interface WizardTemplate {

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -202,6 +202,24 @@ export const serverEnvSchema = z.object({
   // requests. This is a write-only ingestion key, never a personal API key.
   PRODUCT_ANALYTICS_KEY: z.string().optional(),
   PRODUCT_ANALYTICS_HOST: z.string().url().default('https://us.i.posthog.com'),
+
+  // Dapta-estate onboarding sync (cloud only) — the `dapta_sync` outbox kind.
+  // On the wizard's first answer and on completion, the API pushes the new
+  // account into the rest of the Dapta estate: mappable answers to the IAM's
+  // onboarding endpoints, then a call to the FlowStudio contact-sync flow that
+  // upserts the HubSpot contact.
+  //
+  // IAM_BASE_URL here is a DELIBERATE REVERSAL of "the API has no IAM_BASE_URL"
+  // (see completeOnboarding): the cohort *probe* still runs in the web, but the
+  // sync is a durable outbox side-effect and those run in the API. The same
+  // IAM_API_KEY value is ALSO read by the web (the probe's `x-api-key`).
+  //
+  // All four unset (the default, and every bare fork) = the feature does not
+  // exist: nothing is enqueued, no third-party request is ever made.
+  IAM_BASE_URL: z.string().url().optional(),
+  IAM_API_KEY: z.string().optional(),
+  DAPTA_SYNC_FLOW_URL: z.string().url().optional(),
+  DAPTA_SYNC_FLOW_KEY: z.string().optional(),
 });
 
 export type ServerEnv = z.infer<typeof serverEnvSchema>;

--- a/packages/db/migrations/postgres/0012_onboarding_iam_industries.sql
+++ b/packages/db/migrations/postgres/0012_onboarding_iam_industries.sql
@@ -1,0 +1,59 @@
+-- Onboarding industry values → the Dapta IAM's own bank. Data-only, additive.
+--
+-- `account.onboarding.industry` used to hold one of eleven buckets Forms
+-- invented. It now holds one of the fifty-two `option_value`s from the IAM's
+-- `pre_signup` question bank, so a Forms account can be segmented with the lead
+-- score Dapta already computed for it — the same company was `software` here
+-- and `computer_software` there, and no report could span both.
+--
+-- THIS REWRITE IS NOT OPTIONAL. `accountOnboardingSchema` validates the whole
+-- blob with `safeParse`, and `readOnboarding` treats a blob that does not parse
+-- as ABSENT. One stale industry value therefore does not lose the industry — it
+-- loses `role`, `useCase`, `lastStep`, `stepsSeen` and `startedAt` along with it,
+-- silently, on every read. Left unmigrated, every account onboarded before this
+-- release would read as though it had never opened the wizard.
+--
+-- Nine of the eleven map cleanly. Two do not, and are recorded here rather than
+-- guessed at again later:
+--
+--   ecommerce     → retail        The bank has no ecommerce entry. `retail` is
+--                                 the closest by business, `internet` the
+--                                 closest by channel; retail wins because these
+--                                 people sell things, and the channel is the
+--                                 detail.
+--   manufacturing → other         The bank has no manufacturing OR logistics
+--                                 entry at all. `building_materials`,
+--                                 `chemicals` and `consumer_goods` are each a
+--                                 narrower thing, so any of them would be a
+--                                 fabricated specificity. `other` is the honest
+--                                 answer, and `sources` will not claim these
+--                                 were asked.
+--
+-- Idempotent: it only matches values that are no longer legal, so a re-run is a
+-- no-op. Postgres jsonb is written back with `jsonb_set`, which preserves every
+-- other key in the blob.
+UPDATE account
+SET onboarding = jsonb_set(
+  onboarding,
+  '{industry}',
+  to_jsonb(
+    CASE onboarding->>'industry'
+      WHEN 'software'      THEN 'computer_software'
+      WHEN 'ecommerce'     THEN 'retail'
+      WHEN 'services'      THEN 'consumer_services'
+      WHEN 'agency'        THEN 'marketing_advertising'
+      WHEN 'health'        THEN 'hospital_healthcare'
+      WHEN 'finance'       THEN 'financial_services'
+      WHEN 'education'     THEN 'education_management'
+      WHEN 'realestate'    THEN 'real_estate'
+      WHEN 'manufacturing' THEN 'other'
+      WHEN 'nonprofit'     THEN 'nonprofit'
+      ELSE onboarding->>'industry'
+    END
+  )
+)
+WHERE onboarding IS NOT NULL
+  AND onboarding->>'industry' IN (
+    'software', 'ecommerce', 'services', 'agency', 'health',
+    'finance', 'education', 'realestate', 'manufacturing'
+  );

--- a/packages/db/migrations/sqlite/0012_onboarding_iam_industries.sql
+++ b/packages/db/migrations/sqlite/0012_onboarding_iam_industries.sql
@@ -1,0 +1,50 @@
+-- Onboarding industry values → the Dapta IAM's own bank. Data-only, additive.
+--
+-- `account.onboarding` used to hold one of eleven buckets Forms invented. It now
+-- holds one of the fifty-two `option_value`s from the IAM's `pre_signup` bank,
+-- so a Forms account can be segmented with the lead score Dapta already computed
+-- for it — the same company was `software` here and `computer_software` there,
+-- and no report could span both.
+--
+-- THIS REWRITE IS NOT OPTIONAL. `accountOnboardingSchema` validates the whole
+-- blob with `safeParse`, and `readOnboarding` treats a blob that does not parse
+-- as ABSENT. One stale industry value therefore does not lose the industry — it
+-- loses `role`, `useCase`, `lastStep`, `stepsSeen` and `startedAt` with it,
+-- silently, on every read.
+--
+-- Nine of the eleven map cleanly. Two do not:
+--
+--   ecommerce     → retail    The bank has no ecommerce entry; `retail` is the
+--                             closest by business, `internet` the closest by
+--                             channel. These people sell things; the channel is
+--                             the detail.
+--   manufacturing → other     The bank has no manufacturing OR logistics entry.
+--                             `building_materials`, `chemicals` and
+--                             `consumer_goods` are each narrower, so picking one
+--                             would invent a specificity nobody stated.
+--
+-- The column is TEXT here rather than JSONB, so `json_set` does the work — same
+-- semantics as the Postgres file's `jsonb_set`, and it likewise preserves every
+-- other key. Idempotent: only values that are no longer legal match at all.
+UPDATE account
+SET onboarding = json_set(
+  onboarding,
+  '$.industry',
+  CASE json_extract(onboarding, '$.industry')
+    WHEN 'software'      THEN 'computer_software'
+    WHEN 'ecommerce'     THEN 'retail'
+    WHEN 'services'      THEN 'consumer_services'
+    WHEN 'agency'        THEN 'marketing_advertising'
+    WHEN 'health'        THEN 'hospital_healthcare'
+    WHEN 'finance'       THEN 'financial_services'
+    WHEN 'education'     THEN 'education_management'
+    WHEN 'realestate'    THEN 'real_estate'
+    WHEN 'manufacturing' THEN 'other'
+    ELSE json_extract(onboarding, '$.industry')
+  END
+)
+WHERE onboarding IS NOT NULL
+  AND json_extract(onboarding, '$.industry') IN (
+    'software', 'ecommerce', 'services', 'agency', 'health',
+    'finance', 'education', 'realestate', 'manufacturing'
+  );

--- a/packages/db/src/onboarding.spec.ts
+++ b/packages/db/src/onboarding.spec.ts
@@ -4,7 +4,9 @@
  * cover SQLite and Postgres.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { createDb, migrate, sql, type Db } from './index';
+import { jsonParam } from './forms';
 import {
   getAccountOnboarding,
   saveOnboardingProgress,
@@ -79,14 +81,14 @@ describe('saveOnboardingProgress', () => {
 
   it('keeps the ORIGINAL startedAt across later writes', async () => {
     await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 5000);
-    const saved = await saveOnboardingProgress(db, ACCOUNT, { industry: 'software', lastStep: 'industry' }, 9000);
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { industry: 'computer_software', lastStep: 'industry' }, 9000);
     expect(saved?.startedAt).toBe(5000);
   });
 
   it('merges answers instead of replacing them', async () => {
     await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 5000);
-    const saved = await saveOnboardingProgress(db, ACCOUNT, { industry: 'software', lastStep: 'industry' }, 6000);
-    expect(saved).toMatchObject({ role: 'sales', industry: 'software' });
+    const saved = await saveOnboardingProgress(db, ACCOUNT, { industry: 'computer_software', lastStep: 'industry' }, 6000);
+    expect(saved).toMatchObject({ role: 'sales', industry: 'computer_software' });
   });
 
   it('does NOT blank an earlier answer when a later patch omits it', async () => {
@@ -107,11 +109,11 @@ describe('saveOnboardingProgress', () => {
     const saved = await saveOnboardingProgress(
       db,
       ACCOUNT,
-      { role: null, industry: 'software', lastStep: 'industry' },
+      { role: null, industry: 'computer_software', lastStep: 'industry' },
       6000,
     );
     expect(saved?.role).toBe('founder');
-    expect(saved?.industry).toBe('software');
+    expect(saved?.industry).toBe('computer_software');
   });
 
   it('never moves lastStep BACKWARDS', async () => {
@@ -163,7 +165,7 @@ describe('saveOnboardingProgress', () => {
   it('refuses to write once onboarding is COMPLETE', async () => {
     // A stale tab or a retried request must not rewrite the answers of a
     // finished onboarding — the record of what was actually chosen is the point.
-    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, undefined, 7000);
     expect(await saveOnboardingProgress(db, ACCOUNT, { role: 'hr', lastStep: 'role' }, 8000)).toBeNull();
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding?.template).toBe('lead-qualifier');
@@ -177,20 +179,20 @@ describe('saveOnboardingProgress', () => {
 
 describe('claimOnboardingComplete — exactly once, ever', () => {
   it('the first caller wins', async () => {
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, 7000)).toBe(true);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, undefined, 7000)).toBe(true);
   });
 
   it('every later caller loses', async () => {
-    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, 7000);
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 8000)).toBe(false);
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 9000)).toBe(false);
+    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, undefined, 7000);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 8000)).toBe(false);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 9000)).toBe(false);
   });
 
   it('the LOSER does not overwrite the winner’s template', async () => {
     // Losing must be inert. If the second call still wrote, the account would
     // report a template it never created a form from.
-    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, 7000);
-    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 8000);
+    await claimOnboardingComplete(db, ACCOUNT, 'customer-feedback', {}, undefined, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 8000);
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding?.template).toBe('customer-feedback');
     expect(state?.completedAt).toBe(7000);
@@ -201,23 +203,23 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
     // so the two calls serialize there regardless. It is the guarded UPDATE, not
     // the read before it, that makes this single-winner.
     const results = await Promise.all([
-      claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 7000),
-      claimOnboardingComplete(db, ACCOUNT, 'application', {}, 7000),
+      claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, undefined, 7000),
+      claimOnboardingComplete(db, ACCOUNT, 'application', {}, undefined, 7000),
     ]);
     expect(results.filter(Boolean)).toHaveLength(1);
   });
 
   it('preserves the answers gathered along the way', async () => {
     await saveOnboardingProgress(db, ACCOUNT, { role: 'founder', lastStep: 'role' }, 1000);
-    await saveOnboardingProgress(db, ACCOUNT, { industry: 'ecommerce', lastStep: 'industry' }, 2000);
+    await saveOnboardingProgress(db, ACCOUNT, { industry: 'retail', lastStep: 'industry' }, 2000);
     await saveOnboardingProgress(db, ACCOUNT, { useCase: 'leads', lastStep: 'use_case' }, 3000);
-    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 4000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, undefined, 4000);
 
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding).toMatchObject({
       version: 1,
       role: 'founder',
-      industry: 'ecommerce',
+      industry: 'retail',
       useCase: 'leads',
       template: 'lead-qualifier',
       lastStep: 'template',
@@ -230,13 +232,13 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
   it('completes even when the wizard was never patched', async () => {
     // Someone who lands on the last screen via a restored session still has to
     // be able to finish; a missing blob is not an error state.
-    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 7000)).toBe(true);
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 7000)).toBe(true);
     const state = await getAccountOnboarding(db, ACCOUNT);
     expect(state?.onboarding).toMatchObject({ version: 1, template: 'blank', startedAt: 7000 });
   });
 
   it('returns false for an account that does not exist', async () => {
-    expect(await claimOnboardingComplete(db, 'acc_nope', 'blank', {}, 1)).toBe(false);
+    expect(await claimOnboardingComplete(db, 'acc_nope', 'blank', {}, undefined, 1)).toBe(false);
   });
 
   /**
@@ -251,12 +253,13 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
       db,
       ACCOUNT,
       'lead-qualifier',
-      { role: 'founder', industry: 'software', useCase: 'leads' },
+      { role: 'founder', industry: 'computer_software', useCase: 'leads' },
+      undefined,
       7000,
     );
     expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding).toMatchObject({
       role: 'founder',
-      industry: 'software',
+      industry: 'computer_software',
       useCase: 'leads',
       template: 'lead-qualifier',
     });
@@ -264,7 +267,7 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
 
   it('keeps a PATCHed answer the completion did not carry', async () => {
     await saveOnboardingProgress(db, ACCOUNT, { role: 'marketing', lastStep: 'role' }, 1000);
-    await claimOnboardingComplete(db, ACCOUNT, 'blank', { useCase: 'other' }, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', { useCase: 'other' }, undefined, 7000);
     expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding).toMatchObject({
       role: 'marketing',
       useCase: 'other',
@@ -272,9 +275,81 @@ describe('claimOnboardingComplete — exactly once, ever', () => {
   });
 });
 
+describe('the cohort record — why an answer is missing', () => {
+  it('marks what Dapta holds as a POINTER, not a gap', async () => {
+    // The whole reason this field exists. The IAM has no endpoint that returns a
+    // person's answers yet, so skipping industry and CRM leaves them null for the
+    // entire Dapta cohort. Without a reason recorded beside them, "Dapta has it"
+    // and "we never collected it" are the same null, and in three months nobody
+    // remembers which. With it, the eventual fix is a backfill query.
+    await claimOnboardingComplete(
+      db,
+      ACCOUNT,
+      'blank',
+      { leadSource: 'google_ads', useCase: 'leads' },
+      'dapta',
+      7000,
+    );
+    const blob = (await getAccountOnboarding(db, ACCOUNT))?.onboarding;
+    expect(blob?.cohort).toBe('dapta');
+    expect(blob?.sources).toMatchObject({
+      industry: 'dapta',
+      crm: 'dapta',
+      lead_volume: 'dapta',
+      phone: 'dapta',
+      // The two Dapta cannot answer: no equivalent in its bank, and the one that
+      // preselects a template.
+      lead_source: 'asked',
+      use_case: 'asked',
+    });
+  });
+
+  it('tells a declined answer apart from one never asked', async () => {
+    // A cold signup is SHOWN the phone screen. Passing over it is a fact about a
+    // person; being from Dapta is a fact about where the data lives.
+    await claimOnboardingComplete(
+      db,
+      ACCOUNT,
+      'blank',
+      {
+        industry: 'retail',
+        crm: 'hubspot',
+        leadVolume: '201_500',
+        leadSource: 'outbound',
+        useCase: 'leads',
+      },
+      'cold',
+      7000,
+    );
+    const blob = (await getAccountOnboarding(db, ACCOUNT))?.onboarding;
+    expect(blob?.sources).toMatchObject({
+      phone: 'skipped',
+      industry: 'asked',
+      crm: 'asked',
+      lead_volume: 'asked',
+      lead_source: 'asked',
+    });
+  });
+
+  it('completes without a cohort, recording nothing rather than guessing', async () => {
+    // A caller from before this shipped, or a fork. Metadata is not worth
+    // failing a completion over.
+    expect(await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 7000)).toBe(true);
+    const blob = (await getAccountOnboarding(db, ACCOUNT))?.onboarding;
+    expect(blob?.cohort).toBeUndefined();
+    expect(blob?.sources).toBeUndefined();
+  });
+
+  it('does not fail a claim over a cohort it does not recognise', async () => {
+    expect(
+      await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 'from-the-future' as never, 7000),
+    ).toBe(true);
+  });
+});
+
 describe('recordOnboardingFormId', () => {
   it('records the form the winner built', async () => {
-    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 7000);
     await recordOnboardingFormId(db, ACCOUNT, 'form_created_by_winner');
     expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding?.formId).toBe(
       'form_created_by_winner',
@@ -282,7 +357,7 @@ describe('recordOnboardingFormId', () => {
   });
 
   it('is write-once — a retry cannot repoint it at a form built later', async () => {
-    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'blank', {}, undefined, 7000);
     await recordOnboardingFormId(db, ACCOUNT, 'form_first');
     await recordOnboardingFormId(db, ACCOUNT, 'form_second');
     expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding?.formId).toBe('form_first');
@@ -290,7 +365,7 @@ describe('recordOnboardingFormId', () => {
 
   it('leaves the rest of the blob alone', async () => {
     await saveOnboardingProgress(db, ACCOUNT, { role: 'sales', lastStep: 'role' }, 1000);
-    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, 7000);
+    await claimOnboardingComplete(db, ACCOUNT, 'lead-qualifier', {}, undefined, 7000);
     await recordOnboardingFormId(db, ACCOUNT, 'form_x');
     expect((await getAccountOnboarding(db, ACCOUNT))?.onboarding).toMatchObject({
       role: 'sales',
@@ -325,5 +400,92 @@ describe('the 0011 backfill statement', () => {
     );
     const state = await getAccountOnboarding(db, id);
     expect(state?.completedAt).toBe(4242);
+  });
+});
+
+describe('the 0012 industry rewrite', () => {
+  /**
+   * Run migration 0012 exactly as it ships.
+   *
+   * `migrate()` has already applied it in `beforeEach`, before these rows exist,
+   * so the statement has to be replayed — and it is replayed from the FILE, per
+   * dialect, rather than from a copy pasted into this spec. A copy would pass
+   * forever while the real migration rotted.
+   */
+  async function migrateIndustry(): Promise<void> {
+    const file = new URL(
+      `../migrations/${db.dialect}/0012_onboarding_iam_industries.sql`,
+      import.meta.url,
+    );
+    await db.run(sql.raw(readFileSync(file, 'utf8')));
+  }
+
+  /** A row written by the PREVIOUS build, with one of the eleven old buckets. */
+  async function legacyRow(industry: string): Promise<string> {
+    const run = `${Date.now()}_${n++}`;
+    const id = `acc_ob_ind_${run}`;
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${id}, ${`oi${run}`.slice(0, 20)}, ${'legacy'}, 1000)`,
+    );
+    await db.run(
+      sql`UPDATE account SET onboarding = ${jsonParam({
+        version: 1,
+        role: 'founder',
+        industry,
+        useCase: 'leads',
+        lastStep: 'use_case',
+        stepsSeen: ['role', 'industry', 'use_case'],
+        startedAt: 1000,
+      })} WHERE id = ${id}`,
+    );
+    return id;
+  }
+
+  it('a stale value takes the WHOLE blob down, not just the industry', async () => {
+    // The reason the migration is not optional. `readOnboarding` safeParses the
+    // blob and treats a failure as absent — so one unmigrated enum value loses
+    // the role, the use case and the drop-off bucket with it, silently, on every
+    // read. This is the state the migration exists to prevent.
+    const id = await legacyRow('software');
+    const state = await getAccountOnboarding(db, id);
+    expect(state?.onboarding).toBeNull();
+  });
+
+  it('rewrites every old bucket to a value the schema accepts', async () => {
+    const expected: Record<string, string> = {
+      software: 'computer_software',
+      ecommerce: 'retail',
+      services: 'consumer_services',
+      agency: 'marketing_advertising',
+      health: 'hospital_healthcare',
+      finance: 'financial_services',
+      education: 'education_management',
+      realestate: 'real_estate',
+      // No manufacturing OR logistics entry exists in the IAM bank. Anything
+      // narrower would invent a specificity nobody stated.
+      manufacturing: 'other',
+    };
+    for (const [old, want] of Object.entries(expected)) {
+      const id = await legacyRow(old);
+      await migrateIndustry();
+      const state = await getAccountOnboarding(db, id);
+      expect(state?.onboarding?.industry, `${old} -> ${want}`).toBe(want);
+      // The rest of the blob survives — that is the half `jsonb_set`/`json_set`
+      // buy over rewriting the column.
+      expect(state?.onboarding).toMatchObject({
+        role: 'founder',
+        useCase: 'leads',
+        lastStep: 'use_case',
+        startedAt: 1000,
+      });
+    }
+  });
+
+  it('leaves a value that is already legal alone, and re-runs as a no-op', async () => {
+    const id = await legacyRow('nonprofit');
+    await migrateIndustry();
+    await migrateIndustry();
+    expect((await getAccountOnboarding(db, id))?.onboarding?.industry).toBe('nonprofit');
   });
 });

--- a/packages/db/src/onboarding.ts
+++ b/packages/db/src/onboarding.ts
@@ -23,9 +23,12 @@ import type { Db } from './client';
 import { jsonParam, parseJsonColumn } from './forms';
 import {
   accountOnboardingSchema,
+  ONBOARDING_COHORTS,
   ONBOARDING_STEPS,
   type AccountOnboarding,
   type FormTemplateId,
+  type OnboardingAnswerSource,
+  type OnboardingCohort,
   type OnboardingProgressInput,
   type OnboardingStep,
 } from '@quill/types';
@@ -101,8 +104,59 @@ function mergeAnswers(base: AccountOnboarding, patch: OnboardingProgressInput): 
     ...(patch.role != null ? { role: patch.role } : {}),
     ...(patch.industry != null ? { industry: patch.industry } : {}),
     ...(patch.useCase != null ? { useCase: patch.useCase } : {}),
+    ...(patch.crm != null ? { crm: patch.crm } : {}),
+    ...(patch.leadVolume != null ? { leadVolume: patch.leadVolume } : {}),
+    ...(patch.leadSource != null ? { leadSource: patch.leadSource } : {}),
+    ...(patch.phone ? { phone: patch.phone } : {}),
     ...(patch.template != null ? { template: patch.template } : {}),
   };
+}
+
+/** Which stored field each question writes into. */
+const STEP_FIELD = {
+  phone: 'phone',
+  industry: 'industry',
+  crm: 'crm',
+  lead_volume: 'leadVolume',
+  lead_source: 'leadSource',
+  use_case: 'useCase',
+} as const;
+
+/**
+ * Why each unasked answer is unasked — computed here rather than sent by the
+ * client, so it always agrees with what was actually stored.
+ *
+ * Three states, and the third is the reason this exists at all:
+ *
+ *  - `asked`   — we asked and got an answer.
+ *  - `skipped` — we asked and they declined. Only the phone screen allows it,
+ *                and "declined" is a fact about a person, not a gap in the data.
+ *  - `dapta`   — never shown, because Dapta AI already holds it. The IAM has no
+ *                endpoint that returns a person's answers yet
+ *                (`GET /onboarding/responses/:userId` is a 404 today), so this
+ *                marks a POINTER rather than an absence. When that endpoint
+ *                ships, every row carrying it is a backfill query instead of a
+ *                re-survey; without it, half the accounts would just have a null
+ *                industry and nobody would remember why.
+ */
+function answerSources(
+  answers: AccountOnboarding,
+  cohort: OnboardingCohort,
+): Partial<Record<OnboardingStep, OnboardingAnswerSource>> | null {
+  // A cohort this build does not know about is metadata, not a reason to fail a
+  // completion. The person answered the questions; recording why the OTHERS are
+  // empty is strictly less important than letting them finish.
+  const shown: readonly OnboardingStep[] | undefined = ONBOARDING_COHORTS[cohort];
+  if (!shown) return null;
+  const out: Partial<Record<OnboardingStep, OnboardingAnswerSource>> = {};
+  for (const [step, field] of Object.entries(STEP_FIELD) as [
+    OnboardingStep,
+    (typeof STEP_FIELD)[keyof typeof STEP_FIELD],
+  ][]) {
+    if (!shown.includes(step)) out[step] = 'dapta';
+    else out[step] = answers[field] == null ? 'skipped' : 'asked';
+  }
+  return out;
 }
 
 /** The onboarding state for one account, or null when the account does not exist. */
@@ -197,19 +251,24 @@ export async function claimOnboardingComplete(
   accountId: string,
   template: FormTemplateId,
   answers: OnboardingProgressInput = {},
+  cohort?: OnboardingCohort,
   now: number = Date.now(),
 ): Promise<boolean> {
   const current = await getAccountOnboarding(db, accountId);
   if (!current) return false;
 
   const base = current.onboarding ?? emptyOnboarding(now);
+  const merged = mergeAnswers(base, answers);
   const next: AccountOnboarding = {
-    ...mergeAnswers(base, answers),
+    ...merged,
     version: 1,
     template,
     lastStep: 'template',
     stepsSeen: withStepSeen(base.stepsSeen ?? [], 'template'),
     startedAt: base.startedAt ?? now,
+    ...(cohort && ONBOARDING_COHORTS[cohort]
+      ? { cohort, sources: answerSources(merged, cohort) ?? undefined }
+      : {}),
   };
 
   // The guard, not the read above, is what makes this single-winner: a caller

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -36,11 +36,14 @@ import type { Db } from './client';
  * `booking_sync` = CRM sync of a scheduling callback (booking_event → HubSpot
  * contact update, enriched via Calendly); `analytics` = a first-party product
  * analytics event about OUR OWN users (signup, publish, activation), which is a
- * network call and therefore never fired inline from a request handler. Adding
- * a kind here is all the queue needs — the delivery logic lives in the API
- * (DestinationEffects / BookingSyncEffects / AnalyticsCapture).
+ * network call and therefore never fired inline from a request handler;
+ * `dapta_sync` = pushing a new account's onboarding answers into the Dapta
+ * estate (IAM responses + the HubSpot contact-sync flow), same never-inline
+ * rule. Adding a kind here is all the queue needs — the delivery logic lives in
+ * the API (DestinationEffects / BookingSyncEffects / AnalyticsCapture /
+ * DaptaSyncDelivery).
  */
-export type OutboxKind = 'webhook' | 'email' | 'hubspot' | 'booking_sync' | 'analytics';
+export type OutboxKind = 'webhook' | 'email' | 'hubspot' | 'booking_sync' | 'analytics' | 'dapta_sync';
 /**
  * `skipped` = deliberately not performed (e.g. an email row whose tenant
  * context is unrecoverable on a transport that requires it) — recorded ONCE

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1249,16 +1249,122 @@ export interface FormsMessages {
         search: string;
         empty: string;
         options: {
-          software: string;
-          ecommerce: string;
-          services: string;
-          agency: string;
-          health: string;
-          finance: string;
-          education: string;
-          realestate: string;
-          manufacturing: string;
+          accounting: string;
+          airlines_aviation: string;
+          alternative_dispute_resolution: string;
+          alternative_medicine: string;
+          animation: string;
+          apparel_fashion: string;
+          architecture_planning: string;
+          arts_crafts: string;
+          automotive: string;
+          aviation_aerospace: string;
+          banking: string;
+          biotechnology: string;
+          broadcast_media: string;
+          building_materials: string;
+          business_supplies: string;
+          capital_markets: string;
+          chemicals: string;
+          civic_social: string;
+          civil_engineering: string;
+          commercial_real_estate: string;
+          computer_security: string;
+          computer_games: string;
+          computer_hardware: string;
+          computer_networking: string;
+          computer_software: string;
+          construction: string;
+          consumer_electronics: string;
+          consumer_goods: string;
+          consumer_services: string;
+          education_management: string;
+          financial_services: string;
+          health_wellness: string;
+          hospital_healthcare: string;
+          hospitality: string;
+          it_services: string;
+          insurance: string;
+          internet: string;
+          law_practice: string;
+          legal_services: string;
+          marketing_advertising: string;
+          medical_practice: string;
           nonprofit: string;
+          real_estate: string;
+          restaurants: string;
+          retail: string;
+          telecommunications: string;
+          other: string;
+          events_services: string;
+          higher_education: string;
+          human_resources: string;
+          information_services: string;
+          professional_training_coaching: string;
+        };
+      };
+      /** Asked only of a cold signup — someone arriving from Dapta answered it there. */
+      crm: {
+        question: string;
+        helper: string;
+        options: {
+          none: string;
+          hubspot: string;
+          odoo: string;
+          clientify: string;
+          ghl: string;
+          bitrix24: string;
+          salesforce: string;
+          activecampaign: string;
+          pipedrive: string;
+          zoho_crm: string;
+          escala: string;
+          other: string;
+        };
+      };
+      /**
+       * The phone screen, first and cold-cohort only. Worded exactly as Dapta's
+       * own signup words it — a neutral field label, never a verb. "What number
+       * should we call you on?" tells someone they are about to be called, and
+       * the answer to that is no.
+       */
+      phone: {
+        question: string;
+        helper: string;
+        label: string;
+        placeholder: string;
+        skip: string;
+        invalid: string;
+      };
+      /**
+       * Lead volume — the IAM's `contacts_per_month` buckets, so a Forms answer
+       * and a Dapta answer land in the same histogram.
+       */
+      leadVolume: {
+        question: string;
+        helper: string;
+        options: {
+          '0_50': string;
+          '51_200': string;
+          '201_500': string;
+          '501_1000': string;
+          '1001_5000': string;
+          '5000_plus': string;
+        };
+      };
+      /**
+       * Where the leads come from. The one question the IAM has no equivalent
+       * for, so it is asked of BOTH cohorts.
+       */
+      leadSource: {
+        question: string;
+        helper: string;
+        options: {
+          none: string;
+          facebook_ads: string;
+          google_ads: string;
+          outbound: string;
+          internal_lists: string;
           other: string;
         };
       };
@@ -2464,17 +2570,108 @@ export const en: FormsMessages = {
         search: 'Search',
         empty: 'Nothing matches — pick Other.',
         options: {
-          software: 'Software and technology',
-          ecommerce: 'Ecommerce and retail',
-          services: 'Professional services',
-          agency: 'Agency or marketing',
-          health: 'Healthcare',
-          finance: 'Finance and insurance',
-          education: 'Education',
-          realestate: 'Real estate',
-          manufacturing: 'Manufacturing and logistics',
-          nonprofit: 'Nonprofit',
+          accounting: 'Accounting',
+          airlines_aviation: 'Airlines/Aviation',
+          alternative_dispute_resolution: 'Alternative Dispute Resolution',
+          alternative_medicine: 'Alternative Medicine',
+          animation: 'Animation',
+          apparel_fashion: 'Apparel & Fashion',
+          architecture_planning: 'Architecture & Planning',
+          arts_crafts: 'Arts and Crafts',
+          automotive: 'Automotive',
+          aviation_aerospace: 'Aviation & Aerospace',
+          banking: 'Banking',
+          biotechnology: 'Biotechnology',
+          broadcast_media: 'Broadcast Media',
+          building_materials: 'Building Materials',
+          business_supplies: 'Business Supplies and Equipment',
+          capital_markets: 'Capital Markets',
+          chemicals: 'Chemicals',
+          civic_social: 'Civic & Social Organization',
+          civil_engineering: 'Civil Engineering',
+          commercial_real_estate: 'Commercial Real Estate',
+          computer_security: 'Computer & Network Security',
+          computer_games: 'Computer Games',
+          computer_hardware: 'Computer Hardware',
+          computer_networking: 'Computer Networking',
+          computer_software: 'Computer Software',
+          construction: 'Construction',
+          consumer_electronics: 'Consumer Electronics',
+          consumer_goods: 'Consumer Goods',
+          consumer_services: 'Consumer Services',
+          education_management: 'Education Management',
+          financial_services: 'Financial Services',
+          health_wellness: 'Health, Wellness and Fitness',
+          hospital_healthcare: 'Hospital & Health Care',
+          hospitality: 'Hospitality',
+          it_services: 'Information Technology and Services',
+          insurance: 'Insurance',
+          internet: 'Internet',
+          law_practice: 'Law Practice',
+          legal_services: 'Legal Services',
+          marketing_advertising: 'Marketing and Advertising',
+          medical_practice: 'Medical Practice',
+          nonprofit: 'Non-profit Organization Management',
+          real_estate: 'Real Estate',
+          restaurants: 'Restaurants',
+          retail: 'Retail',
+          telecommunications: 'Telecommunications',
+          other: 'Other Industry',
+          events_services: 'Events Services',
+          higher_education: 'Higher Education',
+          human_resources: 'Human Resources',
+          information_services: 'Information Services',
+          professional_training_coaching: 'Professional Training & Coaching',
+        },
+      },
+      crm: {
+        question: 'Which CRM do you use?',
+        helper: 'We can send your responses straight there.',
+        options: {
+          none: 'None',
+          hubspot: 'HubSpot',
+          odoo: 'Odoo',
+          clientify: 'Clientify',
+          ghl: 'GoHighLevel',
+          bitrix24: 'Bitrix24',
+          salesforce: 'Salesforce',
+          activecampaign: 'ActiveCampaign',
+          pipedrive: 'Pipedrive',
+          zoho_crm: 'Zoho CRM',
+          escala: 'Escala',
           other: 'Other',
+        },
+      },
+      phone: {
+        question: 'Tell us about you',
+        helper: 'So we can tailor your experience.',
+        label: 'Your phone number',
+        placeholder: '000 000 0000',
+        skip: 'Skip for now',
+        invalid: 'That phone number does not look right. Check it and try again.',
+      },
+      leadVolume: {
+        question: 'How many leads do you get a month?',
+        helper: 'A rough number is fine.',
+        options: {
+          '0_50': '0-50',
+          '51_200': '51-200',
+          '201_500': '201-500',
+          '501_1000': '501-1000',
+          '1001_5000': '1001-5000',
+          '5000_plus': '5000+',
+        },
+      },
+      leadSource: {
+        question: 'Where do your leads come from?',
+        helper: 'Pick the main one.',
+        options: {
+          none: 'I do not have leads yet',
+          facebook_ads: 'Facebook ads',
+          google_ads: 'Google ads',
+          outbound: 'Outbound',
+          internal_lists: 'Internal lists',
+          other: 'Somewhere else',
         },
       },
       useCase: {
@@ -3703,17 +3900,108 @@ export const es: FormsMessages = {
         search: 'Buscar',
         empty: 'No hay coincidencias. Elige Otra.',
         options: {
-          software: 'Software y tecnología',
-          ecommerce: 'Ecommerce y retail',
-          services: 'Servicios profesionales',
-          agency: 'Agencia o marketing',
-          health: 'Salud',
-          finance: 'Finanzas y seguros',
-          education: 'Educación',
-          realestate: 'Inmobiliaria',
-          manufacturing: 'Manufactura y logística',
-          nonprofit: 'ONG o sin fines de lucro',
-          other: 'Otra',
+          accounting: 'Contabilidad',
+          airlines_aviation: 'Aerolíneas y aviación',
+          alternative_dispute_resolution: 'Resolución alternativa de conflictos',
+          alternative_medicine: 'Medicina alternativa',
+          animation: 'Animación',
+          apparel_fashion: 'Ropa y moda',
+          architecture_planning: 'Arquitectura y urbanismo',
+          arts_crafts: 'Arte y artesanía',
+          automotive: 'Automotriz',
+          aviation_aerospace: 'Aviación y aeroespacial',
+          banking: 'Banca',
+          biotechnology: 'Biotecnología',
+          broadcast_media: 'Medios de comunicación',
+          building_materials: 'Materiales de construcción',
+          business_supplies: 'Suministros y equipos de oficina',
+          capital_markets: 'Mercados de capitales',
+          chemicals: 'Química',
+          civic_social: 'Organizaciones cívicas y sociales',
+          civil_engineering: 'Ingeniería civil',
+          commercial_real_estate: 'Inmobiliaria comercial',
+          computer_security: 'Seguridad informática y de redes',
+          computer_games: 'Videojuegos',
+          computer_hardware: 'Hardware',
+          computer_networking: 'Redes informáticas',
+          computer_software: 'Software',
+          construction: 'Construcción',
+          consumer_electronics: 'Electrónica de consumo',
+          consumer_goods: 'Bienes de consumo',
+          consumer_services: 'Servicios al consumidor',
+          education_management: 'Gestión educativa',
+          financial_services: 'Servicios financieros',
+          health_wellness: 'Salud, bienestar y fitness',
+          hospital_healthcare: 'Hospitales y salud',
+          hospitality: 'Hotelería',
+          it_services: 'Tecnología y servicios de TI',
+          insurance: 'Seguros',
+          internet: 'Internet',
+          law_practice: 'Despachos de abogados',
+          legal_services: 'Servicios legales',
+          marketing_advertising: 'Marketing y publicidad',
+          medical_practice: 'Consultorios médicos',
+          nonprofit: 'Organizaciones sin fines de lucro',
+          real_estate: 'Inmobiliaria',
+          restaurants: 'Restaurantes',
+          retail: 'Comercio minorista',
+          telecommunications: 'Telecomunicaciones',
+          other: 'Otra industria',
+          events_services: 'Servicios para eventos',
+          higher_education: 'Educación superior',
+          human_resources: 'Recursos humanos',
+          information_services: 'Servicios de información',
+          professional_training_coaching: 'Formación profesional y coaching',
+        },
+      },
+      crm: {
+        question: '¿Qué CRM usas?',
+        helper: 'Podemos enviar tus respuestas directo ahí.',
+        options: {
+          none: 'Ninguno',
+          hubspot: 'HubSpot',
+          odoo: 'Odoo',
+          clientify: 'Clientify',
+          ghl: 'GoHighLevel',
+          bitrix24: 'Bitrix24',
+          salesforce: 'Salesforce',
+          activecampaign: 'ActiveCampaign',
+          pipedrive: 'Pipedrive',
+          zoho_crm: 'Zoho CRM',
+          escala: 'Escala',
+          other: 'Otro',
+        },
+      },
+      phone: {
+        question: 'Cuéntanos sobre ti',
+        helper: 'Para que podamos adaptar tu experiencia.',
+        label: 'Tu número de teléfono',
+        placeholder: '000 000 0000',
+        skip: 'Ahora no',
+        invalid: 'Ese número no parece válido. Verifícalo e inténtalo de nuevo.',
+      },
+      leadVolume: {
+        question: '¿Cuántos leads recibes al mes?',
+        helper: 'Un número aproximado está bien.',
+        options: {
+          '0_50': '0-50',
+          '51_200': '51-200',
+          '201_500': '201-500',
+          '501_1000': '501-1000',
+          '1001_5000': '1001-5000',
+          '5000_plus': '5000+',
+        },
+      },
+      leadSource: {
+        question: '¿De dónde vienen tus leads?',
+        helper: 'Elige el principal.',
+        options: {
+          none: 'Todavía no tengo leads',
+          facebook_ads: 'Anuncios de Facebook',
+          google_ads: 'Anuncios de Google',
+          outbound: 'Outbound',
+          internal_lists: 'Listas internas',
+          other: 'De otro lado',
         },
       },
       useCase: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1452,26 +1452,151 @@ export const ONBOARDING_ROLES = [
 export type OnboardingRole = (typeof ONBOARDING_ROLES)[number];
 
 /**
- * Question 2 — "what industry are you in?".
+ * The industry question — the Dapta IAM's own bank, verbatim.
  *
- * Eleven buckets, not the 52 the Dapta IAM's `pre_signup` bank carries. Fifty-two
- * options in a three-screen wizard is noise; these group the same space, and a
- * 52 -> 11 mapping is a lookup table if the two ever need to be joined.
+ * Fifty-two values, and every one of them is an `option_value` from the IAM's
+ * `pre_signup` stage. Forms used to carry eleven buckets of its own invention,
+ * which read fine on the screen and made the two products' data impossible to
+ * join: the same company was `software` here and `computer_software` there, and
+ * no report could span both. Matching the values is what lets a Forms account be
+ * segmented with the lead score Dapta has already computed for it.
+ *
+ * Fifty-two is not too many BECAUSE the screen is a searchable dropdown — that
+ * component exists precisely for a list nobody scans. Two of the old buckets have
+ * no equivalent in the bank (`ecommerce`, `manufacturing`); migration 0012
+ * records where they went.
+ *
+ * Ordered as the IAM orders them, so a diff against the bank stays readable.
  */
 export const ONBOARDING_INDUSTRIES = [
-  'software',
-  'ecommerce',
-  'services',
-  'agency',
-  'health',
-  'finance',
-  'education',
-  'realestate',
-  'manufacturing',
+  'accounting',
+  'airlines_aviation',
+  'alternative_dispute_resolution',
+  'alternative_medicine',
+  'animation',
+  'apparel_fashion',
+  'architecture_planning',
+  'arts_crafts',
+  'automotive',
+  'aviation_aerospace',
+  'banking',
+  'biotechnology',
+  'broadcast_media',
+  'building_materials',
+  'business_supplies',
+  'capital_markets',
+  'chemicals',
+  'civic_social',
+  'civil_engineering',
+  'commercial_real_estate',
+  'computer_security',
+  'computer_games',
+  'computer_hardware',
+  'computer_networking',
+  'computer_software',
+  'construction',
+  'consumer_electronics',
+  'consumer_goods',
+  'consumer_services',
+  'education_management',
+  'financial_services',
+  'health_wellness',
+  'hospital_healthcare',
+  'hospitality',
+  'it_services',
+  'insurance',
+  'internet',
+  'law_practice',
+  'legal_services',
+  'marketing_advertising',
+  'medical_practice',
   'nonprofit',
+  'real_estate',
+  'restaurants',
+  'retail',
+  'telecommunications',
   'other',
+  'events_services',
+  'higher_education',
+  'human_resources',
+  'information_services',
+  'professional_training_coaching',
 ] as const;
 export type OnboardingIndustry = (typeof ONBOARDING_INDUSTRIES)[number];
+
+/**
+ * The CRM question — the IAM's `crm_usage` bank, minus one duplicate.
+ *
+ * The bank ships `none` ("Ninguno/None") AND `no_crm` ("I don't use CRM"): the
+ * same answer twice, with the same score. Offering both would split the one
+ * segment that matters most — the people with nowhere to send a lead — across two
+ * values, so only `none` survives here.
+ *
+ * Asked ONLY of someone who did not arrive from Dapta, and it is the one answer
+ * that is immediately actionable rather than descriptive: Forms already syncs to
+ * HubSpot, so "hubspot" on day one is a connection to offer, not a segment to
+ * file away.
+ */
+/**
+ * "How many leads do you get a month?" — the IAM's `contacts_per_month` bank,
+ * values verbatim.
+ *
+ * Forms asked nothing like this before, on the grounds that a form can be for
+ * anything and lead volume is a lead-gen question. It is here now because the
+ * cold cohort is being qualified, not just profiled — and taking the IAM's own
+ * buckets means a Forms answer and a Dapta answer land in the same histogram
+ * instead of two that cannot be added together.
+ *
+ * Skipped for anyone arriving from Dapta: they answered it at signup.
+ */
+export const ONBOARDING_LEAD_VOLUMES = [
+  '0_50',
+  '51_200',
+  '201_500',
+  '501_1000',
+  '1001_5000',
+  '5000_plus',
+] as const;
+export type OnboardingLeadVolume = (typeof ONBOARDING_LEAD_VOLUMES)[number];
+
+/**
+ * "Where do your leads come from?" — Forms' own question. The IAM has no
+ * equivalent.
+ *
+ * That absence is the interesting part: it is the ONE question here that Dapta
+ * cannot answer on someone's behalf, so it is asked of BOTH cohorts. Everything
+ * else the wizard collects is either already in the IAM's bank or specific to
+ * building a form; this is the only genuinely new signal Forms contributes back.
+ *
+ * `none` sits first rather than last, unlike the `other` escape hatch elsewhere:
+ * "I don't have leads yet" is a real and common answer for a brand-new account,
+ * not a fallback for people whose answer is missing from the list.
+ */
+export const ONBOARDING_LEAD_SOURCES = [
+  'none',
+  'facebook_ads',
+  'google_ads',
+  'outbound',
+  'internal_lists',
+  'other',
+] as const;
+export type OnboardingLeadSource = (typeof ONBOARDING_LEAD_SOURCES)[number];
+
+export const ONBOARDING_CRMS = [
+  'none',
+  'hubspot',
+  'odoo',
+  'clientify',
+  'ghl',
+  'bitrix24',
+  'salesforce',
+  'activecampaign',
+  'pipedrive',
+  'zoho_crm',
+  'escala',
+  'other',
+] as const;
+export type OnboardingCrm = (typeof ONBOARDING_CRMS)[number];
 
 /**
  * Question 3 — "what do you want to use Forms for?".
@@ -1512,9 +1637,76 @@ export const USE_CASE_TEMPLATE: Readonly<Record<OnboardingUseCase, FormTemplateI
 /**
  * The wizard's screens, in order. `lastStep` names the furthest one REACHED, so
  * these are the buckets a drop-off report groups by.
+ *
+ * ORDER IS LOAD-BEARING, twice over: `lastStep` is only ever allowed to advance
+ * along this array (see `furthestStep` in @quill/db), and the cohorts below are
+ * both subsequences of it. Reordering this list silently re-buckets every
+ * drop-off report ever run.
+ *
+ * Not every person sees every screen — see `ONBOARDING_COHORTS`.
  */
-export const ONBOARDING_STEPS = ['role', 'industry', 'use_case', 'template'] as const;
+export const ONBOARDING_STEPS = [
+  'phone',
+  // NO LONGER ASKED, and deliberately still here. Accounts onboarded before this
+  // release carry `lastStep: 'role'` and a stored `role`, and the whole blob is
+  // validated with one `safeParse` — dropping the value from this union would
+  // make those rows unreadable and take `industry`, `useCase` and every
+  // drop-off breadcrumb down with it. It costs one array entry to keep them.
+  'role',
+  'industry',
+  'crm',
+  'lead_volume',
+  'lead_source',
+  'use_case',
+  'template',
+] as const;
 export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+
+/**
+ * Who is asked what.
+ *
+ * The rule is one line: never ask for something Dapta AI already holds. Its
+ * `pre_signup` bank covers industry, CRM and lead volume, and its signup takes a
+ * phone number — so a customer arriving from the platform is asked none of those
+ * four. Re-asking them is the clearest possible way to tell someone that the two
+ * products do not talk to each other.
+ *
+ * Two questions survive for everyone, for opposite reasons:
+ *
+ *  - `lead_source` — the IAM has NO equivalent, so nobody can answer it on the
+ *    person's behalf. It is the only genuinely new signal Forms contributes back.
+ *  - `use_case` — Dapta's `dapta_goals` asks about voice and text agents, not
+ *    about what someone wants a FORM for, and this answer is what preselects a
+ *    template on the very next screen.
+ *
+ * The cold cohort answers six. That is a deliberate trade of raw signups for
+ * qualified ones, and it is measurable rather than arguable: `lastStep` is
+ * written on every advance, so `lastStep: 'phone'` with no completion is exactly
+ * the number that says what the first screen costs.
+ *
+ * `role` is in neither list — no longer asked, kept in the union above so
+ * already-stored answers still parse.
+ */
+export const ONBOARDING_COHORTS = {
+  /** No Dapta account behind this signup — nothing is known, so everything is asked. */
+  cold: ['phone', 'industry', 'crm', 'lead_volume', 'lead_source', 'use_case'],
+  /** Came from Dapta AI. Only what Dapta cannot answer for them. */
+  dapta: ['lead_source', 'use_case'],
+} as const satisfies Readonly<Record<string, readonly OnboardingStep[]>>;
+export type OnboardingCohort = keyof typeof ONBOARDING_COHORTS;
+
+/**
+ * Why an answer is missing.
+ *
+ * `null` alone cannot tell "we never asked" from "we asked and they skipped" from
+ * "Dapta holds it". The third is the one that matters: the IAM has no endpoint
+ * that returns a person's answers yet (`GET /onboarding/responses/:userId` is a
+ * 404 today), so skipping those screens leaves the column empty for the entire
+ * Dapta cohort. Recording the REASON keeps that hole legible and turns the
+ * eventual fix into a backfill query instead of a re-survey.
+ */
+export const ONBOARDING_ANSWER_SOURCES = ['asked', 'skipped', 'dapta'] as const;
+export type OnboardingAnswerSource = (typeof ONBOARDING_ANSWER_SOURCES)[number];
 
 /**
  * `account.onboarding` (migration 0011) — the wizard's working state AND result.
@@ -1539,7 +1731,31 @@ export const accountOnboardingSchema = z.object({
   role: z.enum(ONBOARDING_ROLES).nullable().optional(),
   industry: z.enum(ONBOARDING_INDUSTRIES).nullable().optional(),
   useCase: z.enum(ONBOARDING_USE_CASES).nullable().optional(),
+  crm: z.enum(ONBOARDING_CRMS).nullable().optional(),
+  leadVolume: z.enum(ONBOARDING_LEAD_VOLUMES).nullable().optional(),
+  leadSource: z.enum(ONBOARDING_LEAD_SOURCES).nullable().optional(),
+  /**
+   * E.164, as the phone input produces it. Stored on the ACCOUNT rather than the
+   * member because that is where every other wizard answer lives and the wizard's
+   * only member IS the owner; a per-person number belongs on `member` the day a
+   * second person can answer this.
+   *
+   * Never rendered on a public surface — `member.profile` is the public page and
+   * this is deliberately not in it.
+   */
+  phone: z.string().trim().max(32).nullable().optional(),
   template: z.enum(FORM_TEMPLATE_IDS).nullable().optional(),
+  /** Which set of screens this person was shown — cold, or arriving from Dapta. */
+  cohort: z.enum(['cold', 'dapta']).nullable().optional(),
+  /**
+   * Why each unasked answer is unasked. Absent means "asked and answered".
+   * See `ONBOARDING_ANSWER_SOURCES` — the point is that a NULL industry on a
+   * Dapta account is a pointer, not a gap.
+   */
+  sources: z
+    .record(z.enum(ONBOARDING_STEPS), z.enum(ONBOARDING_ANSWER_SOURCES))
+    .nullable()
+    .optional(),
   /** The furthest screen REACHED — the drop-off bucket. */
   lastStep: z.enum(ONBOARDING_STEPS).nullable().optional(),
   /**
@@ -1576,6 +1792,10 @@ export const onboardingProgressSchema = z.object({
   role: z.enum(ONBOARDING_ROLES).nullable().optional(),
   industry: z.enum(ONBOARDING_INDUSTRIES).nullable().optional(),
   useCase: z.enum(ONBOARDING_USE_CASES).nullable().optional(),
+  crm: z.enum(ONBOARDING_CRMS).nullable().optional(),
+  leadVolume: z.enum(ONBOARDING_LEAD_VOLUMES).nullable().optional(),
+  leadSource: z.enum(ONBOARDING_LEAD_SOURCES).nullable().optional(),
+  phone: z.string().trim().max(32).nullable().optional(),
   template: z.enum(FORM_TEMPLATE_IDS).nullable().optional(),
   lastStep: z.enum(ONBOARDING_STEPS).nullable().optional(),
 });
@@ -1604,6 +1824,17 @@ export const onboardingCompleteSchema = z.object({
   role: z.enum(ONBOARDING_ROLES).nullable().optional(),
   industry: z.enum(ONBOARDING_INDUSTRIES).nullable().optional(),
   useCase: z.enum(ONBOARDING_USE_CASES).nullable().optional(),
+  crm: z.enum(ONBOARDING_CRMS).nullable().optional(),
+  leadVolume: z.enum(ONBOARDING_LEAD_VOLUMES).nullable().optional(),
+  leadSource: z.enum(ONBOARDING_LEAD_SOURCES).nullable().optional(),
+  phone: z.string().trim().max(32).nullable().optional(),
+  /**
+   * Which screens this person was shown, and why the unasked ones were unasked.
+   * Sent from the wizard because the wizard is what resolved the cohort — the API
+   * never probes the IAM itself (that would need `IAM_BASE_URL` in its configmap,
+   * which the web already has).
+   */
+  cohort: z.enum(['cold', 'dapta']).optional(),
   locale: z.enum(['en', 'es']).optional(),
 });
 export type OnboardingCompleteInput = z.infer<typeof onboardingCompleteSchema>;


### PR DESCRIPTION
## Qué hace

El wizard de onboarding se vuelve consciente de cohortes y empuja sus respuestas al estate de Dapta (IAM + HubSpot, vía el flow `sync_hubspot_contact` existente — cero código nuevo de HubSpot).

### Cohortes
- **Fría** (no viene de Dapta): teléfono → industria → CRM → volumen de leads → origen de leads → para qué usás Forms.
- **Dapta** (completó el onboarding de Dapta o es migrado): solo origen de leads + para qué — lo único que Dapta nunca preguntó.
- La decide una sonda server-side a `GET {IAM}/onboarding/status/{sub}` (timeout 800ms, `x-api-key`), que **falla cerrado** al camino corto. El `sub` del JWT es el `users.id` del IAM (verificado contra prd: idéntico a `member.external_id`).
- Industria pasa de 11 buckets propios a **las 52 del banco del IAM** (los valores estándar de HubSpot). La migración 0012 reescribe los valores viejos guardados — un enum stale tumbaba el blob entero al leer.

### Sync al estate (outbox kind `dapta_sync`)
- **early**: la primera respuesta encola una llamada al flow → el contacto nace en HubSpot (email + teléfono + UTMs) aunque abandonen.
- **complete**: el ganador del claim encola el push completo: respuestas mapeables a `POST {IAM}/onboarding/responses` (guardado por su endpoint de status — un retry jamás double-postea) y **después** el flow, que lee las respuestas desde el IAM.
- Mapeo por `question_key` + `option_value` del banco — nunca UUIDs ajenos hardcodeados. `lead_source`/`use_case` no tienen casa en el IAM y quedan solo en nuestra DB.
- Sin las 4 env vars (`IAM_BASE_URL`, `IAM_API_KEY`, `DAPTA_SYNC_FLOW_URL`, `DAPTA_SYNC_FLOW_KEY`) **no se encola nada** — un fork OSS ni se entera de que esto existe.

## Verificación

- 16/16 en `dapta-sync.spec.ts` (SQLite en memoria + worker real + fetch stub: orden IAM→flow, guard de status, cohorte dapta sin llamadas IAM, skip sin external_id, retry en 5xx).
- Suite completa + typecheck + lint en verde; **parity Postgres corrida** (la 0012 con `jsonb_set` ejecutada y los 159 tests de `@quill/db` en PG).
- El contrato del flow y del IAM se verificó **a mano contra producción** antes de escribir esto: `POST /onboarding/responses` acepta parcial (201 real), y el flow corrió e2e con un usuario de prueba cuyas properties quedaron confirmadas en la UI de HubSpot.

## Deploy

Las 4 vars son nuevas y **opcionales**: sin configurarlas el feature queda apagado en silencio. Para prender en dev: las 4 al env del API + `IAM_API_KEY` también al del web (la sonda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
