### PR TITLE
fix: land the public submit/booking transport fixes on develop (#93 follow-through)

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -42,6 +42,7 @@ import { RevealScreen, revealShellProps } from '@/components/public/reveal-scree
 import { MadeWithBadge } from '@/components/made-with-badge';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
+import { callAction, callActionWithRetry, isTransportError } from '@/lib/call-action';
 import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
 import {
   useSessionId,
@@ -186,12 +187,16 @@ export function FormRenderer({
     // whichever config step happens to sit at that position (V5-D3).
     (type: string, stepIndex?: number, stepKey?: string) => {
       if (!sessionId) return;
-      void recordEventAction(accountCode, slug, {
-        sessionId,
-        type,
-        stepIndex: stepIndex ?? null,
-        stepKey: stepKey ?? null,
-      });
+      // Transport-safe fire-and-forget: a rejected invocation must never
+      // surface as an unhandled rejection mid-walk (funnel events are best-effort).
+      void callAction(() =>
+        recordEventAction(accountCode, slug, {
+          sessionId,
+          type,
+          stepIndex: stepIndex ?? null,
+          stepKey: stepKey ?? null,
+        }),
+      );
     },
     [accountCode, slug, sessionId],
   );
@@ -237,12 +242,23 @@ export function FormRenderer({
   const finalize = useCallback(
     async (finalAnswers: Answers) => {
       setPhase('submitting');
-      const res = await submitFormAction(accountCode, slug, {
-        sessionId,
-        data: withData(finalAnswers),
-      });
+      // Transport-safe with retries: a submit whose INVOCATION fails (network
+      // drop, deploy-rotated action id) used to reject unhandled, stranding the
+      // visitor on the "submitting" spinner with the submission silently lost.
+      // Retrying is safe — the server dedupes submissions by session.
+      // 8s per attempt: worst case ~27s on the spinner, not the old forever.
+      const res = await callActionWithRetry(
+        () =>
+          submitFormAction(accountCode, slug, {
+            sessionId,
+            data: withData(finalAnswers),
+          }),
+        { timeoutMs: 8_000 },
+      );
       if (!res.ok) {
-        setError(res.message ?? err('submit'));
+        // Back to the steps with every answer intact; transport messages are
+        // technical noise, so those show the localized submit error instead.
+        setError((isTransportError(res) ? null : res.message) ?? err('submit'));
         setPhase('steps');
         return;
       }
@@ -251,11 +267,13 @@ export function FormRenderer({
       // window.location navigation, silently losing the submit event for every
       // redirect outcome. Same persist-then-navigate pattern as handleBooked.
       if (sessionId) {
-        await recordEventAction(accountCode, slug, {
-          sessionId,
-          type: 'submit',
-          stepIndex: null,
-        }).catch(() => {});
+        await callAction(() =>
+          recordEventAction(accountCode, slug, {
+            sessionId,
+            type: 'submit',
+            stepIndex: null,
+          }),
+        );
       }
       const score = res.score ?? 0;
       const outcome = resolveOutcome(engineConfig, score, finalAnswers);
@@ -300,13 +318,21 @@ export function FormRenderer({
       if (bookedRef.current) return;
       bookedRef.current = true;
       const outcome = booking?.outcome ?? null;
-      await recordBookingAction(accountCode, slug, {
-        sessionId,
-        provider: details.provider,
-        ...(details.eventUri ? { eventUri: details.eventUri } : {}),
-        ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
-        ...(details.startTime ? { startTime: details.startTime } : {}),
-      });
+      // ONE transport-safe attempt, no retries: recording a booking is a plain
+      // INSERT server-side (no session dedupe like submissions have), and a
+      // timed-out attempt may still land — a retry would then write duplicate
+      // booking_events and duplicate CRM notes. A failure no longer strands the
+      // visitor: they continue to the done screen/redirect regardless.
+      const rec = await callAction(() =>
+        recordBookingAction(accountCode, slug, {
+          sessionId,
+          provider: details.provider,
+          ...(details.eventUri ? { eventUri: details.eventUri } : {}),
+          ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
+          ...(details.startTime ? { startTime: details.startTime } : {}),
+        }),
+      );
+      if (isTransportError(rec)) console.warn('[forms] post-submit booking record failed');
       if (outcome?.redirectUrl && isSafeHttpUrl(outcome.redirectUrl)) {
         window.location.href = outcome.redirectUrl;
         return;
@@ -339,11 +365,13 @@ export function FormRenderer({
         if (thresholdKey && completed.key === thresholdKey && !partialSent.current) {
           partialSent.current = true;
           track('partial_submit', index, completed.key);
-          void submitFormAction(accountCode, slug, {
-            sessionId,
-            data: withData(nextAnswers),
-            partial: true,
-          });
+          void callActionWithRetry(() =>
+            submitFormAction(accountCode, slug, {
+              sessionId,
+              data: withData(nextAnswers),
+              partial: true,
+            }),
+          );
         }
 
         // Terminal (disqualify) step → finalize now, skip the reveal screen.
@@ -390,13 +418,20 @@ export function FormRenderer({
     async (schedStep: FormStep, details: BookingScheduledDetails) => {
       if (schedulerBooked.current.has(schedStep.key)) return;
       schedulerBooked.current.add(schedStep.key);
-      await recordBookingAction(accountCode, slug, {
-        sessionId,
-        provider: details.provider,
-        ...(details.eventUri ? { eventUri: details.eventUri } : {}),
-        ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
-        ...(details.startTime ? { startTime: details.startTime } : {}),
-      }).catch(() => {});
+      // ONE transport-safe attempt (see handleBooked: the record INSERT is not
+      // idempotent, so a retry after a timeout could duplicate CRM notes).
+      // Awaited because `advance` below may finalize and REDIRECT — navigating
+      // mid-request would abort the record.
+      const rec = await callAction(() =>
+        recordBookingAction(accountCode, slug, {
+          sessionId,
+          provider: details.provider,
+          ...(details.eventUri ? { eventUri: details.eventUri } : {}),
+          ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
+          ...(details.startTime ? { startTime: details.startTime } : {}),
+        }),
+      );
+      if (isTransportError(rec)) console.warn('[forms] scheduler booking record failed');
       const next = { ...answersRef.current, [schedStep.key]: details.startTime ?? 'booked' };
       setAnswers(next);
       await advance(next, schedStep);

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -56,6 +56,7 @@ import { MadeWithBadge } from '@/components/made-with-badge';
 import { formDesignProps } from '@/lib/form-design';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
+import { callAction, callActionWithRetry, isTransportError } from '@/lib/call-action';
 import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
 import {
   useSessionId,
@@ -259,12 +260,16 @@ export function VerticalFormRenderer({
   const track = useCallback(
     (type: string, stepIndex?: number, stepKey?: string) => {
       if (!sessionId) return;
-      void recordEventAction(accountCode, slug, {
-        sessionId,
-        type,
-        stepIndex: stepIndex ?? null,
-        stepKey: stepKey ?? null,
-      });
+      // Transport-safe fire-and-forget: a rejected invocation must never
+      // surface as an unhandled rejection mid-walk (funnel events are best-effort).
+      void callAction(() =>
+        recordEventAction(accountCode, slug, {
+          sessionId,
+          type,
+          stepIndex: stepIndex ?? null,
+          stepKey: stepKey ?? null,
+        }),
+      );
     },
     [accountCode, slug, sessionId],
   );
@@ -296,12 +301,23 @@ export function VerticalFormRenderer({
   const finalize = useCallback(
     async (finalAnswers: Answers) => {
       setPhase('submitting');
-      const res = await submitFormAction(accountCode, slug, {
-        sessionId,
-        data: withData(finalAnswers),
-      });
+      // Transport-safe with retries: a submit whose INVOCATION fails (network
+      // drop, deploy-rotated action id) used to reject unhandled, stranding the
+      // visitor on the "submitting" spinner with the submission silently lost.
+      // Retrying is safe — the server dedupes submissions by session.
+      // 8s per attempt: worst case ~27s on the spinner, not the old forever.
+      const res = await callActionWithRetry(
+        () =>
+          submitFormAction(accountCode, slug, {
+            sessionId,
+            data: withData(finalAnswers),
+          }),
+        { timeoutMs: 8_000 },
+      );
       if (!res.ok) {
-        setSubmitError(res.message ?? err('submit'));
+        // Back to the page with every answer intact; transport messages are
+        // technical noise, so those show the localized submit error instead.
+        setSubmitError((isTransportError(res) ? null : res.message) ?? err('submit'));
         setPhase('form');
         return;
       }
@@ -309,11 +325,13 @@ export function VerticalFormRenderer({
       // redirect — a fire-and-forget request would be aborted by the immediate
       // window.location navigation (same pattern as the slides layout).
       if (sessionId) {
-        await recordEventAction(accountCode, slug, {
-          sessionId,
-          type: 'submit',
-          stepIndex: null,
-        }).catch(() => {});
+        await callAction(() =>
+          recordEventAction(accountCode, slug, {
+            sessionId,
+            type: 'submit',
+            stepIndex: null,
+          }),
+        );
       }
       const score = res.score ?? 0;
       const outcome = resolveOutcome(engineConfig, score, finalAnswers);
@@ -387,11 +405,13 @@ export function VerticalFormRenderer({
       if (thresholdKey && step.key === thresholdKey && !partialSent.current) {
         partialSent.current = true;
         track('partial_submit', idx >= 0 ? idx : undefined, step.key);
-        void submitFormAction(accountCode, slug, {
-          sessionId,
-          data: withData(nextAnswers),
-          partial: true,
-        });
+        void callActionWithRetry(() =>
+          submitFormAction(accountCode, slug, {
+            sessionId,
+            data: withData(nextAnswers),
+            partial: true,
+          }),
+        );
       }
     },
     [engineConfig, thresholdKey, accountCode, slug, sessionId, track],
@@ -447,13 +467,21 @@ export function VerticalFormRenderer({
     async (schedStep: FormStep, details: BookingScheduledDetails) => {
       if (schedulerBooked.current.has(schedStep.key)) return;
       schedulerBooked.current.add(schedStep.key);
-      await recordBookingAction(accountCode, slug, {
-        sessionId,
-        provider: details.provider,
-        ...(details.eventUri ? { eventUri: details.eventUri } : {}),
-        ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
-        ...(details.startTime ? { startTime: details.startTime } : {}),
-      }).catch(() => {});
+      // ONE transport-safe attempt, fire-and-forget (see handleBooked: the
+      // record INSERT is not idempotent). No navigation to protect here — the
+      // submission is the respondent's explicit Submit later — so the answer
+      // lands immediately instead of blocking the page on the round-trip.
+      void callAction(() =>
+        recordBookingAction(accountCode, slug, {
+          sessionId,
+          provider: details.provider,
+          ...(details.eventUri ? { eventUri: details.eventUri } : {}),
+          ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
+          ...(details.startTime ? { startTime: details.startTime } : {}),
+        }),
+      ).then((rec) => {
+        if (isTransportError(rec)) console.warn('[forms] scheduler booking record failed');
+      });
       setAnswer(schedStep, schedStep.key, details.startTime ?? 'booked', true);
     },
     [accountCode, slug, sessionId],
@@ -465,13 +493,21 @@ export function VerticalFormRenderer({
       if (bookedRef.current) return;
       bookedRef.current = true;
       const outcome = booking?.outcome ?? null;
-      await recordBookingAction(accountCode, slug, {
-        sessionId,
-        provider: details.provider,
-        ...(details.eventUri ? { eventUri: details.eventUri } : {}),
-        ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
-        ...(details.startTime ? { startTime: details.startTime } : {}),
-      });
+      // ONE transport-safe attempt, no retries: recording a booking is a plain
+      // INSERT server-side (no session dedupe like submissions have), and a
+      // timed-out attempt may still land — a retry would then write duplicate
+      // booking_events and duplicate CRM notes. A failure no longer strands the
+      // visitor: they continue to the done screen/redirect regardless.
+      const rec = await callAction(() =>
+        recordBookingAction(accountCode, slug, {
+          sessionId,
+          provider: details.provider,
+          ...(details.eventUri ? { eventUri: details.eventUri } : {}),
+          ...(details.inviteeUri ? { inviteeUri: details.inviteeUri } : {}),
+          ...(details.startTime ? { startTime: details.startTime } : {}),
+        }),
+      );
+      if (isTransportError(rec)) console.warn('[forms] post-submit booking record failed');
       if (outcome?.redirectUrl && isSafeHttpUrl(outcome.redirectUrl)) {
         window.location.href = outcome.redirectUrl;
         return;

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -11,9 +11,6 @@ import base from '@quill/config/eslint';
  */
 const requireCallAction = {
   files: ['app/**/*.tsx', 'components/**/*.tsx'],
-  // The public renderers migrate in their own PR — their submit/booking paths
-  // need visible error states designed alongside the wrapping, not a blind fix.
-  ignores: ['app/\\[accountCode\\]/**'],
   rules: {
     'no-restricted-syntax': [
       'error',

--- a/apps/web/lib/autosave-controller.spec.ts
+++ b/apps/web/lib/autosave-controller.spec.ts
@@ -251,6 +251,56 @@ describe('AutosaveController', () => {
   });
 });
 
+describe('callActionWithRetry', () => {
+  it('retries transport failures with doubling delay until one lands', async () => {
+    const { callActionWithRetry } = await import('./call-action');
+    let attempts = 0;
+    const p = callActionWithRetry(
+      async () => {
+        attempts++;
+        if (attempts < 3) throw new Error('network down');
+        return { ok: true as const };
+      },
+      { attempts: 3, baseDelayMs: 100 },
+    );
+    await settle(); // attempt 1 fails
+    expect(attempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(100); // delay 1 → attempt 2 fails
+    expect(attempts).toBe(2);
+    await vi.advanceTimersByTimeAsync(200); // delay doubled → attempt 3 lands
+    expect(await p).toEqual({ ok: true });
+  });
+
+  it('a server verdict — ok or not — returns immediately, no retry', async () => {
+    const { callActionWithRetry } = await import('./call-action');
+    let attempts = 0;
+    const res = await callActionWithRetry(async () => {
+      attempts++;
+      return { ok: false as const, message: 'validation failed' };
+    });
+    expect(attempts).toBe(1); // the server answered; retrying cannot change it
+    expect(res).toEqual({ ok: false, message: 'validation failed' });
+  });
+
+  it('returns the last TransportError once attempts are exhausted', async () => {
+    const { callActionWithRetry } = await import('./call-action');
+    let attempts = 0;
+    const p = callActionWithRetry(
+      async () => {
+        attempts++;
+        throw new Error('still down');
+      },
+      { attempts: 2, baseDelayMs: 50 },
+    );
+    await settle();
+    await vi.advanceTimersByTimeAsync(50);
+    const res = await p;
+    expect(attempts).toBe(2);
+    expect(isTransportError(res)).toBe(true);
+    if (isTransportError(res)) expect(res.message).toBe('still down');
+  });
+});
+
 describe('callAction', () => {
   it('passes a resolved value through untouched', async () => {
     const res = await callAction(async () => ({ ok: true as const }));

--- a/apps/web/lib/call-action.ts
+++ b/apps/web/lib/call-action.ts
@@ -60,3 +60,33 @@ export async function callAction<T>(
     if (timer) clearTimeout(timer);
   }
 }
+
+/**
+ * `callAction` plus a few in-place retries with doubling delay, for ONE-SHOT
+ * calls that have no autosave loop behind them to try again later — the public
+ * renderer's submit. ONLY wrap idempotent writes: a timed-out attempt may have
+ * landed (see the timeout note above), so the retry can double-apply.
+ * Submissions qualify (deduped by session server-side); booking records do NOT
+ * (plain INSERT — they use single-attempt `callAction`). A server verdict —
+ * ok or not — returns immediately; only transport failures retry.
+ */
+export async function callActionWithRetry<T>(
+  fn: () => Promise<T>,
+  opts?: { attempts?: number; baseDelayMs?: number; timeoutMs?: number },
+): Promise<T | TransportError> {
+  const attempts = Math.max(1, opts?.attempts ?? 3);
+  const baseDelayMs = opts?.baseDelayMs ?? 1_000;
+  let last: T | TransportError = {
+    ok: false,
+    transport: true,
+    message: 'not attempted',
+  };
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    last = await callAction(fn, { timeoutMs: opts?.timeoutMs });
+    if (!isTransportError(last)) return last;
+    if (attempt < attempts - 1) {
+      await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+    }
+  }
+  return last;
+}


### PR DESCRIPTION
#93 was merged into its stacked base branch (`fix/autosave-transport-resilience`) instead of being retargeted to `develop` first, so the public-renderer transport fixes never reached develop — #91's content is already there, this PR carries only the remaining delta (the public submit/booking commit plus its merge commit).

See #93 for the full description and review trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)