### PR TITLE
fix(web): send the WorkOS logout back to the login page

### DIFF
--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const getSession = vi.fn();
+const clearSession = vi.fn();
+vi.mock('@/lib/auth-session', () => ({
+  getSession: (...a: unknown[]) => getSession(...a),
+  clearSession: (...a: unknown[]) => clearSession(...a),
+}));
+
+import { GET } from './route';
+
+const req = () => new NextRequest('https://forms.example.com/api/auth/logout');
+const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+
+describe('GET /api/auth/logout', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    vi.stubEnv('PUBLIC_APP_URL', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('appends return_to to the IAM logoutUrl so WorkOS sends the browser back', async () => {
+    getSession.mockResolvedValue(workosSession);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ logoutUrl: 'https://api.workos.com/user_management/sessions/logout?session_id=sess_123' }),
+    });
+
+    const res = await GET(req());
+
+    const target = new URL(res.headers.get('location')!);
+    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
+    expect(target.searchParams.get('session_id')).toBe('sess_123');
+    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+    // The session id travels to the IAM, and the cookie is cleared after reading it.
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://iam.example.com/iam/auth/logout',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ workos_session_id: 'sess_123' }) }),
+    );
+    expect(clearSession).toHaveBeenCalled();
+  });
+
+  it('keeps a preexisting return_to out of the way by overwriting it', async () => {
+    getSession.mockResolvedValue(workosSession);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        logoutUrl: 'https://api.workos.com/user_management/sessions/logout?session_id=s&return_to=https%3A%2F%2Felsewhere.example',
+      }),
+    });
+
+    const res = await GET(req());
+
+    const target = new URL(res.headers.get('location')!);
+    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  it('lands locally on an unparseable logoutUrl instead of failing the sign-out', async () => {
+    getSession.mockResolvedValue(workosSession);
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ logoutUrl: '/relative-not-a-url' }) });
+
+    const res = await GET(req());
+
+    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  it('falls back to /login?signedout=1 when the IAM call fails', async () => {
+    getSession.mockResolvedValue(workosSession);
+    fetchMock.mockResolvedValue({ ok: false });
+
+    const res = await GET(req());
+
+    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  it('skips the IAM entirely without a workos session id', async () => {
+    getSession.mockResolvedValue({ provider: 'local', email: 'a@b.c' });
+
+    const res = await GET(req());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
+  });
+});

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -25,7 +25,24 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       cache: 'no-store',
     }).catch(() => null);
     const out = res && res.ok ? ((await res.json().catch(() => ({}))) as { logoutUrl?: string }) : null;
-    if (out?.logoutUrl) return NextResponse.redirect(out.logoutUrl);
+    if (out?.logoutUrl) {
+      // The IAM's logoutUrl carries no destination, and the WorkOS environment
+      // has no default logout redirect — followed as-is it ends the session and
+      // then strands the browser on a blank api.workos.com page. `return_to`
+      // must land on the same URL as the fallback branch below: the login page
+      // only suppresses its auto-redirect for `?signedout=1`, so any other
+      // destination would bounce a just-signed-out user straight back into
+      // the login flow. The URL must be allowlisted in WorkOS ("Logout
+      // redirect URIs") for WorkOS to honor it.
+      try {
+        const target = new URL(out.logoutUrl);
+        target.searchParams.set('return_to', new URL('/login?signedout=1', origin).toString());
+        return NextResponse.redirect(target);
+      } catch {
+        // Unparseable logoutUrl — NextResponse.redirect would throw on it too,
+        // so fall through to the local landing below.
+      }
+    }
   }
 
   return NextResponse.redirect(new URL('/login?signedout=1', origin));


### PR DESCRIPTION
## The bug (found live in prd today, right after #84 shipped)

#82 made the single-logout reachable for the first time — and revealed the next layer: the IAM's `logoutUrl` ends the WorkOS session but carries **no destination**, and the WorkOS environment has no default logout redirect configured. Result: sign out works (the session dies, switching users is possible again), but the browser strands on a **blank `api.workos.com` page** instead of returning to the app.

## The fix

Append `return_to={origin}/login?signedout=1` to the received `logoutUrl` before following it.

- Same landing as the route's existing fallback branch — the login page only suppresses its auto-redirect for `?signedout=1`, any other destination would bounce a just-signed-out user straight back into the login flow.
- `origin` comes from `requestOrigin()` (trusts `PUBLIC_APP_URL`), not attacker-controllable headers.
- An unparseable `logoutUrl` now falls through to the local landing instead of reaching `NextResponse.redirect`, which throws on malformed URLs — before this, that edge would have 500'd the sign-out.

New spec (`route.spec.ts`, 5 cases): return_to appended + session id sent to the IAM + cookie cleared after reading, preexisting return_to overwritten, unparseable URL lands locally, IAM failure falls back, `local` provider skips the IAM entirely.

## ⚠️ Deploy prerequisite (dashboard, not code)

WorkOS only honors `return_to` when the URL is allowlisted under **Logout redirect URIs** in the WorkOS dashboard (Felipe/Santiago): add `https://forms.dapta.ai/login`. Until then WorkOS ignores the param and the landing stays as today — this change is safe to ship ahead of the dashboard edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)