### PR TITLE
fix: make the HubSpot form-submission activity say what it did, and stop it duplicating forms

### DIFF
--- a/.changeset/mirror-attribution-and-guid.md
+++ b/.changeset/mirror-attribution-and-guid.md
@@ -1,0 +1,30 @@
+---
+'@quill/destinations': patch
+---
+
+Let the mirror-form submission be what SETS the contact's properties, so the
+"Form submission" activity lists them instead of reading "Updated 0 properties".
+
+HubSpot reports, on that activity, the properties the submission changed. The
+delivery upserted every mapped value through the CRM API and only then posted the
+same values to the mirror, so the post changed nothing: the card appeared, named
+the form, and listed nothing — strictly worse than the note it was built to
+replace. Typeform's integration never touches the CRM API; the submission is the
+write, which is why its cards list fields.
+
+When a mirror is configured, the upsert is now cut back to the contact's key and
+the values ride in on the post. The upsert still runs, and still runs FIRST: it
+is the retryable half of the delivery, it guarantees the contact exists even if
+the portal refuses the post, and the note needs its id.
+
+Three things had to stay true, and each is pinned by a test:
+
+- a refused post falls back to the full upsert, so a portal missing
+  `form-submissions-write` never silently costs an author their mappings. That
+  write may throw — no activity was created, so a retry cannot duplicate one.
+- nothing retryable follows a SUCCESSFUL post. The properties the mirror does not
+  declare (`company`/`website` from `inferCompanyFromEmail`) are written after
+  it, best effort: losing an inferred company beats retrying a delivery into a
+  second card on a real contact's timeline.
+- a form with no mirror, and every partial submission, behave exactly as before —
+  one upsert carrying everything.

--- a/apps/api/src/hubspot-mirror-ownership.spec.ts
+++ b/apps/api/src/hubspot-mirror-ownership.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * The mirror form's guid is the API's, not the caller's.
+ *
+ * `formGuid` and `formSignature` are bookkeeping the server writes for itself:
+ * which form in the portal represents this Dapta form, and what it was built
+ * from. They travel in the same `settings` object as the author's own switches
+ * only because that is where the schema puts them — and the save used to read
+ * them straight out of the request body.
+ *
+ * That made a duplicate factory. A client that did not echo the guid back sent
+ * settings with none, so there was no form to PATCH and no signature to compare
+ * against: every save POSTed a NEW form and abandoned the previous one, which by
+ * then held "Form submission" activities on real contacts. The Connect tab is
+ * exactly that client — it autosaves per keystroke and never learns the guid,
+ * because the save action returns `{ok, formActivityError}` and drops the config
+ * the API just wrote. One editing session with the switch on was one new form in
+ * the portal per debounce, all identically named, with the contact timeline
+ * split across them.
+ *
+ * Fixing it in the editor would have fixed one caller. Sourcing the two keys
+ * from the STORED row fixes every caller there will ever be, so that is what
+ * these tests pin: the request's copy is ignored, on every path, including the
+ * ones that make no HubSpot call at all.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createDb,
+  migrate,
+  seed,
+  getAccountByCode,
+  getFormById,
+  listForms,
+  updateForm,
+  type Db,
+} from '@quill/db';
+import type { ServerEnv } from '@quill/config/env';
+import { FormDestinationsController } from './integrations.controller';
+import { AuthService } from './auth.service';
+import { LocalAuthProvider, type ReqLike } from './auth.provider';
+
+const asOwner = (): ReqLike => ({ headers: {} });
+
+const FORMS_URL = 'https://api.hubapi.com/marketing/v3/forms';
+const STORED_GUID = 'stored-guid-1';
+
+interface Call {
+  url: string;
+  method: string;
+}
+
+let db: Db;
+let controller: FormDestinationsController;
+let accountId: string;
+let formId: string;
+let calls: Call[];
+
+/** Answers every HubSpot call with a created/updated form, recording the shape. */
+function hubspotFetch(newId = 'fresh-guid'): typeof fetch {
+  return (async (url: string, init?: RequestInit) => {
+    calls.push({ url, method: init?.method ?? 'GET' });
+    // PATCH keeps the id it was called on; POST mints a new one — the same
+    // distinction the portal makes, and the one the whole bug turned on.
+    const id = init?.method === 'PATCH' ? url.slice(url.lastIndexOf('/') + 1) : newId;
+    return new Response(JSON.stringify({ id }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+}
+
+/** The HubSpot destination as the Connect tab sends it: no guid, no signature. */
+function fromEditor(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'hubspot',
+    enabled: true,
+    settings: { note: true, formActivity: true },
+    fieldMappings: { contact_email: 'email', first: 'firstname' },
+    ...over,
+  };
+}
+
+/** Put a mirror already in place, below the controller. */
+async function storeMirror(settings: Record<string, unknown>): Promise<void> {
+  await updateForm(db, accountId, formId, {
+    config: {
+      version: 1,
+      steps: [],
+      destinations: [
+        {
+          type: 'hubspot',
+          enabled: true,
+          settings,
+          fieldMappings: { contact_email: 'email', first: 'firstname' },
+        },
+      ],
+    },
+  });
+}
+
+/** The HubSpot settings a form has stored right now. */
+async function storedSettings(): Promise<Record<string, unknown>> {
+  const form = await getFormById(db, accountId, formId);
+  const destinations =
+    (form!.config as { destinations?: Record<string, unknown>[] }).destinations ?? [];
+  return (destinations.find((d) => d.type === 'hubspot')?.settings ?? {}) as Record<string, unknown>;
+}
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db);
+  accountId = (await getAccountByCode(db, 'acme'))!.id;
+  formId = (await listForms(db, accountId)).find((f) => f.slug === 'lead-qualifier')!.id;
+  calls = [];
+
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: 'test',
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
+  });
+  // The server token is enough to reach HubSpot — this spec is about which guid
+  // the sync uses, not about where the credential came from.
+  const env = {
+    NODE_ENV: 'test',
+    FORMS_ENCRYPTION_KEY: undefined,
+    HUBSPOT_PRIVATE_APP_TOKEN: 'server-token',
+  } as unknown as ServerEnv;
+  controller = new FormDestinationsController(db, new AuthService(db, provider), env);
+  controller.fetchImpl = hubspotFetch();
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('the mirror guid comes from the stored row', () => {
+  it('PATCHES the stored form when the caller sends no guid', async () => {
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+
+    await controller.putDestinations(asOwner(), formId, { destinations: [fromEditor()] });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe('PATCH');
+    expect(calls[0]!.url).toBe(`${FORMS_URL}/${STORED_GUID}`);
+    expect((await storedSettings()).formGuid).toBe(STORED_GUID);
+  });
+
+  it('makes NO HubSpot call when the stored signature already matches', async () => {
+    // The common path, and the one the bug destroyed: with no guid in the body
+    // the short-circuit could never fire, so every autosave hit the portal.
+    const first = await controller.putDestinations(asOwner(), formId, {
+      destinations: [fromEditor()],
+    });
+    expect(first).toBeTruthy();
+    const afterCreate = calls.length;
+
+    await controller.putDestinations(asOwner(), formId, { destinations: [fromEditor()] });
+
+    expect(calls).toHaveLength(afterCreate);
+  });
+
+  it('creates ONE form across a burst of saves, not one per save', async () => {
+    // A stand-in for the debounced autosave: same payload, three times.
+    for (let i = 0; i < 3; i++) {
+      await controller.putDestinations(asOwner(), formId, { destinations: [fromEditor()] });
+    }
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(1);
+    expect((await storedSettings()).formGuid).toBe('fresh-guid');
+  });
+
+  it('PATCHES rather than creating when the mapping changes', async () => {
+    await controller.putDestinations(asOwner(), formId, { destinations: [fromEditor()] });
+    calls = [];
+
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [
+        fromEditor({ fieldMappings: { contact_email: 'email', first: 'firstname', role: 'jobtitle' } }),
+      ],
+    });
+
+    expect(calls.map((c) => c.method)).toEqual(['PATCH']);
+    expect((await storedSettings()).formGuid).toBe('fresh-guid');
+  });
+
+  it('IGNORES a guid the caller invented for a form that has none', async () => {
+    // The failure worth being explicit about: a body-supplied guid could point
+    // one account's form at another account's mirror.
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [fromEditor({ settings: { formActivity: true, formGuid: 'someone-elses' } })],
+    });
+
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.url).toBe(FORMS_URL);
+    expect((await storedSettings()).formGuid).toBe('fresh-guid');
+  });
+
+  it('IGNORES a guid the caller invented for a form that already has one', async () => {
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [fromEditor({ settings: { formActivity: true, formGuid: 'someone-elses' } })],
+    });
+
+    expect(calls[0]!.url).toBe(`${FORMS_URL}/${STORED_GUID}`);
+    expect((await storedSettings()).formGuid).toBe(STORED_GUID);
+  });
+
+  it('discards a caller-supplied SIGNATURE, so a lie cannot skip the sync', async () => {
+    // Claiming to be in step is the cheap way to leave a stale form in place.
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [
+        fromEditor({
+          settings: { formActivity: true, formSignature: 'whatever the caller says' },
+          fieldMappings: { contact_email: 'email', role: 'jobtitle' },
+        }),
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+    const stored = await storedSettings();
+    expect(stored.formSignature).not.toBe('whatever the caller says');
+    expect(stored.formGuid).toBe(STORED_GUID);
+  });
+});
+
+describe('the guid survives edits that are not about it', () => {
+  it('keeps the guid when the activity is switched OFF', async () => {
+    // Documented intent: turning the switch off STOPS posting without destroying
+    // the form, whose past submissions are activities on real contacts. Returning
+    // the caller's entry untouched on the `noop` path dropped it instead.
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [fromEditor({ settings: { note: true, formActivity: false } })],
+    });
+
+    expect(calls).toHaveLength(0);
+    const stored = await storedSettings();
+    expect(stored.formGuid).toBe(STORED_GUID);
+    expect(stored.formActivity).toBe(false);
+  });
+
+  it('reuses the same form when the activity is switched back ON', async () => {
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [fromEditor({ settings: { formActivity: false } })],
+    });
+    calls = [];
+
+    await controller.putDestinations(asOwner(), formId, { destinations: [fromEditor()] });
+
+    expect(calls.map((c) => c.method)).toEqual(['PATCH']);
+    expect((await storedSettings()).formGuid).toBe(STORED_GUID);
+  });
+
+  it('keeps the guid when a WEBHOOK is the only thing being edited', async () => {
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [
+        { type: 'webhook', enabled: true, settings: { url: 'https://example.com/hook' } },
+        fromEditor(),
+      ],
+    });
+
+    expect((await storedSettings()).formGuid).toBe(STORED_GUID);
+  });
+
+  it('leaves the author-owned settings exactly as the caller sent them', async () => {
+    // The fix replaces two keys and must not become a merge of everything else —
+    // an author turning the note off has to see it turn off.
+    await storeMirror({ note: true, formActivity: true, formGuid: STORED_GUID });
+
+    await controller.putDestinations(asOwner(), formId, {
+      destinations: [fromEditor({ settings: { note: false, formActivity: true } })],
+    });
+
+    expect((await storedSettings()).note).toBe(false);
+  });
+});

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -39,7 +39,7 @@ import {
   type FormDestination,
 } from '@quill/types';
 import { WebhookDestination, WebhookHttpError } from '@quill/destinations';
-import { syncMirrorForm } from './hubspot-mirror';
+import { syncMirrorForm, type MirrorSyncResult } from './hubspot-mirror';
 import type { ServerEnv } from '@quill/config/env';
 import { AuthService, type ReqLike } from './auth.service';
 import { assertAdmin } from './permissions';
@@ -600,6 +600,68 @@ export class IntegrationsController {
 const destinationsBodySchema = z.object({ destinations: z.array(formDestinationSchema) });
 
 /**
+ * The mirror-form bookkeeping the API writes for itself, as opposed to the
+ * settings an author edits. Kept apart because they are sourced from the stored
+ * row on every save and a caller's copy is never trusted — see `syncMirror`.
+ */
+interface OwnedMirrorState {
+  formGuid?: string | null;
+  formSignature?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Read the owned mirror state off a form's STORED destinations.
+ *
+ * Deliberately duck-typed rather than parsed: a config that no longer satisfies
+ * `formDestinationSchema` (an older shape, a hand-edited row) must still yield
+ * its guid, because failing to find one is precisely what makes the next save
+ * create a duplicate form in the portal. There is at most one HubSpot
+ * destination per form, so the first match is the answer.
+ */
+function storedMirrorState(stored: unknown): OwnedMirrorState {
+  if (!Array.isArray(stored)) return {};
+  for (const entry of stored) {
+    if (!isRecord(entry) || entry.type !== 'hubspot') continue;
+    const settings = isRecord(entry.settings) ? entry.settings : {};
+    const owned: OwnedMirrorState = {};
+    // `null` is meaningful — `syncMirrorForm` writes it to say "the portal no
+    // longer has this form, make a new one on the next save".
+    if (typeof settings.formGuid === 'string' || settings.formGuid === null) {
+      owned.formGuid = settings.formGuid;
+    }
+    if (typeof settings.formSignature === 'string') owned.formSignature = settings.formSignature;
+    return owned;
+  }
+  return {};
+}
+
+/**
+ * The settings to store: the caller's, with the owned keys stripped and then set
+ * from the sync's result.
+ *
+ * Strip-then-set rather than a spread, so a caller that INVENTS a `formGuid` for
+ * a form that has none cannot have it survive. Pointing one account's form at
+ * another's mirror is the failure worth being explicit about; a stale guid is
+ * merely the common one.
+ */
+function mirrorSettingsFor(
+  raw: unknown,
+  settings: MirrorSyncResult['settings'],
+): Record<string, unknown> {
+  const fromCaller = isRecord(raw) && isRecord(raw.settings) ? raw.settings : {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fromCaller)) {
+    if (key !== 'formGuid' && key !== 'formSignature') out[key] = value;
+  }
+  if (settings.formGuid !== undefined) out.formGuid = settings.formGuid;
+  if (settings.formSignature !== undefined) out.formSignature = settings.formSignature;
+  return out;
+}
+
+/**
  * Auth-gated PARTIAL config write for the integrations screen: replaces ONLY the
  * `destinations` key, merged against the row's fresh config server-side in one
  * request — the web tier no longer reads the whole config and writes it back
@@ -653,7 +715,7 @@ export class FormDestinationsController {
     // a form exists in the portal that nothing points at. A HubSpot failure
     // never fails the save: an author must be able to edit their mappings while
     // a portal is unreachable or has not granted the scopes.
-    const mirror = await this.syncMirror(p.accountId, before.name, destinations);
+    const mirror = await this.syncMirror(p.accountId, before.name, destinations, stored);
     const out = await updateFormDestinations(this.db, p.accountId, id, mirror.destinations);
     if (!out.ok) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
     // Never echo the stored webhook secret back to the client (mask on READ).
@@ -672,11 +734,24 @@ export class FormDestinationsController {
    * guid belongs to the destination that owns it, and the caller stores the
    * whole array in one write. Only the HubSpot entries can change; everything
    * else passes through by reference.
+   *
+   * `formGuid` and `formSignature` are read from what is STORED and the caller's
+   * values are discarded — they are this method's own bookkeeping, not settings
+   * an author edits. Trusting the request body meant any client that did not
+   * echo them back created a SECOND form in the portal on the very next save:
+   * with no guid there is no form to PATCH and no signature to compare, so every
+   * write POSTed a new one and abandoned the old — which still holds the
+   * activities already attached to real contacts. The Connect tab autosaves per
+   * keystroke and never learns the guid (the save action returns only
+   * `{ok, formActivityError}`), so one editing session with the switch on was
+   * one new form per debounce. Sourcing them here fixes it for every caller at
+   * once, including the ones that have not been written yet.
    */
   private async syncMirror(
     accountId: string,
     formName: string,
     destinations: unknown[],
+    stored: unknown,
   ): Promise<{ destinations: unknown[]; error?: string }> {
     if (!destinations.some((d) => (d as { type?: string })?.type === 'hubspot')) {
       return { destinations };
@@ -708,22 +783,35 @@ export class FormDestinationsController {
       knownProperties = null;
     }
 
+    // At most one HubSpot destination per form (`hasExtraHubspotDestination`,
+    // enforced by the caller), so the stored mirror state is a single value
+    // rather than something to match up entry by entry.
+    const owned = storedMirrorState(stored);
+
     let error: string | undefined;
     const out = await Promise.all(
       destinations.map(async (raw) => {
         const parsed = formDestinationSchema.safeParse(raw);
         if (!parsed.success || parsed.data.type !== 'hubspot') return raw;
-        const result = await syncMirrorForm(parsed.data, formName, {
-          fetchImpl: this.fetchImpl,
-          token,
-          knownProperties,
-        });
+        // Discarded before the sync ever sees them: a spread would let an
+        // INVENTED guid through whenever nothing is stored, and the sync would
+        // dutifully PATCH whatever form it named.
+        const settings = { ...parsed.data.settings };
+        delete settings.formGuid;
+        delete settings.formSignature;
+        const result = await syncMirrorForm(
+          { ...parsed.data, settings: { ...settings, ...owned } },
+          formName,
+          { fetchImpl: this.fetchImpl, token, knownProperties },
+        );
         if (result.error && !error) error = result.error;
-        if (result.action === 'noop' || result.action === 'unchanged') return raw;
         // Merge onto the RAW entry, not the parsed one: parsing applies schema
         // defaults, and writing those back would rewrite fields this request
-        // never touched.
-        return { ...(raw as object), settings: result.settings };
+        // never touched. The two owned keys are set from the RESULT on every
+        // path — including `noop` and `unchanged`, where returning the caller's
+        // entry unchanged used to drop a stored guid on the floor, so switching
+        // the activity off orphaned the form it was meant to keep.
+        return { ...(raw as object), settings: mirrorSettingsFor(raw, result.settings) };
       }),
     );
     return { destinations: out, error };

--- a/packages/destinations/src/adapters/hubspot-mirror-attribution.spec.ts
+++ b/packages/destinations/src/adapters/hubspot-mirror-attribution.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * WHO writes the mapped properties — and therefore what the "Form submission"
+ * activity says it did.
+ *
+ * HubSpot reports, on the activity, the properties THAT SUBMISSION changed. The
+ * delivery used to upsert every mapped value through the CRM API and only then
+ * post the same values to the mirror, so the post changed nothing and every card
+ * in every portal read "Updated 0 properties": it named the form, listed
+ * nothing, and was strictly worse than the note it was built to replace.
+ * Typeform's integration never touches the CRM API — the submission IS the
+ * write, which is why its cards list fields.
+ *
+ * So when a mirror is configured, the upsert is cut back to the contact's KEY
+ * and the values ride in on the post. Three things have to stay true while that
+ * happens, and each one is a test below:
+ *
+ *  1. the contact still exists even if the portal refuses the post — the upsert
+ *     is the retryable half of the delivery and it still runs FIRST;
+ *  2. a refused post still lands every mapped property, through the full upsert
+ *     it falls back to;
+ *  3. nothing retryable follows a SUCCESSFUL post, or the outbox would retry a
+ *     delivery into a second activity on a real contact's timeline.
+ *
+ * A form with no mirror must behave exactly as it always did, so the no-mirror
+ * path is asserted here too rather than left to the reader.
+ */
+import { describe, it, expect } from 'vitest';
+import { HubspotDestination } from './hubspot';
+import type { DestinationContext } from '../destination.port';
+
+const FORMS_BASE = 'https://forms.test';
+const API_BASE = 'https://api.test';
+const UPSERT = '/crm/v3/objects/contacts/batch/upsert';
+
+const isFormsHost = (url: string): boolean => {
+  try {
+    return new URL(url).origin === FORMS_BASE;
+  } catch {
+    return false;
+  }
+};
+const silent = { warn: () => {} };
+
+function ctx(over: Partial<DestinationContext> = {}): DestinationContext {
+  return {
+    idempotencyKey: 'submission:sub-1:complete:hubspot',
+    submissionId: 'sub-1',
+    formId: 'form-1',
+    formName: 'Lead Qualifier',
+    accountId: 'acc-1',
+    sessionId: 'sess-1',
+    score: 18,
+    outcomeLabel: 'Qualified',
+    phase: 'complete',
+    submittedAt: Date.UTC(2026, 0, 15, 22, 30),
+    data: { contact_email: 'lead@acme.io', first: 'Ada', role: 'Founder' },
+    utm: {},
+    ...over,
+  } as DestinationContext;
+}
+
+const OPTS = {
+  token: 't',
+  fieldMappings: { contact_email: 'email', first: 'firstname', role: 'jobtitle' },
+  note: false as const,
+  portalId: '23824272',
+  formGuid: 'guid-1',
+};
+
+interface Call {
+  url: string;
+  body: unknown;
+}
+
+/**
+ * Records every call in ORDER. The upsert can be made to fail on demand, which
+ * is the only way to prove the fallback is retryable rather than swallowed.
+ */
+function harness(
+  opts: { mirrorStatus?: number; failUpsertsAfter?: number } = {},
+): { calls: Call[]; fetchImpl: typeof fetch } {
+  const calls: Call[] = [];
+  let upserts = 0;
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ url, body });
+    if (isFormsHost(url)) {
+      const status = opts.mirrorStatus ?? 200;
+      return { ok: status < 400, status, text: async () => 'nope', json: async () => ({}) };
+    }
+    upserts += 1;
+    if (opts.failUpsertsAfter !== undefined && upserts > opts.failUpsertsAfter) {
+      return { ok: false, status: 502, text: async () => 'upstream down', json: async () => ({}) };
+    }
+    return { ok: true, status: 200, json: async () => ({ results: [{ id: 'contact-9' }] }) };
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+/** The property names one upsert call carried. */
+const upsertProperties = (call: Call): string[] =>
+  Object.keys(
+    (call.body as { inputs: { properties: Record<string, string> }[] }).inputs[0]!.properties,
+  ).sort();
+
+const upsertCalls = (calls: Call[]): Call[] => calls.filter((c) => c.url.includes(UPSERT));
+const mirrorCalls = (calls: Call[]): Call[] => calls.filter((c) => isFormsHost(c.url));
+
+describe('with a mirror form configured', () => {
+  it('anchors the contact on its EMAIL ALONE, so the post is what sets the values', async () => {
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await dest.deliver(ctx());
+
+    // The regression, stated as an assertion: this call used to carry
+    // `firstname` and `jobtitle`, which is what left the activity with nothing
+    // to report.
+    expect(upsertProperties(upsertCalls(calls)[0]!)).toEqual(['email']);
+  });
+
+  it('still upserts BEFORE it posts, so a refused post cannot cost the contact', async () => {
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await dest.deliver(ctx());
+
+    expect(calls[0]!.url).toContain(UPSERT);
+    expect(isFormsHost(calls[1]!.url)).toBe(true);
+  });
+
+  it('carries every mapped property on the post', async () => {
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await dest.deliver(ctx());
+
+    const body = mirrorCalls(calls)[0]!.body as { fields: { name: string; value: string }[] };
+    expect(body.fields.map((f) => f.name).sort()).toEqual(['email', 'firstname', 'jobtitle']);
+    expect(body.fields.find((f) => f.name === 'jobtitle')?.value).toBe('Founder');
+  });
+
+  it('writes NOTHING more after a successful post', async () => {
+    // The rule that keeps a retry from duplicating an activity: the post is not
+    // idempotent, so it must be the last thing that can fail the delivery.
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await dest.deliver(ctx());
+
+    expect(upsertCalls(calls)).toHaveLength(1);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('falls back to the FULL upsert when the post is refused', async () => {
+    // A portal missing `form-submissions-write` must not silently cost the
+    // author every property they mapped.
+    const { calls, fetchImpl } = harness({ mirrorStatus: 403 });
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    const result = await dest.deliver(ctx());
+
+    const upserts = upsertCalls(calls);
+    expect(upserts).toHaveLength(2);
+    expect(upsertProperties(upserts[1]!)).toEqual(['email', 'firstname', 'jobtitle']);
+    expect(result.delivered).toBe(true);
+    expect(result.detail).toContain('form failed');
+  });
+
+  it('THROWS when that fallback upsert fails, because a retry cannot duplicate anything', async () => {
+    // No activity was created, so sending the outbox round again is safe — and
+    // necessary, or a transient 502 loses the properties for good.
+    const { fetchImpl } = harness({ mirrorStatus: 500, failUpsertsAfter: 1 });
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await expect(dest.deliver(ctx())).rejects.toThrow(/hubspot upsert failed/);
+  });
+
+  it('writes the properties the mirror does not declare, and swallows their failure', async () => {
+    // `inferCompanyFromEmail` fills `company`/`website`, which are deliberately
+    // absent from the mirror's fields. Without this they would silently stop
+    // being written the moment an author turned the activity on.
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(
+      { ...OPTS, inferCompanyFromEmail: true },
+      fetchImpl,
+      API_BASE,
+      silent,
+      FORMS_BASE,
+    );
+    await dest.deliver(ctx());
+
+    const upserts = upsertCalls(calls);
+    expect(upserts).toHaveLength(2);
+    // Only the undeclared ones — re-sending the mapped values would hand the
+    // CRM API the very attribution the post just earned.
+    expect(upsertProperties(upserts[1]!)).toEqual(['company', 'email', 'website']);
+  });
+
+  it('does not fail a delivery whose activity landed just because the residual write did not', async () => {
+    // Losing an inferred company beats retrying into a second card on a real
+    // contact's timeline.
+    const { fetchImpl } = harness({ failUpsertsAfter: 1 });
+    const dest = new HubspotDestination(
+      { ...OPTS, inferCompanyFromEmail: true },
+      fetchImpl,
+      API_BASE,
+      silent,
+      FORMS_BASE,
+    );
+    const result = await dest.deliver(ctx());
+    expect(result.delivered).toBe(true);
+    expect(result.detail).toContain('+form');
+  });
+
+  it('makes no residual call when there is nothing outside the mirror to write', async () => {
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await dest.deliver(ctx());
+    expect(upsertCalls(calls)).toHaveLength(1);
+  });
+});
+
+describe('without a mirror form', () => {
+  it('upserts every property in one call, exactly as it always did', async () => {
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(
+      { ...OPTS, formGuid: undefined },
+      fetchImpl,
+      API_BASE,
+      silent,
+      FORMS_BASE,
+    );
+    await dest.deliver(ctx());
+
+    const upserts = upsertCalls(calls);
+    expect(upserts).toHaveLength(1);
+    expect(upsertProperties(upserts[0]!)).toEqual(['email', 'firstname', 'jobtitle']);
+    expect(mirrorCalls(calls)).toHaveLength(0);
+  });
+
+  it('upserts every property on a PARTIAL, which never mirrors', async () => {
+    // Partials are the reason the branch keys on the phase as well as the guid:
+    // a mirrored form still delivers partials, and those must keep writing
+    // through the CRM API or an abandoned form would sync nothing at all.
+    const { calls, fetchImpl } = harness();
+    const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
+    await dest.deliver(ctx({ phase: 'partial' }));
+
+    const upserts = upsertCalls(calls);
+    expect(upserts).toHaveLength(1);
+    expect(upsertProperties(upserts[0]!)).toEqual(['email', 'firstname', 'jobtitle']);
+    expect(mirrorCalls(calls)).toHaveLength(0);
+  });
+});

--- a/packages/destinations/src/adapters/hubspot-mirror.spec.ts
+++ b/packages/destinations/src/adapters/hubspot-mirror.spec.ts
@@ -7,6 +7,11 @@
  * it targets a different host, and it is not idempotent, so it must never throw:
  * a thrown error would send the outbox round again and duplicate an activity for
  * a contact that already synced.
+ *
+ * WHICH of the two writes carries the mapped values is a separate question, and
+ * the answer changed: see `hubspot-mirror-attribution.spec.ts`. This file is
+ * about the post itself — where it goes, what it carries, and what it does when
+ * the portal says no.
  */
 import { describe, it, expect } from 'vitest';
 import { HubspotDestination } from './hubspot';
@@ -92,7 +97,7 @@ describe('HubspotDestination — the mirror form submission', () => {
     expect(result.detail).toContain('+form');
   });
 
-  it('sends the properties it just wrote to the contact, and the form name as context', async () => {
+  it('sends every mapped property, and the form name as context', async () => {
     const { calls, fetchImpl } = harness();
     const dest = new HubspotDestination(OPTS, fetchImpl, API_BASE, silent, FORMS_BASE);
     await dest.deliver(ctx());

--- a/packages/destinations/src/adapters/hubspot.ts
+++ b/packages/destinations/src/adapters/hubspot.ts
@@ -215,19 +215,55 @@ export class HubspotDestination implements SubmissionDestination {
     const properties = this.buildProperties(ctx);
     properties.email = email;
 
-    const upsert = await this.upsertContact(properties);
-    const contactId = upsert.contactId;
+    // Whether this delivery will actually post to the mirror. Everything below
+    // branches on it so a form WITHOUT the activity behaves exactly as it always
+    // did: one upsert carrying every property, then the note.
+    const mirroring =
+      ctx.phase === 'complete' && Boolean(this.opts.formGuid) && Boolean(this.opts.portalId);
 
-    // Both tail effects are non-throwing by design. Neither is idempotent, so a
-    // thrown error here would be retried by the outbox into a duplicate
-    // activity — and neither is worth failing a delivery whose contact already
-    // synced. That is also why nothing retryable may be added after them.
+    let upsert: { contactId?: string; skippedProperties?: string[] };
     let formDetail = '';
-    if (ctx.phase === 'complete') {
+
+    if (mirroring) {
+      // Anchor the contact on its KEY ALONE, and let the submission carry the
+      // values.
+      //
+      // HubSpot's "Form submission" activity reports the properties THAT
+      // SUBMISSION changed. Upserting the mapped values first left the post
+      // nothing to change, so every activity read "Updated 0 properties" — the
+      // card appeared, named the form, and listed nothing, which is the one
+      // thing it exists to do. Typeform's integration does not hit the CRM API
+      // at all; the submission is the write, which is why its cards list fields.
+      //
+      // The upsert still runs, and still runs FIRST: it is the retryable half of
+      // the delivery, it guarantees the contact exists even if the portal
+      // refuses the post, and the note needs its id.
+      upsert = await this.upsertContact({ email });
       const outcome = await this.submitMirrorForm(ctx, properties);
-      if (outcome) formDetail = outcome === 'ok' ? ' +form' : ` (form ${outcome})`;
+      formDetail = outcome === 'ok' ? ' +form' : outcome ? ` (form ${outcome})` : '';
+
+      if (outcome === 'ok') {
+        // The mirror declares what it declares; anything else this destination
+        // computes — company/website inferred from the email domain — is not on
+        // that form and would otherwise never be written. Best effort, because
+        // the post is not idempotent and nothing retryable may follow it.
+        await this.upsertResidualProperties(properties, email);
+      } else {
+        // No activity was created, so no retry of this delivery can duplicate
+        // one: it is safe for this write to throw and be retried, and it must,
+        // or a portal that refuses the post silently costs the author every
+        // mapped property.
+        upsert = await this.upsertContact(properties);
+      }
+    } else {
+      upsert = await this.upsertContact(properties);
     }
 
+    const contactId = upsert.contactId;
+
+    // The note is the LAST side effect of the delivery, and non-throwing. It is
+    // not idempotent, so anything retryable after it would be retried into a
+    // duplicate note — the same rule the mirror post above is written around.
     let noteDetail = '';
     if (ctx.phase === 'complete' && this.opts.note !== false && contactId) {
       const noteOk = await this.createNote(contactId, ctx, properties);
@@ -242,6 +278,40 @@ export class HubspotDestination implements SubmissionDestination {
       driver: 'hubspot',
       detail: `contact=${contactId ?? '?'}${formDetail}${noteDetail}${skipped}`,
     };
+  }
+
+  /**
+   * Write the properties the MIRROR FORM does not declare, after a submission
+   * that succeeded. Never throws.
+   *
+   * `mirrorFormProperties` deliberately leaves out the values inferred from the
+   * email domain (`company`/`website`), because they are filled for some
+   * respondents and not others and a form field most submissions leave empty is
+   * worse than no field. That exclusion is what makes this call necessary: the
+   * post covered everything else, and without this those two would silently stop
+   * being written the moment an author turned the activity on.
+   *
+   * Silent on failure, and that is the trade: the post already happened and is
+   * not idempotent, so throwing here would have the outbox retry the delivery
+   * into a second activity. Losing an inferred company beats duplicating the
+   * card the whole feature exists to produce.
+   */
+  private async upsertResidualProperties(
+    properties: Record<string, string>,
+    email: string,
+  ): Promise<void> {
+    const declared = new Set(mirrorFormProperties(this.opts));
+    const residual: Record<string, string> = {};
+    for (const [name, value] of Object.entries(properties)) {
+      if (name !== 'email' && !declared.has(name)) residual[name] = value;
+    }
+    if (Object.keys(residual).length === 0) return;
+    residual.email = email;
+    try {
+      await this.upsertContact(residual);
+    } catch (err) {
+      this.logger.warn(`[destination:hubspot] residual property upsert failed: ${String(err)}`);
+    }
   }
 
   /**


### PR DESCRIPTION
Two bugs in the HubSpot form-submission activity, both found by driving the
feature end to end against the real portal after it landed in `develop`.

## 1. Every activity read "Updated 0 properties"

HubSpot reports, on that card, the properties **that submission changed**. The
delivery upserted every mapped value through the CRM API and only then posted the
same values to the mirror form, so the post had nothing left to change. The card
appeared, named the form, and listed nothing — strictly worse than the note it
was built to replace, and the one thing the feature exists to do.

Typeform's integration never touches the CRM API. The submission **is** the
write, which is why its cards list fields.

When a mirror is configured the upsert is now cut back to the contact's key and
the values ride in on the post. The upsert still runs, and still runs first: it
is the retryable half of the delivery, it guarantees the contact exists even if
the portal refuses the post, and the note needs its id.

Three things had to survive the reordering:

- **a refused post falls back to the full upsert**, so a portal missing
  `form-submissions-write` never silently costs an author every property they
  mapped. That write may throw — no activity was created, so a retry cannot
  duplicate one.
- **nothing retryable follows a successful post.** The properties the mirror does
  not declare (`company`/`website`, from `inferCompanyFromEmail`) are written
  after it, best effort. Losing an inferred company beats retrying a delivery
  into a second card on a real contact's timeline.
- **a form with no mirror, and every partial submission, behave exactly as
  before** — one upsert carrying everything.

## 2. Every autosave created a new form in the portal

The save read `formGuid` and `formSignature` out of the **request body**. They
are not settings an author edits; they are the API's own bookkeeping. A client
that did not echo them back sent settings with neither, so there was no form to
PATCH and no signature to compare — every save POSTed a **new** form and
abandoned the previous one, which by then held activities on real contacts.

The Connect tab is exactly that client: it autosaves per keystroke and never
learns the guid, because the save action returns `{ok, formActivityError}` and
drops the config the API just wrote. One editing session with the switch on was
one new form per debounce, all identically named, with the contact's timeline
split across them.

Reproduced by hand against the real portal — two consecutive saves of the same
form, two different guids.

Both keys now come from the stored row and the caller's are discarded:

- **before** the sync, so an invented guid cannot become a PATCH against another
  account's form;
- **after** it, so the `noop` path stops returning the caller's entry verbatim.
  That one is what made switching the activity **off** orphan the very form the
  switch is documented to preserve.

Fixing the editor would have fixed one caller. Sourcing them server-side fixes
every caller, including the ones not written yet.

## Verification

- **22 new tests**, 11 per bug. Ran against `develop`'s code first: 10 of the 11
  ownership tests and 4 of the 11 attribution tests fail there. The rest are
  invariants that must hold on both sides — the residual-write ordering, the
  no-mirror path, partials.
- The API spec drives the real controller → `AuthService` → db on in-memory
  SQLite, with a fetch that mints a new id on POST and echoes it on PATCH — the
  same distinction the portal makes, and the one the whole bug turned on.
- `pnpm test` 1397 passed · `typecheck` · `lint` · `build` · publish gate.

## Blast radius

No schema change, no migration, no new env var, no i18n change. No web change:
the editor keeps sending stale settings and the server keeps ignoring them.

Forms with the activity **off** are untouched on both paths — the adapter branches
on a resolved `formGuid` + `portalId`, and the sync returns early. Since the
switch ships off by default, nothing changes for anyone who has not turned it on.

Worth saying out loud: this does not clean up the duplicate forms already created
in a portal. Those have to be deleted by hand, and the ones carrying submissions
are worth keeping.
