### PR TITLE
feat(web): platform GTM container + onboarding step in the URL

### DIFF
--- a/.changeset/onboarding-step-url.md
+++ b/.changeset/onboarding-step-url.md
@@ -1,0 +1,35 @@
+---
+'@quill/web': patch
+---
+
+Mirror the onboarding wizard's screen into the URL as `/onboarding?step=N`.
+
+The wizard was a single unchanging URL, so page-level analytics saw one visit
+where six questions happened. Every move now stamps `?step=N` — 1-based,
+counting exactly like the on-screen "Question 1 of N", with the template picker
+as the final step — which is the same URL shape the Dapta adminpanel gives its
+onboarding, so one GTM history trigger reads both products' funnels the same
+way.
+
+Three deliberate mechanics:
+
+- **Native `history.pushState`, never `router.push`.** The router would re-run
+  the server page — `me()` plus the IAM cohort probe — on every answer, for a
+  screen whose state lives entirely in the client component. The first screen is
+  a `replaceState`, so question one and the bare `/onboarding` are a single
+  history entry and browser-back from it still exits the wizard.
+- **popstate moves the wizard, not just the URL.** The adminpanel pushes
+  `?step=` but never listens, so its back button walks the address bar while the
+  screen stays put. Here back/forward land on the clamped real screen
+  (`stepIndexFromSearch`), and the step-viewed analytics stay honest because the
+  arrival effect was already keyed on seen steps.
+- **A direct `?step=N` load is normalized server-side.** Answers only live in
+  client state — a reload restarts at question one regardless — so the page
+  redirects stale deep links to the bare path rather than letting the URL lie to
+  analytics, and the wizard re-stamps `?step=1` itself. The redirect runs after
+  the existing gates, so someone already onboarded still exits to `/admin` in
+  one hop.
+
+The pure halves (`stepParam` / `stepIndexFromSearch`) live in `lib/onboarding.ts`
+with unit specs; `qa/e2e/v11-onboarding-step-url.spec.ts` pins the three history
+writers against a real browser.

--- a/.changeset/platform-gtm.md
+++ b/.changeset/platform-gtm.md
@@ -1,0 +1,30 @@
+---
+'@quill/config': minor
+---
+
+Load the deployment's own GTM container on platform pages — login, onboarding,
+and the admin dashboard — never on a public form page.
+
+The marketing site already carries the container; the platform lives on a
+different domain, so until now the funnel went dark the moment someone crossed
+from the landing to the product. `PlatformGtm`
+(`components/analytics/platform-gtm.tsx`) closes that gap from the three
+platform entry points, reusing `buildGtmSnippet` and the noscript iframe shape
+from the public-page tracking module.
+
+The boundary is the same one `ProductAnalytics` already draws, for the same
+reason: a public form page's visitor is a form owner's respondent, and that page
+may already carry the OWNER's GTM container via `NEXT_PUBLIC_GTM_ID` / per-form
+config. Loading ours beside it would cross-fire both containers through the
+shared `dataLayer` and file a customer's traffic under our marketing account —
+which is also why the Script id (`platform-gtm`) differs from `tracking-gtm`:
+next/script dedupes by id, and the two must never suppress one another.
+
+Configured by the new `NEXT_PUBLIC_PLATFORM_GTM_ID` (client env schema,
+`@quill/config`). Resolution is server-side at request time — every mount point
+is a dynamic route — with a fallback that keeps both standing invariants true at
+once: on an `AUTH_PROVIDER=workos` build (every Dapta deployment) a missing env
+var falls back to Dapta's own container in code, so the platform cannot ship a
+silent no-op the way a missing build-time `NEXT_PUBLIC_` once did; anywhere else
+(every bare fork) it resolves to nothing, and the fork keeps making zero
+third-party requests.

--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,17 @@
 # NEXT_PUBLIC_PRODUCT_ANALYTICS_KEY=phc_your_project_api_key
 # NEXT_PUBLIC_PRODUCT_ANALYTICS_HOST=https://us.i.posthog.com
 
+# --- Platform GTM (login / onboarding / admin only) -------------------------
+# The deployment's own Google Tag Manager container for PLATFORM pages — the
+# marketing companion to the product analytics above. NOT the same thing as
+# NEXT_PUBLIC_GTM_ID in the tracking block, which is the form OWNER's container
+# on their PUBLIC form pages; the two never share a variable or a page.
+#
+# Unset on a Dapta (AUTH_PROVIDER=workos) build falls back to Dapta's own
+# container in code; unset anywhere else (the default, and every bare fork) =
+# no platform GTM is loaded at all.
+# NEXT_PUBLIC_PLATFORM_GTM_ID=GTM-XXXXXXX
+
 # --- Email / notifications ------------------------------------------------
 # Provider selector. Unset or "log-only" -> emails are logged, not sent
 # (a bare fork still runs submission flows end-to-end).

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -9,6 +9,7 @@ import { getThemePref } from '@/lib/theme.server';
 import { ToastProvider } from '@/components/toast';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
 import { ProductAnalytics } from '@/components/analytics/product-analytics';
+import { PlatformGtm, resolvePlatformGtmId } from '@/components/analytics/platform-gtm';
 
 export default async function AdminLayout({ children }: { children: ReactNode }) {
   const jar = await cookies();
@@ -52,6 +53,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
 
   return (
     <ToastProvider>
+      <PlatformGtm gtmId={resolvePlatformGtmId()} />
       <ProductAnalytics
         analytics={analytics}
         identity={{

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -4,6 +4,7 @@ import { getMessages } from '@quill/shared';
 import { BrandLockup, PRODUCT_NAME } from '@/components/brand/brand';
 import { getLocale } from '@/lib/locale';
 import { authProvider } from '@/lib/auth-session';
+import { PlatformGtm, resolvePlatformGtmId } from '@/components/analytics/platform-gtm';
 import { LoginForm } from './login-form';
 
 export const metadata = { title: `Sign in — ${PRODUCT_NAME}` };
@@ -23,37 +24,40 @@ export default async function LoginPage({
   if (workos && !error && !signedout) redirect('/api/auth/login');
 
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center gap-8 px-6">
-      {/* Sign-in is an entrance, so it gets the full company lockup at display
-          size. Width-capped as well as height-capped: at ~6:1 a fixed height
-          alone would push past the 24px gutters on a 320px screen. */}
-      <BrandLockup className="h-11 w-auto max-w-[min(400px,86vw)] text-foreground" labelled />
+    <>
+      <PlatformGtm gtmId={resolvePlatformGtmId()} />
+      <main className="flex min-h-dvh flex-col items-center justify-center gap-8 px-6">
+        {/* Sign-in is an entrance, so it gets the full company lockup at display
+            size. Width-capped as well as height-capped: at ~6:1 a fixed height
+            alone would push past the 24px gutters on a 320px screen. */}
+        <BrandLockup className="h-11 w-auto max-w-[min(400px,86vw)] text-foreground" labelled />
 
-      <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6">
-        <h1 className="mb-1 text-xl font-semibold">{m.title}</h1>
-        <p className="mb-6 text-sm text-muted-foreground">{workos ? m.workosSubtitle : m.subtitle}</p>
-        {/* A failed WorkOS login/callback comes back with ?error= — surface it
-            with a retry CTA instead of a silent plain sign-in screen (R22). */}
-        {error ? (
-          <p role="alert" className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-            {m.error}
-          </p>
-        ) : null}
-        {workos ? (
-          // WorkOS provider: hand off to IAM's hosted login (Google/Microsoft/
-          // LinkedIn are rendered by WorkOS — nothing per-provider to build).
-          <Link
-            href="/api/auth/login"
-            className="inline-flex min-h-[44px] w-full items-center justify-center rounded-md bg-primary px-4 py-2.5 font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
-          >
-            {m.workosCta}
-          </Link>
-        ) : (
-          <LoginForm messages={m} />
-        )}
-      </div>
+        <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6">
+          <h1 className="mb-1 text-xl font-semibold">{m.title}</h1>
+          <p className="mb-6 text-sm text-muted-foreground">{workos ? m.workosSubtitle : m.subtitle}</p>
+          {/* A failed WorkOS login/callback comes back with ?error= — surface it
+              with a retry CTA instead of a silent plain sign-in screen (R22). */}
+          {error ? (
+            <p role="alert" className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {m.error}
+            </p>
+          ) : null}
+          {workos ? (
+            // WorkOS provider: hand off to IAM's hosted login (Google/Microsoft/
+            // LinkedIn are rendered by WorkOS — nothing per-provider to build).
+            <Link
+              href="/api/auth/login"
+              className="inline-flex min-h-[44px] w-full items-center justify-center rounded-md bg-primary px-4 py-2.5 font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
+            >
+              {m.workosCta}
+            </Link>
+          ) : (
+            <LoginForm messages={m} />
+          )}
+        </div>
 
-      {!workos ? <p className="max-w-sm text-center text-xs text-muted-foreground">{m.footnote}</p> : null}
-    </main>
+        {!workos ? <p className="max-w-sm text-center text-xs text-muted-foreground">{m.footnote}</p> : null}
+      </main>
+    </>
   );
 }

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { preferredLocale } from '@/lib/locale';
 import { currentOnboardingCohort } from '@/lib/dapta-onboarding';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
 import { ProductAnalytics } from '@/components/analytics/product-analytics';
+import { PlatformGtm, resolvePlatformGtmId } from '@/components/analytics/platform-gtm';
 import { OnboardingWizard } from './wizard';
 
 /**
@@ -48,6 +49,7 @@ export default async function OnboardingPage() {
 
   return (
     <>
+      <PlatformGtm gtmId={resolvePlatformGtmId()} />
       <ProductAnalytics
         analytics={resolveProductAnalytics()}
         identity={{

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -21,7 +21,11 @@ import { OnboardingWizard } from './wizard';
  * is what makes the URL safe to hit directly, on a bookmark or a back button,
  * without re-running an onboarding that already happened.
  */
-export default async function OnboardingPage() {
+export default async function OnboardingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ step?: string }>;
+}) {
   let me: Awaited<ReturnType<typeof adminApi.me>>;
   try {
     me = await adminApi.me();
@@ -33,6 +37,16 @@ export default async function OnboardingPage() {
   }
 
   if (!me.onboardingRequired) redirect('/admin');
+
+  // The wizard mirrors its screen into `?step=N` as it moves, but the answers
+  // live only in client state — a reload or deep link restarts at question one
+  // regardless, so honoring a stale `?step=5` here would only make the URL lie
+  // to analytics. Normalize to the bare path; the wizard re-stamps `?step=1`
+  // itself. AFTER the gates above, so a stale step URL from someone already
+  // onboarded still exits to /admin in one hop. No loop: the target carries no
+  // `step`.
+  const { step } = await searchParams;
+  if (step !== undefined) redirect('/onboarding');
 
   // Their browser's language, not the cookie's default — nobody arriving here
   // has ever seen the switcher.

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -43,6 +43,8 @@ import {
   fill,
   leadVolumeBucket,
   LEAD_VOLUME_SLIDER,
+  stepIndexFromSearch,
+  stepParam,
   wizardQuestions,
   wizardTemplates,
 } from '@/lib/onboarding';
@@ -160,6 +162,43 @@ export function OnboardingWizard({
   }, []);
 
   /**
+   * Mirror every screen move into the URL — `/onboarding?step=N`, the same
+   * shape the Dapta adminpanel uses — so GTM's history trigger sees one
+   * pageview per step without a single custom event.
+   *
+   * Native `history.pushState`, never `router.push`: the router would re-run
+   * the server component — `me()` plus the IAM cohort probe — on every answer,
+   * for a page whose state lives entirely in this client component. A PUSH per
+   * move (matching the adminpanel) is what makes the browser's own back/forward
+   * walk the steps; the popstate listener below is what makes the wizard follow.
+   */
+  const syncStepUrl = useCallback((nextIndex: number) => {
+    window.history.pushState(null, '', stepParam(nextIndex));
+  }, []);
+
+  // Stamp the FIRST screen on arrival — replace, not push, so question one and
+  // the bare `/onboarding` are one history entry and browser-back from it still
+  // EXITS the wizard instead of stepping to itself. Idempotent under
+  // StrictMode's double mount: same URL both times. The server page redirects
+  // any direct `?step=N` load back to bare `/onboarding` first, so this is the
+  // only writer of the first entry.
+  useEffect(() => {
+    window.history.replaceState(null, '', stepParam(0));
+  }, []);
+
+  // The browser's back/forward buttons move the wizard, not just the URL — the
+  // half the adminpanel is missing. Clamped to the screens that exist, and
+  // `pending` is cleared like every other index move (see `back`).
+  useEffect(() => {
+    const onPop = () => {
+      setPending(null);
+      setIndex(stepIndexFromSearch(window.location.search, questions.length + 1));
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, [questions]);
+
+  /**
    * Emit `step_viewed` once per screen ARRIVAL, not once per render.
    *
    * Without the ref this fires on every state change — a keystroke in the
@@ -215,8 +254,9 @@ export function OnboardingWizard({
       const reached = questions[advancing]?.key ?? 'template';
       save({ ...patch, lastStep: reached });
       setIndex(advancing);
+      syncStepUrl(advancing);
     },
-    [questions, save],
+    [questions, save, syncStepUrl],
   );
 
   /** Answer the current question and advance. Choosing IS continuing — one tap. */
@@ -252,8 +292,11 @@ export function OnboardingWizard({
 
   const back = useCallback(() => {
     setPending(null);
-    setIndex((i) => Math.max(0, i - 1));
-  }, []);
+    // Computed rather than a functional update: the URL mirror needs the value.
+    const next = Math.max(0, index - 1);
+    setIndex(next);
+    syncStepUrl(next);
+  }, [index, syncStepUrl]);
 
   const finish = useCallback(
     (id: string) => {

--- a/apps/web/components/analytics/platform-gtm.spec.tsx
+++ b/apps/web/components/analytics/platform-gtm.spec.tsx
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isValidElement, type ReactElement, type ReactNode } from 'react';
+import Script from 'next/script';
+import {
+  DAPTA_PLATFORM_GTM_ID,
+  PlatformGtm,
+  resolvePlatformGtmId,
+  type PlatformGtmEnv,
+} from './platform-gtm';
+
+/**
+ * Same testing stance as tracking-scripts.spec.tsx: next/script renders null
+ * server-side and injects the tag client-side, so these specs assert on the
+ * React element tree rather than serialized markup.
+ */
+
+type AnyProps = Record<string, unknown> & { children?: ReactNode };
+
+/** Depth-first flatten of a React element tree (no rendering, no DOM). */
+function collect(node: ReactNode, out: ReactElement[] = []): ReactElement[] {
+  if (Array.isArray(node)) {
+    for (const child of node) collect(child, out);
+    return out;
+  }
+  if (!isValidElement(node)) return out;
+  out.push(node);
+  collect((node.props as AnyProps).children, out);
+  return out;
+}
+
+function byTestId(elements: ReactElement[], id: string): ReactElement {
+  const found = elements.find((el) => (el.props as AnyProps)['data-testid'] === id);
+  expect(found, `expected an element with data-testid="${id}"`).toBeDefined();
+  return found!;
+}
+
+describe('resolvePlatformGtmId — which container loads where', () => {
+  const resolve = (env: PlatformGtmEnv) => resolvePlatformGtmId(env);
+
+  it('lets an explicit env id beat the hardcoded default', () => {
+    expect(resolve({ NEXT_PUBLIC_PLATFORM_GTM_ID: 'GTM-CUSTOM1', AUTH_PROVIDER: 'workos' })).toBe(
+      'GTM-CUSTOM1',
+    );
+  });
+
+  it('falls back to the Dapta container on a workos build with the env var missing', () => {
+    // The whole reason the default is in code: prd once shipped a no-op because
+    // a NEXT_PUBLIC_ var was missing at build time. A Dapta deployment must not
+    // be able to lose its own marketing container that way.
+    expect(resolve({ AUTH_PROVIDER: 'workos' })).toBe(DAPTA_PLATFORM_GTM_ID);
+  });
+
+  it('treats a whitespace-only id as unset', () => {
+    expect(resolve({ NEXT_PUBLIC_PLATFORM_GTM_ID: '   ', AUTH_PROVIDER: 'workos' })).toBe(
+      DAPTA_PLATFORM_GTM_ID,
+    );
+    expect(resolve({ NEXT_PUBLIC_PLATFORM_GTM_ID: '   ' })).toBeNull();
+  });
+
+  it('resolves to NOTHING on a bare fork — zero third-party requests stays true', () => {
+    expect(resolve({})).toBeNull();
+    expect(resolve({ AUTH_PROVIDER: 'local' })).toBeNull();
+  });
+
+  describe('in a browser bundle', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('throws rather than silently resolving null', () => {
+      // Client-side, `process.env` is empty and the parameter object defeats
+      // Next's inlining — a client call would be the exact silent no-op the
+      // in-code fallback exists to prevent. Loud beats wrong.
+      vi.stubGlobal('window', {});
+      expect(() => resolve({ AUTH_PROVIDER: 'workos' })).toThrow(/server-only/);
+    });
+  });
+});
+
+describe('PlatformGtm', () => {
+  it('renders nothing at all without a container id', () => {
+    expect(PlatformGtm({ gtmId: null })).toBeNull();
+  });
+
+  it('renders the GTM loader + noscript iframe for the resolved container', () => {
+    const els = collect(PlatformGtm({ gtmId: 'GTM-TEST123' }));
+
+    const script = byTestId(els, 'platform-gtm');
+    expect(script.type).toBe(Script);
+    // A DIFFERENT Script id from the public-page `tracking-gtm`: next/script
+    // dedupes by id, and the platform container must never suppress (or be
+    // suppressed by) a form owner's container.
+    expect((script.props as AnyProps).id).toBe('platform-gtm');
+    expect((script.props as AnyProps).strategy).toBe('afterInteractive');
+    const snippet = (script.props as AnyProps).children;
+    expect(typeof snippet).toBe('string');
+    expect(snippet).toContain('https://www.googletagmanager.com/gtm.js');
+    expect(snippet).toContain('"GTM-TEST123"');
+    expect(snippet).toContain("'dataLayer'");
+
+    const noscript = byTestId(els, 'platform-gtm-noscript');
+    expect(noscript.type).toBe('noscript');
+    const iframe = collect((noscript.props as AnyProps).children).find(
+      (el) => el.type === 'iframe',
+    );
+    expect(iframe).toBeDefined();
+    expect((iframe!.props as AnyProps).src).toBe(
+      'https://www.googletagmanager.com/ns.html?id=GTM-TEST123',
+    );
+  });
+
+  it('neutralizes a hostile id — no </script> breakout, URL-encoded iframe src', () => {
+    // Escaping itself is buildGtmSnippet's contract (covered in its own spec);
+    // this pins that THIS component routes the id through it.
+    const hostile = `"</script><script>alert(1)//`;
+    const els = collect(PlatformGtm({ gtmId: hostile }));
+    const snippet = (byTestId(els, 'platform-gtm').props as AnyProps).children as string;
+    expect(snippet).not.toContain('</script>');
+    expect(snippet).not.toContain(hostile);
+    const iframe = collect(
+      (byTestId(els, 'platform-gtm-noscript').props as AnyProps).children,
+    ).find((el) => el.type === 'iframe');
+    expect((iframe!.props as AnyProps).src).toBe(
+      `https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(hostile)}`,
+    );
+  });
+});

--- a/apps/web/components/analytics/platform-gtm.tsx
+++ b/apps/web/components/analytics/platform-gtm.tsx
@@ -1,0 +1,75 @@
+import Script from 'next/script';
+import { buildGtmSnippet } from '@/components/tracking/tracking-scripts';
+
+/**
+ * Dapta's own Google Tag Manager container for PLATFORM pages — login,
+ * onboarding, and the admin dashboard. The marketing site (daptaforms.com)
+ * carries the same container, and mounting it here is what joins the two
+ * domains into one funnel: landing → signup → onboarding → dashboard.
+ *
+ * Mounted from `app/login/page.tsx`, `app/onboarding/page.tsx` and
+ * `app/admin/layout.tsx` ONLY. Public form pages must never load it: the
+ * visitor there is a form owner's respondent, and the page may already carry
+ * the OWNER's GTM container (see components/tracking/tracking-scripts.tsx) —
+ * loading ours beside it would cross-fire both containers through the shared
+ * `dataLayer` and file a customer's traffic under our marketing account.
+ * That is also why the Script id differs from `tracking-gtm`: the two must
+ * never deduplicate against each other.
+ */
+export const DAPTA_PLATFORM_GTM_ID = 'GTM-KXVQBMHD';
+
+export type PlatformGtmEnv = Partial<
+  Record<'NEXT_PUBLIC_PLATFORM_GTM_ID' | 'AUTH_PROVIDER', string | undefined>
+>;
+
+/**
+ * Which container to load, if any. Resolved server-side at request time (every
+ * mount point is a dynamic route), so the value is never baked into the bundle
+ * — the prd build that once shipped a stale NEXT_PUBLIC_ value cannot repeat
+ * here.
+ *
+ * The fallback is gated on `AUTH_PROVIDER=workos` — true for every Dapta
+ * deployment, never for a bare fork — for the same reason the check exists at
+ * all: a Dapta build must load Dapta's container even if the env var goes
+ * missing, and a fork must keep making zero third-party requests. The check
+ * mirrors `authProvider()` (lib/auth-session.ts) rather than importing it:
+ * that module is `server-only`, which this component's node-run spec is not.
+ */
+export function resolvePlatformGtmId(
+  env: PlatformGtmEnv = process.env as PlatformGtmEnv,
+): string | null {
+  // Server-only on purpose. In a client bundle `process.env` is empty — the
+  // parameter object defeats Next's build-time inlining — so a client-side
+  // call would silently resolve null: the exact no-op this resolver exists to
+  // prevent. Fail loud instead; resolve in the page/layout and pass the id in.
+  if (typeof window !== 'undefined') {
+    throw new Error('resolvePlatformGtmId is server-only — pass the resolved id down as a prop.');
+  }
+  const configured = env.NEXT_PUBLIC_PLATFORM_GTM_ID?.trim();
+  if (configured) return configured;
+  return env.AUTH_PROVIDER === 'workos' ? DAPTA_PLATFORM_GTM_ID : null;
+}
+
+/**
+ * Renders the GTM loader + its no-JS iframe. Returns null when no container is
+ * resolved (every bare fork) — no markup, no request.
+ */
+export function PlatformGtm({ gtmId }: { gtmId: string | null }) {
+  if (!gtmId) return null;
+  return (
+    <>
+      <Script id="platform-gtm" data-testid="platform-gtm" strategy="afterInteractive">
+        {buildGtmSnippet(gtmId)}
+      </Script>
+      <noscript data-testid="platform-gtm-noscript">
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(gtmId)}`}
+          height="0"
+          width="0"
+          style={{ display: 'none', visibility: 'hidden' }}
+          title="Google Tag Manager"
+        />
+      </noscript>
+    </>
+  );
+}

--- a/apps/web/lib/onboarding.spec.ts
+++ b/apps/web/lib/onboarding.spec.ts
@@ -14,6 +14,8 @@ import {
   LEAD_VOLUME_SLIDER,
   leadVolumeBucket,
   skippedQuestions,
+  stepIndexFromSearch,
+  stepParam,
   wizardQuestions,
 } from './onboarding';
 
@@ -148,5 +150,42 @@ describe('leadVolumeBucket — the slider folds into the IAM histogram', () => {
 
   it('mirrors the rail of the Dapta sales quiz', () => {
     expect(LEAD_VOLUME_SLIDER).toEqual({ min: 0, max: 5000, step: 25, default: 0 });
+  });
+});
+
+describe('stepParam / stepIndexFromSearch — the URL mirror of the wizard', () => {
+  it('counts exactly like the on-screen "Pregunta 1 de N"', () => {
+    // 1-based: "?step=0" would put every funnel chart off by one from the copy.
+    expect(stepParam(0)).toBe('?step=1');
+    expect(stepParam(1)).toBe('?step=2');
+  });
+
+  it('gives the template picker the step after the cohort\'s LAST question', () => {
+    // Derived, not hardcoded: the two cohorts run different-length wizards, and
+    // the URL has to follow the same denominator the counter does.
+    for (const cohort of ['cold', 'dapta'] as const) {
+      const screens = wizardQuestions(m, cohort).length + 1;
+      expect(stepParam(screens - 1), cohort).toBe(`?step=${screens}`);
+    }
+  });
+
+  it('round-trips its own output', () => {
+    for (const index of [0, 1, 5]) {
+      expect(stepIndexFromSearch(stepParam(index), 7)).toBe(index);
+    }
+  });
+
+  it('clamps a URL pointing past the wizard onto the last real screen', () => {
+    // The URL is user-editable input. Past the end lands on the template
+    // picker, never on an index the wizard has no screen for.
+    expect(stepIndexFromSearch('?step=99', 7)).toBe(6);
+  });
+
+  it('reads garbage, absence and sub-one steps as the first screen', () => {
+    expect(stepIndexFromSearch('?step=0', 7)).toBe(0);
+    expect(stepIndexFromSearch('?step=-3', 7)).toBe(0);
+    expect(stepIndexFromSearch('?step=banana', 7)).toBe(0);
+    expect(stepIndexFromSearch('', 7)).toBe(0);
+    expect(stepIndexFromSearch('?utm_source=landing', 7)).toBe(0);
   });
 });

--- a/apps/web/lib/onboarding.ts
+++ b/apps/web/lib/onboarding.ts
@@ -347,3 +347,30 @@ export function fill(template: string, values: Record<string, string | number>):
     key in values ? String(values[key]) : match,
   );
 }
+
+/**
+ * The wizard's screen index as a URL search string — `?step=1` for the first
+ * question, counting exactly like the on-screen "Pregunta 1 de N", with the
+ * template picker as the final step. The same URL shape the Dapta adminpanel
+ * gives ITS onboarding, so one GTM history trigger reads both products' funnels
+ * the same way.
+ *
+ * 1-based on purpose: the URL is read by people and by marketing tooling, and
+ * "?step=0" would make every funnel chart look off by one from the copy.
+ */
+export function stepParam(index: number): string {
+  return `?step=${index + 1}`;
+}
+
+/**
+ * The inverse: a `?step=` search string back to a screen index, clamped to the
+ * screens that exist. Garbage, absence, and out-of-range values all land on a
+ * REAL screen rather than throwing or rendering past the template picker —
+ * the URL is user-editable input, not state we control.
+ */
+export function stepIndexFromSearch(search: string, totalScreens: number): number {
+  const raw = new URLSearchParams(search).get('step');
+  const step = Number.parseInt(raw ?? '', 10);
+  if (!Number.isFinite(step)) return 0;
+  return Math.min(Math.max(step, 1), Math.max(totalScreens, 1)) - 1;
+}

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -235,6 +235,15 @@ export const clientEnvSchema = z.object({
   // admin loads no analytics script at all.
   NEXT_PUBLIC_PRODUCT_ANALYTICS_KEY: z.string().optional(),
   NEXT_PUBLIC_PRODUCT_ANALYTICS_HOST: z.string().url().default('https://us.i.posthog.com'),
+
+  // The deployment's own GTM container for PLATFORM pages (login, onboarding,
+  // admin) — the marketing half of the telemetry above. NOT to be confused
+  // with NEXT_PUBLIC_GTM_ID, which is the form OWNER's container on their
+  // PUBLIC form pages; the two must never share a variable or a page (see
+  // apps/web/components/analytics/platform-gtm.tsx). Unset on a Dapta (workos)
+  // build falls back to Dapta's own container in code; unset on a bare fork =
+  // no platform GTM at all.
+  NEXT_PUBLIC_PLATFORM_GTM_ID: z.string().optional(),
 });
 
 export type ClientEnv = z.infer<typeof clientEnvSchema>;

--- a/qa/e2e/v11-onboarding-step-url.spec.ts
+++ b/qa/e2e/v11-onboarding-step-url.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * The wizard's URL mirror — `/onboarding?step=N` — from the outside.
+ *
+ * The unit tests pin the pure halves (`stepParam`, `stepIndexFromSearch`); what
+ * only a browser can show is the wiring between three history writers that have
+ * to agree:
+ *
+ *  1. The mount stamp is a REPLACE: question one and the bare `/onboarding` are
+ *     one history entry, so browser-back from the first question exits the
+ *     wizard instead of stepping to itself.
+ *  2. Every move is a PUSH, and popstate moves the WIZARD, not just the URL —
+ *     the half the Dapta adminpanel is missing, where back walks `?step=` while
+ *     the screen stays put.
+ *  3. A direct `?step=N` load is normalized by the server page: answers live
+ *     only in client state, so the wizard restarts at question one and the URL
+ *     must say so rather than lie to analytics.
+ *
+ * Local runs have no IAM_BASE_URL, so every fresh account resolves to the COLD
+ * cohort: six questions starting with the phone screen, then the template
+ * picker. Under test: apps/web/app/onboarding/{page,wizard}.tsx.
+ */
+
+/** A brand-new dev identity. The API's local stub JIT-creates its account. */
+function freshEmail(tag: string): string {
+  return `qa-${tag}-${Date.now()}-${Math.floor(Math.random() * 1e6)}@onboarding.test`;
+}
+
+/** Sign the browser in as `email` through the real local-dev login screen. */
+async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', email);
+  await Promise.all([page.waitForURL(/\/(admin|onboarding)/), page.click('button[type="submit"]')]);
+}
+
+/** The cold cohort's first question: type a usable phone, then Continue. */
+async function answerPhone(page: Page): Promise<void> {
+  const tel = page.locator('.pf__fields input[type="tel"]');
+  await expect(tel).toBeVisible();
+  await tel.fill('3001234567');
+  await page.locator('.ob__cta').click();
+}
+
+test.describe('the step in the URL', () => {
+  test('stamps, pushes, and follows the browser buttons', async ({ page }) => {
+    await signIn(page, freshEmail('stepurl'));
+
+    // Arrival: the mount effect re-writes the bare `/onboarding` entry.
+    await page.waitForURL(/\/onboarding\?step=1$/);
+    await expect(page.locator('.ob__eyebrow')).toContainText('1 of 6');
+
+    // Answering pushes the next step.
+    await answerPhone(page);
+    await page.waitForURL(/\/onboarding\?step=2$/);
+    await expect(page.locator('.ob__eyebrow')).toContainText('2 of 6');
+
+    // The in-page back arrow mirrors too. `button.pf__back`, not `.pf__back`:
+    // the topbar keeps a placeholder SPAN with the same class for centering.
+    await page.locator('button.pf__back').click();
+    await page.waitForURL(/\/onboarding\?step=1$/);
+    await expect(page.locator('.ob__eyebrow')).toContainText('1 of 6');
+
+    // Browser BACK returns to the pushed `?step=2` entry — and the wizard
+    // follows the URL: question two is genuinely on screen, not just named in
+    // the address bar. This is the popstate half.
+    await page.goBack();
+    await page.waitForURL(/\/onboarding\?step=2$/);
+    await expect(page.locator('.ob__eyebrow')).toContainText('2 of 6');
+  });
+
+  test('normalizes a direct ?step=N load back to the first question', async ({ page }) => {
+    await signIn(page, freshEmail('deeplink'));
+    await page.waitForURL(/\/onboarding\?step=1$/);
+
+    // A deep link cannot restore answers that never left the client, so the
+    // server strips the stale step and the wizard re-stamps step one.
+    await page.goto('/onboarding?step=5');
+    await page.waitForURL(/\/onboarding\?step=1$/);
+    await expect(page.locator('.ob__eyebrow')).toContainText('1 of 6');
+  });
+});


### PR DESCRIPTION
## What

Two tracking gaps closed for forms.dapta.ai, decided with the team:

1. **Platform GTM.** The marketing site (daptaforms.com) already carries Dapta's GTM container (`GTM-KXVQBMHD`); the platform lives on a different domain, so the funnel went dark at the domain crossing. `PlatformGtm` (new, `components/analytics/platform-gtm.tsx`) now loads it from the three platform entry points — `/login`, `/onboarding`, and the `/admin` layout — and **nowhere else**.
2. **Onboarding step in the URL.** The wizard now mirrors every screen move into `/onboarding?step=N` (1-based, matching the on-screen "Question 1 of N"; template picker last). Same URL shape the Dapta adminpanel gives its onboarding, so one GTM History-Change trigger reads both products' funnels.

## Boundaries kept

- **Never on public form pages.** A public form's visitor is a form owner's respondent, and that page may already carry the *owner's* GTM (`NEXT_PUBLIC_GTM_ID` / per-form config). Same boundary `ProductAnalytics` already draws; distinct `next/script` id so the two containers can never dedupe each other. Live-verified: zero `googletagmanager.com` requests on the seeded public form.
- **Bare fork = zero third-party requests.** `NEXT_PUBLIC_PLATFORM_GTM_ID` (new optional client env, `@quill/config`) resolves server-side at request time, with an in-code fallback to Dapta's container **gated on `AUTH_PROVIDER=workos`** — a Dapta build can't ship a silent no-op when the env var goes missing, and a fork resolves to nothing. The resolver throws if called client-side.
- **No server refetch per step.** Native `history.pushState` (never `router.push`, which would re-run `me()` + the IAM cohort probe per answer); `replaceState` stamps `?step=1` on mount so browser-back from question one still exits; a popstate listener moves the *wizard* on back/forward (the half the adminpanel is missing); the server page normalizes direct `?step=N` loads to the bare path since answers only live in client state.

## Tests

- Unit: `platform-gtm.spec.tsx` (8) + `stepParam`/`stepIndexFromSearch` specs in `onboarding.spec.ts` — web suite 314/314 green.
- E2e: new `qa/e2e/v11-onboarding-step-url.spec.ts` (2/2 green against the QA harness): mount stamp, push on answer, in-page back, browser back moving the rendered question, deep-link normalization.
- `pnpm typecheck` / `lint` / `test` / `build` green; publish-gate (gitleaks) clean; changeset included for `@quill/config` (web-only changeset for the wizard change).

## Out of repo (follow-up for marketing)

GTM container-side: History-Change trigger for `?step=` + hostname filter; GA4 step funnels should read `page_location` (query included), not `page_path`.

Known pre-existing: v10's `walkQuestions` e2e helper still targets the old 3-question wizard — tracked separately, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)