### PR TITLE
feat(forms): reveal-screen logo, HubSpot value pickers, collapsible value maps

### DIFF
--- a/.changeset/reveal-logo-and-value-pickers.md
+++ b/.changeset/reveal-logo-and-value-pickers.md
@@ -1,0 +1,51 @@
+---
+'@quill/shared': minor
+---
+
+Put the brand on the reveal screen, and stop making people retype HubSpot values
+by hand.
+
+**The reveal screen shows the form's logo.** It was the last of three blockers
+named for migrating the live forms over (the top banner and the cover logo landed
+already). The logo comes from `branding.logo` — the FORM's logo, not the cover's;
+the reveal is a phase inside the form, not its front door. Both renderers show it,
+and so does the `submitting` screen they draw inline, so it does not blink out at
+the moment of submission. The builder canvas draws its own reveal, so it shows the
+logo too — a preview that disagrees with the published form is the bug, not a
+follow-up.
+
+`FormLogo` gained `fallback="none"` for this. Its text fallback prints the FORM
+NAME, which is the author's internal name; a respondent must never be shown
+"Q3 paid-ads lead gen v2" because an image 404'd. A form with no logo renders
+byte-identically to before.
+
+**The HubSpot property picker now carries each property's allowed values**, and
+two places that made you type an internal value exactly — static properties, and
+the right-hand side of a value map — became dropdowns.
+
+- Values ride along only for enumeration properties; the key is omitted, not
+  empty, so the response doesn't gain ~400 empty arrays. Options HubSpot marks
+  `hidden` are dropped: it hides them from its own pickers, so offering one lets
+  you configure a write HubSpot then rejects.
+- Their order is HubSpot's own and is never re-sorted — a picklist's order carries
+  meaning (stages, seniority, sizes). Properties themselves stay sorted by label.
+- A value map is keyed by QUESTION, and a question can be mapped to several
+  properties. The offered values are the **intersection** of those properties',
+  not the union: the adapter writes one translated value to all of them, so a
+  value only one accepts is a guaranteed half-written contact. A hint under the
+  header names the targets, so a text box on a fanned-out question reads as a
+  reason rather than a broken picker.
+- A stored value the list doesn't contain opens in text mode showing that value.
+  In a dropdown it would render as an empty box — still configured, still saved,
+  and looking unset.
+- Nothing constrains the value (no mapping, a text property, a portal without the
+  picker configured)? The same free-text input as before. No config shape changed.
+
+**Value-map groups collapse**, showing the question and how many translations are
+inside. A fifty-value industry map turned this panel into a scroll with no
+landmarks. A group with nothing filled in yet stays open — there is nothing to
+summarise, and collapsing the rows out from under someone who just picked a
+question would be worse than the scroll.
+
+The growth badge now reads **"Powered by Dapta"** ("Con tecnología de Dapta"),
+naming the platform rather than this one product.

--- a/apps/api/src/integrations-connect.spec.ts
+++ b/apps/api/src/integrations-connect.spec.ts
@@ -322,6 +322,77 @@ describe('HubSpot property picker token resolution', () => {
     const res = await controller.hubspotProperties(asOwner());
     expect(res.enabled).toBe(false);
   });
+
+  it('passes enumeration options through — hidden dropped, order kept, text omitted', async () => {
+    build(
+      makeEnv({ HUBSPOT_PRIVATE_APP_TOKEN: 'env-fallback-token' }),
+      recordingFetch([], {
+        [HUBSPOT_PROPERTIES_URL]: () =>
+          jsonResponse({
+            results: [
+              // Deliberately NOT alphabetical, and with the retired value in the
+              // middle: the mapping must keep HubSpot's order and drop `hidden`.
+              {
+                name: 'company_size',
+                label: 'Company size',
+                type: 'enumeration',
+                options: [
+                  { value: '2', label: '11-50 employees' },
+                  { value: 'legacy', label: 'Retired bucket', hidden: true },
+                  { value: '1', label: '1-10 employees' },
+                  // No `value` — nothing to write, so nothing to offer.
+                  { label: 'Malformed' },
+                ],
+              },
+              { name: 'email', label: 'Email', type: 'string' },
+              // An enumeration whose options are ALL hidden is not a picklist an
+              // author can use — it must come back like a text property.
+              {
+                name: 'dead_enum',
+                label: 'Dead enum',
+                type: 'enumeration',
+                options: [{ value: 'x', label: 'X', hidden: true }],
+              },
+            ],
+          }),
+      }),
+    );
+    const res = await controller.hubspotProperties(asOwner());
+    expect(res.enabled).toBe(true);
+    if (!res.enabled) return;
+    const by = (name: string) => res.properties.find((p) => p.name === name)!;
+
+    expect(by('company_size').options).toEqual([
+      { value: '2', label: '11-50 employees' },
+      { value: '1', label: '1-10 employees' },
+    ]);
+    // Absent, never `[]` — `options?.length` is the whole picklist test in the UI.
+    expect(by('email')).not.toHaveProperty('options');
+    expect(by('dead_enum')).not.toHaveProperty('options');
+
+    // Properties themselves stay sorted by label, as before.
+    expect(res.properties.map((p) => p.label)).toEqual(['Company size', 'Dead enum', 'Email']);
+  });
+
+  it('serves options from the per-account cache on the second call', async () => {
+    const calls: RecordedCall[] = [];
+    build(
+      makeEnv({ HUBSPOT_PRIVATE_APP_TOKEN: 'env-fallback-token' }),
+      recordingFetch(calls, {
+        [HUBSPOT_PROPERTIES_URL]: () =>
+          jsonResponse({
+            results: [
+              { name: 'tier', label: 'Tier', type: 'enumeration', options: [{ value: 'a', label: 'A' }] },
+            ],
+          }),
+      }),
+    );
+    const first = await controller.hubspotProperties(asOwner());
+    const second = await controller.hubspotProperties(asOwner());
+    expect(calls).toHaveLength(1);
+    expect(second.enabled && second.cached).toBe(true);
+    expect(second.enabled && second.properties).toEqual(first.enabled && first.properties);
+  });
 });
 
 describe('Calendly event-type picker token resolution', () => {

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -40,11 +40,31 @@ import { assertAdmin } from './permissions';
 import { RateLimitGuard } from './rate-limit';
 import { DB, ENV } from './tokens';
 
+/**
+ * One allowed value of an enumeration property, as HubSpot defines it.
+ *
+ * `value` is what an integration must WRITE; `label` is what a human sees in
+ * HubSpot's own UI. They are routinely different (`value: "2"` /
+ * `label: "11-50 employees"`), which is precisely why typing the value by hand
+ * is error-prone enough to be worth a picker.
+ */
+export interface HubSpotPropertyOptionDto {
+  value: string;
+  label: string;
+}
+
 /** A HubSpot contact property surfaced to the mapping UI. */
 export interface HubSpotPropertyDto {
   name: string;
   label: string;
   type: string;
+  /**
+   * The allowed values, for enumeration properties only — absent (not `[]`) on
+   * the text/number/date majority, so the response doesn't carry ~400 empty
+   * arrays. Order is HubSpot's own and is deliberately NOT sorted: a picklist's
+   * order carries meaning (deal stages, seniority levels, sizes).
+   */
+  options?: HubSpotPropertyOptionDto[];
 }
 
 /** The property-picker response: disabled (no token) or the cached property list. */
@@ -92,8 +112,37 @@ const HUBSPOT_PROPERTIES_URL = 'https://api.hubapi.com/crm/v3/properties/contact
 const CALENDLY_ME_URL = 'https://api.calendly.com/users/me';
 const CALENDLY_EVENT_TYPES_URL = 'https://api.calendly.com/event_types';
 
+interface HubSpotPropertyOptionApi {
+  value?: string;
+  label?: string;
+  hidden?: boolean;
+}
 interface HubSpotPropertiesApiResponse {
-  results?: Array<{ name: string; label?: string; type?: string }>;
+  results?: Array<{
+    name: string;
+    label?: string;
+    type?: string;
+    options?: HubSpotPropertyOptionApi[];
+  }>;
+}
+
+/**
+ * The values a mapping may legally write to one property, or `undefined` when
+ * the property is not an enumeration.
+ *
+ * Hidden options are dropped: HubSpot hides them from its own pickers (retired
+ * values kept for historical records), so offering one would let an author
+ * configure a write that HubSpot then rejects. An option with no `value` is
+ * dropped for the same reason — there is nothing to write.
+ */
+function toPropertyOptions(
+  options: HubSpotPropertyOptionApi[] | undefined,
+): HubSpotPropertyOptionDto[] | undefined {
+  if (!Array.isArray(options)) return undefined;
+  const usable = options
+    .filter((o) => o && o.hidden !== true && typeof o.value === 'string' && o.value !== '')
+    .map((o) => ({ value: o.value as string, label: o.label?.trim() || (o.value as string) }));
+  return usable.length ? usable : undefined;
 }
 
 /**
@@ -108,6 +157,11 @@ export class HubspotPropertiesService {
   // account's connected token must never surface another account's list. Keyed
   // by accountId (accounts sharing the env fallback cache separately — a minor
   // duplication, never a cross-account leak).
+  //
+  // The keying carries MORE weight now that entries include enumeration options:
+  // a global cache would leak not just property names but their values — a
+  // portal's internal sales taxonomy (deal stages, lead grades, account tiers).
+  // Do not "optimize" this into a single shared map.
   private readonly cache = new Map<string, { data: HubSpotPropertyDto[]; expires: number }>();
 
   constructor(
@@ -154,7 +208,18 @@ export class HubspotPropertiesService {
     }
     const body = (await res.json().catch(() => ({}))) as HubSpotPropertiesApiResponse;
     const properties = (body.results ?? [])
-      .map((prop) => ({ name: prop.name, label: prop.label || prop.name, type: prop.type ?? 'string' }))
+      .map((prop) => {
+        const options = toPropertyOptions(prop.options);
+        const dto: HubSpotPropertyDto = {
+          name: prop.name,
+          label: prop.label || prop.name,
+          type: prop.type ?? 'string',
+        };
+        // Omitted, not empty — see the DTO. Sorting PROPERTIES by label is right
+        // (an author scans them alphabetically); sorting their options is not.
+        if (options) dto.options = options;
+        return dto;
+      })
       .sort((a, b) => a.label.localeCompare(b.label));
     this.cache.set(accountId, { data: properties, expires: now + CACHE_TTL_MS });
     return { enabled: true, cached: false, properties };

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -560,6 +560,8 @@ export function FormRenderer({
           reveal={config.reveal}
           answers={answers}
           messages={revealMessages}
+          logo={logos.form}
+          name={name}
           onComplete={onRevealComplete}
         >
           <ClientLogosMarquee logos={revealLogos} label={m.trustedBy} />
@@ -577,7 +579,16 @@ export function FormRenderer({
         aria-live="polite"
         cover={chrome}
       >
+        {/* Hand-built rather than a `RevealScreen` — this screen has no timer and
+            no configurable copy. It shares the reveal's markup, so it has to
+            share the logo too: the two render back to back, and a logo that
+            vanished at the handover would read as a flicker on every submit. */}
         <div className="pf-reveal__inner">
+          {logos.form ? (
+            <div className="pf-reveal__brand">
+              <FormLogo src={logos.form} name={name} fallback="none" />
+            </div>
+          ) : null}
           <div className="pf-reveal__spinner" aria-hidden="true" />
           <p className="pf-reveal__subtitle">{m.submitting}</p>
         </div>
@@ -651,6 +662,8 @@ export function FormRenderer({
           reveal={step.reveal ?? { enabled: true }}
           answers={answers}
           messages={revealMessages}
+          logo={logos.form}
+          name={name}
           onComplete={() => {
             // Completing an interstitial is completing a step: reuse `advance`
             // so the partial-submit threshold, forward jumps and the finalize

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -1094,6 +1094,15 @@
   --pf-reveal-headline: clamp(22px, 5vw, 28px);
   --pf-reveal-subtitle: 15px;
 }
+/* The form's logo, above everything else on the screen. Margin only — the image
+   itself is already sized by `.pf__logo-img`, and the `data-pf-logo-size` presets
+   ride on the `.pf` root, so the reveal inherits whatever size the form is
+   configured for without this rule knowing about any of it. */
+.pf-reveal__brand {
+  margin: 0 0 28px;
+  display: flex;
+  justify-content: center;
+}
 /* Spread around the pinned `md`. `sm` has to sit clearly BELOW 52px or the two
    smallest steps are 4px apart on a laptop and read as the same choice. */
 .pf-reveal__inner[data-pf-reveal-mark='sm'] {

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -178,6 +178,12 @@ export function VerticalFormRenderer({
   const marqueeLogos = chrome?.clientLogos ?? config.branding?.clientLogos ?? [];
   const heroLogos = showClientLogosOn(chrome, 'cover') ? marqueeLogos : [];
   const revealLogos = showClientLogosOn(chrome, 'reveal') ? marqueeLogos : [];
+  // Resolved up here, not next to the header that consumes it: the reveal and
+  // submitting phases return BEFORE that point, and they need the logo too. One
+  // page, one header — and the hero right under it IS the cover screen when one
+  // is on, so the header carries the cover's logo there and the form's own when
+  // the cover is off. Either can be cleared to nothing independently.
+  const logos = resolveFormLogos(config);
   const revealMessages = {
     headline: m.revealHeadline,
     subtitle: m.revealSubtitle,
@@ -557,6 +563,8 @@ export function VerticalFormRenderer({
           reveal={pendingReveal ?? { enabled: true }}
           answers={answers}
           messages={revealMessages}
+          logo={logos.form}
+          name={name}
           onComplete={onRevealComplete}
         >
           <ClientLogosMarquee logos={revealLogos} label={m.trustedBy} />
@@ -574,7 +582,15 @@ export function VerticalFormRenderer({
         aria-live="polite"
         cover={chrome}
       >
+        {/* Same markup as the reveal, by hand — see the note on the slides
+            layout's copy of this screen. The logo has to be here too or it
+            blinks out at the reveal → submitting handover. */}
         <div className="pf-reveal__inner">
+          {logos.form ? (
+            <div className="pf-reveal__brand">
+              <FormLogo src={logos.form} name={name} fallback="none" />
+            </div>
+          ) : null}
           <div className="pf-reveal__spinner" aria-hidden="true" />
           <p className="pf-reveal__subtitle">{m.submitting}</p>
         </div>
@@ -582,10 +598,6 @@ export function VerticalFormRenderer({
     );
   }
 
-  // One page, one header — and the hero right under it IS the cover screen when
-  // one is on, so the header carries the cover's logo there and the form's own
-  // when the cover is off. Either can be cleared to nothing independently.
-  const logos = resolveFormLogos(config);
   const headerLogo = coverScreen ? logos.cover : logos.form;
   const total = answerable.length;
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -9,6 +9,7 @@ import {
   resolveOptionLayout,
   resolveOptionIcon,
   resolveDesign,
+  resolveFormLogos,
   resolveRevealPresentation,
 } from '@quill/engine';
 import { onAccent, DEFAULT_ACCENT, getMessages } from '@quill/shared';
@@ -168,6 +169,7 @@ export function CanvasQuestion({
         step={step}
         accent={accent}
         device={device}
+        logo={resolveFormLogos(config).form}
         onUpdate={onUpdate}
         m={m}
       />
@@ -664,12 +666,15 @@ function RevealCanvas({
   step,
   accent,
   device,
+  logo,
   onUpdate,
   m,
 }: {
   step: FormStep;
   accent: string;
   device: 'desktop' | 'mobile';
+  /** The form's logo, mirrored from the published screen. Absent renders nothing. */
+  logo?: string | null;
   onUpdate: (patch: Partial<FormStep>) => void;
   m: BuilderMessages;
 }) {
@@ -709,6 +714,18 @@ function RevealCanvas({
         )}
         style={accentBackground ? { background: accent, color: onAccentColor } : undefined}
       >
+        {/* Above the mark, as the published screen draws it. Plain `img` and not
+            `FormLogo`: the canvas mirrors the public markup by hand (see the note
+            on this component), and a broken URL should just leave a gap here
+            rather than print the form's internal name to its author. */}
+        {logo ? (
+          <img
+            src={logo}
+            alt=""
+            data-testid="canvas-reveal-logo"
+            className="mb-7 block h-[30px] w-auto max-w-[160px] object-contain"
+          />
+        ) : null}
         {loader === 'spinner' ? (
           <div
             aria-hidden

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -21,12 +21,19 @@ import { cn } from '@/lib/cn';
 import { bookingLabel } from '@/lib/booking-fields';
 import type {
   HubSpotPropertiesResponse,
+  HubSpotPropertyOption,
   WebhookPingReason,
   WebhookPingResult,
 } from '@/lib/admin-api';
 import { trackDestinationWrite } from '@/lib/connect-sync';
 import { propertyLookup, suggestProperty, type QuestionMeta } from './auto-map';
 import { Card } from './integrations-card';
+import {
+  isCustomValue,
+  optionsForProperty,
+  sharedOptionsFor,
+  targetPropertiesFor,
+} from './property-options';
 import { pingWebhookAction, saveIntegrationsAction } from './actions';
 
 type Msgs = FormsMessages['admin']['integrations'];
@@ -63,6 +70,8 @@ const NOT_READY: ContactKeyReadiness = { ok: false, blocker: 'no_source', source
 const CUSTOM_KEY_OPTION = '__custom_key__';
 const KEY_GROUP_QUESTIONS = '__group_questions__';
 const KEY_GROUP_SYSTEM = '__group_system__';
+/** Same idea for the value pickers — never a valid HubSpot picklist value. */
+const CUSTOM_VALUE_OPTION = '__custom_value__';
 
 /** Question types whose answers come from a fixed option list — the typical
  *  "translate this answer" case, so they lead the value-map key picker. */
@@ -665,6 +674,267 @@ function PropertyField({
 }
 
 /**
+ * A VALUE picker: the same free-text `Input` as before when nothing constrains
+ * the value, or a searchable Select of the property's own picklist when
+ * something does — plus a "Custom value…" escape hatch back to text.
+ *
+ * Deliberately NOT folded into `PropertyField` or `KeySelect`. Their branches
+ * turn on different questions (is the picker connected at all? / is this key one
+ * of the form's questions?), and `KeySelect`'s markup is asserted by two
+ * Playwright suites. ~25 duplicated lines is the cheaper side of that trade.
+ *
+ * `options === undefined` is the whole "no picklist" test — the API omits the
+ * key rather than sending `[]` (see `HubSpotProperty`).
+ */
+function OptionValueField({
+  value,
+  onChange,
+  options,
+  m,
+  ariaLabel,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  /** The values this may legally be, or undefined for free text. */
+  options: HubSpotPropertyOption[] | undefined;
+  m: Msgs;
+  ariaLabel: string;
+  placeholder: string;
+}) {
+  const locale = useContext(LocaleContext);
+  // A value the list can't show opens in text mode with the value VISIBLE. In a
+  // Select it would render as an empty box — configured, still written to
+  // HubSpot, and looking unset. Initial state only: switching modes later is
+  // the author's choice, made through the two buttons below.
+  const [customMode, setCustomMode] = useState(() => isCustomValue(options, value));
+
+  if (!options || customMode) {
+    return (
+      <div className="flex flex-1 items-center gap-2">
+        <Input
+          value={value}
+          aria-label={ariaLabel}
+          placeholder={placeholder}
+          className="flex-1"
+          onChange={(e) => onChange(e.target.value)}
+        />
+        {/* Only offered when there IS a list to go back to. */}
+        {options ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              // Never destroy a typed value on a mis-click — but a value the
+              // list cannot show would look unselected, so clear that one.
+              if (isCustomValue(options, value)) onChange('');
+              setCustomMode(false);
+            }}
+          >
+            {m.valueCustomBack}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  const selectOptions: SelectOption[] = [
+    { value: '', label: m.selectValue },
+    // HubSpot's own order, never re-sorted — a picklist's order means something.
+    // The internal value is shown next to the label because it is what actually
+    // gets written, and the two routinely differ ("1-10 employees" → `1`).
+    ...options.map((o) => ({ value: o.value, label: `${o.label} (${o.value})` })),
+    { value: CUSTOM_VALUE_OPTION, label: m.valueCustomOption },
+  ];
+  return (
+    <div className="min-w-0 flex-1">
+      <Select
+        ariaLabel={ariaLabel}
+        value={value}
+        options={selectOptions}
+        searchable
+        locale={locale}
+        onChange={(v) => {
+          if (v === CUSTOM_VALUE_OPTION) {
+            setCustomMode(true);
+            return;
+          }
+          onChange(v);
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * One value-map group: a question, and the answer→HubSpot-value rows for it.
+ *
+ * **Collapsed by default**, unlike `AdvancedSettings`, and for the opposite
+ * reason. There a closed group could hide behaviour someone didn't configure,
+ * so it opens when anything is set. Here the long group IS the complaint — an
+ * industry question with fifty values turns this panel into a scroll with no
+ * landmarks — and nothing is hidden by closing it: the header carries the
+ * question and the row count. A group with no question and no filled rows is
+ * brand new, so it opens; there is nothing to summarise yet.
+ *
+ * The header is a ROW of controls, not one big `<button>` like
+ * `AdvancedSettings`. It contains the key picker (itself a button) and Remove;
+ * nesting those inside a button is invalid HTML and the clicks fight. So the
+ * chevron is its own button and owns `aria-expanded`.
+ *
+ * No `overflow-hidden` on the wrapper — same flex `min-height:auto` trap
+ * documented at length in `advanced-settings.tsx`. Corners round on the header.
+ */
+function ValueMapGroupCard({
+  group,
+  questionOptions,
+  targets,
+  properties,
+  pickerEnabled,
+  m,
+  onGroupChange,
+  onRemove,
+}: {
+  group: ValueMapGroup;
+  questionOptions: QuestionMeta[];
+  /** Contact properties this question's answer is written to (0, 1, or many). */
+  targets: string[];
+  properties: { name: string; label: string; options?: HubSpotPropertyOption[] }[];
+  pickerEnabled: boolean;
+  m: Msgs;
+  onGroupChange: (next: ValueMapGroup) => void;
+  onRemove: () => void;
+}) {
+  // Nothing filled in yet = nothing for a collapsed header to summarise, so it
+  // opens. That covers a brand-new group AND the moment right after picking the
+  // question — collapsing the rows out from under someone who just chose one
+  // would be worse than the long scroll this is fixing.
+  const filled = group.rows.filter((r) => r.from.trim() || r.to.trim()).length;
+  const [open, setOpen] = useState(filled === 0);
+
+  // INTERSECTION, not union: the HubSpot adapter writes the one translated
+  // value to every target property, so a value only one of them accepts is a
+  // guaranteed partial write. `undefined` → the rows keep their text boxes.
+  const options = pickerEnabled ? sharedOptionsFor(properties, targets) : undefined;
+
+  const setRows = (rows: ValueMapRow[]) => onGroupChange({ ...group, rows });
+
+  return (
+    <div className="flex flex-col rounded-md border border-border" data-testid="valuemap-group">
+      <div
+        className={cn(
+          'flex items-center gap-2 p-3',
+          open && 'border-b border-border',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-label={open ? m.collapseGroup : m.expandGroup}
+          data-testid="valuemap-toggle"
+          className="shrink-0 rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i
+            aria-hidden
+            className={`pi ${open ? 'pi-chevron-down' : 'pi-chevron-right'}`}
+            style={{ fontSize: 11 }}
+          />
+        </button>
+        <KeySelect
+          value={group.stepKey}
+          questionOptions={questionOptions}
+          systemKeys={[]}
+          m={m}
+          testId="valuemap-key-select"
+          customTestId="valuemap-key-custom"
+          onChange={(v) => onGroupChange({ ...group, stepKey: v })}
+        />
+        {/* What a closed group would otherwise hide. Counts filled rows only —
+            a trailing blank row is scaffolding, not a configured translation. */}
+        <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+          {fill(m.valueMapRowCount, { n: String(filled) })}
+        </span>
+        <Button variant="ghost" size="sm" aria-label={m.remove} onClick={onRemove}>
+          {m.remove}
+        </Button>
+      </div>
+
+      {open ? (
+        <div className="flex flex-col gap-2 p-3">
+          {/* Why the right-hand side looks the way it does. Without this, a text
+              box on a fanned-out question reads as the picker being broken. */}
+          {pickerEnabled ? (
+            <p className="pl-4 text-xs text-muted-foreground" data-testid="valuemap-targets-hint">
+              {targets.length === 0
+                ? m.valueMapNoTarget
+                : fill(m.valueMapTargets, { properties: targets.join(', ') })}
+            </p>
+          ) : null}
+          {group.rows.map((row, ri) => (
+            <div key={ri} className="flex items-center gap-2 pl-4">
+              {/* The LEFT side stays free text: it is the answer as the form
+                  stores it, and `QuestionMeta` is built without the question's
+                  own options — surfacing those is a separate change. */}
+              <Input
+                value={row.from}
+                aria-label={m.valueMapAnswer}
+                placeholder={m.valueMapAnswer}
+                className="flex-1"
+                onChange={(e) => {
+                  const rows = [...group.rows];
+                  rows[ri] = { ...row, from: e.target.value };
+                  setRows(rows);
+                }}
+              />
+              <span aria-hidden className="text-muted-foreground">
+                →
+              </span>
+              {/* Keyed by the constraint, not the row: `OptionValueField`
+                  decides text-vs-dropdown once, on mount. Re-pointing the group
+                  at another question changes which values are legal, so the
+                  control has to re-derive — otherwise a stored value that the
+                  NEW picklist doesn't contain would render as an empty Select
+                  (configured, still saved, looking unset). */}
+              <OptionValueField
+                key={targets.join('|')}
+                value={row.to}
+                ariaLabel={m.valueMapCrmValue}
+                placeholder={m.valueMapCrmValue}
+                options={options}
+                m={m}
+                onChange={(v) => {
+                  const rows = [...group.rows];
+                  rows[ri] = { ...row, to: v };
+                  setRows(rows);
+                }}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={m.remove}
+                onClick={() => setRows(group.rows.filter((_, j) => j !== ri))}
+              >
+                {m.remove}
+              </Button>
+            </div>
+          ))}
+          <div className="pl-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRows([...group.rows, { from: '', to: '' }])}
+            >
+              {m.addValueMapRow}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
  * Step-key picker for "Custom field mappings" rows and "Value maps" groups: a
  * branded searchable Select over the form's own question keys (grouped, with
  * the UTM system fields where relevant) plus a "Custom key…" escape hatch that
@@ -995,7 +1265,8 @@ export function HubspotCard({
 }: {
   state: HubspotState;
   onChange: (s: HubspotState) => void;
-  properties: { name: string; label: string }[];
+  /** `options` rides along for the value pickers; absent = not an enumeration. */
+  properties: { name: string; label: string; options?: HubSpotPropertyOption[] }[];
   pickerEnabled: boolean;
   accountConnected: boolean;
   showMapping: boolean;
@@ -1375,91 +1646,25 @@ export function HubspotCard({
             <p className="text-xs text-muted-foreground">{m.emptyValueMaps}</p>
           ) : (
             state.valueMaps.map((group, gi) => (
-              <div key={gi} className="flex flex-col gap-2 rounded-md border border-border p-3">
-                <div className="flex items-center gap-2">
-                  <KeySelect
-                    value={group.stepKey}
-                    questionOptions={valueMapQuestions}
-                    systemKeys={[]}
-                    m={m}
-                    testId="valuemap-key-select"
-                    customTestId="valuemap-key-custom"
-                    onChange={(v) => {
-                      const next = [...state.valueMaps];
-                      next[gi] = { ...group, stepKey: v };
-                      onChange({ ...state, valueMaps: next });
-                    }}
-                  />
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    aria-label={m.remove}
-                    onClick={() =>
-                      onChange({ ...state, valueMaps: state.valueMaps.filter((_, j) => j !== gi) })
-                    }
-                  >
-                    {m.remove}
-                  </Button>
-                </div>
-                {group.rows.map((row, ri) => (
-                  <div key={ri} className="flex items-center gap-2 pl-4">
-                    <Input
-                      value={row.from}
-                      aria-label={m.valueMapAnswer}
-                      placeholder={m.valueMapAnswer}
-                      className="flex-1"
-                      onChange={(e) => {
-                        const next = [...state.valueMaps];
-                        const rows = [...group.rows];
-                        rows[ri] = { ...row, from: e.target.value };
-                        next[gi] = { ...group, rows };
-                        onChange({ ...state, valueMaps: next });
-                      }}
-                    />
-                    <span aria-hidden className="text-muted-foreground">
-                      →
-                    </span>
-                    <Input
-                      value={row.to}
-                      aria-label={m.valueMapCrmValue}
-                      placeholder={m.valueMapCrmValue}
-                      className="flex-1"
-                      onChange={(e) => {
-                        const next = [...state.valueMaps];
-                        const rows = [...group.rows];
-                        rows[ri] = { ...row, to: e.target.value };
-                        next[gi] = { ...group, rows };
-                        onChange({ ...state, valueMaps: next });
-                      }}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      aria-label={m.remove}
-                      onClick={() => {
-                        const next = [...state.valueMaps];
-                        next[gi] = { ...group, rows: group.rows.filter((_, j) => j !== ri) };
-                        onChange({ ...state, valueMaps: next });
-                      }}
-                    >
-                      {m.remove}
-                    </Button>
-                  </div>
-                ))}
-                <div className="pl-4">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      const next = [...state.valueMaps];
-                      next[gi] = { ...group, rows: [...group.rows, { from: '', to: '' }] };
-                      onChange({ ...state, valueMaps: next });
-                    }}
-                  >
-                    {m.addValueMapRow}
-                  </Button>
-                </div>
-              </div>
+              <ValueMapGroupCard
+                key={gi}
+                group={group}
+                questionOptions={valueMapQuestions}
+                // Which properties this question's answer is written to — the
+                // whole reason the right-hand side can offer a picklist at all.
+                targets={targetPropertiesFor(state.fieldMappings, group.stepKey)}
+                properties={properties}
+                pickerEnabled={pickerEnabled}
+                m={m}
+                onGroupChange={(next) => {
+                  const all = [...state.valueMaps];
+                  all[gi] = next;
+                  onChange({ ...state, valueMaps: all });
+                }}
+                onRemove={() =>
+                  onChange({ ...state, valueMaps: state.valueMaps.filter((_, j) => j !== gi) })
+                }
+              />
             ))
           )}
           <div>
@@ -1567,14 +1772,21 @@ export function HubspotCard({
                 <span aria-hidden className="text-muted-foreground">
                   →
                 </span>
-                <Input
+                {/* The property is picked right here, so its allowed values are
+                    known — no reason to make anyone retype an internal value.
+                    Keyed by the property so switching it re-reads the picklist,
+                    while the VALUE itself is deliberately left alone: a
+                    mis-click on the property must not destroy typed work. */}
+                <OptionValueField
+                  key={row.key}
                   value={row.value}
-                  aria-label={m.staticValue}
+                  ariaLabel={m.staticValue}
                   placeholder={m.staticValue}
-                  className="flex-1"
-                  onChange={(e) => {
+                  options={pickerEnabled ? optionsForProperty(properties, row.key) : undefined}
+                  m={m}
+                  onChange={(v) => {
                     const next = [...state.staticProperties];
-                    next[i] = { ...row, value: e.target.value };
+                    next[i] = { ...row, value: v };
                     onChange({ ...state, staticProperties: next });
                   }}
                 />

--- a/apps/web/app/admin/forms/[id]/integrations/property-options.spec.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/property-options.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { HubSpotProperty } from '@/lib/admin-api';
+import {
+  isCustomValue,
+  optionsForProperty,
+  sharedOptionsFor,
+  targetPropertiesFor,
+} from './property-options';
+
+const PROPERTIES: HubSpotProperty[] = [
+  { name: 'email', label: 'Email', type: 'string' },
+  {
+    name: 'hs_role',
+    label: 'Role',
+    type: 'enumeration',
+    options: [
+      { value: 'ic', label: 'Individual contributor' },
+      { value: 'manager', label: 'Manager' },
+      { value: 'exec', label: 'Executive' },
+    ],
+  },
+  {
+    name: 'jobtitle_enum',
+    label: 'Job title',
+    type: 'enumeration',
+    // Overlaps hs_role on manager/exec only, and in a DIFFERENT order.
+    options: [
+      { value: 'exec', label: 'C-level' },
+      { value: 'manager', label: 'People manager' },
+      { value: 'founder', label: 'Founder' },
+    ],
+  },
+  {
+    name: 'lifecyclestage',
+    label: 'Lifecycle stage',
+    type: 'enumeration',
+    options: [{ value: 'lead', label: 'Lead' }],
+  },
+];
+
+describe('optionsForProperty', () => {
+  it('returns the options of an enumeration property', () => {
+    expect(optionsForProperty(PROPERTIES, 'hs_role')?.map((o) => o.value)).toEqual([
+      'ic',
+      'manager',
+      'exec',
+    ]);
+  });
+
+  it('returns undefined for a text property, a blank name, and an unknown name', () => {
+    expect(optionsForProperty(PROPERTIES, 'email')).toBeUndefined();
+    expect(optionsForProperty(PROPERTIES, '')).toBeUndefined();
+    expect(optionsForProperty(PROPERTIES, '   ')).toBeUndefined();
+    // An author may type a property the picker has never seen (env fallback,
+    // stale cache). Free text, not an empty dropdown they can't type into.
+    expect(optionsForProperty(PROPERTIES, 'not_a_property')).toBeUndefined();
+  });
+
+  it('keeps HubSpot’s own order — never alphabetises', () => {
+    expect(optionsForProperty(PROPERTIES, 'hs_role')?.map((o) => o.label)).toEqual([
+      'Individual contributor',
+      'Manager',
+      'Executive',
+    ]);
+  });
+});
+
+describe('targetPropertiesFor', () => {
+  const mappings = [
+    { key: 'role', property: 'hs_role' },
+    { key: 'email', property: 'email' },
+    { key: 'role', property: 'jobtitle_enum' },
+    { key: 'role', property: '  ' },
+    { key: 'role', property: 'hs_role' },
+  ];
+
+  it('collects every property a question fans out to, de-duplicated', () => {
+    expect(targetPropertiesFor(mappings, 'role')).toEqual(['hs_role', 'jobtitle_enum']);
+  });
+
+  it('is empty for an unmapped key and for a blank key', () => {
+    expect(targetPropertiesFor(mappings, 'company')).toEqual([]);
+    expect(targetPropertiesFor(mappings, '')).toEqual([]);
+  });
+});
+
+describe('sharedOptionsFor', () => {
+  it('with no targets there is nothing to constrain the value', () => {
+    expect(sharedOptionsFor(PROPERTIES, [])).toBeUndefined();
+  });
+
+  it('a single enumeration target yields its own options', () => {
+    expect(sharedOptionsFor(PROPERTIES, ['hs_role'])?.map((o) => o.value)).toEqual([
+      'ic',
+      'manager',
+      'exec',
+    ]);
+  });
+
+  it('a single text target yields nothing (free text)', () => {
+    expect(sharedOptionsFor(PROPERTIES, ['email'])).toBeUndefined();
+  });
+
+  it('fan-out intersects — a value valid for only one target is a partial write', () => {
+    const shared = sharedOptionsFor(PROPERTIES, ['hs_role', 'jobtitle_enum']);
+    // `ic` is hs_role-only and `founder` is jobtitle-only: both are excluded.
+    expect(shared?.map((o) => o.value)).toEqual(['manager', 'exec']);
+    // Labels + order come from the FIRST target, not the second.
+    expect(shared?.map((o) => o.label)).toEqual(['Manager', 'Executive']);
+  });
+
+  it('fan-out where any target is free text falls back to free text', () => {
+    expect(sharedOptionsFor(PROPERTIES, ['hs_role', 'email'])).toBeUndefined();
+    expect(sharedOptionsFor(PROPERTIES, ['email', 'hs_role'])).toBeUndefined();
+    expect(sharedOptionsFor(PROPERTIES, ['hs_role', 'not_a_property'])).toBeUndefined();
+  });
+
+  it('fan-out with an empty intersection falls back to free text, not an empty list', () => {
+    // Two enumerations that share nothing: there is no value the adapter could
+    // write to both, so offering a dropdown would offer only wrong answers.
+    expect(sharedOptionsFor(PROPERTIES, ['hs_role', 'lifecyclestage'])).toBeUndefined();
+  });
+});
+
+describe('isCustomValue', () => {
+  const opts = optionsForProperty(PROPERTIES, 'hs_role');
+
+  it('a value that is not in the list opens the text escape hatch', () => {
+    // The exact regression this exists for: a config typed by hand before the
+    // picker existed must show what it holds, not render as unset.
+    expect(isCustomValue(opts, 'Gerente')).toBe(true);
+  });
+
+  it('a listed value, an empty value, and no options at all are not custom', () => {
+    expect(isCustomValue(opts, 'manager')).toBe(false);
+    expect(isCustomValue(opts, '')).toBe(false);
+    expect(isCustomValue(undefined, 'anything')).toBe(false);
+  });
+
+  it('matches on value, not on label — the label is not what gets written', () => {
+    expect(isCustomValue(opts, 'Manager')).toBe(true);
+  });
+});

--- a/apps/web/app/admin/forms/[id]/integrations/property-options.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/property-options.ts
@@ -1,0 +1,118 @@
+/**
+ * Which values a mapping may legally write to HubSpot — the join between the
+ * live property list and what this form's mapping actually targets.
+ *
+ * Pure functions, no React: the interesting part of the value pickers is this
+ * resolution, and it is easier to be sure about it here than through a rendered
+ * dropdown. The UI layer (`OptionValueField`) only decides between a `Select`
+ * and an `Input` based on what these return.
+ */
+
+import type { HubSpotPropertyOption } from '@/lib/admin-api';
+
+/**
+ * The only part of a property these functions read. Structural on purpose: the
+ * editor narrows its own `properties` prop, and nothing here needs `label` or
+ * `type` — `options` being present IS "this is an enumeration".
+ */
+export interface PropertyWithOptions {
+  name: string;
+  options?: HubSpotPropertyOption[];
+}
+
+/** One mapping row as the editor holds it: a form step key → a contact property. */
+export interface MappingPair {
+  key: string;
+  property: string;
+}
+
+/**
+ * The allowed values of one property, or `undefined` when it is not an
+ * enumeration (or is unknown to the picker — an author typing a property name
+ * the portal has never heard of must keep a free-text box, not get an empty
+ * dropdown they cannot escape).
+ */
+export function optionsForProperty(
+  properties: readonly PropertyWithOptions[],
+  name: string,
+): HubSpotPropertyOption[] | undefined {
+  const wanted = name.trim();
+  if (!wanted) return undefined;
+  const found = properties.find((p) => p.name === wanted);
+  // `options` is omitted (never `[]`) by the API for non-enumeration properties.
+  return found?.options?.length ? found.options : undefined;
+}
+
+/**
+ * Every contact property this step key's answer is written to.
+ *
+ * A value map is keyed by QUESTION, but the property is on the mapping — and a
+ * question may be mapped more than once (fan-out to `hs_role` AND `jobtitle`).
+ * Blank properties are dropped; duplicates collapse, so mapping the same
+ * question to the same property twice is one target, not two.
+ */
+export function targetPropertiesFor(
+  fieldMappings: readonly MappingPair[],
+  stepKey: string,
+): string[] {
+  const wanted = stepKey.trim();
+  if (!wanted) return [];
+  const out: string[] = [];
+  for (const pair of fieldMappings) {
+    if (pair.key !== wanted) continue;
+    const prop = pair.property.trim();
+    if (prop && !out.includes(prop)) out.push(prop);
+  }
+  return out;
+}
+
+/**
+ * The values that are valid for EVERY target — an intersection, deliberately
+ * not a union.
+ *
+ * The HubSpot adapter writes one translated value to all of a question's target
+ * properties. Offering a value that only one of them accepts would therefore
+ * guarantee a partial write: the sync succeeds for one property and HubSpot
+ * rejects it for the other, which surfaces later as a contact that is half
+ * updated. If any target is free-text (or unknown), there is no picklist to
+ * intersect and the answer is `undefined` → the UI keeps its text box.
+ *
+ * Labels and order come from the FIRST target: they are the same value either
+ * way, and a picklist's order carries meaning worth preserving.
+ */
+export function sharedOptionsFor(
+  properties: readonly PropertyWithOptions[],
+  targets: readonly string[],
+): HubSpotPropertyOption[] | undefined {
+  if (targets.length === 0) return undefined;
+  const first = optionsForProperty(properties, targets[0]!);
+  if (!first) return undefined;
+  let shared = first;
+  for (const target of targets.slice(1)) {
+    const next = optionsForProperty(properties, target);
+    if (!next) return undefined;
+    const allowed = new Set(next.map((o) => o.value));
+    shared = shared.filter((o) => allowed.has(o.value));
+    // Nothing writable to all of them — a text box is the only honest control.
+    if (shared.length === 0) return undefined;
+  }
+  return shared;
+}
+
+/**
+ * Does this stored value need the "custom value" escape hatch?
+ *
+ * A config written before the picker existed (or against a property whose
+ * options have since changed) holds a value that is not in the list. Rendering
+ * it in a `Select` would show an empty box — the value would look unset while
+ * still being saved and still being written to HubSpot. So a non-matching
+ * non-empty value opens the control in text mode, showing exactly what is
+ * configured. Empty is not "unrecognised", it is unset.
+ */
+export function isCustomValue(
+  options: readonly HubSpotPropertyOption[] | undefined,
+  value: string,
+): boolean {
+  if (!options || value === '') return false;
+  return !options.some((o) => o.value === value);
+}

--- a/apps/web/app/admin/forms/[id]/integrations/value-pickers.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/value-pickers.spec.tsx
@@ -1,0 +1,234 @@
+/**
+ * The value pickers, rendered through `HubspotCard` for real.
+ *
+ * `property-options.spec.ts` proves WHICH values are offered; this file proves
+ * the UI reaches that conclusion — that a picklist becomes a dropdown and
+ * everything else stays a text box, that a fanned-out question falls back to
+ * text with a hint saying why, and that a filled value-map group is born
+ * collapsed.
+ *
+ * Rendered with `renderToStaticMarkup` because these components use hooks (the
+ * web suite runs in plain node — see `vitest.config.ts`).
+ *
+ * The shared `Select` renders only its TRIGGER until it is opened, so its option
+ * list is not in this markup. Asserting on the trigger's visible label is not a
+ * workaround — it is the stronger assertion: the label shown for a value proves
+ * the picker resolved that value against the list it was given, which is exactly
+ * what these functions decide.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ContactKeyReadiness } from '@quill/engine';
+import { getMessages } from '@quill/shared';
+import type { HubSpotProperty } from '@/lib/admin-api';
+import { HubspotCard } from './integrations-editor';
+
+const m = getMessages('en').admin.integrations;
+
+const ready: ContactKeyReadiness = {
+  ok: true,
+  blocker: null,
+  source: { kind: 'question', key: 'email' },
+} as ContactKeyReadiness;
+
+const PROPERTIES: HubSpotProperty[] = [
+  { name: 'email', label: 'Email', type: 'string' },
+  {
+    name: 'hs_role',
+    label: 'Role',
+    type: 'enumeration',
+    options: [
+      { value: 'ic', label: 'Individual contributor' },
+      { value: 'manager', label: 'Manager' },
+    ],
+  },
+  {
+    name: 'jobtitle_enum',
+    label: 'Job title',
+    type: 'enumeration',
+    // Overlaps hs_role on `manager` only.
+    options: [
+      { value: 'manager', label: 'People manager' },
+      { value: 'founder', label: 'Founder' },
+    ],
+  },
+];
+
+type Over = {
+  pickerEnabled?: boolean;
+  properties?: HubSpotProperty[];
+  fieldMappings?: { key: string; property: string }[];
+  valueMaps?: { stepKey: string; rows: { from: string; to: string }[] }[];
+  staticProperties?: { key: string; value: string }[];
+};
+
+function markup(over: Over = {}): string {
+  return renderToStaticMarkup(
+    <HubspotCard
+      state={{
+        enabled: true,
+        fieldMappings: over.fieldMappings ?? [],
+        utmMappings: {},
+        scoreProperty: '',
+        dateProperty: '',
+        note: true,
+        valueMaps: over.valueMaps ?? [],
+        outcomeProperty: '',
+        staticProperties: over.staticProperties ?? [],
+        inferCompanyFromEmail: false,
+        bookingSync: {
+          stageProperty: '',
+          stageValue: '',
+          dateProperty: '',
+          hoursProperty: '',
+          dateTimezone: '',
+        },
+      }}
+      onChange={() => {}}
+      properties={over.properties ?? PROPERTIES}
+      pickerEnabled={over.pickerEnabled ?? true}
+      accountConnected
+      showMapping
+      extraHubspotStored={false}
+      readiness={ready}
+      questions={[
+        { key: 'email', type: 'email', label: 'Email' },
+        { key: 'role', type: 'dropdown', label: 'Your role' },
+      ]}
+      m={m}
+    />,
+  );
+}
+
+/**
+ * The markup of one labelled control — from its own opening tag through the
+ * text the user sees, which is enough to tell a dropdown trigger
+ * (`aria-haspopup="listbox"`) from an `<input>`.
+ */
+function controlFor(html: string, ariaLabel: string): string {
+  const at = html.indexOf(`aria-label="${ariaLabel}"`);
+  expect(at, `no control labelled ${ariaLabel}`).toBeGreaterThan(-1);
+  const from = html.lastIndexOf('<', at);
+  const end = html.indexOf('</button>', at);
+  return html.slice(from, end === -1 ? at + 400 : end);
+}
+
+const isDropdown = (control: string) => control.includes('aria-haspopup="listbox"');
+const isTextBox = (control: string) => control.trimStart().startsWith('<input');
+
+describe('static property values', () => {
+  it('an enumeration property gets a dropdown, showing the label AND the written value', () => {
+    const html = markup({ staticProperties: [{ key: 'hs_role', value: 'manager' }] });
+    const control = controlFor(html, m.staticValue);
+    expect(isDropdown(control)).toBe(true);
+    // Both, because they differ and the second is what actually reaches HubSpot.
+    expect(control).toContain('Manager (manager)');
+  });
+
+  it('an empty value on an enumeration shows the prompt, not a blank box', () => {
+    const html = markup({ staticProperties: [{ key: 'hs_role', value: '' }] });
+    expect(controlFor(html, m.staticValue)).toContain(m.selectValue);
+  });
+
+  it('a text property keeps the free-text box it has always had', () => {
+    const html = markup({ staticProperties: [{ key: 'email', value: 'ops@acme.test' }] });
+    expect(isTextBox(controlFor(html, m.staticValue))).toBe(true);
+  });
+
+  it('a value the picklist does not contain opens in TEXT mode showing that value', () => {
+    // The regression this guards: a hand-typed legacy value must not render as
+    // an empty dropdown — configured, still saved, and looking unset.
+    const html = markup({ staticProperties: [{ key: 'hs_role', value: 'Gerente' }] });
+    const control = controlFor(html, m.staticValue);
+    expect(isTextBox(control)).toBe(true);
+    expect(control).toContain('Gerente');
+  });
+
+  it('with the picker unavailable every value is free text', () => {
+    const html = markup({
+      pickerEnabled: false,
+      properties: [],
+      staticProperties: [{ key: 'hs_role', value: 'manager' }],
+    });
+    expect(isTextBox(controlFor(html, m.staticValue))).toBe(true);
+  });
+});
+
+describe('value-map groups', () => {
+  it('a group with filled rows is born COLLAPSED, with the count in the header', () => {
+    const html = markup({
+      valueMaps: [
+        {
+          stepKey: 'role',
+          rows: [
+            { from: 'Boss', to: 'manager' },
+            { from: 'Doer', to: 'ic' },
+            // A trailing blank row is scaffolding, not a configured translation.
+            { from: '', to: '' },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain('data-testid="valuemap-group"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('2 value(s)');
+    // Collapsed means the rows really are not rendered — otherwise nothing above
+    // is evidence of anything.
+    expect(html).not.toContain(`aria-label="${m.valueMapCrmValue}"`);
+  });
+
+  it('a group with nothing filled in opens — there is nothing to summarise', () => {
+    for (const stepKey of ['', 'role']) {
+      const html = markup({ valueMaps: [{ stepKey, rows: [{ from: '', to: '' }] }] });
+      expect(html, `stepKey=${stepKey || '(none)'}`).toContain('aria-expanded="true"');
+      expect(html).toContain(`aria-label="${m.valueMapCrmValue}"`);
+    }
+  });
+
+  it('one enumeration target → the right side is that property’s dropdown', () => {
+    const html = markup({
+      fieldMappings: [{ key: 'role', property: 'hs_role' }],
+      valueMaps: [{ stepKey: 'role', rows: [{ from: '', to: '' }] }],
+    });
+    expect(isDropdown(controlFor(html, m.valueMapCrmValue))).toBe(true);
+    expect(html).toContain('Values are written to: hs_role');
+    // The LEFT side is the answer as the form stores it — always free text.
+    expect(isTextBox(controlFor(html, m.valueMapAnswer))).toBe(true);
+  });
+
+  it('an unmapped question gets free text and says why', () => {
+    const html = markup({ valueMaps: [{ stepKey: 'role', rows: [{ from: '', to: '' }] }] });
+    expect(isTextBox(controlFor(html, m.valueMapCrmValue))).toBe(true);
+    expect(html).toContain(m.valueMapNoTarget);
+  });
+
+  // These use blank rows on purpose: a filled group renders collapsed (proved
+  // above), and `renderToStaticMarkup` cannot click the chevron open. Which
+  // values survive the intersection is `property-options.spec.ts`'s job; what
+  // matters here is that the UI ends up with the right KIND of control and
+  // names its targets.
+
+  it('fan-out to two overlapping enumerations still offers a dropdown, and names both', () => {
+    const html = markup({
+      fieldMappings: [
+        { key: 'role', property: 'hs_role' },
+        { key: 'role', property: 'jobtitle_enum' },
+      ],
+      valueMaps: [{ stepKey: 'role', rows: [{ from: '', to: '' }] }],
+    });
+    expect(html).toContain('Values are written to: hs_role, jobtitle_enum');
+    expect(isDropdown(controlFor(html, m.valueMapCrmValue))).toBe(true);
+  });
+
+  it('fan-out where one target is free text falls back to free text', () => {
+    const html = markup({
+      fieldMappings: [
+        { key: 'role', property: 'hs_role' },
+        { key: 'role', property: 'email' },
+      ],
+      valueMaps: [{ stepKey: 'role', rows: [{ from: '', to: '' }] }],
+    });
+    expect(html).toContain('Values are written to: hs_role, email');
+    expect(isTextBox(controlFor(html, m.valueMapCrmValue))).toBe(true);
+  });
+});

--- a/apps/web/components/made-with-badge.tsx
+++ b/apps/web/components/made-with-badge.tsx
@@ -3,8 +3,12 @@ import { BrandMark } from '@/components/brand/brand';
 import { signupHref } from '@/lib/growth';
 
 /**
- * "Made with Dapta Forms" — the growth-loop attribution on every public
- * surface (R11).
+ * "Powered by Dapta" — the growth-loop attribution on every public surface (R11).
+ *
+ * The copy names the PLATFORM, not the product: a respondent who has just filled
+ * a form is a warmer lead for Dapta than for Dapta Forms, and the badge's whole
+ * job is to send them somewhere. Where it sends them is `NEXT_PUBLIC_SIGNUP_URL`
+ * — never a domain in this file (see `signupHref`).
  *
  * It is FORM CHROME, not a document footer. It used to render as a `<footer>`
  * AFTER the renderer in `page.tsx`, and `.pf` carries `min-height: 100dvh` —
@@ -41,9 +45,8 @@ export function MadeWithBadge({
         target="_blank"
         rel="noopener noreferrer"
       >
-        {/* The product's own mark, not the parent Dapta D — the copy next to it
-            reads "Made with Dapta Forms". Ink is currentColor, so it picks up
-            the pill's foreground and stays legible on any host background. */}
+        {/* Ink is currentColor, so the mark picks up the pill's foreground and
+            stays legible on any host background. */}
         <BrandMark className="pf__attribution-mark" />
         <span>{m.growth.madeWith}</span>
         {/* Localized, like every other string on this surface — this used to be

--- a/apps/web/components/public/form-logo.tsx
+++ b/apps/web/components/public/form-logo.tsx
@@ -6,8 +6,23 @@ import { useState } from 'react';
  * The form's logo in the top bar. Uses the per-form logo URL when set, else a
  * text fallback (the form name). No hardcoded tenant asset — the pilot's baked-in
  * Dapta logo is generalized to config-driven branding.
+ *
+ * `fallback` is what happens when there is no usable image. `'name'` prints the
+ * form's name, which is right for the top bar: a form with no logo still needs a
+ * header. `'none'` renders nothing, and exists for surfaces where the name would
+ * be worse than silence — the name here is the ADMIN's name for the form, and a
+ * respondent has no business reading "Q3 paid-ads lead gen v2" because an image
+ * 404'd.
  */
-export function FormLogo({ src, name }: { src?: string | null; name: string }) {
+export function FormLogo({
+  src,
+  name,
+  fallback = 'name',
+}: {
+  src?: string | null;
+  name: string;
+  fallback?: 'name' | 'none';
+}) {
   const [failed, setFailed] = useState(false);
   if (src && !failed) {
     return (
@@ -20,6 +35,7 @@ export function FormLogo({ src, name }: { src?: string | null; name: string }) {
       />
     );
   }
+  if (fallback === 'none') return null;
   return (
     <span className="pf__logo--fallback">
       {name}

--- a/apps/web/components/public/reveal-screen.spec.tsx
+++ b/apps/web/components/public/reveal-screen.spec.tsx
@@ -4,7 +4,8 @@
  * the engine's `interpolate`, and the 2200ms default duration.
  */
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_REVEAL_MS, resolveRevealCopy } from './reveal-screen';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DEFAULT_REVEAL_MS, RevealScreen, resolveRevealCopy } from './reveal-screen';
 
 const messages = {
   headline: 'Reviewing your answers…',
@@ -89,5 +90,51 @@ describe('resolveRevealCopy', () => {
     expect(resolveRevealCopy({ durationMs: 5000 }, {}, messages).durationMs).toBe(5000);
     expect(resolveRevealCopy({}, {}, messages).durationMs).toBe(DEFAULT_REVEAL_MS);
     expect(DEFAULT_REVEAL_MS).toBe(2200);
+  });
+});
+
+/**
+ * The brand logo on the interstitial.
+ *
+ * Two guarantees worth a test rather than an eyeball. The first is the absent
+ * case: a form with no logo has to render byte-identical to what it rendered
+ * before this prop existed, and "byte-identical" is exactly the kind of claim
+ * that rots silently. The second is that a broken image prints NOTHING — the
+ * `name` here is the author's internal name for the form, and it must never
+ * reach a respondent because a URL 404'd.
+ */
+describe('RevealScreen — the brand logo', () => {
+  const base = { answers: {}, messages, name: 'Q3 paid-ads lead gen v2' };
+
+  it('renders no brand block, and no name, when there is no logo', () => {
+    const html = renderToStaticMarkup(<RevealScreen {...base} />);
+    expect(html).not.toContain('pf-reveal__brand');
+    // The whole reason for `fallback="none"`.
+    expect(html).not.toContain('Q3 paid-ads lead gen v2');
+  });
+
+  it('a null logo is the same as no logo', () => {
+    expect(renderToStaticMarkup(<RevealScreen {...base} logo={null} />)).toBe(
+      renderToStaticMarkup(<RevealScreen {...base} />),
+    );
+  });
+
+  it('renders the logo above the copy when there is one', () => {
+    const html = renderToStaticMarkup(<RevealScreen {...base} logo="https://cdn.test/logo.svg" />);
+    expect(html).toContain('pf-reveal__brand');
+    expect(html).toContain('https://cdn.test/logo.svg');
+    // Above the headline, not merely present.
+    expect(html.indexOf('pf-reveal__brand')).toBeLessThan(html.indexOf('pf-reveal__headline'));
+    // The name rides as the alt only — never as visible text.
+    expect(html).toContain('alt="Q3 paid-ads lead gen v2"');
+  });
+
+  it('sits above every loader variant', () => {
+    for (const loader of ['spinner', 'bar', 'versus', 'none'] as const) {
+      const html = renderToStaticMarkup(
+        <RevealScreen {...base} reveal={{ enabled: true, loader }} logo="https://cdn.test/l.svg" />,
+      );
+      expect(html).toContain('pf-reveal__brand');
+    }
   });
 });

--- a/apps/web/components/public/reveal-screen.tsx
+++ b/apps/web/components/public/reveal-screen.tsx
@@ -7,6 +7,7 @@ import {
   type Answers,
   type FormReveal,
 } from '@quill/engine';
+import { FormLogo } from '@/components/public/form-logo';
 
 /** The interstitial's default play time when the config sets none. */
 export const DEFAULT_REVEAL_MS = 2200;
@@ -159,12 +160,22 @@ export function RevealScreen({
   reveal,
   answers,
   messages,
+  logo,
+  name,
   children,
   onComplete,
 }: {
   reveal?: FormReveal | null;
   answers: Answers;
   messages: RevealScreenMessages;
+  /**
+   * The form's logo (`resolveFormLogos(...).form`), shown above the copy. The
+   * FORM's logo and not the cover's: this is a phase inside the form, not the
+   * front door. Absent/null renders nothing, so a form without one is unchanged.
+   */
+  logo?: string | null;
+  /** Only the image's `alt`; never printed — see `fallback="none"` below. */
+  name: string;
   /**
    * Rendered under the interstitial — the "trusted by" marquee, when scoped
    * here. Presented to assistive tech as decoration; see the wrapper below.
@@ -206,6 +217,15 @@ export function RevealScreen({
       data-pf-reveal-mark={loaderSize}
       data-pf-reveal-text={textSize}
     >
+      {/* Above everything, including the spinner: this is the brand the
+          respondent came for, and the wait is the one screen where nothing else
+          is competing for the space. `fallback="none"` because a broken image
+          must render nothing here — the name is the author's internal one. */}
+      {logo ? (
+        <div className="pf-reveal__brand">
+          <FormLogo src={logo} name={name} fallback="none" />
+        </div>
+      ) : null}
       {loader === 'spinner' ? <div className="pf-reveal__spinner" aria-hidden="true" /> : null}
       <h1 className="pf-reveal__headline">{headline}</h1>
       <p className="pf-reveal__subtitle">{subtitle}</p>

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -259,11 +259,27 @@ function qs(params: Record<string, string | number | undefined | null>): string 
 
 export const isAdminRole = (role: AccountRole): boolean => role === 'owner' || role === 'admin';
 
+/**
+ * One allowed value of an enumeration property. `value` is what gets WRITTEN to
+ * HubSpot, `label` is what HubSpot shows a human — routinely different, which
+ * is why these are worth a picker instead of a text box.
+ */
+export interface HubSpotPropertyOption {
+  value: string;
+  label: string;
+}
+
 /** A HubSpot contact property surfaced to the mapping UI. */
 export interface HubSpotProperty {
   name: string;
   label: string;
   type: string;
+  /**
+   * Allowed values, for enumeration properties only — ABSENT on text/number/date
+   * ones (never `[]`), so `options?.length` is the whole "is this a picklist?"
+   * test. Order is HubSpot's own; never re-sort it.
+   */
+  options?: HubSpotPropertyOption[];
 }
 
 /** The property-picker response: disabled (no server token) or the property list. */

--- a/packages/shared/src/growth.ts
+++ b/packages/shared/src/growth.ts
@@ -1,5 +1,5 @@
 /**
- * Growth loop — the "Made with Dapta Forms" attribution on public pages.
+ * Growth loop — the "Powered by Dapta" attribution on public pages.
  *
  * Open-core rule: like the app-switcher's platform URL, the signup destination
  * comes ONLY from the deployment (NEXT_PUBLIC_SIGNUP_URL) — no internal host
@@ -55,9 +55,9 @@ export function buildSignupUrl(opts: {
  *    `signupUrl` otherwise.
  *
  * They were the same value once, and that was the bug: both surfaces greet a
- * STRANGER — the badge says "Made with Dapta Forms", the CTA asks "Want your
- * own form?" — and both were dropping that person on the app's login screen for
- * a product they had never heard of. A landing page is written for exactly that
+ * STRANGER — the badge says "Powered by Dapta", the CTA asks "Want your own
+ * form?" — and both were dropping that person on the app's login screen for a
+ * product they had never heard of. A landing page is written for exactly that
  * reader; a login screen is written for someone who already decided.
  */
 export function growthTarget(opts: {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1151,6 +1151,18 @@ export interface FormsMessages {
       bookingStart: string;
       keyCustomBack: string;
       selectKeyPlaceholder: string;
+      // Value pickers — choosing a HubSpot value instead of typing it exactly
+      selectValue: string;
+      valueCustomOption: string;
+      valueCustomBack: string;
+      /** Which properties a value map writes to. `{properties}` = a comma list. */
+      valueMapTargets: string;
+      /** Why a value map has no picker: nothing is mapped, so nothing constrains it. */
+      valueMapNoTarget: string;
+      /** Rows inside a collapsed value-map group. `{n}` = the row count. */
+      valueMapRowCount: string;
+      expandGroup: string;
+      collapseGroup: string;
       webhookEvents: string;
       webhookEventsHelp: string;
       eventPartial: string;
@@ -1429,7 +1441,7 @@ export interface FormsMessages {
 
 export const en: FormsMessages = {
   growth: {
-    madeWith: 'Made with Dapta Forms',
+    madeWith: 'Powered by Dapta',
     ctaQuestion: 'Want your own form?',
     ctaAction: 'Get Dapta Forms — free',
     seoForm: 'Fill out {name} online.',
@@ -2480,6 +2492,14 @@ export const en: FormsMessages = {
       bookingStart: 'Booking — meeting time',
       keyCustomBack: 'Back to list',
       selectKeyPlaceholder: 'Select a field…',
+      selectValue: 'Select a value…',
+      valueCustomOption: 'Custom value…',
+      valueCustomBack: 'Back to list',
+      valueMapTargets: 'Values are written to: {properties}',
+      valueMapNoTarget: 'Map this question to a property above to pick from its values.',
+      valueMapRowCount: '{n} value(s)',
+      expandGroup: 'Expand',
+      collapseGroup: 'Collapse',
       webhookEvents: 'Trigger on',
       webhookEventsHelp: 'Choose which submissions are sent to this webhook. Both are sent by default.',
       eventPartial: 'Partial submissions',
@@ -2752,7 +2772,7 @@ export const en: FormsMessages = {
 
 export const es: FormsMessages = {
   growth: {
-    madeWith: 'Hecho con Dapta Forms',
+    madeWith: 'Con tecnología de Dapta',
     ctaQuestion: '¿Quieres tu propio formulario?',
     ctaAction: 'Consigue Dapta Forms — gratis',
     seoForm: 'Completa {name} en línea.',
@@ -3810,6 +3830,14 @@ export const es: FormsMessages = {
       bookingStart: 'Agenda — hora de la reunión',
       keyCustomBack: 'Volver a la lista',
       selectKeyPlaceholder: 'Selecciona un campo…',
+      selectValue: 'Selecciona un valor…',
+      valueCustomOption: 'Valor personalizado…',
+      valueCustomBack: 'Volver a la lista',
+      valueMapTargets: 'Los valores se escriben en: {properties}',
+      valueMapNoTarget: 'Asigna esta pregunta a una propiedad arriba para elegir entre sus valores.',
+      valueMapRowCount: '{n} valor(es)',
+      expandGroup: 'Desplegar',
+      collapseGroup: 'Plegar',
       webhookEvents: 'Disparar en',
       webhookEventsHelp: 'Elige qué respuestas se envían a este webhook. Por defecto se envían ambas.',
       eventPartial: 'Respuestas parciales',


### PR DESCRIPTION
Tres pedidos de la revisión de migración, más el copy del badge.

## El logo en la pantalla de reveal ⭐

Era el último de los tres bloqueos nombrados para migrar los formularios en vivo
(el banner de arriba y el logo de portada ya entraron en #74/#75).

Usa `branding.logo`, **no** el de portada: el reveal es una fase *dentro* del
formulario, no su puerta de entrada. Lo muestran los dos renderers y también la
pantalla de `submitting`, que dibuja su propio `.pf-reveal__inner` inline — sin
eso el logo parpadearía justo al enviar.

El canvas del builder dibuja su propio reveal, así que también lo lleva: un
preview que no coincide con el formulario publicado es el bug, no un follow-up.

⚠️ `resolveFormLogos` en el renderer vertical estaba **después** del early
return del reveal. Hubo que subirlo; falla en silencio, no en compilación.

`FormLogo` gana `fallback="none"`. Su fallback de texto imprime el nombre del
formulario, que es el nombre **interno** de admin — un respondiente no debe leer
"Q3 paid-ads lead gen v2" porque una imagen dio 404. Un formulario sin logo
renderiza byte a byte igual que antes.

## Las `options` de HubSpot llegan al front

El picker de propiedades descartaba el array `options` que HubSpot manda en la
misma respuesta. Ahora viaja, sólo para propiedades de enumeración:

- La clave se **omite**, no se manda vacía, para que la respuesta no gane ~400
  arrays vacíos.
- Las opciones con `hidden` se descartan: HubSpot las esconde de sus propios
  pickers, así que ofrecerlas dejaría configurar una escritura que luego rechaza.
- **No se reordenan.** El orden de una picklist significa algo (etapas,
  seniority, tamaños). El `.sort()` que ya existía ordena *propiedades*, y ése
  se queda.

🔒 El caché es por cuenta y ahora lleva **valores**, no sólo nombres: uno global
filtraría la taxonomía comercial interna de un portal. El keying es
load-bearing; no convertirlo en caché compartido.

## Dropdowns donde antes se tecleaba el valor exacto

Dos sitios: static properties y el lado derecho de un value map.

Un value map se guarda por **pregunta**, y una pregunta puede estar mapeada a
varias propiedades. Los valores ofrecidos son la **intersección**, no la unión:
el adapter escribe el mismo valor traducido en *todas* las propiedades destino,
así que un valor que sólo acepta una es una escritura a medias garantizada. Un
hint nombra los destinos, para que una caja de texto en una pregunta abanicada
se lea como un motivo y no como un picker roto.

Un valor guardado que no esté en la lista abre en **modo texto mostrando ese
valor**. En un dropdown saldría como una caja vacía: configurado, guardado, y
con pinta de sin poner.

Sin nada que restrinja el valor (sin mapeo, propiedad de texto, portal sin
picker) → el mismo `<Input>` de siempre.

## Los grupos de value maps colapsan

Con la pregunta y el número de traducciones en la cabecera. Un mapa de industria
con cincuenta valores convertía el panel en un scroll sin puntos de referencia.
Un grupo sin nada relleno **abre**: no hay nada que resumir, y colapsarle las
filas a alguien que acaba de elegir la pregunta es peor que el scroll.

La cabecera es una fila de controles y no un solo `<button>`: contiene el
`KeySelect` y el botón de Remove, que no pueden anidarse dentro de un botón.

## Copy del badge

"Powered by Dapta" / "Con tecnología de Dapta" — la plataforma, no este producto
suelto. A dónde apunta sigue siendo configuración del deploy
(`NEXT_PUBLIC_SIGNUP_URL`); no hay dominio hardcodeado.

---

**Invariante #4 intacta.** `staticProperties` y `valueMaps` siguen guardando los
mismos strings, un valor elegido escribe exactamente lo que escribía uno
tecleado, y las listas de opciones de HubSpot son metadata viva que nunca se
snapshotea.

## Verificación

- typecheck 16/16, lint 16/16 (0 warnings), **1178 tests**, publish-gate verde
- `property-options.spec.ts` — 14 tests de la lógica pura del join
- `value-pickers.spec.tsx` — 11 tests renderizando `HubspotCard` de verdad
- Mutación comprobada: cambiar la intersección por unión rompe tests en **las
  dos** capas
- Verificado en vivo el logo del reveal con la app corriendo

⚠️ Lo único no verificado en vivo: el logo en la pantalla de `submitting`. Está
confirmado por código y typecheck en los dos renderers, pero no llegué a
observar la transición.