### PR TITLE
feat(builder): restore the placeholder field in question settings

### DIFF
--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -278,6 +278,10 @@ export interface BuilderMessages {
     prefillCopy: string;
     prefillCopied: string;
     prefillUtmWarning: string;
+    /** Ghost text inside an empty input (text/email/textarea/dropdown). */
+    placeholder: string;
+    placeholderHint: string;
+    placeholderEmpty: string;
     /** A value the answer starts with; anything in the URL wins over it. */
     defaultAnswer: string;
     defaultAnswerHint: string;
@@ -670,6 +674,9 @@ const en: BuilderMessages = {
     prefillCopied: 'Copied',
     prefillUtmWarning:
       'A key starting with utm_ is never read from the URL — those are captured separately as campaign data. Rename the key to make prefill work.',
+    placeholder: 'Placeholder',
+    placeholderHint: 'Ghost text shown inside the input while it is empty.',
+    placeholderEmpty: 'Leave empty for none',
     defaultAnswer: 'Default answer',
     defaultAnswerHint: 'Used when the link carries no value. Anything in the URL wins over this.',
     defaultAnswerPlaceholder: 'Leave empty for none',
@@ -1046,6 +1053,9 @@ const es: BuilderMessages = {
     prefillCopied: 'Copiado',
     prefillUtmWarning:
       'Una clave que empieza con utm_ nunca se lee de la URL: esas se capturan aparte como datos de campaña. Renombra la clave para que el prellenado funcione.',
+    placeholder: 'Placeholder',
+    placeholderHint: 'Texto guía que se muestra dentro del campo mientras está vacío.',
+    placeholderEmpty: 'Vacío para ninguno',
     defaultAnswer: 'Respuesta por defecto',
     defaultAnswerHint: 'Se usa cuando el link no trae valor. Lo que venga en la URL gana sobre esto.',
     defaultAnswerPlaceholder: 'Vacío para ninguna',

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -44,6 +44,14 @@ import type { BuilderMessages } from './builder-messages';
 
 const ALL_ITEMS: GalleryItem[] = GALLERY_GROUPS.flatMap((g) => GALLERY[g]);
 
+/** Types whose public input renders `step.placeholder` (see step-input.tsx). */
+const PLACEHOLDER_TYPES: ReadonlySet<FormStep['type']> = new Set([
+  'text',
+  'email',
+  'textarea',
+  'dropdown',
+]);
+
 /** The reveal card's play-time bounds — mirrors `formRevealSchema`. */
 const DEFAULT_REVEAL_MS = 2200;
 const MIN_REVEAL_MS = 500;
@@ -235,6 +243,26 @@ export function QuestionSettings({
             aria-label={bm.settings.required}
           />
         </InlineField>
+      ) : null}
+
+      {/* Only the types whose public input actually renders `step.placeholder`
+          (step-input.tsx) get the control — phone brings its own placeholder,
+          name edits per-field placeholders below, choices have none. The first
+          builder had this field; the WYSIWYG rewrite dropped it silently, which
+          left API-authored placeholders visible on the canvas but uneditable. */}
+      {PLACEHOLDER_TYPES.has(step.type) ? (
+        <Field label={bm.settings.placeholder} hint={bm.settings.placeholderHint}>
+          <TextField
+            value={step.placeholder ?? ''}
+            maxLength={200}
+            placeholder={bm.settings.placeholderEmpty}
+            data-testid="step-placeholder"
+            aria-label={bm.settings.placeholder}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onUpdate({ placeholder: e.target.value || null })
+            }
+          />
+        </Field>
       ) : null}
 
       {/* Type-specific: options, then the scoring switch that controls whether


### PR DESCRIPTION
## Qué

Devuelve al panel **Question settings** el campo **Placeholder** para los tipos cuyo input público lo renderiza: `text`, `email`, `textarea`, `dropdown`.

## Por qué

El primer builder visual (d64692a) tenía este control; el redesign WYSIWYG (308aad5) reescribió el panel y lo perdió sin mencionarlo. Desde entonces `step.placeholder` era write-only: el schema lo valida, el renderer público y el canvas lo muestran, pero el admin no podía editarlo. Los valores escritos por API (plantillas, migraciones) quedaban congelados — ej.: el quiz `dapta-ventas` en prd mostró «Nombre de tu empresa» bajo «¿Cuál es la página web de tu empresa?» sin forma de corregirlo desde el UI.

## Alcance

- Control solo en los 4 tipos que lo consumen (`step-input.tsx`): phone trae su propio input con placeholder fijo, `name` ya edita sus placeholders por campo, choices no tienen input.
- Vacío guarda `null` (igual que el control original); el canvas y el público caen a sus defaults.
- `maxLength={200}` espejando `formStepSchema`.
- i18n EN/ES en `builder-messages.ts`.
- El canvas ya renderizaba `step.placeholder` — se actualiza en vivo al escribir.

## Test

- `pnpm --filter @quill/web typecheck` ✅ (tras build de packages)
- `pnpm --filter @quill/web test` — 314 pasan ✅
- `pnpm --filter @quill/web lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)