### PR TITLE
fix(web): the badge names Dapta — mark, destination, and a quiet skip

### DIFF
--- a/.changeset/dapta-mark-and-quiet-skip.md
+++ b/.changeset/dapta-mark-and-quiet-skip.md
@@ -1,0 +1,42 @@
+---
+'@quill/web': patch
+---
+
+Sign the attribution badge with Dapta's `d`, and stop the scheduler's skip
+shouting over the calendar.
+
+**The badge's mark now matches its own sentence.** The copy became "Powered by
+Dapta" in the last release, but the mark beside it stayed the product's `F`, so
+the pill named the company and drew the product — the two halves arguing about
+where the reader was being sent. `PlatformMark` renders the parent artwork
+(`components/brand/dapta-logo.tsx`, the shipped "Dapta D" copied path-for-path),
+and it is a separate component from `BrandMark` precisely so a surface signs
+itself with the mark that matches the name written next to it. Every other call
+site — the app switcher, the admin rail, the error pages — is in-product chrome
+that says "Forms", and keeps the `F`.
+
+The bowl draws in `currentColor` so it inherits the pill's foreground and follows
+dark/light and any host branding; only the lime tick is literal, which is the
+role the official light/dark files split into two assets. The viewBox is cropped
+to the ink — the source file pads the same artwork to 279×298, which would have
+rendered a 16px mark at about 8px of visible glyph. Both properties are pinned by
+`dapta-logo.spec.tsx`, including the crop, which caught a hundredth-of-a-unit
+clip on the tick's left edge.
+
+The open-core gate is unchanged: a fork gets its own initial, never Dapta's `d`.
+
+**"Skip for now" is a quiet control, not the loudest thing on the screen.** It
+carried `pf__btn`, so an optional scheduler step rendered a full-width, 54px,
+accent-filled bar directly under the calendar — the way OUT of the step styled as
+the primary action, which left the booking itself looking optional. It is now
+`.pf__skip`, in the same no-fill idiom as `.pf__back`.
+
+Its colour is derived from the form's own two colours rather than taken from
+`--muted-foreground`. That token is a 62% mix tuned for helper text and lands at
+3.97:1 on a cream form, under the 4.5:1 AA floor for a 15px label; 74% measures
+5.71:1 there and 8.75:1 on the default dark ground, against body text at 12.81
+and 15.70. It is deliberately not scoped under `.pf[data-pf-button=…]` — those
+styles describe the primary action, and a form with outlined buttons should not
+also outline its escape hatch.
+
+Nothing about when the skip appears changed: still `!step.required` only.

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -735,10 +735,15 @@ export function FormRenderer({
                     {m.schedulerUnconfigured}
                   </p>
                 )}
+                {/* An escape hatch, so it is styled as one — `.pf__skip`, NOT
+                    `.pf__btn`. As a primary button it rendered full-width and
+                    accent-filled directly under the calendar, which made the way
+                    OUT of the step the loudest thing on it and left the booking
+                    itself looking optional. */}
                 {!step.required ? (
                   <button
                     type="button"
-                    className="pf__btn pf__btn--inline"
+                    className="pf__skip"
                     onClick={() => void advance(answers, step)}
                   >
                     {m.schedulerSkip}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -848,6 +848,64 @@
   margin-top: 28px;
 }
 
+/* ── Skip (optional scheduler step) ── */
+/* Deliberately NOT a `.pf__btn`. It was one, and that made "Skip for now" a
+   full-width 54px accent bar sitting right under the calendar — the most
+   prominent control on the screen, telling the respondent that leaving was the
+   intended move. An escape hatch has to be findable, not louder than the thing
+   it escapes, so this is the quiet-control idiom `.pf__back` already uses:
+   no fill, muted ink, a wash of `--muted` on hover.
+
+   Every colour here is derived from the form's OWN two colours, which is what
+   makes it follow the form's contrast: `formThemeVars` builds the palette by
+   mixing the ground toward the text, so this control lightens on a dark form and
+   darkens on a light one with no branch and no second rule. It deliberately
+   never takes `--pf-primary` — the brand kit paints that exactly as chosen with
+   no contrast correction, and a label is the one place that is not safe (see the
+   B3 note below). Measured on a cream form whose accent is lime, `--pf-primary`
+   against the ground is **1.14:1**.
+
+   Not scoped under `.pf[data-pf-button=…]` either, and that is the point: the
+   solid/outline/soft styles describe the PRIMARY action. A form whose buttons
+   are outlined should not also outline its skip. */
+.pf__skip {
+  display: block;
+  margin: 20px auto 0;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.2;
+  /* NOT `--muted-foreground`, and the 12 points are the whole reason. That token
+     is a 62% mix tuned for helper text, and at 15px it lands at 3.97:1 on a cream
+     form — under the 4.5:1 AA floor for text this size. Measured against the
+     composited ground, 74% gives:
+
+           form            skip    helper(62%)   body    accent
+           default dark    8.75       7.00       15.70   13.49
+           cream + lime    5.71       3.97       12.81    1.15
+
+     Quiet against the body text it must not compete with, readable everywhere,
+     and the accent column is the argument for never colouring a label with it.
+
+     Two traps if you re-measure: composite the translucent card over the page
+     first, and let the entry transition settle — CSS interpolates colour in
+     oklab, so an early sample reads a mid-flight frame, not what ships. */
+  color: color-mix(in srgb, var(--foreground) 74%, var(--background));
+  /* The quiet controls follow the form's radius scale like everything else, but
+     via `--pf-radius-btn`'s own fallback rather than the button role: on a
+     `round` form a pill-shaped hover wash is right, on a sharp one it is not. */
+  border-radius: var(--pf-radius-btn, var(--pf-radius-sm));
+  cursor: pointer;
+  transition: background 0.12s var(--pf-ease), color 0.12s var(--pf-ease);
+}
+.pf__skip:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
 /* ── Cover ── */
 .pf--cover .pf__cover-header {
   flex-shrink: 0;

--- a/apps/web/components/brand/brand.tsx
+++ b/apps/web/components/brand/brand.tsx
@@ -1,3 +1,4 @@
+import { DaptaMark } from './dapta-logo';
 import { FormsLockup, FormsMark, FormsWordmark } from './forms-logo';
 
 /**
@@ -9,14 +10,21 @@ import { FormsLockup, FormsMark, FormsWordmark } from './forms-logo';
  * from whatever it called the product. That is the same principle as
  * `MadeWithBadge`: a fork is never forced to carry Dapta branding.
  *
- * Call sites use `<BrandLockup>` / `<BrandMark>` and never the raw marks, so the
- * gate cannot be forgotten on a new surface.
+ * Call sites use `<BrandLockup>` / `<BrandMark>` / `<PlatformMark>` and never the
+ * raw marks, so the gate cannot be forgotten on a new surface.
  */
 
 export const PRODUCT_NAME = process.env.NEXT_PUBLIC_PRODUCT_NAME || 'Forms';
 
 /** True only on a build that identifies itself as Dapta's own. */
 export const IS_DAPTA_BRAND = PRODUCT_NAME === 'Dapta Forms';
+
+/**
+ * The company behind the product. Constant, not env-driven: unlike
+ * `PRODUCT_NAME` there is nothing here for a deployment to rename — on a fork
+ * the gate above means this string is never reached.
+ */
+const PLATFORM_NAME = 'Dapta';
 
 /**
  * Full wordmark. Roughly 6:1 — size it with a height class and let width follow
@@ -62,6 +70,25 @@ export function BrandWordmark({ className, labelled }: { className?: string; lab
 export function BrandMark({ className, labelled }: { className?: string; labelled?: boolean }) {
   if (IS_DAPTA_BRAND) {
     return <FormsMark className={className} title={labelled ? PRODUCT_NAME : undefined} />;
+  }
+  return <FallbackChip />;
+}
+
+/**
+ * The PLATFORM's mark — Dapta's `d`, not the product's `F`.
+ *
+ * Distinct from `BrandMark` on purpose, and the two are not interchangeable: a
+ * surface signs itself with the mark that matches the name written next to it.
+ * In-product chrome says "Forms" and takes `BrandMark`; the attribution badge on
+ * a public form says "Powered by Dapta" and takes this one. Pairing either mark
+ * with the other name is the bug this split exists to prevent.
+ *
+ * Same open-core gate as every other surface here — a fork gets its own initial,
+ * never Dapta's `d`.
+ */
+export function PlatformMark({ className, labelled }: { className?: string; labelled?: boolean }) {
+  if (IS_DAPTA_BRAND) {
+    return <DaptaMark className={className} title={labelled ? PLATFORM_NAME : undefined} />;
   }
   return <FallbackChip />;
 }

--- a/apps/web/components/brand/dapta-logo.spec.tsx
+++ b/apps/web/components/brand/dapta-logo.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * The parent mark's two invariants: it is TWO-TONE the right way round, and its
+ * viewBox is cropped to the ink.
+ *
+ * Both are the kind of thing a well-meaning edit undoes silently. Flattening the
+ * bowl to a literal hex still looks correct on the light form it was checked on
+ * and disappears on a dark one; pasting the source file's 279×298 viewBox back
+ * still renders a `d`, just at half the height every call site asked for.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DaptaMark } from './dapta-logo';
+
+const markup = (props?: { title?: string; className?: string }) =>
+  renderToStaticMarkup(<DaptaMark {...props} />);
+
+/** Every `d="…"` in the rendered mark. */
+function paths(svg: string): string[] {
+  return [...svg.matchAll(/ d="([^"]+)"/g)].map((m) => m[1]!);
+}
+
+/**
+ * Bounding box of an SVG path, walking the commands this artwork actually uses
+ * (M, H, L, C, Z) so that H's single x is not mistaken for an x/y pair. Control
+ * points count: a Bézier never leaves its hull, so the hull is a safe over-
+ * estimate — which is the direction that matters for asserting a tight crop.
+ */
+function bounds(d: string) {
+  const tokens = d.match(/[MHLCZ]|-?\d*\.?\d+/gi) ?? [];
+  const box = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+  const seeX = (v: number) => {
+    box.minX = Math.min(box.minX, v);
+    box.maxX = Math.max(box.maxX, v);
+  };
+  const seeY = (v: number) => {
+    box.minY = Math.min(box.minY, v);
+    box.maxY = Math.max(box.maxY, v);
+  };
+  let cmd = '';
+  let i = 0;
+  while (i < tokens.length) {
+    const t = tokens[i]!;
+    if (/[MHLCZ]/i.test(t)) {
+      cmd = t.toUpperCase();
+      i += 1;
+      continue;
+    }
+    const n = (k: number) => Number(tokens[i + k]);
+    if (cmd === 'H') {
+      seeX(n(0));
+      i += 1;
+    } else if (cmd === 'M' || cmd === 'L') {
+      seeX(n(0));
+      seeY(n(1));
+      i += 2;
+    } else if (cmd === 'C') {
+      for (let p = 0; p < 6; p += 2) {
+        seeX(n(p));
+        seeY(n(p + 1));
+      }
+      i += 6;
+    } else {
+      i += 1; // V is not used by this artwork; skip anything unexpected
+    }
+  }
+  return box;
+}
+
+describe('DaptaMark', () => {
+  it('draws the bowl in currentColor and keeps only the tick literal', () => {
+    const svg = markup();
+    // The bowl must adapt: a literal here is invisible on a form whose ground
+    // matches it, and the badge sits on arbitrary host branding.
+    expect(svg).toContain('fill="currentColor"');
+    expect(svg).toContain('fill="#cbe84f"');
+    // Exactly one of each — not a flat single-colour variant, not a bowl that
+    // has quietly become lime too.
+    expect(svg.match(/fill="currentColor"/g)).toHaveLength(1);
+    expect(svg.match(/fill="#cbe84f"/gi)).toHaveLength(1);
+  });
+
+  it('crops the viewBox to the ink, so a CSS height is the height of the glyph', () => {
+    const svg = markup();
+    const [, x, y, w, h] = /viewBox="(-?[\d.]+) (-?[\d.]+) ([\d.]+) ([\d.]+)"/
+      .exec(svg)!
+      .map(Number) as [unknown, number, number, number, number];
+
+    const all = paths(svg).map(bounds);
+    const ink = {
+      minX: Math.min(...all.map((b) => b.minX)),
+      minY: Math.min(...all.map((b) => b.minY)),
+      maxX: Math.max(...all.map((b) => b.maxX)),
+      maxY: Math.max(...all.map((b) => b.maxY)),
+    };
+
+    // Nothing clipped…
+    expect(ink.minX).toBeGreaterThanOrEqual(x);
+    expect(ink.minY).toBeGreaterThanOrEqual(y);
+    expect(ink.maxX).toBeLessThanOrEqual(x + w);
+    expect(ink.maxY).toBeLessThanOrEqual(y + h);
+    // …and no baked-in padding either. The source file pads the same artwork to
+    // 279×298, which would leave the ink filling barely half of each axis.
+    expect((ink.maxX - ink.minX) / w).toBeGreaterThan(0.98);
+    expect((ink.maxY - ink.minY) / h).toBeGreaterThan(0.98);
+  });
+
+  it('is decorative by default and only announces itself when labelled', () => {
+    // The badge sets no title: the visible "Powered by Dapta" beside it already
+    // names the link, and a title would have a screen reader say it twice.
+    expect(markup()).toContain('aria-hidden="true"');
+    expect(markup()).not.toContain('<title>');
+
+    const labelled = renderToStaticMarkup(<DaptaMark title="Dapta" />);
+    expect(labelled).toContain('role="img"');
+    expect(labelled).toContain('<title>Dapta</title>');
+    expect(labelled).not.toContain('aria-hidden');
+  });
+
+  it('carries no element ids, so two instances on one page cannot collide', () => {
+    expect(markup()).not.toMatch(/\sid="/);
+  });
+
+  it('forwards className, since callers size it with CSS', () => {
+    expect(markup({ className: 'pf__attribution-mark' })).toContain(
+      'class="pf__attribution-mark"',
+    );
+  });
+});

--- a/apps/web/components/brand/dapta-logo.tsx
+++ b/apps/web/components/brand/dapta-logo.tsx
@@ -1,0 +1,62 @@
+import type { SVGProps } from 'react';
+
+/**
+ * The PARENT company's mark — Dapta's `d`, not the product's `F`.
+ *
+ * Kept in its own file, away from `forms-logo.tsx`, for the reason that file
+ * states in its own header: the parent mark is never redrawn. The geometry below
+ * is the shipped brand artwork ("Dapta D", 279×298) copied path-for-path; no
+ * point was moved, rounded, or re-exported through a tracer.
+ *
+ * Two paths, and they are not interchangeable:
+ *  - the **`d` bowl**, drawn in `currentColor` so it inherits whatever text
+ *    colour it sits in and follows dark/light with no second asset. This is the
+ *    role the official files call "Dark" (`#1A1A1C`) on a light ground and
+ *    "Light" (`#EFEFEF`) on a dark one — one token replaces both.
+ *  - the **lime tick**, literal. It is the one constant across every official
+ *    variant except the flat single-colour ones, and it is what makes the mark
+ *    read as Dapta's rather than as a generic lowercase d.
+ *
+ * The viewBox is CROPPED to the artwork (the source file pads it to 279×298).
+ * A mark sized by CSS height must put its ink in that height — padding baked
+ * into the viewBox would render a 16px `d` at about 8px of visible glyph. The
+ * brand's clear space is supplied by the layout instead (`gap` on the badge).
+ */
+
+/**
+ * Dapta's lime, taken from the parent artwork. It is a hair off `forms-logo.tsx`'s
+ * `LIME` (`#cae940`) — that value comes from the Forms logotype, this one from
+ * the Dapta files, and each stays faithful to its own source. The two marks never
+ * appear side by side, so the difference is never visible as an inconsistency.
+ */
+const DAPTA_LIME = '#cbe84f';
+
+/**
+ * Just the `d`. Near-square (~0.98:1) — size it with a height and let width
+ * follow, never the other way round.
+ */
+export function DaptaMark({ title, ...props }: SVGProps<SVGSVGElement> & { title?: string }) {
+  return (
+    <svg
+      /* Ink runs x 60.0684→202.425, y 76.9297→221.953; the box is rounded
+         OUTWARD from those, never inward — rounding the origin up by a
+         hundredth shaves the tick's left edge. `dapta-logo.spec.tsx` asserts
+         both directions. */
+      viewBox="60.06 76.92 142.37 145.04"
+      role={title ? 'img' : 'presentation'}
+      aria-hidden={title ? undefined : true}
+      focusable="false"
+      {...props}
+    >
+      {title ? <title>{title}</title> : null}
+      <path
+        fill="currentColor"
+        d="M144.491 76.9297H115.499L110.071 99.3098H141.586C165.257 99.3098 177.302 112.571 177.302 134.941C177.302 167.053 155.707 199.573 122.067 199.573H87.1699L82.0732 221.953H116.873C170.247 221.953 202.425 179.069 202.425 132.452C202.425 96.1988 179.378 76.9297 144.491 76.9297Z"
+      />
+      <path
+        fill={DAPTA_LIME}
+        d="M93.4453 172.547L87.1694 199.574H60.0684L66.3442 172.547H93.4453Z"
+      />
+    </svg>
+  );
+}

--- a/apps/web/components/made-with-badge.tsx
+++ b/apps/web/components/made-with-badge.tsx
@@ -1,5 +1,5 @@
 import { getMessages } from '@quill/shared';
-import { BrandMark } from '@/components/brand/brand';
+import { PlatformMark } from '@/components/brand/brand';
 import { signupHref } from '@/lib/growth';
 
 /**
@@ -9,6 +9,11 @@ import { signupHref } from '@/lib/growth';
  * a form is a warmer lead for Dapta than for Dapta Forms, and the badge's whole
  * job is to send them somewhere. Where it sends them is `NEXT_PUBLIC_SIGNUP_URL`
  * — never a domain in this file (see `signupHref`).
+ *
+ * The MARK follows the copy, which is why this is the one surface taking
+ * `PlatformMark` and not `BrandMark`: the badge used to set the product's `F`
+ * beside a sentence naming the company, so the two halves of the pill argued
+ * with each other about who the reader was being sent to.
  *
  * It is FORM CHROME, not a document footer. It used to render as a `<footer>`
  * AFTER the renderer in `page.tsx`, and `.pf` carries `min-height: 100dvh` —
@@ -45,9 +50,11 @@ export function MadeWithBadge({
         target="_blank"
         rel="noopener noreferrer"
       >
-        {/* Ink is currentColor, so the mark picks up the pill's foreground and
-            stays legible on any host background. */}
-        <BrandMark className="pf__attribution-mark" />
+        {/* The bowl is currentColor, so it picks up the pill's foreground and
+            stays legible on any host background; only the lime tick is literal.
+            Unlabelled on purpose — the visible text right beside it already
+            names the destination, so a title here would read it out twice. */}
+        <PlatformMark className="pf__attribution-mark" />
         <span>{m.growth.madeWith}</span>
         {/* Localized, like every other string on this surface — this used to be
             a hardcoded English "(opens in a new tab)". Same catalog key the


### PR DESCRIPTION
Three things on the attribution badge and the scheduler step, all visible on a live form.

## 1. The badge went to daptaforms.ai instead of dapta.ai

The destination is a **Dockerfile default, not a deploy-repo build arg** — which is why grepping the pipeline for the wrong host turns up nothing. `growthTarget` prefers `NEXT_PUBLIC_LANDING_URL` over `NEXT_PUBLIC_SIGNUP_URL`, CI never passes the former, so the image default wins.

That default was written when the copy read "Made with Dapta Forms", and its comment says exactly that. The copy now reads "Powered by Dapta" — the sentence moved to the platform, and the destination is the same change finished.

**Apex, no `www.`** The two domains are mirror images, and the wrong one silently kills the loop it exists to feed:

```
https://dapta.ai/?utm_…      → 200, no redirect, query INTACT
https://www.dapta.ai/?utm_…  → 301 to apex, query DROPPED
```

`daptaforms.ai` behaves the opposite way, which is where the old `www.` came from. Copying that habit across would have dropped `utm_source`, `utm_medium`, `utm_campaign` and `utm_content` — every attributed signup would look like direct traffic.

Set in **both** Dockerfile stages: the client bundle inlines the build stage's value, SSR reads the run stage's. A drift between them serves one host in the HTML and another after hydration.

> Note for the deploy repo: `fix/badge-target-landing` (unmerged) targets `www.daptaforms.ai` and also **deletes both `NEXT_PUBLIC_PRODUCT_ANALYTICS_*` build args**, which would drop Dapta's own telemetry from the bundle. It is superseded by this PR and should be closed rather than merged.

## 2. The badge drew the wrong mark

The copy became "Powered by Dapta" in #79, but the mark beside it stayed the product's `F` — the pill named the company and drew the product. There was no Dapta mark in the tree at all; it had never been written.

`components/brand/dapta-logo.tsx` is the shipped **"Dapta D"** artwork copied path-for-path. `PlatformMark` is a **separate component from `BrandMark` on purpose**: a surface signs itself with the mark that matches the name written next to it. App switcher, admin rail and error pages all say "Forms" and keep the `F`.

- The **bowl is `currentColor`** → follows dark/light and any host branding; only the **lime tick is literal**, which is the role the official light/dark files split into two assets
- The **viewBox is cropped to the ink** — the source pads the same artwork to 279×298, which would render a 16px mark at ~8px of glyph
- **Open-core gate unchanged**: a fork gets its own initial, never Dapta's `d`

The crop test earned its keep immediately: it caught a hundredth-of-a-unit clip on the tick's left edge from rounding the viewBox origin inward.

## 3. "Skip for now" was the loudest thing on the scheduler step

It carried `pf__btn`, so an optional scheduler step rendered a **full-width, 54px, accent-filled bar directly under the calendar**. The way *out* of the step was styled as the primary action, leaving the booking itself looking optional. Now `.pf__skip`, in the no-fill idiom `.pf__back` already uses.

**Colour derives from the form's own two colours**, not `--muted-foreground`. That token is a 62% mix tuned for helper text and fails AA at 15px on a light form:

| form | skip | helper (62%) | body | accent |
|---|---|---|---|---|
| default dark | **8.75** | 7.00 | 15.70 | 13.49 |
| cream + lime | **5.71** | 3.97 | 12.81 | 1.15 |

That accent column is the standing argument for never colouring a label with `--pf-primary`.

Deliberately **not** scoped under `.pf[data-pf-button=…]` — those styles describe the *primary* action, and a form with outlined buttons should not also outline its escape hatch. **When the skip appears is unchanged**: still `!step.required` only.

## Verification

- `pnpm lint` · `pnpm typecheck` · `pnpm test` — **1188 tests green**, 5 new
- publish-gate **PASSED**
- Badge href checked **in the SSR HTML and after hydration** — both `https://dapta.ai?utm_source=dapta-forms&utm_medium=badge&utm_campaign=made-with-dapta&utm_content=acme`
- Redirect behaviour of both hosts measured with `curl -L`, not assumed
- Driven with Playwright on a real optional-scheduler form in **both** themes — default dark, and cream with `buttonStyle: outline` + `radius: round` — confirming the skip does not inherit the primary button's styling
- Contrast measured by compositing the translucent card over the page, **after the entry transition settles**: CSS interpolates colour in oklab, so an early sample reads a mid-flight frame (that mistake read 12.57 where the truth is 8.75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)