### PR TITLE
fix(api): build the HubSpot mirror form from properties the portal will accept

### DIFF
--- a/apps/api/src/hubspot-mirror.spec.ts
+++ b/apps/api/src/hubspot-mirror.spec.ts
@@ -255,3 +255,164 @@ describe('the whole point', () => {
     expect('validation' in other).toBe(false);
   });
 });
+
+describe('properties the portal does not have', () => {
+  // Measured: a form field naming a missing property makes the create fail with
+  // `400 internal error` — no property named, nothing to act on. One stale
+  // mapping among many would cost the whole activity.
+  const KNOWN = new Set(['email', 'jobtitle', 'lifecyclestage']);
+
+  it('drops a mapped property the portal lacks, and builds the rest', async () => {
+    const { calls, fetchImpl } = harness();
+    const out = await syncMirrorForm(
+      hubspot({
+        fieldMappings: { work_email: 'email', role: 'jobtitle' },
+        scoreProperty: 'lead_score_that_does_not_exist',
+        staticProperties: { lifecyclestage: 'lead' },
+      }),
+      'Lead qualifier',
+      { ...deps(fetchImpl), knownProperties: KNOWN },
+    );
+    expect(out.action).toBe('created');
+    const names = (calls[0]!.body.fieldGroups as { fields: { name: string }[] }[]).flatMap((g) =>
+      g.fields.map((f) => f.name),
+    );
+    expect(names).toEqual(['email', 'jobtitle', 'lifecyclestage']);
+  });
+
+  it('keeps email even if the lookup somehow omits it', async () => {
+    // The form's key. A mirror without it is not a contact form.
+    const { calls, fetchImpl } = harness();
+    await syncMirrorForm(hubspot({ fieldMappings: { work_email: 'email' } }), 'F', {
+      ...deps(fetchImpl),
+      knownProperties: new Set<string>(),
+    });
+    const names = (calls[0]!.body.fieldGroups as { fields: { name: string }[] }[]).flatMap((g) =>
+      g.fields.map((f) => f.name),
+    );
+    expect(names).toEqual(['email']);
+  });
+
+  it('filters nothing when the portal list could not be read', async () => {
+    // Unknown is not the same as empty — filtering on a failed lookup would
+    // silently strip every field.
+    const { calls, fetchImpl } = harness();
+    await syncMirrorForm(hubspot(), 'F', { ...deps(fetchImpl), knownProperties: null });
+    const names = (calls[0]!.body.fieldGroups as { fields: { name: string }[] }[]).flatMap((g) =>
+      g.fields.map((f) => f.name),
+    );
+    expect(names).toEqual(['email', 'jobtitle']);
+  });
+
+  it('does not rebuild when only a DROPPED property changed', async () => {
+    // The signature is built from what the mirror will actually declare, so
+    // editing a mapping the portal cannot accept is not a reason to touch it.
+    const { calls, fetchImpl } = harness();
+    const out = await syncMirrorForm(
+      hubspot({
+        fieldMappings: { work_email: 'email', role: 'jobtitle' },
+        scoreProperty: 'ghost_property',
+        settings: {
+          formActivity: true,
+          formGuid: 'guid-1',
+          formSignature: mirrorSignature('F', ['email', 'jobtitle']),
+        },
+      }),
+      'F',
+      { ...deps(fetchImpl), knownProperties: KNOWN },
+    );
+    expect(out.action).toBe('unchanged');
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('properties HubSpot refuses as form fields', () => {
+  /**
+   * Measured: a portal's `lifecyclestage` exists, is not calculated, and its own
+   * metadata says `formField: true` — and a form declaring it is rejected with
+   * `400 internal error`, naming nothing. Nothing predicts it, so the mirror
+   * degrades instead of guessing.
+   */
+  function rejecting(badProperty: string) {
+    const calls: { body: Record<string, unknown> }[] = [];
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      calls.push({ body });
+      const names = (body.fieldGroups as { fields: { name: string }[] }[]).flatMap((g) =>
+        g.fields.map((f) => f.name),
+      );
+      const bad = names.includes(badProperty);
+      return {
+        ok: !bad,
+        status: bad ? 400 : 200,
+        json: async () => ({ id: 'guid-new' }),
+        text: async () => JSON.stringify({ message: 'internal error' }),
+      };
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl };
+  }
+
+  const rich = () =>
+    hubspot({
+      fieldMappings: { work_email: 'email', role: 'jobtitle' },
+      utmMappings: { utm_source: 'dapta_source' },
+      dateProperty: 'date_booking',
+      staticProperties: { lifecyclestage: 'lead' },
+    });
+
+  const declared = (body: Record<string, unknown>) =>
+    (body.fieldGroups as { fields: { name: string }[] }[])
+      .flatMap((g) => g.fields.map((f) => f.name))
+      .sort();
+
+  it('retries WITHOUT the fixed stamps, keeping every other property', async () => {
+    // One bad property must not cost three good ones.
+    const { calls, fetchImpl } = rejecting('lifecyclestage');
+    const out = await syncMirrorForm(rich(), 'F', deps(fetchImpl));
+    expect(out.action).toBe('created');
+    expect(calls).toHaveLength(2);
+    expect(declared(calls[0]!.body)).toContain('lifecyclestage');
+    expect(declared(calls[1]!.body)).toEqual(['dapta_source', 'date_booking', 'email', 'jobtitle']);
+  });
+
+  it('falls back to the answers when a mapped property is the one refused', async () => {
+    const { calls, fetchImpl } = rejecting('dapta_source');
+    const out = await syncMirrorForm(rich(), 'F', deps(fetchImpl));
+    expect(out.action).toBe('created');
+    expect(declared(calls[calls.length - 1]!.body)).toEqual(['email', 'jobtitle']);
+  });
+
+  it('falls back to the email alone rather than losing the activity', async () => {
+    const { calls, fetchImpl } = rejecting('jobtitle');
+    const out = await syncMirrorForm(rich(), 'F', deps(fetchImpl));
+    expect(out.action).toBe('created');
+    expect(declared(calls[calls.length - 1]!.body)).toEqual(['email']);
+  });
+
+  it('records what was ACCEPTED, so the next save does not think it is in step', async () => {
+    // Storing the full set after a degraded create would mean never trying the
+    // fuller mirror again.
+    const { fetchImpl } = rejecting('lifecyclestage');
+    const out = await syncMirrorForm(rich(), 'F', deps(fetchImpl));
+    expect(out.settings.formSignature).toBe(
+      mirrorSignature('F', ['dapta_source', 'date_booking', 'email', 'jobtitle']),
+    );
+  });
+
+  it('does NOT retry smaller on a token or server problem', async () => {
+    // Neither gets better with fewer fields; retrying would just be noise.
+    for (const status of [401, 403, 500]) {
+      const { calls, fetchImpl } = harness({ status, body: { message: 'nope' } });
+      const out = await syncMirrorForm(rich(), 'F', deps(fetchImpl));
+      expect(out.action, `status ${status}`).toBe('failed');
+      expect(calls, `status ${status}`).toHaveLength(1);
+    }
+  });
+
+  it('gives up with the reason when even the email is refused', async () => {
+    const { fetchImpl } = harness({ status: 400, body: { message: 'internal error' } });
+    const out = await syncMirrorForm(rich(), 'F', deps(fetchImpl));
+    expect(out.action).toBe('failed');
+    expect(out.error).toContain('internal error');
+  });
+});

--- a/apps/api/src/hubspot-mirror.ts
+++ b/apps/api/src/hubspot-mirror.ts
@@ -50,6 +50,42 @@ export function mirrorSignature(formName: string, properties: string[]): string 
   return JSON.stringify([mirrorFormName(formName), [...properties].sort()]);
 }
 
+/**
+ * The property sets to try, best first.
+ *
+ * HubSpot refuses some properties as form fields and will not say which. A
+ * portal's `lifecyclestage` is the one this was found on: it exists, it is not
+ * calculated, and its own metadata says `formField: true` — and a form
+ * declaring it is still rejected with `400 internal error`, naming nothing.
+ * Nothing in the property schema predicts it, so the offender cannot be
+ * identified before the call or from the failure.
+ *
+ * Rather than maintain a list of HubSpot's special cases, the mirror degrades in
+ * order of what the activity is FOR, and gently: the fixed stamps go first
+ * because that is where a portal's system properties tend to be configured, then
+ * everything but the answers, and finally the email. A single bad property
+ * should not cost three good ones.
+ *
+ * The contact receives every property either way — the upsert is a separate
+ * call that already strips what the portal rejects. What degrades here is only
+ * what the ACTIVITY lists.
+ *
+ * Bounded, so a portal that refuses everything costs a handful of calls on a
+ * save rather than a search.
+ */
+function propertyTiers(
+  answers: string[],
+  withoutStatic: string[],
+  everything: string[],
+): string[][] {
+  const tiers: string[][] = [];
+  for (const tier of [everything, withoutStatic, answers, ['email']]) {
+    // Each step must actually be smaller, or it is a wasted call.
+    if (!tiers.some((t) => t.length === tier.length)) tiers.push(tier);
+  }
+  return tiers;
+}
+
 /** HubSpot's error body, which puts the useful part in `message`. */
 function reasonFrom(status: number, body: string): string {
   try {
@@ -69,6 +105,24 @@ export interface MirrorSyncDeps {
   baseUrl?: string;
   /** Passed in so the payload stays a pure function of its arguments. */
   now?: () => Date;
+  /**
+   * The contact properties that actually exist in the portal.
+   *
+   * A form field naming a property the portal does not have makes the CREATE
+   * fail — with `400 internal error`, which names nothing and is impossible to
+   * act on. One stale mapping among many therefore costs the whole activity,
+   * and mappings do go stale: `extractRetryablePropertyNames` exists precisely
+   * because the contact upsert meets the same thing routinely.
+   *
+   * Filtering is not a compromise, it is the correct behaviour. The upsert
+   * already strips these before writing, so a property the portal lacks never
+   * reaches the contact — declaring it on the mirror would promise the activity
+   * a field the submission cannot set.
+   *
+   * `null` = unknown (the lookup failed); nothing is filtered, and a create
+   * that then fails is reported like any other.
+   */
+  knownProperties?: Set<string> | null;
 }
 
 /**
@@ -92,7 +146,7 @@ export async function syncMirrorForm(
   // the activities already attached to it.
   if (settings.formActivity !== true) return { settings, action: 'noop' };
 
-  const properties = mirrorFormProperties({
+  const mapped = mirrorFormProperties({
     token: '',
     fieldMappings: destination.fieldMappings ?? {},
     utmMappings: destination.utmMappings ?? {},
@@ -101,6 +155,30 @@ export async function syncMirrorForm(
     outcomeProperty: destination.outcomeProperty ?? undefined,
     staticProperties: destination.staticProperties,
   });
+  // Drop what the portal does not have. `email` always stays: it is the form's
+  // key, every portal has it, and a mirror without it is not a contact form.
+  // The answers alone — the fallback tier, and the part of the activity that is
+  // actually the point.
+  const answersMapped = mirrorFormProperties({
+    token: '',
+    fieldMappings: destination.fieldMappings ?? {},
+  });
+  // Everything but the fixed stamps — where a portal's system properties
+  // (`lifecyclestage` and friends) are typically configured.
+  const withoutStaticMapped = mirrorFormProperties({
+    token: '',
+    fieldMappings: destination.fieldMappings ?? {},
+    utmMappings: destination.utmMappings ?? {},
+    scoreProperty: destination.scoreProperty ?? undefined,
+    dateProperty: destination.dateProperty ?? undefined,
+    outcomeProperty: destination.outcomeProperty ?? undefined,
+  });
+  const known = deps.knownProperties;
+  const keep = (list: string[]) =>
+    known ? list.filter((p) => p === 'email' || known.has(p)) : list;
+  const properties = keep(mapped);
+  const answerProperties = keep(answersMapped);
+  const withoutStaticProperties = keep(withoutStaticMapped);
   const signature = mirrorSignature(formName, properties);
 
   // Already in step. This is the common path — the Connect tab autosaves, and
@@ -119,32 +197,38 @@ export async function syncMirrorForm(
 
   const base = deps.baseUrl ?? HUBSPOT_API_BASE;
   const createdAt = (deps.now?.() ?? new Date()).toISOString();
-  const payload = buildMirrorFormPayload(formName, properties, createdAt);
   const existing = settings.formGuid;
   const url = existing
     ? `${base}/marketing/v3/forms/${encodeURIComponent(existing)}`
     : `${base}/marketing/v3/forms`;
 
-  let res: Response;
-  try {
-    res = await deps.fetchImpl(url, {
-      method: existing ? 'PATCH' : 'POST',
-      headers: {
-        authorization: `Bearer ${deps.token}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
-  } catch (err) {
-    return { settings, action: 'failed', error: `Could not reach HubSpot: ${String(err)}` };
-  }
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => '');
+  // Best set first, degrading to the answers alone and then to the email. See
+  // `propertyTiers`: HubSpot refuses some properties as form fields without
+  // saying which, so the offender cannot be identified — only designed around.
+  const tiers = propertyTiers(answerProperties, withoutStaticProperties, properties);
+  let res: Response | null = null;
+  let sent: string[] = properties;
+  let lastBody = '';
+  for (const tier of tiers) {
+    sent = tier;
+    try {
+      res = await deps.fetchImpl(url, {
+        method: existing ? 'PATCH' : 'POST',
+        headers: {
+          authorization: `Bearer ${deps.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(buildMirrorFormPayload(formName, tier, createdAt)),
+      });
+    } catch (err) {
+      return { settings, action: 'failed', error: `Could not reach HubSpot: ${String(err)}` };
+    }
+    if (res.ok) break;
+    lastBody = await res.text().catch(() => '');
     // A mirror the portal no longer has is not an error to report back — the
     // author did not delete it from here, and refusing to make a new one would
     // leave the feature permanently broken for them. Drop the guid so the next
-    // save creates one.
+    // save creates one. Never worth retrying with fewer fields.
     if (existing && res.status === 404) {
       return {
         settings: { ...settings, formGuid: null, formSignature: undefined },
@@ -152,7 +236,13 @@ export async function syncMirrorForm(
         error: 'The HubSpot form for this Dapta form no longer exists — it will be recreated.',
       };
     }
-    return { settings, action: 'failed', error: reasonFrom(res.status, body) };
+    // Only a rejected PAYLOAD is worth retrying smaller. A 401/403 is about the
+    // token, and a 5xx is about HubSpot; neither gets better with fewer fields.
+    if (res.status !== 400) break;
+  }
+
+  if (!res || !res.ok) {
+    return { settings, action: 'failed', error: reasonFrom(res?.status ?? 0, lastBody) };
   }
 
   const body = (await res.json().catch(() => ({}))) as { id?: string };
@@ -160,8 +250,11 @@ export async function syncMirrorForm(
   if (!guid) {
     return { settings, action: 'failed', error: 'HubSpot accepted the form but returned no id.' };
   }
+  // The signature records what was ACCEPTED, not what was asked for. Storing the
+  // full set after a degraded create would make the next save think it was in
+  // step and never try the fuller mirror again.
   return {
-    settings: { ...settings, formGuid: guid, formSignature: signature },
+    settings: { ...settings, formGuid: guid, formSignature: mirrorSignature(formName, sent) },
     action: existing ? 'updated' : 'created',
   };
 }

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -615,6 +615,10 @@ export class FormDestinationsController {
     @Inject(DB) private readonly db: Db,
     @Inject(AuthService) private readonly auth: AuthService,
     @Optional() @Inject(ENV) private readonly env?: ServerEnv,
+    /** Reused for its per-account cache — the mirror needs the same list. */
+    @Optional()
+    @Inject(HubspotPropertiesService)
+    private readonly hubspotProperties?: HubspotPropertiesService,
   ) {}
 
   @Put('forms/:id/destinations')
@@ -691,6 +695,19 @@ export class FormDestinationsController {
       token = null;
     }
 
+    // Which contact properties the portal actually has. A form field naming one
+    // it does not makes the CREATE fail with `400 internal error`, so a single
+    // stale mapping among many would cost the whole activity. Cached per
+    // account by the same service the property picker uses, so this is normally
+    // free. A failure here leaves it unknown and nothing is filtered.
+    let knownProperties: Set<string> | null = null;
+    try {
+      const listed = await this.hubspotProperties?.listProperties(accountId);
+      if (listed?.enabled) knownProperties = new Set(listed.properties.map((p) => p.name));
+    } catch {
+      knownProperties = null;
+    }
+
     let error: string | undefined;
     const out = await Promise.all(
       destinations.map(async (raw) => {
@@ -699,6 +716,7 @@ export class FormDestinationsController {
         const result = await syncMirrorForm(parsed.data, formName, {
           fetchImpl: this.fetchImpl,
           token,
+          knownProperties,
         });
         if (result.error && !error) error = result.error;
         if (result.action === 'noop' || result.action === 'unchanged') return raw;


### PR DESCRIPTION
Follow-up to #87. The mirror form it introduced fails on a realistic set of field
mappings, and it fails invisibly: HubSpot answers `400 internal error`, naming
nothing. This commit was pushed a few minutes after #87 merged and so missed it —
`develop` currently has the feature without the fix.

Found while proving that swapping an account's HubSpot token leaves its field
mappings alone (it does). The same run surfaced two separate causes, both certain
to hit a real account.

## A mapped property the portal does not have kills the whole create

Mappings go stale. `extractRetryablePropertyNames` exists precisely because the
contact upsert meets this routinely — one dead mapping among many would cost the
entire activity.

The portal's property list is now consulted first and unknown names are dropped.
That is not a compromise: the upsert already strips them before writing, so a
property the portal lacks never reaches the contact either, and declaring it
would promise the activity a field the submission cannot set. The list comes from
the same per-account cache the property picker already uses, so it is normally
free; a failed lookup filters nothing rather than everything, since unknown is
not the same as empty.

## Some properties are refused as form fields with nothing to predict it

A portal's `lifecyclestage` exists, is not calculated, and its own metadata says
`formField: true` — and a form declaring it is rejected all the same. Measured as
a dropdown, as a radio, and as text; all three rejected. Another enumeration in
the same portal (`dapta_source`) is accepted as text, so the type is not the
rule either.

The offender cannot be identified before the call or from the error, so rather
than maintain a list of HubSpot's special cases the mirror degrades in order of
what the activity is FOR: the fixed stamps first (where a portal's system
properties tend to be configured), then everything but the answers, then the
email alone. A single bad property must not cost three good ones. Only a 400
retries — a 401/403 is about the token and a 5xx is about HubSpot, and neither
improves with fewer fields.

The stored signature records what was ACCEPTED rather than what was asked for, or
the next save would think it was in step and never attempt the fuller mirror
again.

## Verification

Against the real portal, with a mapping set carrying both faults (a property that
does not exist plus `lifecyclestage`):

- **before**: `400 internal error`, no form created, no useful reason
- **after**: the form is created declaring `email, jobtitle, dapta_source,
  date_booking` — every property the portal accepts — and nothing surfaces to the
  author

The contact still receives all of them either way; what degrades is only what the
activity lists.

Ten new unit tests cover the tiering, including that a token or server error does
not retry smaller, and that the accepted set is what gets recorded.

```
1443 tests · typecheck · lint · build · publish-gate
```

## Note on scope

The six production forms that carry HubSpot mappings today all use
`bz___optin_form` as their only static property, and every property they map
exists in the portal — so none of them would have degraded. This is a fix for the
next mapping someone edits, not for a break already in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
