### PR TITLE
fix: transport-resilient autosave — no more stuck 'Saving…', no lost work on refresh

### DIFF
--- a/.changeset/autosave-transport-resilience.md
+++ b/.changeset/autosave-transport-resilience.md
@@ -1,0 +1,5 @@
+---
+'@quill/shared': minor
+---
+
+New i18n strings for transport-resilient autosave: `admin.editor.saveOffline`, `admin.integrations.saveOffline`, and `admin.integrations.saveRetrying` (EN + ES) — shown when a save request never reaches the server and autosave is retrying on its own.

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
+import { redirect, unstable_rethrow } from 'next/navigation';
 import { adminApi } from '@/lib/admin-api';
 
 /** Create a form and jump straight into its editor. */
@@ -44,11 +44,16 @@ export async function saveFormAction(
 ): Promise<{ ok: boolean; message?: string }> {
   try {
     await adminApi.updateForm(id, patch);
-    revalidatePath(`/admin/forms/${id}/edit`);
-    revalidatePath('/admin');
+    // No revalidatePath here on purpose: this fires on every debounced
+    // keystroke, every admin read is already `cache: 'no-store'`, and the
+    // draft it writes is visible only to this editor. Publish revalidates.
     return { ok: true };
   } catch (e) {
-    return { ok: false, message: e instanceof Error ? e.message : 'Failed to save.' };
+    unstable_rethrow(e);
+    return {
+      ok: false,
+      message: e instanceof Error ? e.message : 'Failed to save.',
+    };
   }
 }
 
@@ -64,6 +69,10 @@ export async function publishFormAction(id: string): Promise<{ ok: boolean; mess
     revalidatePath('/admin');
     return { ok: true };
   } catch (e) {
-    return { ok: false, message: e instanceof Error ? e.message : 'Failed to publish.' };
+    unstable_rethrow(e);
+    return {
+      ok: false,
+      message: e instanceof Error ? e.message : 'Failed to publish.',
+    };
   }
 }

--- a/apps/web/app/admin/branding/brand-kit-panel.tsx
+++ b/apps/web/app/admin/branding/brand-kit-panel.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_FORM_FONT } from '@quill/engine';
 import { DEFAULT_ACCENT, DEFAULT_CANVAS, onAccent, readableOn, t, type FormsMessages } from '@quill/shared';
 import type { BrandKit, FormSummary } from '@/lib/admin-api';
 import { formDesignProps } from '@/lib/form-design';
-import { callAction } from '@/lib/call-action';
+import { callAction, isTransportError } from '@/lib/call-action';
 import { cn } from '@/lib/cn';
 import { Field, PanelSection, SegmentedToggle, TextField } from '../forms/[id]/edit/_components/fields';
 import { ColorPicker } from '../forms/[id]/edit/_components/color-picker';
@@ -66,7 +66,7 @@ export function BrandKitPanel({
       if (res.ok) {
         setSavedAt(res.value.updatedAt);
         flash(bk.saved);
-      } else setError(res.message ?? bk.saved);
+      } else setError(isTransportError(res) ? bk.saveOffline : (res.message ?? bk.saved));
     });
 
   const apply = () => {
@@ -74,6 +74,10 @@ export function BrandKitPanel({
     if (!ids.length) return;
     startApplying(async () => {
       const res = await callAction(() => applyBrandKitAction(ids));
+      if (isTransportError(res)) {
+        setError(bk.saveOffline);
+        return;
+      }
       if (res.ok) {
         setApplied((a) => ({ ...a, ...Object.fromEntries(res.value.applied.map((id) => [id, true])) }));
         setSelected(new Set());
@@ -86,6 +90,10 @@ export function BrandKitPanel({
     setRevertingId(id);
     try {
       const res = await callAction(() => revertBrandKitAction([id]));
+      if (isTransportError(res)) {
+        setError(bk.saveOffline);
+        return;
+      }
       if (res.ok && res.value.reverted.includes(id)) {
         setApplied((a) => ({ ...a, [id]: false }));
         flash(bk.revertedToast);

--- a/apps/web/app/admin/branding/brand-kit-panel.tsx
+++ b/apps/web/app/admin/branding/brand-kit-panel.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_FORM_FONT } from '@quill/engine';
 import { DEFAULT_ACCENT, DEFAULT_CANVAS, onAccent, readableOn, t, type FormsMessages } from '@quill/shared';
 import type { BrandKit, FormSummary } from '@/lib/admin-api';
 import { formDesignProps } from '@/lib/form-design';
+import { callAction } from '@/lib/call-action';
 import { cn } from '@/lib/cn';
 import { Field, PanelSection, SegmentedToggle, TextField } from '../forms/[id]/edit/_components/fields';
 import { ColorPicker } from '../forms/[id]/edit/_components/color-picker';
@@ -61,7 +62,7 @@ export function BrandKitPanel({
 
   const save = () =>
     startSaving(async () => {
-      const res = await saveBrandKitAction(kit);
+      const res = await callAction(() => saveBrandKitAction(kit));
       if (res.ok) {
         setSavedAt(res.value.updatedAt);
         flash(bk.saved);
@@ -72,7 +73,7 @@ export function BrandKitPanel({
     const ids = [...selected];
     if (!ids.length) return;
     startApplying(async () => {
-      const res = await applyBrandKitAction(ids);
+      const res = await callAction(() => applyBrandKitAction(ids));
       if (res.ok) {
         setApplied((a) => ({ ...a, ...Object.fromEntries(res.value.applied.map((id) => [id, true])) }));
         setSelected(new Set());
@@ -84,7 +85,7 @@ export function BrandKitPanel({
   const revert = async (id: string) => {
     setRevertingId(id);
     try {
-      const res = await revertBrandKitAction([id]);
+      const res = await callAction(() => revertBrandKitAction([id]));
       if (res.ok && res.value.reverted.includes(id)) {
         setApplied((a) => ({ ...a, [id]: false }));
         flash(bk.revertedToast);

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -19,6 +19,13 @@ export interface BuilderMessages {
     saving: string;
     draft: string;
     saveError: string;
+    /** A save that could not reach the server is being retried automatically. */
+    retrying: string;
+    /** Banner offering to restore work recovered from the local crash backup. */
+    recoveryTitle: string;
+    recoveryBody: string;
+    recoveryRestore: string;
+    recoveryDiscard: string;
     preview: string;
     publish: string;
     publishing: string;
@@ -491,6 +498,12 @@ const en: BuilderMessages = {
     saving: 'Saving…',
     draft: 'Draft',
     saveError: 'Not saved',
+    retrying: 'Retrying…',
+    recoveryTitle: 'Unsaved changes recovered',
+    recoveryBody:
+      'This form has edits from a previous session that never reached the server. Restore them, or keep the saved version?',
+    recoveryRestore: 'Restore edits',
+    recoveryDiscard: 'Discard',
     preview: 'Preview',
     publish: 'Publish',
     publishing: 'Publishing…',
@@ -766,7 +779,10 @@ const en: BuilderMessages = {
       slider: { title: 'Slider', desc: 'Rating scale' },
       message: { title: 'Message', desc: 'Text, no input' },
       reveal: { title: 'Reveal screen', desc: 'A short processing pause' },
-      scheduler: { title: 'Scheduler', desc: 'Book a meeting on your calendar' },
+      scheduler: {
+        title: 'Scheduler',
+        desc: 'Book a meeting on your calendar',
+      },
     },
   },
   map: {
@@ -874,6 +890,12 @@ const es: BuilderMessages = {
     saving: 'Guardando…',
     draft: 'Borrador',
     saveError: 'Sin guardar',
+    retrying: 'Reintentando…',
+    recoveryTitle: 'Cambios sin guardar recuperados',
+    recoveryBody:
+      'Este formulario tiene cambios de una sesión anterior que nunca llegaron al servidor. ¿Restaurarlos o quedarte con la versión guardada?',
+    recoveryRestore: 'Restaurar cambios',
+    recoveryDiscard: 'Descartar',
     preview: 'Vista previa',
     publish: 'Publicar',
     publishing: 'Publicando…',
@@ -1150,8 +1172,14 @@ const es: BuilderMessages = {
       long: { title: 'Texto largo', desc: 'Párrafo' },
       slider: { title: 'Deslizador', desc: 'Escala de valoración' },
       message: { title: 'Mensaje', desc: 'Texto, sin campo' },
-      reveal: { title: 'Pantalla de revelación', desc: 'Una breve pausa de procesamiento' },
-      scheduler: { title: 'Agendador', desc: 'Agenda una reunión en tu calendario' },
+      reveal: {
+        title: 'Pantalla de revelación',
+        desc: 'Una breve pausa de procesamiento',
+      },
+      scheduler: {
+        title: 'Agendador',
+        desc: 'Agenda una reunión en tu calendario',
+      },
     },
   },
   map: {

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { unstable_rethrow } from 'next/navigation';
 import { adminApi, ApiError, type FailedDelivery, type HubSpotPropertiesResponse } from '@/lib/admin-api';
 import { getMessages } from '@quill/shared';
 import type { FormDestination } from '@quill/types';
@@ -37,6 +38,7 @@ export async function loadConnectIntegrationsAction(
   try {
     form = await adminApi.getForm(id);
   } catch (e) {
+    unstable_rethrow(e);
     if (e instanceof ApiError) return { ok: false, message: e.message };
     throw e;
   }
@@ -46,7 +48,8 @@ export async function loadConnectIntegrationsAction(
   let hubspot: HubSpotPropertiesResponse;
   try {
     hubspot = await adminApi.hubspotProperties();
-  } catch {
+  } catch (e) {
+    unstable_rethrow(e); // a 401 must bounce to /login, not fake "disabled"
     hubspot = { enabled: false, reason: m.loadError };
   }
 
@@ -61,7 +64,8 @@ export async function loadConnectIntegrationsAction(
     calendlyConnected = integrations.providers.some(
       (p) => p.provider === 'calendly' && p.connected,
     );
-  } catch {
+  } catch (e) {
+    unstable_rethrow(e);
     hubspotConnected = false;
     calendlyConnected = false;
   }
@@ -87,7 +91,8 @@ export async function loadFailedDeliveriesAction(id: string): Promise<FailedDeli
   try {
     const res = await adminApi.formDeliveries(id);
     return res.items;
-  } catch {
+  } catch (e) {
+    unstable_rethrow(e);
     return [];
   }
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { unstable_rethrow } from 'next/navigation';
+
 import {
   adminApi,
   ApiError,
@@ -42,6 +44,7 @@ export async function loadFormNotificationsAction(
     const res = await adminApi.getFormNotifications(formId);
     return { ok: true, settings: res.settings };
   } catch (e) {
+    unstable_rethrow(e);
     return failure(e);
   }
 }
@@ -58,6 +61,7 @@ export async function saveFormNotificationAction(
     const setting = await adminApi.updateFormNotification(formId, emailKey, patch);
     return { ok: true, setting };
   } catch (e) {
+    unstable_rethrow(e);
     return failure(e);
   }
 }
@@ -73,6 +77,7 @@ export async function resetFormNotificationAction(
     const setting = await adminApi.resetFormNotification(formId, emailKey);
     return { ok: true, setting };
   } catch (e) {
+    unstable_rethrow(e);
     return failure(e);
   }
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
@@ -17,6 +17,7 @@ import {
   saveFormNotificationAction,
 } from './connect-emails-actions';
 import type { EditorMessages } from './messages';
+import { callAction } from '@/lib/call-action';
 
 /**
  * Emails on the Connect tab — PER-FORM template overrides (Typeform's per-form
@@ -181,11 +182,13 @@ function FormEmailCard({
       // The override PINS this form's copy verbatim (subject/body/enabled) —
       // unlike the account editor there is no "equals default → null" collapse:
       // customizing means "keep this exact copy even if the account changes".
-      const res = await saveFormNotificationAction(formId, key, {
-        enabled: value.enabled,
-        subject: value.subject,
-        body: value.body,
-      });
+      const res = await callAction(() =>
+        saveFormNotificationAction(formId, key, {
+          enabled: value.enabled,
+          subject: value.subject,
+          body: value.body,
+        }),
+      );
       if (res.ok) {
         setOverride(res.setting.override);
         toast.success(nm.saveSuccess);
@@ -209,7 +212,7 @@ function FormEmailCard({
     });
     if (!ok) return;
     startTransition(async () => {
-      const res = await resetFormNotificationAction(formId, key);
+      const res = await callAction(() => resetFormNotificationAction(formId, key));
       if (res.ok) {
         setOverride(null);
         setEditing(false);

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot-actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { unstable_rethrow } from 'next/navigation';
+
 import { adminApi, ApiError } from '@/lib/admin-api';
 import { propertiesFor, type FormDestination } from '@quill/types';
 
@@ -74,9 +76,17 @@ export async function renameQuestionMappingAction(
           : d,
       ),
     );
-    return { ok: true, destinations: (updated.config.destinations ?? []) as FormDestination[] };
+    return {
+      ok: true,
+      destinations: (updated.config.destinations ?? []) as FormDestination[],
+    };
   } catch (e) {
-    return { ok: false, code: 'error', message: e instanceof ApiError ? e.message : undefined };
+    unstable_rethrow(e);
+    return {
+      ok: false,
+      code: 'error',
+      message: e instanceof ApiError ? e.message : undefined,
+    };
   }
 }
 
@@ -112,8 +122,16 @@ export async function saveQuestionMappingAction(
       id,
       destinations.map((d) => (d === current ? { ...current, fieldMappings } : d)),
     );
-    return { ok: true, destinations: (updated.config.destinations ?? []) as FormDestination[] };
+    return {
+      ok: true,
+      destinations: (updated.config.destinations ?? []) as FormDestination[],
+    };
   } catch (e) {
-    return { ok: false, code: 'error', message: e instanceof ApiError ? e.message : undefined };
+    unstable_rethrow(e);
+    return {
+      ok: false,
+      code: 'error',
+      message: e instanceof ApiError ? e.message : undefined,
+    };
   }
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-hubspot.tsx
@@ -15,6 +15,7 @@ import { bookingLabel } from '@/lib/booking-fields';
 import { loadConnectIntegrationsAction, type ConnectIntegrationsData } from './connect-actions';
 import { saveQuestionMappingAction } from './question-hubspot-actions';
 import type { BuilderMessages } from './builder-messages';
+import { callAction, isTransportError } from '@/lib/call-action';
 
 /**
  * QuestionHubspotSection — the Build tab's per-question "HubSpot / Map to"
@@ -173,7 +174,10 @@ export function QuestionHubspotSection({
   const options = useMemo<SelectOption[]>(
     () => [
       { value: '', label: m.none },
-      ...properties.map((p) => ({ value: p.name, label: `${p.label} (${p.name})` })),
+      ...properties.map((p) => ({
+        value: p.name,
+        label: `${p.label} (${p.name})`,
+      })),
     ],
     [properties, m.none],
   );
@@ -216,10 +220,15 @@ export function QuestionHubspotSection({
 
     const seq = (saveSeq.current.get(key) ?? 0) + 1;
     saveSeq.current.set(key, seq);
-    void saveQuestionMappingAction(formId, key, nextValue || null)
+    void callAction(() => saveQuestionMappingAction(formId, key, nextValue || null))
       .then((res) => {
         if (seq !== saveSeq.current.get(key)) return; // superseded by a newer pick
         setSaving((k) => (k === key ? null : k));
+        if (isTransportError(res)) {
+          setState({ status: 'ready', data: before });
+          toastError(m.saveError);
+          return;
+        }
         if (res.ok) {
           const confirmed: ConnectIntegrationsData = {
             ...optimistic,

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { unstable_rethrow } from 'next/navigation';
+
 import { adminApi, ApiError, type CalendlyEventTypesResponse } from '@/lib/admin-api';
 
 /**
@@ -12,6 +14,7 @@ export async function loadCalendlyEventTypesAction(): Promise<CalendlyEventTypes
   try {
     return await adminApi.calendlyEventTypes();
   } catch (e) {
+    unstable_rethrow(e);
     const reason = e instanceof ApiError ? e.message : 'Could not reach Calendly.';
     return { enabled: false, reason };
   }

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -23,6 +23,9 @@ import type { FormTracking } from '@quill/types';
 import { formConfigSchema } from '@quill/types';
 import { saveFormAction } from '@/app/admin/actions';
 import { useToast } from '@/components/toast';
+import { callAction, isTransportError } from '@/lib/call-action';
+import { useAutosave } from '@/lib/use-autosave';
+import { clearDraftBackup, readDraftBackup, writeDraftBackup } from '@/lib/draft-backup';
 import { cn } from '@/lib/cn';
 import { anchorRevealsLast } from './_components/logic-util';
 import { QuestionSpine } from './_components/question-spine';
@@ -60,12 +63,13 @@ import { getBuilderMessages, tb, type TemplateId } from './_components/builder-m
 import type { EditorMessages } from './_components/messages';
 import './_components/builder.css';
 
-type SaveStatus = 'saved' | 'saving' | 'draft' | 'error';
 const AUTOSAVE_MS = 900;
-/** One backoff retry after a failed/transient save so a blip self-heals. */
-const RETRY_MS = 1500;
-/** Same admin API base the server-side admin-api client uses (client-exposed). */
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+/** What one autosave write carries — always read fresh via `latest`. */
+interface EditorSnapshot {
+  name: string;
+  config: FormConfig;
+}
 
 // `results` is deliberately NOT in this list: `parseTab('results')` falls
 // through to Build, so a bookmark or an old link lands somewhere real instead
@@ -124,6 +128,7 @@ export function FormEditor({
   locale,
   m,
   initialHasDraft = false,
+  updatedAt,
 }: {
   id: string;
   initialName: string;
@@ -133,6 +138,8 @@ export function FormEditor({
   m: EditorMessages;
   /** Whether the form already had an unpublished draft when the page loaded. */
   initialHasDraft?: boolean;
+  /** Server row's last-write stamp — gates the crash-recovery offer. */
+  updatedAt?: number;
 }) {
   const bm = getBuilderMessages(locale);
   const searchParams = useSearchParams();
@@ -177,132 +184,113 @@ export function FormEditor({
   const isDesktop = useIsDesktop();
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
-  const [status, setStatus] = useState<SaveStatus>(initialConfig.steps.length ? 'saved' : 'draft');
   const [focusCanvas, setFocusCanvas] = useState(0);
   const [saveCount, setSaveCount] = useState(0);
-  // The server's reason for the last failed save — shown in the status tooltip.
-  const [lastError, setLastError] = useState<string | null>(null);
-  // `migrateRevealToStep` returns the SAME object when there was nothing legacy
-  // to fold in, so an identity check is an exact "did we migrate?" — start dirty
-  // in that case and the very first autosave persists the new shape.
-  const dirty = useRef(config !== initialConfig);
-  const retry = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Freshest name/config for the leave handlers + retry (no stale closures).
-  const latest = useRef({ name, config });
+  // Freshest name/config for save/flush/backup paths (no stale closures).
+  const latest = useRef<EditorSnapshot>({ name, config });
   const toast = useToast();
   const toastRef = useRef(toast);
   toastRef.current = toast;
-
-  // --- Autosave (debounced; each successful save stores an unpublished draft) ---
-  // Bulletproofing: (1) surface WHY a save failed, (2) client-side pre-validate
-  // so a doomed PUT never fires, (4) auto-retry a transient failure once — and
-  // keep `dirty` true until a save actually SUCCEEDS so nothing is silently lost.
-  const persist = useCallback(
-    async (nextName: string, nextConfig: FormConfig, opts?: { isRetry?: boolean }): Promise<boolean> => {
-      const normalized = normalizeConfig(nextConfig);
-      const parsed = formConfigSchema.safeParse(normalized);
-      if (!parsed.success) {
-        const issue = parsed.error.issues[0];
-        const field = issue?.path.join('.') || 'config';
-        const reason = `${field}: ${issue?.message ?? 'invalid value'}`;
-        setStatus('error');
-        setLastError(reason);
-        console.error('[forms] autosave blocked — config failed validation:', reason, parsed.error.issues);
-        toastRef.current.error(tb(m.saveInvalid, { reason }));
-        return false; // dirty stays true; the next edit re-attempts
-      }
-      setStatus('saving');
-      const res = await saveFormAction(id, { name: nextName, config: normalized });
-      if (res.ok) {
-        dirty.current = false;
-        setStatus('saved');
-        setLastError(null);
-        setSaveCount((n) => n + 1);
-        return true;
-      }
-      const reason = res.message ?? 'unknown error';
-      console.error('[forms] autosave failed:', reason);
-      setStatus('error');
-      setLastError(reason);
-      if (!opts?.isRetry) {
-        toastRef.current.error(tb(m.saveErrorReason, { reason }));
-        if (retry.current) clearTimeout(retry.current);
-        retry.current = setTimeout(() => {
-          void persist(latest.current.name, latest.current.config, { isRetry: true });
-        }, RETRY_MS);
-      }
-      return false; // dirty stays true until a save actually succeeds
-    },
-    [id, m],
-  );
 
   useEffect(() => {
     latest.current = { name, config };
   }, [name, config]);
 
-  useEffect(() => {
-    if (!dirty.current) return;
-    const t = setTimeout(() => void persist(name, config), AUTOSAVE_MS);
-    return () => clearTimeout(t);
-  }, [name, config, persist]);
-
-  // (3) Flush a pending (debounced) save on leave so a change still sitting in
-  // the debounce window is never dropped. `beacon` = a keepalive PUT that
-  // survives a hard tab close/reload; the SPA-nav + tab-hidden paths use the
-  // cookie-authed server action (the component is still able to fire it).
-  const flush = useCallback(
-    (beacon: boolean) => {
-      if (!dirty.current) return;
-      const { name: n, config: c } = latest.current;
-      const normalized = normalizeConfig(c);
-      if (!formConfigSchema.safeParse(normalized).success) return; // never flush invalid config
-      if (beacon) {
-        try {
-          void fetch(`${API_BASE}/v1/forms/${id}`, {
-            method: 'PUT',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ name: n, config: normalized }),
-            keepalive: true,
-            credentials: 'include',
-          });
-        } catch {
-          /* best-effort on the unload path — nothing to recover to */
-        }
-      } else {
-        void persist(n, c);
+  // --- Autosave (each successful save stores an unpublished draft) -----------
+  // The debounce/serialize/retry machinery lives in `useAutosave` (shared with
+  // the integrations editor). What this component owes it: the freshest
+  // snapshot, the zod pre-validation gate, the server write (transport-safe via
+  // `callAction` — a rejected invocation is a retryable value, never a stuck
+  // "Saving…"), the same-origin keepalive flush for hard tab closes, and a
+  // localStorage backup so even a lost tab can offer its work back on reopen.
+  const autosave = useAutosave<EditorSnapshot>({
+    getSnapshot: () => latest.current,
+    validate: useCallback((s: EditorSnapshot) => {
+      const parsed = formConfigSchema.safeParse(normalizeConfig(s.config));
+      if (parsed.success) return { ok: true as const };
+      const issue = parsed.error.issues[0];
+      const field = issue?.path.join('.') || 'config';
+      return {
+        ok: false as const,
+        reason: `${field}: ${issue?.message ?? 'invalid value'}`,
+      };
+    }, []),
+    save: (s) =>
+      callAction(() => saveFormAction(id, { name: s.name, config: normalizeConfig(s.config) })),
+    beacon: (s) => {
+      try {
+        void fetch(`/admin/forms/${id}/flush`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            kind: 'config',
+            name: s.name,
+            config: normalizeConfig(s.config),
+          }),
+          keepalive: true,
+        });
+      } catch {
+        /* best-effort on the unload path — the localStorage backup remains */
       }
     },
-    [id, persist],
-  );
-  const flushRef = useRef(flush);
-  useEffect(() => {
-    flushRef.current = flush;
-  }, [flush]);
+    backup: {
+      write: (s) => writeDraftBackup(id, s.name, s.config),
+      clear: () => clearDraftBackup(id),
+    },
+    onFailure: (message, transport) => {
+      console.error('[forms] autosave failed:', message);
+      toastRef.current.error(
+        transport ? m.saveOffline : tb(m.saveErrorReason, { reason: message }),
+      );
+    },
+    onSaved: () => setSaveCount((n) => n + 1),
+    // `migrateRevealToStep` returns the SAME object when there was nothing
+    // legacy to fold in, so an identity check is an exact "did we migrate?" —
+    // start dirty in that case and the first autosave persists the new shape.
+    initiallyDirty: config !== initialConfig,
+    debounceMs: AUTOSAVE_MS,
+  });
+  const status = autosave.status;
 
+  // --- Crash recovery: work the backup caught that never reached the server --
+  const [recovery, setRecovery] = useState<EditorSnapshot | null>(null);
   useEffect(() => {
-    const onVisibility = () => {
-      if (document.visibilityState === 'hidden') flushRef.current(false);
-    };
-    const onBeforeUnload = () => flushRef.current(true);
-    document.addEventListener('visibilitychange', onVisibility);
-    window.addEventListener('beforeunload', onBeforeUnload);
-    return () => {
-      document.removeEventListener('visibilitychange', onVisibility);
-      window.removeEventListener('beforeunload', onBeforeUnload);
-      if (retry.current) clearTimeout(retry.current);
-      flushRef.current(false); // SPA nav / unmount → reliable server-action flush
-    };
-  }, []); // subscribe once; the cleanup flushes exactly once on real unmount
+    const b = readDraftBackup(id);
+    if (!b) return;
+    // Only offer a backup that is NEWER than the server row, parses, and
+    // actually differs from what the server already has — else drop it quietly.
+    const stale = updatedAt != null && b.ts <= updatedAt;
+    const unchanged =
+      b.name === initialName && JSON.stringify(b.config) === JSON.stringify(initialConfig);
+    if (stale || unchanged || !formConfigSchema.safeParse(b.config).success) {
+      clearDraftBackup(id);
+      return;
+    }
+    // Restore the RAW stored config (not the zod output): parsing only gates
+    // validity — stripping unknown-but-additive keys here would lose data.
+    setRecovery({ name: b.name, config: b.config as FormConfig });
+    // Mount-only: the backup verdict is about the page load, not later edits.
+  }, []);
+  function restoreRecovery() {
+    if (!recovery) return;
+    setName(recovery.name);
+    setConfig(recovery.config);
+    setSelected(recovery.config.steps.length ? 0 : null);
+    setRecovery(null);
+    autosave.markDirty(); // the restored work goes straight into the save loop
+  }
+  function discardRecovery() {
+    clearDraftBackup(id);
+    setRecovery(null);
+  }
 
   function mutate(updater: (c: FormConfig) => FormConfig) {
-    dirty.current = true;
-    setStatus('saving');
     setConfig(updater);
+    autosave.markDirty();
   }
   function rename(next: string) {
-    dirty.current = true;
-    setStatus('saving');
     setName(next);
+    autosave.markDirty();
   }
 
   // --- Step operations ------------------------------------------------------
@@ -324,8 +312,8 @@ export function FormEditor({
     if (!current) return;
     const oldKey = current.key;
     mutate((c) => engineRenameStepKey(c, oldKey, nextKey));
-    void renameQuestionMappingAction(id, oldKey, nextKey).then((res) => {
-      if (!res.ok && res.code === 'error') {
+    void callAction(() => renameQuestionMappingAction(id, oldKey, nextKey)).then((res) => {
+      if (isTransportError(res) || (!res.ok && res.code === 'error')) {
         // The config rename already applied and autosaved; only the CRM mapping
         // is behind. Say so rather than implying the whole rename failed.
         toastRef.current.error(m.behavior.fieldKeyMappingFailed);
@@ -358,7 +346,11 @@ export function FormEditor({
       return {
         ...c,
         steps,
-        partialSubmitAfterStep: reanchorAfterDelete(c.partialSubmitAfterStep, index, c.steps.length),
+        partialSubmitAfterStep: reanchorAfterDelete(
+          c.partialSubmitAfterStep,
+          index,
+          c.steps.length,
+        ),
       };
     });
     setSelected((sel) => {
@@ -392,19 +384,17 @@ export function FormEditor({
   }
   function applyTemplate(tid: TemplateId) {
     const cfg = TEMPLATES[tid];
-    dirty.current = true;
     // Preserve a name the user already typed; only fall back to the template's
     // name when the field is still blank (V4-11 — templates swap config, not name).
     setName((n) => (n.trim() ? n : bm.empty.templates[tid].name));
     setConfig(cfg);
     setSelected(0);
     setTab('build');
-    setStatus('saving');
+    autosave.markDirty();
   }
 
   // Public title (V7): what the tab/OG/cover show. Empty clears back to `name`.
-  const setTitle = (title: string) =>
-    mutate((c) => ({ ...c, title: title.trim() ? title : null }));
+  const setTitle = (title: string) => mutate((c) => ({ ...c, title: title.trim() ? title : null }));
   const patchCover = (patch: Partial<FormCover>) =>
     mutate((c) => ({ ...c, cover: { ...c.cover, ...patch } }));
   const patchBranding = (patch: Partial<FormBranding>) =>
@@ -485,12 +475,18 @@ export function FormEditor({
       const keep = c.steps.filter((s) => s.type !== 'reveal');
       // Re-anchor the partial marker by the key it pointed at (a reveal can't
       // be the anchor's own step — it captures no answer — but positions shift).
-      const anchorKey = c.partialSubmitAfterStep != null ? c.steps[c.partialSubmitAfterStep - 1]?.key : undefined;
+      const anchorKey =
+        c.partialSubmitAfterStep != null ? c.steps[c.partialSubmitAfterStep - 1]?.key : undefined;
       const idx = anchorKey ? keep.findIndex((s) => s.key === anchorKey) : -1;
-      return { ...c, steps: keep, partialSubmitAfterStep: idx >= 0 ? idx + 1 : undefined };
+      return {
+        ...c,
+        steps: keep,
+        partialSubmitAfterStep: idx >= 0 ? idx + 1 : undefined,
+      };
     });
     // Removing cards can strand the selection past the end of the list.
-    if (!on) setSelected((sel) => (sel == null ? sel : keepLen === 0 ? null : Math.min(sel, keepLen - 1)));
+    if (!on)
+      setSelected((sel) => (sel == null ? sel : keepLen === 0 ? null : Math.min(sel, keepLen - 1)));
   }
 
   /**
@@ -537,13 +533,21 @@ export function FormEditor({
   const statusLabel =
     status === 'saving'
       ? bm.shell.saving
-      : status === 'error'
-        ? bm.shell.saveError
-        : hasQuestions
-          ? bm.shell.saved
-          : bm.shell.draft;
+      : status === 'retrying'
+        ? bm.shell.retrying
+        : status === 'error'
+          ? bm.shell.saveError
+          : hasQuestions
+            ? bm.shell.saved
+            : bm.shell.draft;
   const statusDot =
-    status === 'error' ? 'bg-destructive' : status === 'saving' ? 'bg-muted-foreground' : 'bg-primary-edge';
+    status === 'error'
+      ? 'bg-destructive'
+      : status === 'saving' || status === 'retrying'
+        ? 'bg-muted-foreground'
+        : 'bg-primary-edge';
+  /** Kept for tests/tools reading `data-status`: an empty saved form is "draft". */
+  const displayStatus = status === 'saved' && !hasQuestions ? 'draft' : status;
 
   return (
     <div className="flex h-[100dvh] flex-col overflow-hidden bg-background">
@@ -574,12 +578,16 @@ export function FormEditor({
           <span
             className={cn(
               'hidden shrink-0 items-center gap-1.5 text-xs text-muted-foreground xl:inline-flex',
-              status === 'error' && lastError ? 'cursor-help' : '',
+              (status === 'error' || status === 'retrying') && autosave.detail ? 'cursor-help' : '',
             )}
             data-testid="editor-save-status"
-            data-status={status}
+            data-status={displayStatus}
             // Native tooltip: hover the "Not saved" indicator to read WHY it failed.
-            title={status === 'error' && lastError ? tb(m.saveErrorReason, { reason: lastError }) : undefined}
+            title={
+              (status === 'error' || status === 'retrying') && autosave.detail
+                ? tb(m.saveErrorReason, { reason: autosave.detail })
+                : undefined
+            }
           >
             <span className={cn('h-1.5 w-1.5 rounded-full', statusDot)} />
             {statusLabel}
@@ -642,6 +650,41 @@ export function FormEditor({
           />
         </div>
       </header>
+
+      {/* Crash recovery: edits the local backup caught that never reached the
+          server (closed tab mid-outage, hung API). Offered once per load. */}
+      {recovery ? (
+        <div
+          data-testid="draft-recovery-banner"
+          className="flex flex-wrap items-center gap-3 border-b border-border bg-muted px-3 py-2 text-sm sm:px-4"
+        >
+          <i
+            aria-hidden
+            className="pi pi-history shrink-0 text-muted-foreground"
+            style={{ fontSize: 14 }}
+          />
+          <p className="min-w-0 flex-1">
+            <span className="font-medium">{bm.shell.recoveryTitle}</span>{' '}
+            <span className="text-muted-foreground">{bm.shell.recoveryBody}</span>
+          </p>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              onClick={restoreRecovery}
+              className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-xs font-semibold text-primary-foreground hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {bm.shell.recoveryRestore}
+            </button>
+            <button
+              type="button"
+              onClick={discardRecovery}
+              className="inline-flex h-8 items-center rounded-md border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {bm.shell.recoveryDiscard}
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       {/* Topbar, row 2 — contextual: only what acts on the CURRENT section. */}
       <EditorToolbar m={bm}>
@@ -788,7 +831,9 @@ export function FormEditor({
                       />
                     )
                   ) : (
-                    <p className="py-16 text-center text-sm text-muted-foreground">{bm.settings.empty}</p>
+                    <p className="py-16 text-center text-sm text-muted-foreground">
+                      {bm.settings.empty}
+                    </p>
                   )}
                 </div>
                 {/* Mobile question strip */}
@@ -800,7 +845,9 @@ export function FormEditor({
                       onClick={() => setSelected(i)}
                       className={cn(
                         'inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs',
-                        i === selected ? 'border-primary-edge bg-primary/10 text-foreground' : 'border-border text-muted-foreground',
+                        i === selected
+                          ? 'border-primary-edge bg-primary/10 text-foreground'
+                          : 'border-border text-muted-foreground',
                       )}
                     >
                       <span className="font-bold tabular-nums">{i + 1}</span>
@@ -844,7 +891,11 @@ export function FormEditor({
             </div>
           ) : (
             <div className="h-full overflow-y-auto">
-              <EmptyState onPickTemplate={applyTemplate} onScratch={() => setGalleryOpen(true)} m={bm} />
+              <EmptyState
+                onPickTemplate={applyTemplate}
+                onScratch={() => setGalleryOpen(true)}
+                m={bm}
+              />
             </div>
           )
         ) : tab === 'logic' ? (
@@ -912,7 +963,11 @@ export function FormEditor({
         m={bm}
         // Vertical: one reveal, always at the end — a second tile pick would
         // create a card the renderer ignores, so it's offered exactly once.
-        disabled={layout === 'vertical' && hasReveal ? { reveal: bm.gallery.revealVerticalTaken } : undefined}
+        disabled={
+          layout === 'vertical' && hasReveal
+            ? { reveal: bm.gallery.revealVerticalTaken }
+            : undefined
+        }
       />
       {/* The three form-wide views. Branching edits INLINE (R7) — same
           LogicRules/LogicConditions the per-question dialog hosts, same
@@ -931,7 +986,9 @@ export function FormEditor({
         onClose={() => setLogicView(null)}
         config={config}
         onScoringChange={setScoring}
-        onStepScoringChange={(index, on) => patchStep(index, { scoringEnabled: on ? undefined : false })}
+        onStepScoringChange={(index, on) =>
+          patchStep(index, { scoringEnabled: on ? undefined : false })
+        }
         onStepPatch={patchStep}
         bm={bm}
         em={m}

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -286,10 +286,14 @@ export function FormEditor({
 
   function mutate(updater: (c: FormConfig) => FormConfig) {
     setConfig(updater);
+    // A fresh edit outdates the crash backup — restoring it now would clobber
+    // what was just typed, so the offer leaves with the first real edit.
+    setRecovery(null);
     autosave.markDirty();
   }
   function rename(next: string) {
     setName(next);
+    setRecovery(null);
     autosave.markDirty();
   }
 

--- a/apps/web/app/admin/forms/[id]/edit/page.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/page.tsx
@@ -33,6 +33,7 @@ export default async function EditFormPage({ params }: { params: Promise<{ id: s
         // draft, and the explicit Publish action makes it live.
         initialConfig={form.draftConfig ?? form.config}
         initialHasDraft={form.draftConfig != null}
+        updatedAt={form.updatedAt}
         publicPath={publicPath}
         locale={locale}
         m={m}

--- a/apps/web/app/admin/forms/[id]/edit/publish-button.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/publish-button.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { getMessages } from '@quill/shared';
 import { publishFormAction } from '@/app/admin/actions';
 import { useToast } from '@/components/toast';
+import { callAction, isTransportError } from '@/lib/call-action';
 import { cn } from '@/lib/cn';
 
 /**
@@ -45,13 +46,18 @@ export function PublishButton({
     // Snapshot BEFORE the round-trip: a save landing mid-publish wrote a draft
     // the publish may not have carried, so the badge must come back for it.
     const snapshot = saveCount;
-    const res = await publishFormAction(formId);
-    setPublishing(false);
-    if (res.ok) {
-      setPublishedAtCount(snapshot);
-      toast.success(m.published);
-    } else {
-      toast.error(res.message ?? m.publishError);
+    try {
+      // Transport-safe: a rejected invocation (network drop, deploy-rotated
+      // action id) must re-enable the button, not strand it on "Publishing…".
+      const res = await callAction(() => publishFormAction(formId));
+      if (res.ok) {
+        setPublishedAtCount(snapshot);
+        toast.success(m.published);
+      } else {
+        toast.error((isTransportError(res) ? null : res.message) ?? m.publishError);
+      }
+    } finally {
+      setPublishing(false);
     }
   }
 

--- a/apps/web/app/admin/forms/[id]/flush/route.ts
+++ b/apps/web/app/admin/forms/[id]/flush/route.ts
@@ -28,6 +28,9 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
   }
 
   const { id } = await ctx.params;
+  // The id rides into the upstream path — reject anything that is not a plain
+  // opaque token so an encoded `../` can never re-aim the identity-carrying PUT.
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) return Response.json({ ok: false }, { status: 400 });
   let body: {
     kind?: string;
     name?: string;

--- a/apps/web/app/admin/forms/[id]/flush/route.ts
+++ b/apps/web/app/admin/forms/[id]/flush/route.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from 'next/server';
+import { hostFetch } from '@/lib/auth-session';
+
+/**
+ * Unload-flush proxy for the editors' last-gasp save (V5 stuck-"Saving…" fix).
+ *
+ * A hard tab close can't await a server action, so the editors fire a
+ * `keepalive` fetch instead. That fetch used to go STRAIGHT to the API host —
+ * which authenticates with identity headers minted from the httpOnly session
+ * cookie (`Authorization: Bearer` / `x-quill-email`), headers client JS can
+ * never attach. Every unload flush was a guaranteed 401; it also pinned the
+ * API's absolute URL into the client bundle. This same-origin route carries
+ * the session cookie like any admin page, attaches identity via `hostFetch`,
+ * and forwards the write — so the flush finally lands, from the same origin.
+ *
+ * Body: `{ kind: 'config', name, config }` → PUT /v1/forms/:id
+ *       `{ kind: 'destinations', destinations }` → PUT /v1/forms/:id/destinations
+ * The API validates payloads and scopes the write to the session's account —
+ * this proxy adds no authority beyond what the session already has.
+ */
+export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string }> }): Promise<Response> {
+  // Same-origin guard: browsers always send Origin on cross-origin POSTs, so a
+  // mismatched value is a cross-site request riding the session cookie.
+  const origin = req.headers.get('origin');
+  const host = req.headers.get('host');
+  if (origin && host && new URL(origin).host !== host) {
+    return Response.json({ ok: false }, { status: 403 });
+  }
+
+  const { id } = await ctx.params;
+  let body: {
+    kind?: string;
+    name?: string;
+    config?: unknown;
+    destinations?: unknown;
+  };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json({ ok: false }, { status: 400 });
+  }
+
+  try {
+    const upstream =
+      body.kind === 'destinations'
+        ? await hostFetch(`/v1/forms/${id}/destinations`, {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ destinations: body.destinations }),
+          })
+        : await hostFetch(`/v1/forms/${id}`, {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ name: body.name, config: body.config }),
+          });
+    return Response.json({ ok: upstream.ok }, { status: upstream.ok ? 200 : upstream.status });
+  } catch {
+    // `hostFetch` redirects on 401 (throws) — the tab is closing anyway; a
+    // plain status is all this best-effort path owes anyone.
+    return Response.json({ ok: false }, { status: 401 });
+  }
+}

--- a/apps/web/app/admin/forms/[id]/integrations/actions.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { unstable_rethrow } from 'next/navigation';
+
 import { revalidatePath } from 'next/cache';
 import { adminApi, type WebhookPingResult } from '@/lib/admin-api';
 import type { FormDestination } from '@quill/types';
@@ -29,7 +31,11 @@ export async function saveIntegrationsAction(
     const reason = (saved as { formActivityError?: string }).formActivityError;
     return reason ? { ok: true, formActivityError: reason } : { ok: true };
   } catch (e) {
-    return { ok: false, message: e instanceof Error ? e.message : 'Failed to save.' };
+    unstable_rethrow(e);
+    return {
+      ok: false,
+      message: e instanceof Error ? e.message : 'Failed to save.',
+    };
   }
 }
 
@@ -44,6 +50,7 @@ export async function pingWebhookAction(id: string): Promise<WebhookPingResult> 
   try {
     return await adminApi.pingWebhook(id);
   } catch (e) {
+    unstable_rethrow(e);
     return {
       ok: false,
       reason: 'unknown',

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -573,7 +573,7 @@ export function IntegrationsEditor({
         /* best-effort on the unload path */
       }
     },
-    onFailure: (message, transport) => errorRef.current(transport ? m.saveOffline : message),
+    onFailure: (message, kind) => errorRef.current(kind === 'transport' ? m.saveOffline : message),
     debounceMs: AUTOSAVE_MS,
   });
   const { markDirty } = autosave;

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -6,7 +6,7 @@ import {
   emailMappingsConflictingWithScheduler,
   type ContactKeyReadiness,
 } from '@quill/engine';
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import type { FormsMessages, Locale } from '@quill/shared';
 import { WEBHOOK_SECRET_MASK, type DestinationEvent, type FormDestination } from '@quill/types';
@@ -17,6 +17,8 @@ import { Select, type SelectOption } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { GoogleSheetsLogo, ProviderLogo } from '@/components/ui/provider-logo';
 import { useToast } from '@/components/toast';
+import { callAction, isTransportError } from '@/lib/call-action';
+import { useAutosave } from '@/lib/use-autosave';
 import { cn } from '@/lib/cn';
 import { bookingLabel } from '@/lib/booking-fields';
 import type {
@@ -38,11 +40,8 @@ import { pingWebhookAction, saveIntegrationsAction } from './actions';
 
 type Msgs = FormsMessages['admin']['integrations'];
 
-type SaveStatus = 'saved' | 'saving' | 'error' | 'partial';
 /** Same debounce as the builder's autosave, so both tabs feel identical. */
 const AUTOSAVE_MS = 900;
-/** Same admin API base the server-side admin-api client uses (client-exposed). */
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 
 export type { QuestionMeta } from './auto-map';
 
@@ -64,7 +63,11 @@ interface SystemKey {
 }
 
 /** No config supplied → nothing can key a contact. Never claims readiness. */
-const NOT_READY: ContactKeyReadiness = { ok: false, blocker: 'no_source', source: null };
+const NOT_READY: ContactKeyReadiness = {
+  ok: false,
+  blocker: 'no_source',
+  source: null,
+};
 
 /** Sentinel option values for the key pickers — never valid step keys. */
 const CUSTOM_KEY_OPTION = '__custom_key__';
@@ -222,7 +225,14 @@ function initialWebhook(destinations: FormDestination[]): WebhookState {
       fireComplete: both || ev!.includes('complete'),
     };
   }
-  return { enabled: false, url: '', secret: '', hasSecret: false, firePartial: true, fireComplete: true };
+  return {
+    enabled: false,
+    url: '',
+    secret: '',
+    hasSecret: false,
+    firePartial: true,
+    fireComplete: true,
+  };
 }
 
 function initialHubspot(destinations: FormDestination[]): HubspotState {
@@ -249,7 +259,10 @@ function initialHubspot(destinations: FormDestination[]): HubspotState {
         rows: Object.entries(map).map(([from, to]) => ({ from, to })),
       })),
       outcomeProperty: h.outcomeProperty ?? '',
-      staticProperties: Object.entries(h.staticProperties ?? {}).map(([key, value]) => ({ key, value })),
+      staticProperties: Object.entries(h.staticProperties ?? {}).map(([key, value]) => ({
+        key,
+        value,
+      })),
       inferCompanyFromEmail: h.inferCompanyFromEmail === true,
       bookingSync: {
         stageProperty: h.bookingSync?.stageProperty ?? '',
@@ -367,7 +380,10 @@ export function IntegrationsEditor({
    *    the last successful save.
    *  - valid url → persist it with the current enabled flag.
    */
-  function buildDestinations(): { destinations: FormDestination[]; webhookError: string | null } {
+  function buildDestinations(): {
+    destinations: FormDestination[];
+    webhookError: string | null;
+  } {
     const out: FormDestination[] = [];
     let webhookError: string | null = null;
     const url = webhook.url.trim();
@@ -503,42 +519,70 @@ export function IntegrationsEditor({
   // and a status line that says which state you are in.
   const buildRef = useRef(buildDestinations);
   buildRef.current = buildDestinations;
-  const dirty = useRef(false);
-  const [status, setStatus] = useState<SaveStatus>('saved');
-  /** What exactly was not saved — shown next to the status, never just a colour. */
-  const [statusDetail, setStatusDetail] = useState<string | null>(null);
+  /** Webhook half saved AROUND, not saved — renders as "partial" once saved. */
+  const [partialBlocked, setPartialBlocked] = useState<string | null>(null);
 
-  const persist = useCallback(
-    async (built: FormDestination[], blocked: string | null = null): Promise<boolean> => {
-      setStatus('saving');
-      const write = saveIntegrationsAction(id, built);
+  // The debounce/serialize/retry machinery is `useAutosave`, shared with the
+  // builder — including the beforeunload guard and the same-origin keepalive
+  // flush (the old direct-to-API beacon sent cookies to a host that only
+  // accepts identity headers, so it never authenticated).
+  const autosave = useAutosave<{
+    destinations: FormDestination[];
+    webhookError: string | null;
+  }>({
+    getSnapshot: () => buildRef.current(),
+    // `buildDestinations` already quarantines the only invalid input (a bad
+    // webhook URL) onto its own card, so a snapshot is always sendable.
+    validate: useCallback(() => ({ ok: true as const }), []),
+    save: async (built) => {
+      // A bad webhook URL is reported on its own card and blocks only itself —
+      // the rest of the tab still persists.
+      setWebhookError(built.webhookError);
+      const write = callAction(() => saveIntegrationsAction(id, built.destinations));
       // Register the write so a Connect-tab remount reads it back, not the state
       // it is about to overwrite (V4-05 race).
       trackDestinationWrite(id, write);
       const res = await write;
-      if (!res.ok) {
-        setStatus('error');
-        setStatusDetail(res.message ?? m.saveError);
-        errorRef.current(res.message ?? m.saveError);
-        return false;
-      }
+      if (isTransportError(res)) return res;
+      if (!res.ok) return { ok: false, message: res.message ?? m.saveError };
       // HubSpot refused to build the mirror form. The save itself went through,
       // so this is a NOTICE on the card and not a save error — losing the
       // author's mappings because a portal is missing a scope would be worse
       // than the missing activity.
       setFormActivityError(res.formActivityError ?? null);
-      dirty.current = false;
       // This array is now the server truth — the malformed-URL fallback carries
       // it forward instead of the stale mount snapshot.
-      savedDestinations.current = built;
+      savedDestinations.current = built.destinations;
       // Saved, but one card was left out — say WHICH, instead of a green check
       // that implies the webhook edit went through too.
-      setStatus(blocked ? 'partial' : 'saved');
-      setStatusDetail(blocked);
-      return true;
+      setPartialBlocked(built.webhookError);
+      return { ok: true };
     },
-    [id, m.saveError],
-  );
+    beacon: (built) => {
+      try {
+        void fetch(`/admin/forms/${id}/flush`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            kind: 'destinations',
+            destinations: built.destinations,
+          }),
+          keepalive: true,
+        });
+      } catch {
+        /* best-effort on the unload path */
+      }
+    },
+    onFailure: (message, transport) => errorRef.current(transport ? m.saveOffline : message),
+    debounceMs: AUTOSAVE_MS,
+  });
+  const { markDirty } = autosave;
+  const status: 'saved' | 'saving' | 'retrying' | 'error' | 'partial' =
+    autosave.status === 'saved' && partialBlocked ? 'partial' : autosave.status;
+  const statusDetail =
+    autosave.status === 'error' || autosave.status === 'retrying'
+      ? autosave.detail
+      : partialBlocked;
 
   /**
    * Every card edit funnels through these so an edit is marked dirty at the
@@ -546,70 +590,20 @@ export function IntegrationsEditor({
    * effect) keeps the initial render from counting as an edit and autosaving
    * a form nobody touched.
    */
-  const editWebhook = useCallback((next: WebhookState) => {
-    dirty.current = true;
-    setStatus('saving');
-    setWebhook(next);
-  }, []);
-  const editHubspot = useCallback((next: HubspotState) => {
-    dirty.current = true;
-    setStatus('saving');
-    setHs(next);
-  }, []);
-
-  useEffect(() => {
-    if (!dirty.current) return;
-    const t = setTimeout(() => {
-      const built = buildRef.current();
-      // A bad webhook URL is reported on its own card and blocks only itself —
-      // the rest of the tab still persists.
-      setWebhookError(built.webhookError);
-      void persist(built.destinations, built.webhookError);
-    }, AUTOSAVE_MS);
-    return () => clearTimeout(t);
-  }, [webhook, hs, persist]);
-
-  // Leaving with an edit still in the debounce window: flush it. A hard tab
-  // close cannot await a server action, so that path uses a `keepalive` PUT to
-  // the same endpoint the action wraps; SPA nav and tab-hide use the
-  // cookie-authed action while the component is still alive. Mirrors the
-  // builder's flush exactly, so both tabs lose work in the same (zero) cases.
-  useEffect(() => {
-    function flush(beacon: boolean) {
-      if (!dirty.current) return;
-      const built = buildRef.current();
-      if (beacon) {
-        try {
-          void fetch(`${API_BASE}/v1/forms/${id}/destinations`, {
-            method: 'PUT',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ destinations: built.destinations }),
-            keepalive: true,
-            credentials: 'include',
-          });
-        } catch {
-          /* best-effort on the unload path — nothing to recover to */
-        }
-      } else {
-        // SPA nav / unmount: fire-and-forget, but register it so the tab's next
-        // remount waits for this write before it re-reads (V4-05 race).
-        const write = saveIntegrationsAction(id, built.destinations);
-        trackDestinationWrite(id, write);
-        void write;
-      }
-    }
-    const onVisibility = () => {
-      if (document.visibilityState === 'hidden') flush(false);
-    };
-    const onBeforeUnload = () => flush(true);
-    document.addEventListener('visibilitychange', onVisibility);
-    window.addEventListener('beforeunload', onBeforeUnload);
-    return () => {
-      document.removeEventListener('visibilitychange', onVisibility);
-      window.removeEventListener('beforeunload', onBeforeUnload);
-      flush(false); // SPA nav / unmount → reliable server-action flush
-    };
-  }, [id]);
+  const editWebhook = useCallback(
+    (next: WebhookState) => {
+      setWebhook(next);
+      markDirty();
+    },
+    [markDirty],
+  );
+  const editHubspot = useCallback(
+    (next: HubspotState) => {
+      setHs(next);
+      markDirty();
+    },
+    [markDirty],
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -636,9 +630,7 @@ export function IntegrationsEditor({
           // Legacy shape: this screen edits the FIRST HubSpot destination and
           // saves exactly one, so a stored second silently disappears on the
           // next save. Say so rather than letting it vanish (`buildDestinations`).
-          extraHubspotStored={
-            initialDestinations.filter((d) => d.type === 'hubspot').length > 1
-          }
+          extraHubspotStored={initialDestinations.filter((d) => d.type === 'hubspot').length > 1}
           formActivityError={formActivityError}
           readiness={readiness}
           questions={questions}
@@ -696,7 +688,9 @@ export function IntegrationsEditor({
               ? (statusDetail ?? m.saveError)
               : status === 'partial'
                 ? `${m.autosavedPartial} ${statusDetail ?? ''}`.trim()
-                : m.saving}
+                : status === 'retrying'
+                  ? m.saveRetrying
+                  : m.saving}
         </span>
       </div>
     </div>
@@ -737,7 +731,10 @@ function PropertyField({
   // empty option preserves the native "(no property)" / "Select…" prompt row.
   const options: SelectOption[] = [
     { value: '', label: allowNone ? m.noProperty : m.selectProperty },
-    ...properties.map((p) => ({ value: p.name, label: `${p.label} (${p.name})` })),
+    ...properties.map((p) => ({
+      value: p.name,
+      label: `${p.label} (${p.name})`,
+    })),
   ];
   return (
     <Select
@@ -821,7 +818,10 @@ function OptionValueField({
     // HubSpot's own order, never re-sorted — a picklist's order means something.
     // The internal value is shown next to the label because it is what actually
     // gets written, and the two routinely differ ("1-10 employees" → `1`).
-    ...options.map((o) => ({ value: o.value, label: `${o.label} (${o.value})` })),
+    ...options.map((o) => ({
+      value: o.value,
+      label: `${o.label} (${o.value})`,
+    })),
     { value: CUSTOM_VALUE_OPTION, label: m.valueCustomOption },
   ];
   return (
@@ -877,7 +877,11 @@ function ValueMapGroupCard({
   questionOptions: QuestionMeta[];
   /** Contact properties this question's answer is written to (0, 1, or many). */
   targets: string[];
-  properties: { name: string; label: string; options?: HubSpotPropertyOption[] }[];
+  properties: {
+    name: string;
+    label: string;
+    options?: HubSpotPropertyOption[];
+  }[];
   pickerEnabled: boolean;
   m: Msgs;
   onGroupChange: (next: ValueMapGroup) => void;
@@ -899,12 +903,7 @@ function ValueMapGroupCard({
 
   return (
     <div className="flex flex-col rounded-md border border-border" data-testid="valuemap-group">
-      <div
-        className={cn(
-          'flex items-center gap-2 p-3',
-          open && 'border-b border-border',
-        )}
-      >
+      <div className={cn('flex items-center gap-2 p-3', open && 'border-b border-border')}>
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
@@ -1081,11 +1080,24 @@ function KeySelect({
 
   const options: SelectOption[] = [];
   if (questionOptions.length > 0) {
-    options.push({ value: KEY_GROUP_QUESTIONS, label: m.keyGroupQuestions, disabled: true });
-    options.push(...questionOptions.map((q) => ({ value: q.key, label: `${q.label} (${q.key})` })));
+    options.push({
+      value: KEY_GROUP_QUESTIONS,
+      label: m.keyGroupQuestions,
+      disabled: true,
+    });
+    options.push(
+      ...questionOptions.map((q) => ({
+        value: q.key,
+        label: `${q.label} (${q.key})`,
+      })),
+    );
   }
   if (systemKeys.length > 0) {
-    options.push({ value: KEY_GROUP_SYSTEM, label: m.keyGroupSystem, disabled: true });
+    options.push({
+      value: KEY_GROUP_SYSTEM,
+      label: m.keyGroupSystem,
+      disabled: true,
+    });
     options.push(...systemKeys.map((k) => ({ value: k.key, label: k.label })));
   }
   options.push({ value: CUSTOM_KEY_OPTION, label: m.keyCustomOption });
@@ -1242,8 +1254,9 @@ export function WebhookCard({
     }
     setPinging(true);
     try {
-      const res = await pingWebhookAction(formId);
-      if (res.ok) success(m.pingOk);
+      const res = await callAction(() => pingWebhookAction(formId));
+      if (isTransportError(res)) toastError(m.saveOffline);
+      else if (res.ok) success(m.pingOk);
       else toastError(explainPingFailure(res, m));
     } finally {
       setPinging(false);
@@ -1255,7 +1268,11 @@ export function WebhookCard({
     const nextPartial = which === 'partial' ? checked : state.firePartial;
     const nextComplete = which === 'complete' ? checked : state.fireComplete;
     if (!nextPartial && !nextComplete) return;
-    onChange({ ...state, firePartial: nextPartial, fireComplete: nextComplete });
+    onChange({
+      ...state,
+      firePartial: nextPartial,
+      fireComplete: nextComplete,
+    });
   }
 
   // Goes in the `notice` slot rather than among the children, for the same
@@ -1371,7 +1388,11 @@ export function HubspotCard({
   /** Why HubSpot refused to build the mirror form on the last save, if it did. */
   formActivityError?: string | null;
   /** `options` rides along for the value pickers; absent = not an enumeration. */
-  properties: { name: string; label: string; options?: HubSpotPropertyOption[] }[];
+  properties: {
+    name: string;
+    label: string;
+    options?: HubSpotPropertyOption[];
+  }[];
   pickerEnabled: boolean;
   accountConnected: boolean;
   showMapping: boolean;
@@ -1591,10 +1612,7 @@ export function HubspotCard({
           copy ends "a form that never asks for an email cannot be synced",
           which is FALSE for a form whose address comes from the booking — and
           it sat directly above the note saying the opposite. */}
-      <div
-        data-testid="hubspot-how"
-        className="rounded-md border border-border bg-muted/30 p-3"
-      >
+      <div data-testid="hubspot-how" className="rounded-md border border-border bg-muted/30 p-3">
         <p className="text-xs font-medium text-foreground">{m.hubspotHowTitle}</p>
         <p className="mt-1 text-xs text-muted-foreground">
           {emailSource?.kind === 'scheduler' ? m.hubspotHowBodyScheduler : m.hubspotHowBody}
@@ -1616,7 +1634,9 @@ export function HubspotCard({
         >
           <p className="text-xs font-medium text-foreground">{m.emailMappingConflictTitle}</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            {fill(m.emailMappingConflictBody, { keys: emailConflicts.join(', ') })}
+            {fill(m.emailMappingConflictBody, {
+              keys: emailConflicts.join(', '),
+            })}
           </p>
         </div>
       ) : null}
@@ -1624,9 +1644,7 @@ export function HubspotCard({
       {/* Map questions — each form question → a HubSpot contact property */}
       <Section
         title={m.mapQuestions}
-        help={
-          emailSource?.kind === 'scheduler' ? m.mapQuestionsHelpScheduler : m.mapQuestionsHelp
-        }
+        help={emailSource?.kind === 'scheduler' ? m.mapQuestionsHelpScheduler : m.mapQuestionsHelp}
         action={
           <Button variant="outline" size="sm" onClick={autoMap} disabled={questions.length === 0}>
             <i aria-hidden className="pi pi-bolt" style={{ fontSize: 12 }} />
@@ -1727,7 +1745,10 @@ export function HubspotCard({
               variant="outline"
               size="sm"
               onClick={() =>
-                onChange({ ...state, fieldMappings: [...state.fieldMappings, { key: '', property: '' }] })
+                onChange({
+                  ...state,
+                  fieldMappings: [...state.fieldMappings, { key: '', property: '' }],
+                })
               }
             >
               {m.addMapping}
@@ -1767,7 +1788,10 @@ export function HubspotCard({
                   onChange({ ...state, valueMaps: all });
                 }}
                 onRemove={() =>
-                  onChange({ ...state, valueMaps: state.valueMaps.filter((_, j) => j !== gi) })
+                  onChange({
+                    ...state,
+                    valueMaps: state.valueMaps.filter((_, j) => j !== gi),
+                  })
                 }
               />
             ))
@@ -1807,7 +1831,12 @@ export function HubspotCard({
                     enabled={pickerEnabled}
                     allowNone
                     m={m}
-                    onChange={(v) => onChange({ ...state, utmMappings: { ...state.utmMappings, [k]: v } })}
+                    onChange={(v) =>
+                      onChange({
+                        ...state,
+                        utmMappings: { ...state.utmMappings, [k]: v },
+                      })
+                    }
                   />
                 </div>
               </div>
@@ -1942,7 +1971,10 @@ export function HubspotCard({
               allowNone
               m={m}
               onChange={(v) =>
-                onChange({ ...state, bookingSync: { ...state.bookingSync, stageProperty: v } })
+                onChange({
+                  ...state,
+                  bookingSync: { ...state.bookingSync, stageProperty: v },
+                })
               }
             />
           </Field>
@@ -1954,7 +1986,10 @@ export function HubspotCard({
               onChange={(e) =>
                 onChange({
                   ...state,
-                  bookingSync: { ...state.bookingSync, stageValue: e.target.value },
+                  bookingSync: {
+                    ...state.bookingSync,
+                    stageValue: e.target.value,
+                  },
                 })
               }
             />
@@ -1968,7 +2003,10 @@ export function HubspotCard({
               allowNone
               m={m}
               onChange={(v) =>
-                onChange({ ...state, bookingSync: { ...state.bookingSync, dateProperty: v } })
+                onChange({
+                  ...state,
+                  bookingSync: { ...state.bookingSync, dateProperty: v },
+                })
               }
             />
           </Field>
@@ -1989,7 +2027,10 @@ export function HubspotCard({
               onChange={(e) =>
                 onChange({
                   ...state,
-                  bookingSync: { ...state.bookingSync, dateTimezone: e.target.value },
+                  bookingSync: {
+                    ...state.bookingSync,
+                    dateTimezone: e.target.value,
+                  },
                 })
               }
             />
@@ -2008,7 +2049,10 @@ export function HubspotCard({
               allowNone
               m={m}
               onChange={(v) =>
-                onChange({ ...state, bookingSync: { ...state.bookingSync, hoursProperty: v } })
+                onChange({
+                  ...state,
+                  bookingSync: { ...state.bookingSync, hoursProperty: v },
+                })
               }
             />
           </Field>
@@ -2066,7 +2110,11 @@ export function HubspotCard({
           data-testid="hubspot-form-activity-error"
           className="flex items-start gap-1.5 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-2 text-xs leading-relaxed text-destructive"
         >
-          <i aria-hidden className="pi pi-exclamation-triangle mt-0.5 shrink-0" style={{ fontSize: 11 }} />
+          <i
+            aria-hidden
+            className="pi pi-exclamation-triangle mt-0.5 shrink-0"
+            style={{ fontSize: 11 }}
+          />
           {fill(m.formActivityError, { reason: formActivityError })}
         </p>
       ) : null}

--- a/apps/web/app/admin/forms/[id]/submissions/row-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/row-actions.tsx
@@ -5,6 +5,7 @@ import { getMessages } from '@quill/shared';
 import { clientLocale } from '@/lib/client-locale';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import { deleteSubmissionAction } from './actions';
+import { callAction } from '@/lib/call-action';
 
 /** Delete-with-confirm for a submission row (branded dialog → server action). */
 export function DeleteSubmissionButton({
@@ -30,7 +31,8 @@ export function DeleteSubmissionButton({
             confirmLabel: labels.delete,
             destructive: true,
           }).then((ok) => {
-            if (ok) start(() => void deleteSubmissionAction(formId, submissionId));
+            if (ok)
+              start(() => void callAction(() => deleteSubmissionAction(formId, submissionId)));
           });
         }}
         className="text-sm text-destructive transition-opacity hover:opacity-80 disabled:opacity-50"

--- a/apps/web/app/admin/forms/form-row-actions.tsx
+++ b/apps/web/app/admin/forms/form-row-actions.tsx
@@ -5,6 +5,7 @@ import { getMessages } from '@quill/shared';
 import { duplicateFormAction, deleteFormAction } from '@/app/admin/actions';
 import { clientLocale } from '@/lib/client-locale';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
+import { callAction } from '@/lib/call-action';
 
 /**
  * Overflow menu for a form row (WAI-ARIA menu-button). The cross-links
@@ -81,7 +82,7 @@ export function FormRowActions({
             disabled={pending}
             onClick={() => {
               setOpen(false);
-              start(() => void duplicateFormAction(id));
+              start(() => void callAction(() => duplicateFormAction(id)));
             }}
             className={`${itemClass} disabled:opacity-50`}
           >
@@ -101,7 +102,7 @@ export function FormRowActions({
                 confirmLabel: labels.delete,
                 destructive: true,
               }).then((ok) => {
-                if (ok) start(() => void deleteFormAction(id));
+                if (ok) start(() => void callAction(() => deleteFormAction(id)));
               });
             }}
             className="flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:opacity-50"

--- a/apps/web/app/admin/integrations/connections-panel.tsx
+++ b/apps/web/app/admin/integrations/connections-panel.tsx
@@ -9,6 +9,7 @@ import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useToast } from '@/components/toast';
 import { GoogleSheetsLogo, ProviderLogo } from '@/components/ui/provider-logo';
 import { connectIntegrationAction, disconnectIntegrationAction } from './actions';
+import { callAction } from '@/lib/call-action';
 
 type Msgs = FormsMessages['admin']['connections'];
 
@@ -51,7 +52,10 @@ export function ConnectionsPanel({
   ];
 
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus | null>>(() => {
-    const map: Record<string, IntegrationStatus | null> = { hubspot: null, calendly: null };
+    const map: Record<string, IntegrationStatus | null> = {
+      hubspot: null,
+      calendly: null,
+    };
     for (const s of initialProviders) if (s.connected) map[s.provider] = s;
     return map;
   });
@@ -118,7 +122,7 @@ function ProviderCard({
       return;
     }
     start(async () => {
-      const res = await connectIntegrationAction(meta.id, trimmed);
+      const res = await callAction(() => connectIntegrationAction(meta.id, trimmed));
       if (res.ok) {
         onStatusChange(res.status);
         setToken('');
@@ -132,7 +136,9 @@ function ProviderCard({
 
   async function disconnect() {
     const ok = await confirmDialog({
-      title: fill(getMessages(locale).dialog.disconnectIntegrationTitle, { provider: meta.name }),
+      title: fill(getMessages(locale).dialog.disconnectIntegrationTitle, {
+        provider: meta.name,
+      }),
       message: fill(m.disconnectConfirm, { provider: meta.name }),
       confirmLabel: m.disconnect,
       cancelLabel: m.cancel,
@@ -140,7 +146,7 @@ function ProviderCard({
     });
     if (!ok) return;
     start(async () => {
-      const res = await disconnectIntegrationAction(meta.id);
+      const res = await callAction(() => disconnectIntegrationAction(meta.id));
       if (res.ok) {
         onStatusChange(null);
         success(fill(m.disconnectSuccess, { provider: meta.name }));

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { unstable_rethrow } from 'next/navigation';
+
 import { revalidatePath } from 'next/cache';
 import type { MemberProfile } from '@quill/types';
 import {
@@ -48,6 +50,7 @@ export async function inviteMemberAction(
     revalidatePath('/admin/settings');
     return { ok: true };
   } catch (e) {
+    unstable_rethrow(e);
     if (e instanceof ApiError) {
       if (e.code === 'EMAIL_TAKEN') return { ok: false, code: 'TAKEN' };
       if (e.status === 400) return { ok: false, code: 'INVALID' };
@@ -93,6 +96,7 @@ export async function updateMemberRoleAction(
     revalidatePath('/admin/settings');
     return { ok: true };
   } catch (e) {
+    unstable_rethrow(e);
     return manageError(e);
   }
 }
@@ -112,6 +116,7 @@ export async function removeMemberAction(id: string): Promise<ManageMemberState>
     revalidatePath('/admin/settings');
     return { ok: true };
   } catch (e) {
+    unstable_rethrow(e);
     return manageError(e);
   }
 }
@@ -138,6 +143,7 @@ export async function saveNotificationAction(
     revalidatePath('/admin/settings');
     return { ok: true, setting };
   } catch (e) {
+    unstable_rethrow(e);
     if (e instanceof ApiError && (e.status === 403 || e.code === 'FORBIDDEN')) {
       return { ok: false, code: 'FORBIDDEN' };
     }
@@ -156,6 +162,7 @@ export async function resetNotificationAction(
     revalidatePath('/admin/settings');
     return { ok: true, setting };
   } catch (e) {
+    unstable_rethrow(e);
     if (e instanceof ApiError && (e.status === 403 || e.code === 'FORBIDDEN')) {
       return { ok: false, code: 'FORBIDDEN' };
     }
@@ -175,6 +182,10 @@ export async function saveMyProfileAction(
     revalidatePath('/admin/settings');
     return { ok: true };
   } catch (e) {
-    return { ok: false, message: e instanceof Error ? e.message : 'Could not save.' };
+    unstable_rethrow(e);
+    return {
+      ok: false,
+      message: e instanceof Error ? e.message : 'Could not save.',
+    };
   }
 }

--- a/apps/web/app/admin/settings/member-row-actions.tsx
+++ b/apps/web/app/admin/settings/member-row-actions.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/components/toast';
 import { clientLocale } from '@/lib/client-locale';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import type { AccountRole } from '@/lib/admin-api';
+import { callAction, isTransportError, type TransportError } from '@/lib/call-action';
 import {
   removeMemberAction,
   updateMemberRoleAction,
@@ -70,7 +71,11 @@ export function MemberRowActions({
   }, [open]);
 
   /** Turn a failure code into its localized toast; success carries its own message. */
-  const handle = (result: ManageMemberState, successMessage: string) => {
+  const handle = (result: ManageMemberState | TransportError, successMessage: string) => {
+    if (isTransportError(result)) {
+      toast.error(labels.manageErrorFailed);
+      return;
+    }
     if (result.ok) {
       toast.success(successMessage);
       return;
@@ -86,7 +91,9 @@ export function MemberRowActions({
 
   const changeRole = (next: 'admin' | 'member') => {
     setOpen(false);
-    start(async () => handle(await updateMemberRoleAction(memberId, next), labels.roleChangeSuccess));
+    start(async () =>
+      handle(await callAction(() => updateMemberRoleAction(memberId, next)), labels.roleChangeSuccess),
+    );
   };
 
   const remove = () => {
@@ -97,7 +104,10 @@ export function MemberRowActions({
       confirmLabel: labels.removeMember,
       destructive: true,
     }).then((ok) => {
-      if (ok) start(async () => handle(await removeMemberAction(memberId), labels.removeSuccess));
+      if (ok)
+        start(async () =>
+          handle(await callAction(() => removeMemberAction(memberId)), labels.removeSuccess),
+        );
     });
   };
 

--- a/apps/web/app/admin/settings/notification-settings.tsx
+++ b/apps/web/app/admin/settings/notification-settings.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/notification-email-fields';
 import type { NotificationSettingView } from '@/lib/admin-api';
 import { saveNotificationAction, resetNotificationAction } from './actions';
+import { callAction } from '@/lib/call-action';
 
 export interface NotificationLabels {
   heading: string;
@@ -138,11 +139,13 @@ function NotificationEmailCard({
     startTransition(async () => {
       // Fields equal to the shipped default persist as `null` (stay on default),
       // so editing back to the default cleanly reverts "Customized".
-      const res = await saveNotificationAction(setting.emailKey, {
-        enabled: value.enabled,
-        subject: value.subject === def.subject ? null : value.subject,
-        body: value.body === def.body ? null : value.body,
-      });
+      const res = await callAction(() =>
+        saveNotificationAction(setting.emailKey, {
+          enabled: value.enabled,
+          subject: value.subject === def.subject ? null : value.subject,
+          body: value.body === def.body ? null : value.body,
+        }),
+      );
       if (res.ok) {
         applyPersisted(res.setting);
         toast.success(labels.saveSuccess);
@@ -161,7 +164,7 @@ function NotificationEmailCard({
     });
     if (!ok) return;
     startTransition(async () => {
-      const res = await resetNotificationAction(setting.emailKey);
+      const res = await callAction(() => resetNotificationAction(setting.emailKey));
       if (res.ok) {
         applyPersisted(res.setting);
         toast.success(labels.resetSuccess);

--- a/apps/web/app/admin/settings/public-page.tsx
+++ b/apps/web/app/admin/settings/public-page.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/toast';
 import { saveMyProfileAction } from './actions';
+import { callAction, isTransportError } from '@/lib/call-action';
 
 type Msgs = FormsMessages['admin']['settings'];
 
@@ -49,9 +50,9 @@ export function PublicPageSettings({
         formSlugs: initial?.formSlugs,
         branding: initial?.branding,
       };
-      const res = await saveMyProfileAction(profile);
+      const res = await callAction(() => saveMyProfileAction(profile));
       if (res.ok) success(m.publicPageSaved);
-      else error(res.message ?? m.publicPageError);
+      else error((isTransportError(res) ? null : res.message) ?? m.publicPageError);
     });
   }
 

--- a/apps/web/app/admin/settings/theme-settings.tsx
+++ b/apps/web/app/admin/settings/theme-settings.tsx
@@ -5,6 +5,7 @@ import type { FormsMessages } from '@quill/shared';
 import { setThemeAction } from '@/app/admin/theme-actions';
 import { SegmentedToggle } from '@/app/admin/forms/[id]/edit/_components/fields';
 import { THEME_ICON, THEME_PREFS, type ThemePref } from '@/lib/theme';
+import { callAction } from '@/lib/call-action';
 
 type SettingsMessages = FormsMessages['admin']['settings'];
 type ThemeMessages = FormsMessages['admin']['chrome']['theme'];
@@ -42,7 +43,7 @@ export function ThemeSettings({ pref, s, m }: { pref: ThemePref; s: SettingsMess
           label: m[option],
           icon: THEME_ICON[option],
         }))}
-        onChange={(next) => start(() => void setThemeAction(next))}
+        onChange={(next) => start(() => void callAction(() => setThemeAction(next)))}
       />
     </section>
   );

--- a/apps/web/app/onboarding/wizard.tsx
+++ b/apps/web/app/onboarding/wizard.tsx
@@ -39,6 +39,7 @@ import type { FormsMessages, Locale } from '@quill/shared';
 import { StepInput } from '@/components/public/step-input';
 import { FormsLockup, FormsMark } from '@/components/brand/forms-logo';
 import { captureEvent } from '@/lib/product-analytics';
+import { callAction } from '@/lib/call-action';
 import {
   fill,
   leadVolumeBucket,
@@ -315,21 +316,28 @@ export function OnboardingWizard({
         // The answers travel WITH the completion, so the claim writes them in
         // its own single statement and cannot lose the last one to a PATCH still
         // in flight. `locale` so the created form is named like the card.
-        const result = await completeOnboardingAction({
-          template: id,
-          role: answers.role ?? null,
-          industry: answers.industry ?? null,
-          useCase: answers.useCase ?? null,
-          crm: answers.crm ?? null,
-          leadVolume: answers.leadVolume ?? null,
-          leadSource: answers.leadSource ?? null,
-          phone: answers.phone ?? null,
-          // The cohort travels too, so the server can record WHY the questions
-          // this person never saw are empty. Without it a Dapta account's null
-          // industry is indistinguishable from a gap in our own data.
-          cohort,
-          locale,
-        });
+        // Transport-safe (30s: this one call creates the account's first form):
+        // a rejected invocation lands on the Failed screen with a retry, not on
+        // an unhandled rejection that silently drops them back into the wizard.
+        const result = await callAction(
+          () =>
+            completeOnboardingAction({
+              template: id,
+              role: answers.role ?? null,
+              industry: answers.industry ?? null,
+              useCase: answers.useCase ?? null,
+              crm: answers.crm ?? null,
+              leadVolume: answers.leadVolume ?? null,
+              leadSource: answers.leadSource ?? null,
+              phone: answers.phone ?? null,
+              // The cohort travels too, so the server can record WHY the questions
+              // this person never saw are empty. Without it a Dapta account's null
+              // industry is indistinguishable from a gap in our own data.
+              cohort,
+              locale,
+            }),
+          { timeoutMs: 30_000 },
+        );
         // Only a FAILURE returns: every path where the API answered ends in a
         // redirect, which throws. `/admin` is not a fallback while the claim is
         // unwritten — the first-run gate reads the same column this request

--- a/apps/web/components/language-switcher.tsx
+++ b/apps/web/components/language-switcher.tsx
@@ -4,6 +4,7 @@ import { useTransition } from 'react';
 import type { Locale } from '@quill/shared';
 import { setLocaleAction } from '@/app/admin/locale-actions';
 import { Select } from '@/components/ui/select';
+import { callAction } from '@/lib/call-action';
 
 /** F8 language toggle — persists the choice via a cookie (server action) and
  *  re-renders the admin in EN/ES. Mirrors the old app's language selector. */
@@ -18,7 +19,7 @@ export function LanguageSwitcher({ locale, label }: { locale: Locale; label: str
           locale={locale}
           value={locale}
           disabled={pending}
-          onChange={(next) => start(() => void setLocaleAction(next))}
+          onChange={(next) => start(() => void callAction(() => setLocaleAction(next)))}
           options={[
             { value: 'en', label: 'English' },
             { value: 'es', label: 'Español' },

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -4,6 +4,7 @@ import { useTransition } from 'react';
 import type { FormsMessages } from '@quill/shared';
 import { setThemeAction } from '@/app/admin/theme-actions';
 import { THEME_ICON, THEME_PREFS, type ThemePref } from '@/lib/theme';
+import { callAction } from '@/lib/call-action';
 
 type ThemeMessages = FormsMessages['admin']['chrome']['theme'];
 
@@ -34,7 +35,7 @@ export function ThemeToggle({ pref, m }: { pref: ThemePref; m: ThemeMessages }) 
       title={label}
       aria-label={label}
       disabled={pending}
-      onClick={() => start(() => void setThemeAction(next))}
+      onClick={() => start(() => void callAction(() => setThemeAction(next)))}
       className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.98] disabled:opacity-60"
     >
       <i aria-hidden className={`pi ${THEME_ICON[pref]}`} style={{ fontSize: 16 }} />

--- a/apps/web/components/workspace-switcher.tsx
+++ b/apps/web/components/workspace-switcher.tsx
@@ -5,6 +5,7 @@ import type { FormsMessages } from '@quill/shared';
 import type { Workspace } from '@/lib/admin-api';
 import { switchWorkspaceAction } from '@/app/admin/workspace-actions';
 import { AnchoredMenu } from '@/components/ui/anchored-menu';
+import { callAction } from '@/lib/call-action';
 
 type Messages = FormsMessages['admin']['chrome']['workspaces'];
 
@@ -56,7 +57,7 @@ export function WorkspaceSwitcher({
       return;
     }
     start(async () => {
-      await switchWorkspaceAction(accountId);
+      await callAction(() => switchWorkspaceAction(accountId));
     });
   }
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,1 +1,34 @@
-export { default } from '@quill/config/eslint';
+import base from '@quill/config/eslint';
+
+/**
+ * A client component that invokes a server action with a bare `await`/`void`
+ * has no seam for the INVOCATION itself failing — a deploy rotating action ids
+ * or a dropped connection rejects the promise, skipping every state update
+ * after it (the "stuck on Saving…" bug). `callAction` (lib/call-action.ts)
+ * turns that rejection into a value, so this rule forces every call through it.
+ * Scoped to client component trees; server-side code (actions, RSC pages,
+ * route handlers) awaits its own helpers, not remote action stubs.
+ */
+const requireCallAction = {
+  files: ['app/**/*.tsx', 'components/**/*.tsx'],
+  // The public renderers migrate in their own PR — their submit/booking paths
+  // need visible error states designed alongside the wrapping, not a blind fix.
+  ignores: ['app/\\[accountCode\\]/**'],
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: "AwaitExpression > CallExpression[callee.name=/Action$/]:not([callee.name='callAction'])",
+        message:
+          'Invoke server actions via callAction(() => theAction(…)) from @/lib/call-action — a bare await rejects on transport failures (deploy-rotated action ids, network drops) and strands UI state.',
+      },
+      {
+        selector: "UnaryExpression[operator='void'] > CallExpression[callee.name=/Action$/]:not([callee.name='callAction'])",
+        message:
+          'Invoke server actions via void callAction(() => theAction(…)) from @/lib/call-action — a bare void call swallows transport rejections instead of handling them.',
+      },
+    ],
+  },
+};
+
+export default [...base, requireCallAction];

--- a/apps/web/lib/autosave-controller.spec.ts
+++ b/apps/web/lib/autosave-controller.spec.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AutosaveController, type AutosaveStatus, type SaveOutcome } from './autosave-controller';
+import { callAction, isTransportError } from './call-action';
+
+/** Test harness: a controller over a mutable snapshot with a scripted save. */
+function harness(overrides?: {
+  save?: (s: string) => Promise<SaveOutcome>;
+  validate?: (s: string) => { ok: true } | { ok: false; reason: string };
+}) {
+  const statuses: Array<{ status: AutosaveStatus; detail: string | null }> = [];
+  const failures: Array<{ message: string; transport: boolean }> = [];
+  let savedCount = 0;
+  const state = { snapshot: 'v1' };
+  const saves: string[] = [];
+  const controller = new AutosaveController<string>({
+    getSnapshot: () => state.snapshot,
+    validate: overrides?.validate ?? (() => ({ ok: true })),
+    save:
+      overrides?.save ??
+      (async (s) => {
+        saves.push(s);
+        return { ok: true };
+      }),
+    onStatus: (status, detail) => statuses.push({ status, detail }),
+    onFailure: (message, transport) => failures.push({ message, transport }),
+    onSaved: () => savedCount++,
+    debounceMs: 100,
+    initialBackoffMs: 1000,
+    maxBackoffMs: 8000,
+  });
+  return {
+    controller,
+    state,
+    saves,
+    statuses,
+    failures,
+    savedCount: () => savedCount,
+    lastStatus: () => statuses[statuses.length - 1]?.status,
+  };
+}
+
+/** Let queued microtasks (the awaited save) settle. */
+const settle = () => vi.advanceTimersByTimeAsync(0);
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('AutosaveController', () => {
+  it('debounces edits into one save and reports saved', async () => {
+    const h = harness();
+    h.controller.markDirty();
+    h.controller.markDirty();
+    expect(h.lastStatus()).toBe('saving');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(h.saves).toEqual(['v1']);
+    expect(h.lastStatus()).toBe('saved');
+    expect(h.savedCount()).toBe(1);
+    expect(h.controller.dirty).toBe(false);
+  });
+
+  it('a transport failure never strands "saving": it retries with backoff until success', async () => {
+    let attempts = 0;
+    const h = harness({
+      save: async () => {
+        attempts++;
+        if (attempts < 3) return { ok: false, transport: true, message: 'offline' };
+        return { ok: true };
+      },
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100); // debounce → attempt 1 fails
+    expect(h.lastStatus()).toBe('retrying');
+    await vi.advanceTimersByTimeAsync(1000); // backoff 1 → attempt 2 fails
+    expect(h.lastStatus()).toBe('retrying');
+    await vi.advanceTimersByTimeAsync(2000); // backoff 2 (doubled) → attempt 3 succeeds
+    expect(h.lastStatus()).toBe('saved');
+    expect(attempts).toBe(3);
+    expect(h.controller.dirty).toBe(false);
+    // The user was told once, not once per retry.
+    expect(h.failures).toHaveLength(1);
+    expect(h.failures[0]).toEqual({ message: 'offline', transport: true });
+  });
+
+  it('a server rejection surfaces as error but still retries', async () => {
+    let attempts = 0;
+    const h = harness({
+      save: async () => (++attempts === 1 ? { ok: false, message: 'boom' } : { ok: true }),
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(h.lastStatus()).toBe('error');
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.lastStatus()).toBe('saved');
+  });
+
+  it('a save that THROWS (unwrapped rejection) is treated as transport, not a freeze', async () => {
+    let attempts = 0;
+    const h = harness({
+      save: async () => {
+        if (++attempts === 1) throw new Error('Failed to find Server Action');
+        return { ok: true };
+      },
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(h.lastStatus()).toBe('retrying');
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.lastStatus()).toBe('saved');
+  });
+
+  it('edits during an in-flight save keep dirty=true and trigger a follow-up save', async () => {
+    let release!: (o: SaveOutcome) => void;
+    const gate = new Promise<SaveOutcome>((r) => (release = r));
+    let attempts = 0;
+    const h = harness({
+      save: async (s) => {
+        attempts++;
+        if (attempts === 1) return gate; // slow first save
+        h.saves.push(s);
+        return { ok: true };
+      },
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100); // save of v1 now in flight
+    h.state.snapshot = 'v2';
+    h.controller.markDirty(); // edit lands mid-flight
+    release({ ok: true }); // old save resolves AFTER the new edit
+    await settle();
+    // The old save must NOT clear the newer edit's dirtiness…
+    // …and the follow-up save must carry v2.
+    await vi.advanceTimersByTimeAsync(100);
+    await settle();
+    expect(h.saves).toContain('v2');
+    expect(h.controller.dirty).toBe(false);
+    expect(h.lastStatus()).toBe('saved');
+    expect(attempts).toBe(2);
+  });
+
+  it('never runs overlapping saves', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const h = harness({
+      save: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 50));
+        inFlight--;
+        return { ok: true };
+      },
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100);
+    h.controller.markDirty();
+    h.controller.flush();
+    h.controller.flush();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('an invalid snapshot blocks the save with error and does NOT retry', async () => {
+    const h = harness({ validate: () => ({ ok: false, reason: 'steps.0: bad' }) });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(h.statuses[h.statuses.length - 1]).toEqual({ status: 'error', detail: 'steps.0: bad' });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(h.saves).toEqual([]); // nothing ever sent, nothing retried
+    expect(h.controller.dirty).toBe(true); // the work is still owed
+  });
+
+  it('flush saves immediately without waiting out the debounce', async () => {
+    const h = harness();
+    h.controller.markDirty();
+    h.controller.flush();
+    await settle();
+    expect(h.saves).toEqual(['v1']);
+    expect(h.lastStatus()).toBe('saved');
+  });
+
+  it('flush is a no-op when clean', async () => {
+    const h = harness();
+    h.controller.flush();
+    await settle();
+    expect(h.saves).toEqual([]);
+    expect(h.statuses).toEqual([]);
+  });
+
+  it('dispose stops pending retries', async () => {
+    let attempts = 0;
+    const h = harness({
+      save: async () => {
+        attempts++;
+        return { ok: false, transport: true, message: 'offline' };
+      },
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(attempts).toBe(1);
+    h.controller.dispose();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(attempts).toBe(1);
+  });
+
+  it('a fresh edit resets the pending retry (debounce path takes over)', async () => {
+    let attempts = 0;
+    const h = harness({
+      save: async () => (++attempts === 1 ? { ok: false, transport: true, message: 'x' } : { ok: true }),
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100); // fails, retry scheduled at +1000
+    h.controller.markDirty(); // user keeps typing
+    await vi.advanceTimersByTimeAsync(100); // debounce fires the save instead
+    expect(attempts).toBe(2);
+    expect(h.lastStatus()).toBe('saved');
+  });
+});
+
+describe('callAction', () => {
+  it('passes a resolved value through untouched', async () => {
+    const res = await callAction(async () => ({ ok: true as const }));
+    expect(res).toEqual({ ok: true });
+    expect(isTransportError(res)).toBe(false);
+  });
+
+  it('converts a rejection into a TransportError instead of throwing', async () => {
+    const res = await callAction(async () => {
+      throw new Error('Failed to find Server Action "abc123"');
+    });
+    expect(isTransportError(res)).toBe(true);
+    if (isTransportError(res)) expect(res.message).toContain('Failed to find Server Action');
+  });
+
+  it('times out a hung invocation', async () => {
+    vi.useFakeTimers();
+    const hang = callAction(() => new Promise<never>(() => {}), { timeoutMs: 1000 });
+    await vi.advanceTimersByTimeAsync(1001);
+    const res = await hang;
+    expect(isTransportError(res)).toBe(true);
+    if (isTransportError(res)) expect(res.message).toContain('timed out');
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/lib/autosave-controller.spec.ts
+++ b/apps/web/lib/autosave-controller.spec.ts
@@ -8,7 +8,7 @@ function harness(overrides?: {
   validate?: (s: string) => { ok: true } | { ok: false; reason: string };
 }) {
   const statuses: Array<{ status: AutosaveStatus; detail: string | null }> = [];
-  const failures: Array<{ message: string; transport: boolean }> = [];
+  const failures: Array<{ message: string; kind: string }> = [];
   let savedCount = 0;
   const state = { snapshot: 'v1' };
   const saves: string[] = [];
@@ -22,7 +22,7 @@ function harness(overrides?: {
         return { ok: true };
       }),
     onStatus: (status, detail) => statuses.push({ status, detail }),
-    onFailure: (message, transport) => failures.push({ message, transport }),
+    onFailure: (message, kind) => failures.push({ message, kind }),
     onSaved: () => savedCount++,
     debounceMs: 100,
     initialBackoffMs: 1000,
@@ -78,7 +78,7 @@ describe('AutosaveController', () => {
     expect(h.controller.dirty).toBe(false);
     // The user was told once, not once per retry.
     expect(h.failures).toHaveLength(1);
-    expect(h.failures[0]).toEqual({ message: 'offline', transport: true });
+    expect(h.failures[0]).toEqual({ message: 'offline', kind: 'transport' });
   });
 
   it('a server rejection surfaces as error but still retries', async () => {
@@ -184,7 +184,7 @@ describe('AutosaveController', () => {
     expect(h.statuses).toEqual([]);
   });
 
-  it('dispose stops pending retries', async () => {
+  it('dispose stops the retry loop after one terminal attempt', async () => {
     let attempts = 0;
     const h = harness({
       save: async () => {
@@ -196,8 +196,45 @@ describe('AutosaveController', () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(attempts).toBe(1);
     h.controller.dispose();
+    await settle(); // still dirty → dispose owes ONE fire-and-forget attempt
+    expect(attempts).toBe(2);
+    await vi.advanceTimersByTimeAsync(60_000); // …and never retries again
+    expect(attempts).toBe(2);
+  });
+
+  it('dispose while CLEAN fires nothing', async () => {
+    const h = harness();
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100); // saved
+    h.controller.dispose();
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(attempts).toBe(1);
+    expect(h.saves).toEqual(['v1']); // just the one debounced save
+  });
+
+  it('unmount during an in-flight save does NOT lose edits made mid-flight (terminal save)', async () => {
+    let release!: (o: SaveOutcome) => void;
+    const gate = new Promise<SaveOutcome>((r) => (release = r));
+    let attempts = 0;
+    const h = harness({
+      save: async (s) => {
+        attempts++;
+        if (attempts === 1) return gate; // gen-1 save hangs in flight
+        h.saves.push(s);
+        return { ok: true };
+      },
+    });
+    h.controller.markDirty();
+    await vi.advanceTimersByTimeAsync(100); // save of v1 in flight
+    h.state.snapshot = 'v2';
+    h.controller.markDirty(); // edit lands mid-flight
+    // SPA nav: cleanup runs flush (no-ops: in flight) then dispose.
+    h.controller.flush();
+    h.controller.dispose();
+    await settle();
+    // The terminal save carried the LATEST snapshot despite the in-flight save.
+    expect(h.saves).toContain('v2');
+    release({ ok: true });
+    await settle(); // late resolution is inert — no status after disposal
   });
 
   it('a fresh edit resets the pending retry (debounce path takes over)', async () => {

--- a/apps/web/lib/autosave-controller.ts
+++ b/apps/web/lib/autosave-controller.ts
@@ -18,6 +18,8 @@ import { isTransportError, type TransportError } from './call-action';
 
 export type AutosaveStatus = 'saved' | 'saving' | 'retrying' | 'error';
 
+export type AutosaveFailureKind = 'invalid' | 'server' | 'transport';
+
 /** What a save attempt produced, as the controller sees it. `ok` is a plain
  *  boolean (not a discriminant) because server actions type it that way. */
 export type SaveOutcome = { ok: boolean; message?: string } | TransportError;
@@ -33,9 +35,11 @@ export interface AutosaveOptions<T> {
   onStatus: (status: AutosaveStatus, detail: string | null) => void;
   /**
    * First failure after a healthy stretch — the "toast once" hook. Retries of
-   * the same outage stay quiet; a later recovery re-arms it.
+   * the same outage stay quiet; a later recovery re-arms it. `kind` picks the
+   * copy: `invalid` (client validation), `server` (the API said no), or
+   * `transport` (never reached the server; quietly retrying).
    */
-  onFailure?: (message: string, transport: boolean) => void;
+  onFailure?: (message: string, kind: AutosaveFailureKind) => void;
   /** Fired on every save that left the server holding the LATEST edits. */
   onSaved?: () => void;
   debounceMs?: number;
@@ -96,11 +100,30 @@ export class AutosaveController<T> {
     void this.run();
   }
 
-  /** Stop timers. In-flight saves settle harmlessly (status is not touched). */
+  /**
+   * Stop timers and fire one TERMINAL save if edits are still unsaved.
+   *
+   * The terminal attempt is unconditional on `inFlight` — that is the point.
+   * `flush()` no-ops while a save is in flight, so "gen-1 save in flight, user
+   * edits gen-2, user navigates away" would otherwise lose gen-2 forever: the
+   * in-flight save resolves after disposal and its dirty-recheck never runs.
+   * Server actions from one client run serially, so this write queues behind
+   * any in-flight save and lands carrying the LATEST snapshot (last write
+   * wins). In-flight saves otherwise settle harmlessly (status not touched).
+   */
   dispose(): void {
+    if (this.disposed) return;
     this.disposed = true;
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.clearRetry();
+    if (!this.dirty) return;
+    const snapshot = this.opts.getSnapshot();
+    if (!this.opts.validate(snapshot).ok) return; // backup (hook cleanup) still holds it
+    void Promise.resolve()
+      .then(() => this.opts.save(snapshot))
+      .catch(() => {
+        /* fire-and-forget: past disposal there is no state left to update */
+      });
   }
 
   private clearRetry(): void {
@@ -129,7 +152,7 @@ export class AutosaveController<T> {
       this.opts.onStatus('error', valid.reason);
       if (!this.failureNotified) {
         this.failureNotified = true;
-        this.opts.onFailure?.(valid.reason, false);
+        this.opts.onFailure?.(valid.reason, 'invalid');
       }
       return;
     }
@@ -172,7 +195,7 @@ export class AutosaveController<T> {
     this.opts.onStatus(transport ? 'retrying' : 'error', message);
     if (!this.failureNotified) {
       this.failureNotified = true;
-      this.opts.onFailure?.(message, transport);
+      this.opts.onFailure?.(message, transport ? 'transport' : 'server');
     }
     this.scheduleRetry();
   }

--- a/apps/web/lib/autosave-controller.ts
+++ b/apps/web/lib/autosave-controller.ts
@@ -1,0 +1,179 @@
+/**
+ * The autosave state machine, framework-free so it can be unit-tested in node.
+ * `useAutosave` (use-autosave.ts) is the thin React binding; the builder and the
+ * integrations editor both run on this controller instead of hand-rolled copies
+ * of the same debounce/flush logic — the two copies had already drifted, and
+ * both shared the bugs this class exists to kill:
+ *
+ * - A save whose INVOCATION failed (transport) left the status on "saving"
+ *   forever with no retry. Here every failure moves to `retrying`/`error` and
+ *   schedules a bounded-backoff re-attempt that only a successful save stops.
+ * - Overlapping saves raced: an old save resolving late could clear the dirty
+ *   flag over newer edits (losing them on nav) or stamp a stale status. Here
+ *   saves are serialized and dirtiness is a GENERATION NUMBER — a save only
+ *   counts as "caught up" if nothing was edited while it was in flight.
+ */
+
+import { isTransportError, type TransportError } from './call-action';
+
+export type AutosaveStatus = 'saved' | 'saving' | 'retrying' | 'error';
+
+/** What a save attempt produced, as the controller sees it. `ok` is a plain
+ *  boolean (not a discriminant) because server actions type it that way. */
+export type SaveOutcome = { ok: boolean; message?: string } | TransportError;
+
+export interface AutosaveOptions<T> {
+  /** Latest data to persist. Called at save time — never a stale closure. */
+  getSnapshot: () => T;
+  /** Client-side gate: an invalid snapshot is never sent (status → error). */
+  validate: (snapshot: T) => { ok: true } | { ok: false; reason: string };
+  /** The server write, already transport-safe (wrap the action in callAction). */
+  save: (snapshot: T) => Promise<SaveOutcome>;
+  /** Status changes for the UI. `detail` carries the failure reason, if any. */
+  onStatus: (status: AutosaveStatus, detail: string | null) => void;
+  /**
+   * First failure after a healthy stretch — the "toast once" hook. Retries of
+   * the same outage stay quiet; a later recovery re-arms it.
+   */
+  onFailure?: (message: string, transport: boolean) => void;
+  /** Fired on every save that left the server holding the LATEST edits. */
+  onSaved?: () => void;
+  debounceMs?: number;
+  /** First retry delay; doubles per consecutive failure up to `maxBackoffMs`. */
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 900;
+const DEFAULT_INITIAL_BACKOFF_MS = 1_500;
+const DEFAULT_MAX_BACKOFF_MS = 30_000;
+
+export class AutosaveController<T> {
+  /** Bumped on every edit; the save that persists generation N clears N only. */
+  private generation = 0;
+  private savedGeneration = 0;
+  private inFlight = false;
+  private disposed = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private backoffMs: number;
+  private failureNotified = false;
+
+  constructor(private readonly opts: AutosaveOptions<T>) {
+    this.backoffMs = opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+  }
+
+  get dirty(): boolean {
+    return this.generation !== this.savedGeneration;
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  /** An edit happened. Debounces a save; shows "saving" immediately. */
+  markDirty(): void {
+    if (this.disposed) return;
+    this.generation++;
+    // A fresh edit supersedes any scheduled retry — the debounce path owns it.
+    this.clearRetry();
+    this.opts.onStatus('saving', null);
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.run();
+    }, this.opts.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+  }
+
+  /** Save now if there are unsaved edits (nav-away, tab hidden, unmount). */
+  flush(): void {
+    if (this.disposed || !this.dirty) return;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.clearRetry();
+    void this.run();
+  }
+
+  /** Stop timers. In-flight saves settle harmlessly (status is not touched). */
+  dispose(): void {
+    this.disposed = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.clearRetry();
+  }
+
+  private clearRetry(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.disposed || this.retryTimer) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.run();
+    }, this.backoffMs);
+    this.backoffMs = Math.min(this.backoffMs * 2, this.opts.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS);
+  }
+
+  private async run(): Promise<void> {
+    if (this.disposed || this.inFlight || !this.dirty) return;
+
+    const snapshot = this.opts.getSnapshot();
+    const valid = this.opts.validate(snapshot);
+    if (!valid.ok) {
+      // Never retried: only the next edit can fix an invalid config.
+      this.opts.onStatus('error', valid.reason);
+      if (!this.failureNotified) {
+        this.failureNotified = true;
+        this.opts.onFailure?.(valid.reason, false);
+      }
+      return;
+    }
+
+    const attempted = this.generation;
+    this.inFlight = true;
+    this.opts.onStatus('saving', null);
+    let outcome: SaveOutcome;
+    try {
+      outcome = await this.opts.save(snapshot);
+    } catch (e) {
+      // Belt and braces — `save` should already be transport-safe via callAction.
+      outcome = { ok: false, transport: true, message: e instanceof Error ? e.message : 'save failed' };
+    }
+    this.inFlight = false;
+    if (this.disposed) return;
+
+    if (outcome.ok) {
+      this.savedGeneration = attempted;
+      this.backoffMs = this.opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+      this.failureNotified = false;
+      if (this.dirty) {
+        // Edited while the save was in flight — the server holds a stale
+        // snapshot. Keep "saving" on screen and go again immediately (the
+        // debounce already elapsed; there is no user pause left to wait for).
+        this.opts.onStatus('saving', null);
+        void this.run();
+      } else {
+        this.opts.onStatus('saved', null);
+        this.opts.onSaved?.();
+      }
+      return;
+    }
+
+    const transport = isTransportError(outcome);
+    const message = outcome.message ?? 'save failed';
+    // Transport = "never reached the server", quietly self-healing → retrying.
+    // A server rejection is worth the louder ERROR state, but it is retried
+    // too: 500s and restarts are as transient as a dropped connection.
+    this.opts.onStatus(transport ? 'retrying' : 'error', message);
+    if (!this.failureNotified) {
+      this.failureNotified = true;
+      this.opts.onFailure?.(message, transport);
+    }
+    this.scheduleRetry();
+  }
+}

--- a/apps/web/lib/call-action.ts
+++ b/apps/web/lib/call-action.ts
@@ -31,7 +31,10 @@ export const isTransportError = (r: unknown): r is TransportError =>
   typeof r === 'object' && r !== null && (r as TransportError).transport === true;
 
 /** Per-attempt ceiling. Server actions from one tab run serially, so a hung
- *  call would otherwise queue every later action (publish included) forever. */
+ *  call would otherwise queue every later action (publish included) forever.
+ *  NOTE: the timeout does not ABORT the underlying request — a timed-out call
+ *  may still land server-side while a retry also lands. Only wrap retries
+ *  around idempotent writes (all current callers are last-write-wins PUTs). */
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 export async function callAction<T>(

--- a/apps/web/lib/call-action.ts
+++ b/apps/web/lib/call-action.ts
@@ -1,0 +1,59 @@
+/**
+ * Safe invocation of a Next.js server action from client code.
+ *
+ * A server action's own try/catch handles errors that happen ON the server —
+ * those come back as a value (`{ ok: false, message }`). What it cannot handle
+ * is the invocation itself failing on the CLIENT: the network dropping, the
+ * request hanging, or a deploy rotating the compiled action ids while a tab is
+ * open ("Failed to find Server Action"). Those reject the returned promise, and
+ * an unguarded `await someAction()` then skips every state update after it —
+ * which is exactly how the editor froze on "Saving…" with no retry and no log.
+ *
+ * `callAction` turns that transport failure into a value too, so a call site
+ * always gets a result it can branch on:
+ *
+ *   const res = await callAction(() => saveFormAction(id, patch));
+ *   if (isTransportError(res)) …  // did not reach the server — safe to retry
+ *   else if (!res.ok) …           // the server said no
+ *
+ * Client components must invoke server actions through this wrapper — never
+ * with a bare `await`/`void`. An eslint restriction under app/admin enforces it.
+ */
+
+export interface TransportError {
+  ok: false;
+  /** Discriminant: the call never produced a server verdict. Always retryable. */
+  transport: true;
+  message: string;
+}
+
+export const isTransportError = (r: unknown): r is TransportError =>
+  typeof r === 'object' && r !== null && (r as TransportError).transport === true;
+
+/** Per-attempt ceiling. Server actions from one tab run serially, so a hung
+ *  call would otherwise queue every later action (publish included) forever. */
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export async function callAction<T>(
+  fn: () => Promise<T>,
+  opts?: { timeoutMs?: number },
+): Promise<T | TransportError> {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } catch (e) {
+    return {
+      ok: false,
+      transport: true,
+      message: e instanceof Error ? e.message : 'network error',
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/apps/web/lib/draft-backup.ts
+++ b/apps/web/lib/draft-backup.ts
@@ -1,0 +1,47 @@
+/**
+ * Crash-safety copy of the builder's unsaved work, in localStorage. Written on
+ * the way out (beforeunload/tab-hide) and before each save attempt; cleared the
+ * moment a save catches up with the latest edits. If every server path fails —
+ * offline, mid-deploy, a hung API — the work survives the reload, and the
+ * editor offers to restore it on the next open.
+ *
+ * All accessors swallow storage errors (private mode, quota): the backup is a
+ * safety net UNDER autosave, never something that can break the editor.
+ */
+
+export interface DraftBackup {
+  name: string;
+  config: unknown;
+  /** Epoch-ms of the backup write — compared against the form's `updatedAt`. */
+  ts: number;
+}
+
+const key = (formId: string) => `quill:draft-backup:${formId}`;
+
+export function writeDraftBackup(formId: string, name: string, config: unknown): void {
+  try {
+    localStorage.setItem(key(formId), JSON.stringify({ name, config, ts: Date.now() }));
+  } catch {
+    /* storage unavailable/full — autosave still owns durability */
+  }
+}
+
+export function readDraftBackup(formId: string): DraftBackup | null {
+  try {
+    const raw = localStorage.getItem(key(formId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as DraftBackup;
+    if (typeof parsed !== 'object' || parsed === null || typeof parsed.ts !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDraftBackup(formId: string): void {
+  try {
+    localStorage.removeItem(key(formId));
+  } catch {
+    /* nothing to do */
+  }
+}

--- a/apps/web/lib/use-autosave.ts
+++ b/apps/web/lib/use-autosave.ts
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * React binding for AutosaveController — the ONE autosave implementation the
+ * admin editors share (builder + integrations). The controller owns the state
+ * machine (debounce, serialization, generation-numbered dirtiness, retry with
+ * backoff); this hook owns the browser wiring:
+ *
+ * - `visibilitychange` → flush through the server action while the component
+ *   can still run one.
+ * - `beforeunload` while dirty → (1) fire the caller's `beacon` (a keepalive
+ *   POST to a same-origin flush route — it survives the tab closing), and
+ *   (2) `preventDefault()` so the browser asks before discarding work. Both:
+ *   the beacon is best-effort, the dialog is the guarantee.
+ * - unmount (SPA nav) → flush through the server action.
+ *
+ * Callers provide snapshot/validate/save via a ref-read options object, so the
+ * controller always sees the latest state and callbacks without re-subscribing.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AutosaveController,
+  type AutosaveStatus,
+  type SaveOutcome,
+} from './autosave-controller';
+
+export type { AutosaveStatus } from './autosave-controller';
+
+export interface UseAutosaveOptions<T> {
+  getSnapshot: () => T;
+  validate: (snapshot: T) => { ok: true } | { ok: false; reason: string };
+  save: (snapshot: T) => Promise<SaveOutcome>;
+  /** Keepalive path for a hard tab close — fired only for a VALID snapshot. */
+  beacon?: (snapshot: T) => void;
+  /** Crash-safety copy of the snapshot (localStorage), taken before saves and
+   *  on the way out — even for a snapshot that fails validation. */
+  backup?: { write: (snapshot: T) => void; clear: () => void };
+  onFailure?: (message: string, transport: boolean) => void;
+  onSaved?: () => void;
+  /** Start with unsaved changes (e.g. a config migrated on open). */
+  initiallyDirty?: boolean;
+  debounceMs?: number;
+}
+
+export interface Autosave {
+  status: AutosaveStatus;
+  /** Failure reason accompanying `error`/`retrying`, for tooltips/status lines. */
+  detail: string | null;
+  /** Call on every edit, after updating state. */
+  markDirty: () => void;
+  flush: () => void;
+}
+
+export function useAutosave<T>(options: UseAutosaveOptions<T>): Autosave {
+  const [status, setStatus] = useState<AutosaveStatus>('saved');
+  const [detail, setDetail] = useState<string | null>(null);
+
+  // Latest options every controller callback reads through — one controller
+  // instance per mounted life, zero stale closures.
+  const optsRef = useRef(options);
+  optsRef.current = options;
+
+  const controllerRef = useRef<AutosaveController<T> | null>(null);
+  const makeController = useCallback(
+    () =>
+      new AutosaveController<T>({
+        getSnapshot: () => optsRef.current.getSnapshot(),
+        validate: (s) => optsRef.current.validate(s),
+        save: (s) => {
+          optsRef.current.backup?.write(s);
+          return optsRef.current.save(s);
+        },
+        onStatus: (next, d) => {
+          setStatus(next);
+          setDetail(d);
+        },
+        onFailure: (m, t) => optsRef.current.onFailure?.(m, t),
+        onSaved: () => {
+          optsRef.current.backup?.clear();
+          optsRef.current.onSaved?.();
+        },
+        debounceMs: optsRef.current.debounceMs,
+      }),
+    [],
+  );
+  if (controllerRef.current === null) controllerRef.current = makeController();
+
+  useEffect(() => {
+    // Strict mode runs mount→cleanup→mount; the cleanup disposed the first
+    // controller, so the second mount needs a live one.
+    if (!controllerRef.current || controllerRef.current.isDisposed) {
+      controllerRef.current = makeController();
+    }
+    const controller = controllerRef.current;
+    if (optsRef.current.initiallyDirty && !controller.dirty) controller.markDirty();
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden' && controller.dirty) {
+        optsRef.current.backup?.write(optsRef.current.getSnapshot());
+        controller.flush();
+      }
+    };
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!controller.dirty) return;
+      const snapshot = optsRef.current.getSnapshot();
+      // Backup first — synchronous, survives even a cancelled dialog.
+      optsRef.current.backup?.write(snapshot);
+      if (optsRef.current.validate(snapshot).ok) optsRef.current.beacon?.(snapshot);
+      // Ask before discarding: the beacon is fire-and-forget, not a guarantee.
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      controller.flush(); // SPA nav / unmount — last chance on the action path
+      controller.dispose();
+    };
+    // Subscribe once per mounted life; all state flows through optsRef.
+  }, []);
+
+  const markDirty = useCallback(() => controllerRef.current?.markDirty(), []);
+  const flush = useCallback(() => controllerRef.current?.flush(), []);
+  return { status, detail, markDirty, flush };
+}

--- a/apps/web/lib/use-autosave.ts
+++ b/apps/web/lib/use-autosave.ts
@@ -21,11 +21,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   AutosaveController,
+  type AutosaveFailureKind,
   type AutosaveStatus,
   type SaveOutcome,
 } from './autosave-controller';
 
-export type { AutosaveStatus } from './autosave-controller';
+export type { AutosaveFailureKind, AutosaveStatus } from './autosave-controller';
 
 export interface UseAutosaveOptions<T> {
   getSnapshot: () => T;
@@ -36,7 +37,7 @@ export interface UseAutosaveOptions<T> {
   /** Crash-safety copy of the snapshot (localStorage), taken before saves and
    *  on the way out — even for a snapshot that fails validation. */
   backup?: { write: (snapshot: T) => void; clear: () => void };
-  onFailure?: (message: string, transport: boolean) => void;
+  onFailure?: (message: string, kind: AutosaveFailureKind) => void;
   onSaved?: () => void;
   /** Start with unsaved changes (e.g. a config migrated on open). */
   initiallyDirty?: boolean;
@@ -75,7 +76,7 @@ export function useAutosave<T>(options: UseAutosaveOptions<T>): Autosave {
           setStatus(next);
           setDetail(d);
         },
-        onFailure: (m, t) => optsRef.current.onFailure?.(m, t),
+        onFailure: (m, k) => optsRef.current.onFailure?.(m, k),
         onSaved: () => {
           optsRef.current.backup?.clear();
           optsRef.current.onSaved?.();
@@ -115,7 +116,9 @@ export function useAutosave<T>(options: UseAutosaveOptions<T>): Autosave {
     return () => {
       document.removeEventListener('visibilitychange', onVisibility);
       window.removeEventListener('beforeunload', onBeforeUnload);
-      controller.flush(); // SPA nav / unmount — last chance on the action path
+      // SPA nav / unmount: back up the LATEST snapshot (an in-flight save may
+      // carry an older one), then dispose — which fires the terminal save.
+      if (controller.dirty) optsRef.current.backup?.write(optsRef.current.getSnapshot());
       controller.dispose();
     };
     // Subscribe once per mounted life; all state flows through optsRef.

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -391,6 +391,8 @@ export interface FormsMessages {
       /** V4 autosave hardening: surface WHY a save failed + client pre-validation. */
       saveErrorReason: string;
       saveInvalid: string;
+      /** V5: the save request never reached the server; autosave keeps retrying. */
+      saveOffline: string;
       /** Results tab clarity (V4-16 outcome heading + message + redirect field). */
       resultsHelp: {
         outcomeHeadingHelp: string;
@@ -1012,6 +1014,9 @@ export interface FormsMessages {
       /** V5-QA — saved, except one card that has a problem of its own. */
       autosavedPartial: string;
       saveError: string;
+      /** V5: the save never reached the server; autosave is retrying on its own. */
+      saveOffline: string;
+      saveRetrying: string;
       loadError: string;
       enabled: string;
       disabled: string;
@@ -1822,6 +1827,8 @@ export const en: FormsMessages = {
       saveError: 'Could not save — please try again.',
       saveErrorReason: 'Couldn’t save: {reason}',
       saveInvalid: 'Can’t save yet — {reason}',
+      saveOffline:
+        'Can’t reach the server — your changes are kept and saving will retry automatically.',
       resultsHelp: {
         outcomeHeadingHelp:
           'Shown to respondents as the heading on the thank-you screen when their score lands in this range.',
@@ -2396,6 +2403,9 @@ export const en: FormsMessages = {
       autosaved: 'Changes saved automatically',
       autosavedPartial: 'Saved everything except the webhook —',
       saveError: 'Could not save integrations.',
+      saveOffline:
+        'Can’t reach the server — your changes are kept and saving will retry automatically.',
+      saveRetrying: 'Connection lost — retrying…',
       loadError: 'Could not load integrations.',
       enabled: 'Enabled',
       disabled: 'Disabled',
@@ -3181,6 +3191,8 @@ export const es: FormsMessages = {
       saveError: 'No se pudo guardar — inténtalo de nuevo.',
       saveErrorReason: 'No se pudo guardar: {reason}',
       saveInvalid: 'Aún no se puede guardar — {reason}',
+      saveOffline:
+        'No se pudo contactar al servidor — tus cambios se conservan y el guardado se reintentará automáticamente.',
       resultsHelp: {
         outcomeHeadingHelp:
           'Se muestra a los respondientes como el encabezado de la pantalla de agradecimiento cuando su puntaje cae en este rango.',
@@ -3757,6 +3769,9 @@ export const es: FormsMessages = {
       autosaved: 'Cambios guardados automáticamente',
       autosavedPartial: 'Se guardó todo menos el webhook —',
       saveError: 'No se pudieron guardar las integraciones.',
+      saveOffline:
+        'No se pudo contactar al servidor — tus cambios se conservan y el guardado se reintentará automáticamente.',
+      saveRetrying: 'Se perdió la conexión — reintentando…',
       loadError: 'No se pudieron cargar las integraciones.',
       enabled: 'Activado',
       disabled: 'Desactivado',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -2994,6 +2994,7 @@ export const es: FormsMessages = {
       save: 'Guardar kit de marca',
       saving: 'Guardando…',
       saved: 'Kit de marca guardado.',
+      saveOffline: 'No se pudo contactar al servidor — revisa tu conexión e inténtalo de nuevo.',
       adminOnly: 'Solo un admin o el owner puede editar el kit de marca.',
       logoTitle: 'Logo',
       logoSubtitle: 'Se muestra en portadas y encabezados salvo que un formulario tenga el suyo.',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -183,6 +183,8 @@ export interface FormsMessages {
       save: string;
       saving: string;
       saved: string;
+      /** V5: the save request never reached the server (kept, retry manually). */
+      saveOffline: string;
       /** Read-only banner for non-admin members. */
       adminOnly: string;
       logoTitle: string;
@@ -1629,6 +1631,7 @@ export const en: FormsMessages = {
       save: 'Save brand kit',
       saving: 'Saving…',
       saved: 'Brand kit saved.',
+      saveOffline: 'Can’t reach the server — check your connection and try again.',
       adminOnly: 'Only an admin or owner can edit the brand kit.',
       logoTitle: 'Logo',
       logoSubtitle: 'Shown on covers and headers unless a form sets its own.',


### PR DESCRIPTION
## Problema

El editor quedaba clavado en **"Saving…"** para siempre, Publish se bloqueaba, y al refrescar se perdía todo el progreso. Causa raíz: todos los call sites invocaban server actions con `await` pelado — cuando la **invocación** misma rechaza (deploy rota los action IDs con el tab abierto, red caída, API colgado), la excepción salta todos los `setStatus` posteriores: sin retry, sin estado de error, rejection tragada por `void`. Dev auto-deploya cada 10 min, así que cualquier sesión de edición larga cruzaba un deploy → el "a veces" del reporte.

Encima, el flush de `beforeunload` **nunca funcionó**: mandaba cookies a un API que solo autentica con headers de identidad (401 en cada unload desde el día uno), apuntando además a la `NEXT_PUBLIC_API_URL` horneada.

## Fix (defensa en capas)

- **`lib/call-action.ts`** — wrapper obligatorio para invocar server actions desde cliente: fallo de transporte ⇒ valor reintentable, timeout 15s por intento (un action colgado ya no encola el publish detrás).
- **`lib/autosave-controller.ts` + `lib/use-autosave.ts`** — UN autosave compartido (builder + integrations): saves serializados, dirty por número de generación (mata las carreras de saves solapados), retry con backoff hasta que un save aterrice, save terminal en unmount (cubre el caso "save en vuelo + edit nuevo + navegación"), y `beforeunload` con confirmación del browser. **16 tests** del controller.
- **`app/admin/forms/[id]/flush/route.ts`** — proxy same-origin para el flush de cierre duro: lleva la cookie de sesión y adjunta la identidad server-side. Valida el id (token opaco) y el header Origin.
- **`lib/draft-backup.ts`** — backup en localStorage + banner de recuperación en el builder («Cambios sin guardar recuperados — Restaurar / Descartar»); se descarta solo si es más viejo que el server o al primer edit nuevo.
- **Migrados todos los call sites del admin + onboarding** a `callAction` (publish button ya no se clava en "Publishing…").
- **`unstable_rethrow`** en los catch de los actions del admin — sesión expirada redirige a /login en vez de devolver un error críptico en loop.
- **`revalidatePath` fuera del autosave** — ya no revalida `/admin` en cada keystroke debounced.
- **Candado ESLint** — `no-restricted-syntax` prohíbe `await`/`void` directo de `*Action(` en componentes cliente. Los renderers públicos están excluidos a propósito: migran en el PR siguiente (submit + booking necesitan sus propios estados de error visibles).
- **i18n** EN+ES: `saveOffline`, `saveRetrying`, strings del banner de recuperación. Changeset minor para `@quill/shared`.

## Cómo probar

1. `pnpm dev`, abrir el editor de un form.
2. Editar → matar el API (`kill` del proceso :4000) → editar más: el status pasa a "Reintentando…" con toast una sola vez; revivir el API → "Saved" solo, sin tocar nada.
3. Con el API muerto, refrescar: el browser pregunta antes de salir; al recargar aparece el banner de recuperación con los cambios.
4. Publish con un save colgado ya no queda en "Publishing…" eterno.

Review previo con el agente `forms-reviewer`: 1 hallazgo bloqueante (carrera de pérdida de edits mid-flight en unmount) corregido en el segundo commit con tests que lo cubren, más los should-fixes (id del proxy, copy de validación, banner, mensajes de transporte localizados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)