### PR TITLE
fix(web): give the IAM single-logout the session it needs

### DIFF
--- a/.changeset/dark-default-drop-system-theme.md
+++ b/.changeset/dark-default-drop-system-theme.md
@@ -1,0 +1,28 @@
+---
+'@quill/shared': minor
+---
+
+Make dark the theme, and light the opt-in — no more "System".
+
+The colour scheme had three values and the third one served nobody. `System`
+followed the OS by stamping no `data-theme` at all, so a viewer on a light-mode
+machine got a dashboard neither they nor we had chosen, and the choice they
+thought they had made was really a choice not to make one. The product is
+authored dark, an unbranded public form is pinned dark regardless of any cookie
+(`lib/form-design.ts`), and the one surface that followed the OS was the admin
+chrome — the only place the inconsistency could show.
+
+Dark is now the default and light is a deliberate opt-in. The sidebar control
+becomes a two-state flip instead of a three-state cycle, and the Settings picker
+names both. `admin.chrome.theme.system` is gone from the message catalog in both
+locales.
+
+No migration: `isThemePref` no longer recognises `system`, and `getThemePref`
+already falls back to `dark` for anything it does not recognise, so a browser
+still carrying the old cookie lands on the new default rather than on a scheme
+that can no longer be selected.
+
+The token sheet's `@media (prefers-color-scheme: light)` block stays. Dapta Forms
+can no longer reach it — the root layout now always stamps `dark` or `light` —
+but it is the fallback for a self-host that embeds these tokens without our
+layout, which would otherwise be stuck on the dark base with no way to opt out.

--- a/apps/web/app/admin/settings/theme-settings.tsx
+++ b/apps/web/app/admin/settings/theme-settings.tsx
@@ -12,11 +12,10 @@ type ThemeMessages = FormsMessages['admin']['chrome']['theme'];
 /**
  * The colour-scheme preference, named and explained.
  *
- * The sidebar already has a one-click cycle for switching fast; this is the other
- * half of the same setting — the place where all three choices are visible at once
- * and `System` says in words that it follows the OS. A cycle button is the wrong
- * control to *learn* a setting from: you cannot see what the options are without
- * pressing it repeatedly.
+ * The sidebar already has a one-click flip for switching fast; this is the other
+ * half of the same setting — the place where both choices are named at once. An
+ * icon-only button is the wrong control to *learn* a setting from: you cannot see
+ * what the options are without pressing it.
  *
  * Rendered with the builder's own `SegmentedToggle` rather than a second copy of
  * it. This used to re-implement the same radiogroup shell, the same selected-chip

--- a/apps/web/app/admin/theme-actions.ts
+++ b/apps/web/app/admin/theme-actions.ts
@@ -18,6 +18,10 @@ export async function setThemeAction(pref: ThemePref): Promise<void> {
   // anything unknown to `dark` — a stale client bundle after a rename, or a typo,
   // silently flipped someone's pinned Light and revalidated the whole app with no
   // error anywhere to explain it. Ignoring the write leaves their choice intact.
+  //
+  // This is also what retires the removed `system` value with no migration: a
+  // stale tab still posting it is ignored, and the cookie it already wrote reads
+  // back as unrecognised, so `getThemePref` hands out the `dark` default.
   if (!isThemePref(pref)) return;
   const value: ThemePref = pref;
   const jar = await cookies();

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import 'primeicons/primeicons.css';
 import './globals.css';
 import { fontVariables } from '@/lib/fonts';
-import { themeAttribute } from '@/lib/theme';
 import { getThemePref } from '@/lib/theme.server';
 
 // Customer-facing name comes from the deployment (NEXT_PUBLIC_PRODUCT_NAME,
@@ -29,10 +28,10 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
-  // The scheme used to be the literal `data-theme="dark"`, which pinned the whole
-  // product to dark and made the token sheet's light theme unreachable. It is now
-  // the viewer's persisted choice, resolved on the server so the first response
-  // already carries it — see lib/theme.ts for why that matters.
+  // The viewer's persisted choice, resolved on the server so the first response
+  // already carries it — see lib/theme.server.ts for why that matters. Dark
+  // unless they opted into light; the attribute is ALWAYS stamped, so the token
+  // sheet's `prefers-color-scheme` fallback never decides for us.
   //
   // This is ADMIN chrome only, despite being the root. A public form does not
   // take the scheme from here: `formDesignProps` pins an unbranded form to the
@@ -40,7 +39,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   // builder's preview cannot show the author's dashboard preference and call it
   // the published page. Read that comment before widening this one — "the viewer's
   // preference" is not what a respondent gets, because a respondent has no cookie.
-  const theme = themeAttribute(await getThemePref());
+  const theme = await getThemePref();
   return (
     // Every curated face is declared here so a public form can switch typeface
     // without a rebuild; only the brand face is preloaded (see lib/fonts.ts).

--- a/apps/web/app/login/actions.ts
+++ b/apps/web/app/login/actions.ts
@@ -25,10 +25,18 @@ export async function signInAction(
  * Logout (AUTH-WEB-CONTRACT §2/§3.5). Clearing the cookie is what makes logout
  * real in AUTH_LOCAL_STRICT mode (the next /v1/me is a 401 → /login). For workos
  * a cookie-only clear leaves the WorkOS session alive, so we must also redirect
- * through the IAM/WorkOS logout — handled by /api/auth/logout (scaffolded).
+ * through the IAM/WorkOS logout — handled by /api/auth/logout.
+ *
+ * On workos we must NOT clear the cookie here. `delete()` lands as a Set-Cookie
+ * on THIS response, so the browser drops the session before it navigates to
+ * /api/auth/logout — which then reads a null session, finds no `sessionId`, and
+ * skips the IAM single-logout entirely. That left the upstream WorkOS session
+ * alive: sign out looked like it worked, and the next "sign in" silently
+ * re-authenticated the same person straight back into /admin. The route reads
+ * the session id and then clears the cookie itself, in that order.
  */
 export async function signOutAction(): Promise<void> {
-  await clearSession();
   if (authProvider() === 'workos') redirect('/api/auth/logout');
+  await clearSession();
   redirect('/login');
 }

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -8,13 +8,12 @@ import { THEME_ICON, THEME_PREFS, type ThemePref } from '@/lib/theme';
 type ThemeMessages = FormsMessages['admin']['chrome']['theme'];
 
 /**
- * The colour-scheme toggle: one icon button that cycles system → light → dark.
+ * The colour-scheme toggle: one icon button that flips dark ↔ light.
  *
- * A cycle rather than a select because it lives in the sidebar's icon row beside
- * "view public page" and "sign out", and because switching is the whole point —
- * the fast path matters more than naming all three states at once. `system` is in
- * the cycle rather than hidden behind a menu so a viewer who pinned a scheme can
- * hand the decision back to their OS.
+ * A flip rather than a select because it lives in the sidebar's icon row beside
+ * "view public page" and "sign out", and because switching is the whole point.
+ * There is no `system` state to return to — the product is dark by default and
+ * light is an opt-in (see lib/theme.ts), so two states name themselves.
  *
  * The icon shows the CURRENT state and the tooltip names the NEXT one, so the
  * control is readable without a label: an icon-only button whose tooltip repeats

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -49,12 +49,18 @@ async function req<T>(method: string, path: string, body?: unknown): Promise<T> 
     cache: 'no-store',
   });
   if (res.status === 401) {
+    // Workos: leave the cookie alone. /api/auth/logout reads the session id off
+    // it to revoke upstream and then clears it itself — deleting it here first
+    // hands that route a null session and silently skips the single-logout (see
+    // `signOutAction`). This path only appeared to work because `delete()` throws
+    // during a Server Component render; from a Server Action it lands and breaks.
+    if (authProvider() === 'workos') redirect('/api/auth/logout');
     try {
       await clearSession();
     } catch {
       /* cookies are immutable during render — the redirect still fires */
     }
-    redirect(authProvider() === 'workos' ? '/api/auth/logout' : '/login');
+    redirect('/login');
   }
   // The stored workspace is no longer ours — the membership was revoked, or the
   // account is gone. Self-heal rather than leaving every page 403ing with no way

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -137,8 +137,13 @@ export async function hostFetch(path: string, init?: RequestInit): Promise<Respo
     cache: 'no-store',
   });
   if (res.status === 401) {
+    // Workos goes through /api/auth/logout, which needs the cookie STILL PRESENT
+    // to read the session id and revoke upstream — clearing it here would land a
+    // Set-Cookie on this response and hand that route a null session (see
+    // `signOutAction`). The route clears it itself, unconditionally.
+    if (authProvider() === 'workos') redirect('/api/auth/logout');
     await clearSession();
-    redirect(authProvider() === 'workos' ? '/api/auth/logout' : '/login');
+    redirect('/login');
   }
   return res;
 }

--- a/apps/web/lib/theme.server.ts
+++ b/apps/web/lib/theme.server.ts
@@ -11,9 +11,10 @@ import { isThemePref, THEME_COOKIE, type ThemePref } from './theme';
  * judged by. Reading it here means there is nothing to correct after hydration
  * and no blocking inline script in `<head>`.
  *
- * Defaults to `dark`, which is what the app rendered when the scheme was pinned
- * in the root layout — a viewer with no cookie sees exactly what they saw before
- * the toggle existed.
+ * Defaults to `dark`. That covers three cases with one line: never chose, cleared
+ * their cookies, or still carries the retired `system` value — `isThemePref` no
+ * longer recognises it, so it reads as "no choice" and lands on the default
+ * instead of on a scheme nobody can select any more.
  */
 export async function getThemePref(): Promise<ThemePref> {
   const value = (await cookies()).get(THEME_COOKIE)?.value;

--- a/apps/web/lib/theme.ts
+++ b/apps/web/lib/theme.ts
@@ -12,43 +12,34 @@
 export const THEME_COOKIE = 'quill_theme';
 
 /**
- * What the viewer asked for — not what they get.
+ * What the viewer chose. Two values, not three.
  *
- * `system` is a real third value rather than the absence of a choice: it means
- * "follow the OS", which is a decision the toggle has to be able to return to
- * once someone has pinned a scheme.
+ * There used to be a `system` preference that followed the OS by stamping no
+ * attribute at all. It is gone on purpose: the product is authored dark, dark is
+ * what an unbranded public form is pinned to (see `lib/form-design.ts`), and
+ * "follow the OS" meant a viewer on a light-mode laptop got a dashboard that
+ * neither they nor we had chosen. Dark is the default and light is an opt-in.
+ *
+ * Dropping the value costs no migration: `isThemePref` now rejects a stored
+ * `system`, and `getThemePref` already falls back to `dark` for anything it does
+ * not recognise — so a browser still carrying the old cookie lands on the new
+ * default rather than on a broken state.
  */
-export type ThemePref = 'dark' | 'light' | 'system';
+export type ThemePref = 'dark' | 'light';
 
-/** Cycle order for the toggle. */
-export const THEME_PREFS: readonly ThemePref[] = ['system', 'light', 'dark'];
+/** Cycle order for the toggle — the default first, so index 0 is "unset". */
+export const THEME_PREFS: readonly ThemePref[] = ['dark', 'light'];
 
 /**
  * The PrimeIcon naming each preference. Here rather than in a component because
- * two of them render it — the sidebar's cycle button and the Settings picker —
- * and they had byte-identical copies, so a fourth preference meant remembering to
- * edit both.
+ * two of them render it — the sidebar's toggle and the Settings picker — and they
+ * had byte-identical copies, so a third preference meant remembering to edit both.
  */
 export const THEME_ICON: Record<ThemePref, string> = {
-  system: 'pi-desktop',
   light: 'pi-sun',
   dark: 'pi-moon',
 };
 
 export function isThemePref(value: string | undefined): value is ThemePref {
-  return value === 'dark' || value === 'light' || value === 'system';
-}
-
-/**
- * The `data-theme` attribute value for a preference, or `undefined` to omit the
- * attribute entirely.
- *
- * Omission is the whole mechanism for `system`: the token sheet's
- * `@media (prefers-color-scheme: light)` block is written as
- * `:root:not([data-theme='dark'])`, so it only takes effect when nothing is
- * pinned. Stamping `data-theme="system"` would match neither branch and leave the
- * viewer on the dark base tokens no matter what their OS says.
- */
-export function themeAttribute(pref: ThemePref): 'dark' | 'light' | undefined {
-  return pref === 'system' ? undefined : pref;
+  return value === 'dark' || value === 'light';
 }

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -116,7 +116,6 @@ export interface FormsMessages {
         label: string;
         dark: string;
         light: string;
-        system: string;
         next: string;
       };
       /** Left-nav item labels (icon + label). */
@@ -1516,7 +1515,6 @@ export const en: FormsMessages = {
         label: 'Theme',
         dark: 'Dark',
         light: 'Light',
-        system: 'System',
         next: 'Switch to',
       },
       nav: {
@@ -2839,7 +2837,6 @@ export const es: FormsMessages = {
         label: 'Tema',
         dark: 'Oscuro',
         light: 'Claro',
-        system: 'Sistema',
         next: 'Cambiar a',
       },
       nav: {

--- a/packages/shared/src/tokens.css
+++ b/packages/shared/src/tokens.css
@@ -211,10 +211,16 @@
   --ring: hsl(var(--acc-h) var(--acc-s) 28%);
 }
 
-/* The `system` preference: no `data-theme` is stamped, so this decides. Must stay
-   value-for-value identical to the `[data-theme='light']` block above — a token
-   that lands in only one of the two makes the OS-following path silently different
-   from the pinned one, which is the hardest kind of theme bug to notice. */
+/* The no-attribute fallback: whoever renders this sheet stamped no `data-theme`,
+   so the OS decides. Dapta Forms no longer reaches it — the retired `system`
+   preference was the only way to omit the attribute, and the root layout now
+   always stamps `dark` or `light`. It stays for a self-host that embeds these
+   tokens without our layout, which would otherwise get the dark base on a
+   light-mode machine with no way to opt out.
+
+   Must stay value-for-value identical to the `[data-theme='light']` block above:
+   both apply at once when light is pinned, and a token that lands in only one of
+   them is the hardest kind of theme bug to notice. */
 @media (prefers-color-scheme: light) {
   :root:not([data-theme='dark']) {
     --background: #f4f6f8;


### PR DESCRIPTION
Two changes, one branch. The sign-out fix is the reason the branch exists; the theme change is a small rider that shipped alongside it.

1. **`fix(web)`** — sign out never closed the upstream session
2. **`feat(web)`** — dark is the theme, light is the opt-in, `System` is gone

---

# 1. Sign out never closed the session

It cleared the local cookie, landed the user on `/login?signedout=1`, and left the upstream WorkOS/AuthKit session alive — so the next "Continue with Dapta" silently re-authenticated the same person straight back into `/admin` without ever showing a login screen.

`signOutAction` cleared the cookie **before** redirecting to the handler that needs it:

```ts
// apps/web/app/login/actions.ts (before)
await clearSession();                                     // cookie gone here
if (authProvider() === 'workos') redirect('/api/auth/logout');
```

```ts
// apps/web/app/api/auth/logout/route.ts (unchanged)
const session = await getSession();                       // null, always
const sessionId = session?.provider === 'workos' ? session.sessionId : undefined;
if (iam && sessionId) { ...POST {IAM}/auth/logout... }    // dead branch
return NextResponse.redirect(new URL('/login?signedout=1', origin));
```

The `delete()` lands as a `Set-Cookie` on the **action's** response. The browser applies it and only *then* navigates to `/api/auth/logout`, which reads a null session, finds no `sessionId`, and skips the single-logout entirely. The IAM logout code has been in the tree since the initial platform snapshot and was never reachable from the UI.

The `?signedout=1` landing is itself the tell — [`login/page.tsx:23`](https://github.com/Dapta-Tech/dapta-forms/blob/develop/apps/web/app/login/page.tsx#L23) only renders the sign-in card for `?error=` or `?signedout=1`, and that param is produced at exactly one place: the fallback branch of the logout route.

### The fix

Stop clearing the cookie first. The route already reads the session id and then clears it itself, in that order.

The same `clearSession()` → `redirect('/api/auth/logout')` pattern exists on both 401 paths, so a mid-session expiry did not revoke upstream either. Both are fixed alongside. Note `admin-api.ts` only *appeared* to work: its `clearSession()` sits in a `try/catch` because `cookies().delete()` throws during a Server Component render, so the cookie survived by accident — from a Server Action (branding, integrations, onboarding actions) the delete lands and the single-logout is skipped exactly as above.

| File | Path |
|---|---|
| `apps/web/app/login/actions.ts` | the sign-out button |
| `apps/web/lib/auth-session.ts` | `hostFetch` on 401 |
| `apps/web/lib/admin-api.ts` | `req()` on 401 |

`?signedout=1` stays. It is still the landing for the fallback branch (no `IAM_BASE_URL`, no `sessionId`, IAM error) and for the `local` provider, and its single reader is what stops a signed-out user from being bounced straight back into `/api/auth/login`.

### Verification

The real IAM cannot be exercised from localhost (its redirect-URI allowlist rejects a loopback `returnTo`), so this was verified against a stub speaking the two documented endpoints — `GET /auth/login-url` and `POST /auth/logout` — with the access token signed by the same `JWT_SECRET` the API validates. The stub logs every request, so the assertion is on **what was sent**, not just that a redirect happened.

**With the fix:**

```
POST /admin → signOutAction() → GET /api/auth/logout 307 → the IAM's logoutUrl
IAM received: POST /auth/logout {"workos_session_id":"workos_session_STUB_123"}
```

**With the fix reverted, same environment:**

```
POST /admin → signOutAction() → GET /api/auth/logout 307 → GET /login?signedout=1
IAM received: nothing. Zero calls.
```

**`local` provider:** sign out → `/login`, no `/api/auth/logout` hop, and the following `/admin` resolves the seeded developer instead of the signed-in email — i.e. the cookie was cleared. Unchanged.

### Blast radius

**Onboarding is unaffected.** The gate is pure DB state — `onboardingRequired` is `onboardingEnabled && account.onboarding_completed_at == null && isAdmin(role)`. No cookie, no localStorage; the wizard's answers live in React state. The JIT account/member resolve is idempotent on `external_id`, and the IAM write is double-guarded (`GET /onboarding/status/:id` short-circuit plus `hasMappableAnswer`). A real re-login by an existing user re-runs none of it.

**Tracking does not double-count.** Every milestone is an atomic write-once SQL claim keyed on row existence, not on session state: `forms_signup_completed` fires only on the JIT path (covered by `analytics-events.spec.ts` — *"fires when a login JIT-creates a member, and not on later logins"*), and attribution is guarded by `attribution IS NULL AND created_at > now - 10min` (covered by `milestones.spec.ts`). `resetAnalytics()` still runs on the sign-out button's `onClick`, before the action.

### Known, not addressed here

1. **Where WorkOS lands the user after the `logoutUrl`** is configured in IAM/WorkOS, not in this repo. If it returns to our `/login` without `?signedout=1`, `login/page.tsx:23` starts a fresh login immediately — correct if the AuthKit session is genuinely dead, and the same silent re-auth if it is not. Worth confirming in dev.
2. **`session_id` in the callback blob is unverified against the real IAM.** The stub sends it because it was written to. If the IAM uses a different key or omits it, `sessionId` is `undefined` from the callback onward and this reorder is necessary but not sufficient.
3. **The 10-minute cookie TTLs.** `quill_oauth_state` and `quill_attribution` are both `maxAge: 600`. Silent re-auth took under a second and never stressed that window; a real login with MFA or a password reset can exceed it, and past it the callback bounces to `/login?error=state`. Not new — every genuine signup already crosses this — but returning users now do too.
4. **`quill_workspace` survives logout.** `clearSession()` deletes only the session cookie. Pre-existing, and the `WORKSPACE_FORBIDDEN` → `/api/workspace/reset` self-heal covers it, but a real logout makes "different user on the same browser" an actually reachable state, and events are attributed to the previous workspace for that one hop.
5. **No test coverage.** The repo has none for logout, login, or the session cookie, and Playwright cannot reach this: `qa/playwright.config.ts` runs the SQLite QA instance, which is the `local` provider. Deliberately out of scope for this PR.

---

# 2. Dark is the theme, light is the opt-in

The colour scheme had three values and the third one served nobody. `System` followed the OS by stamping no `data-theme` at all, so a viewer on a light-mode machine got a dashboard neither they nor we had chosen — and the choice they thought they had made was really a choice not to make one.

The product is authored dark, and an unbranded public form is already pinned dark regardless of any cookie (`lib/form-design.ts` explains why: a respondent has no preference, and the author's must never leak into the preview of what visitors see). The admin chrome was the only surface that followed the OS, which made it the only surface where the inconsistency could show.

Dark is now the default and light a deliberate opt-in. The sidebar control is a two-state flip rather than a three-state cycle; the Settings picker names both at once.

| Surface | Change |
|---|---|
| `apps/web/lib/theme.ts` | `ThemePref` drops `system`; `themeAttribute` deleted (it existed only to return `undefined` for it) |
| `apps/web/app/layout.tsx` | always stamps `data-theme`, never omits it |
| `apps/web/components/theme-toggle.tsx` | two-state flip |
| `apps/web/app/admin/settings/theme-settings.tsx` | two options |
| `packages/shared/src/i18n/index.ts` | `admin.chrome.theme.system` removed from the interface and both locales |
| `packages/shared/src/tokens.css` | comment retargeted — see below |

**No migration.** `isThemePref` no longer recognises `system`, and `getThemePref` already falls back to `dark` for anything unrecognised, so a browser still carrying the old cookie lands on the new default rather than on a scheme nobody can select. The same guard in `setThemeAction` ignores a stale tab still posting the removed value.

**The `@media (prefers-color-scheme: light)` block in `tokens.css` is kept deliberately.** Nothing in this app reaches it any more — the root layout always stamps a scheme — but it is the fallback for a self-host embedding these tokens without our layout, which would otherwise be stuck on the dark base with no way to opt out. Removing it would be a behaviour change to a shared package for no gain here. Its comment previously documented itself as the mechanism behind `system` and is retargeted to say what it actually is now. Both blocks apply at once when light is pinned, and they are value-for-value identical, so nothing changes visually.

### Verification

Checked in the browser, `local` provider:

- Settings offers **Dark** and **Light** only, with Dark selected on a fresh profile.
- The sidebar flips dark → light → dark and never lands on a third state; the cookie follows (`quill_theme=light`, then `dark`).
- A stale `quill_theme=system` cookie renders `data-theme="dark"` with the dark background token — the fallback, not a broken state.
- The seeded public form resolves `data-theme="dark"` on its own `div.pf` container with `rgb(10, 12, 14)` while the author's cookie is set to `light`, i.e. the respondent surface is untouched.

---

`pnpm typecheck`, `pnpm lint`, `pnpm test` (1188 tests across 8 workspaces) and `scripts/publish-gate.sh` all pass. A changeset is included for the `@quill/shared` message-catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
