### PR TITLE
feat(connect): give every integration its own readable delivery log

### DIFF
--- a/.changeset/delivery-history-per-integration.md
+++ b/.changeset/delivery-history-per-integration.md
@@ -1,0 +1,51 @@
+---
+'@quill/db': minor
+'@quill/destinations': minor
+'@quill/notifications': minor
+'@quill/shared': minor
+'@quill/types': minor
+---
+
+Every integration carries its own delivery log, and a delivery can be read back.
+
+**The failure list was loud in the wrong place.** The Connect tab rendered one
+flat "Deliveries that did not land" block, sitting loose between the integrations
+and Tracking and mixing all four outbox kinds. It answered "something is broken"
+without answering "which of these three integrations", and on a form with a dead
+endpoint its retries pushed Tracking and Emails off the screen — the diagnosis
+was louder than everything it was diagnosing. Each card now owns its history, so
+the reason a webhook is failing is read beside the URL that is failing.
+
+The log does not live *inside* the card either. A card is a settings form, and
+twenty-five rows of history in the middle of one buries the endpoint URL the
+reader came for. The card carries a single line — a count, red when something
+failed — and the log opens in a dialog where a long list is free to be long.
+
+**It is a history, not a failure list.** The queue never deleted its `done` rows;
+nothing had ever asked for them, so a webhook that works and a webhook that has
+never fired looked identical. `listFormDeliveries` takes `kinds` and `statuses`
+(defaulting to the original failures-only answer, so existing callers are
+unaffected), and the `kinds` filter runs in SQL — which is what makes asking for
+landed rows viable at all, since they are most of the table. A new
+`(account_id, kind, updated_at)` index serves that read; the only index this
+table had served the worker's opposite question.
+
+**Deliveries can now be read back.** Three nullable columns record the request
+body actually sent and the status and body that came back. The enqueued `payload`
+is not those bytes, and only those bytes answer the question every webhook
+debugging session opens with. `NULL` means NOT RECORDED — an older row, or a kind
+whose adapter has no single request to report — never "an empty body was sent".
+Both bodies are truncated on write. An attempt that reports no transcript leaves
+the stored one alone, so the last retry of a host that stopped resolving cannot
+erase what the endpoint used to say.
+
+**Test deliveries are listed.** The admin's "Send test" is synchronous and never
+passed through the queue, so the log stayed empty during exactly the session it
+exists to help — wiring up an endpoint, when the test is often the only delivery
+that has run. It is a real signed POST, so it is recorded, badged as a test, and
+written already-terminal so the worker can never send it a second time.
+
+**Email rows can be attributed to a form.** `SubmissionNotification` never
+carried `formId` — it was used to resolve the template and then dropped — so no
+email delivery could be traced to the form that sent it. Additive; rows enqueued
+before this stay unattributable.

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -32,7 +32,7 @@ import {
   getFormById,
   getNotificationSettings,
   inviteMember,
-  listFailedDeliveries,
+  listFormDeliveries,
   listForms,
   listMembers,
   publishForm,
@@ -75,7 +75,7 @@ import { AuthService, type ReqLike } from './auth.service';
 import { EmailEffects } from './email-effects';
 import { AnalyticsEffects } from './analytics-effects';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
-import { parseBound, parseIntParam, parseStatus } from './query-params';
+import { parseBound, parseIntParam, parseKinds, parseOutboxStatuses, parseStatus } from './query-params';
 import { DB } from './tokens';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
@@ -496,21 +496,37 @@ export class AdminCrudController {
   }
 
   /**
-   * Deliveries for this form that ended without landing.
+   * This form's deliveries, newest first.
    *
    * A side-effect that died — an expired CRM token, a disconnected scheduling
    * provider, a form with no resolvable respondent email — used to exist only in
    * server logs, so a form could stop syncing leads while every visible signal
    * said it was working.
+   *
+   * `?kind=` and `?status=` narrow it (comma-separated). Both are optional and
+   * the defaults are the ORIGINAL behaviour — every kind, failures only — so a
+   * caller written before the per-integration history keeps getting exactly what
+   * it got. `?status=done,failed,…` is what turns this from a failure list into
+   * a history.
    */
   @Get('forms/:id/deliveries')
-  async formDeliveries(@Req() req: ReqLike, @Param('id') id: string, @Query('limit') limit?: string) {
+  async formDeliveries(
+    @Req() req: ReqLike,
+    @Param('id') id: string,
+    @Query('limit') limit?: string,
+    @Query('kind') kind?: string,
+    @Query('status') status?: string,
+  ) {
     const p = await this.auth.resolveHost(req);
     // Account scoping twice on purpose: the form lookup proves this caller owns
     // the form, and the query itself is filtered by account_id in SQL.
     const f = await getFormById(this.db, p.accountId, id);
     if (!f) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    const items = await listFailedDeliveries(this.db, p.accountId, id, parseIntParam(limit) ?? 50);
+    const items = await listFormDeliveries(this.db, p.accountId, id, {
+      kinds: parseKinds(kind),
+      statuses: parseOutboxStatuses(status),
+      limit: parseIntParam(limit) ?? 50,
+    });
     return { items };
   }
 

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -9,6 +9,7 @@ import {
 import {
   createDestination,
   HUBSPOT_API_BASE,
+  type DeliveryTranscript,
   type DestinationContext,
   type DestinationSpec,
   type DnsResolver,
@@ -148,7 +149,8 @@ export class DestinationEffects {
    * error propagates so the worker retries; a permanent no-op (delivered:false)
    * resolves so the row is marked done.
    */
-  async deliver(action: string, payloadJson: string): Promise<void> {
+  /** Returns what crossed the wire, for the queue to record. */
+  async deliver(action: string, payloadJson: string): Promise<DeliveryTranscript> {
     const { destination, ctx } = JSON.parse(payloadJson) as DestinationOutboxPayload;
     // ctx.accountId is the form's account — resolve that account's HubSpot token
     // (else the env fallback) at delivery time.
@@ -166,6 +168,11 @@ export class DestinationEffects {
           (result.detail ? `: ${result.detail}` : ''),
       );
     }
+    return {
+      requestBody: result.requestBody,
+      responseStatus: result.responseStatus,
+      responseBody: result.responseBody,
+    };
   }
 
   /** Resolve a stored destination config into a delivery spec (inject secrets). */

--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -95,6 +95,11 @@ export class EmailEffects {
       const payload: SubmissionNotification = {
         ...n,
         accountId,
+        // Stamped into the payload, not merely used to resolve the template
+        // above: `outbox` has no form column, so a row that does not NAME its
+        // form cannot be attributed to one, and every email this queue has ever
+        // carried was invisible to the per-form delivery history for that reason.
+        formId: formId ?? null,
         to,
         locale: n.locale ?? owner?.locale ?? null,
         subjectTemplate: setting.subject,
@@ -134,6 +139,9 @@ export class EmailEffects {
       const payload: SubmissionNotification = {
         ...n,
         accountId,
+        // See `enqueueSubmissionReceived` — the payload has to name the form or
+        // the admin cannot tell whose send this was.
+        formId: formId ?? null,
         to: [n.respondentEmail],
         locale: n.locale ?? null,
         subjectTemplate: setting.subject,

--- a/apps/api/src/form-deliveries.spec.ts
+++ b/apps/api/src/form-deliveries.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * `GET /v1/forms/:id/deliveries` — one form's delivery log, end to end on
+ * in-memory SQLite through the real controller → AuthService → db.
+ *
+ * What it locks:
+ *   1. the no-params answer is the ORIGINAL one (failures, every kind), because
+ *      the per-integration history added the params and must not have moved the
+ *      floor under anything already calling this;
+ *   2. `?kind=` narrows, and narrowing to a kind that does not exist answers with
+ *      nothing rather than failing open into every kind — the difference between
+ *      an empty webhook card and a webhook card full of somebody's emails;
+ *   3. `?status=` is what turns the failure list into a history;
+ *   4. the tenant boundary holds on every variant, including the ones that read
+ *      landed rows.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createDb,
+  migrate,
+  seed,
+  enqueueOutbox,
+  markOutboxDone,
+  markOutboxFailed,
+  getAccountByCode,
+  insertAccountWithShortCode,
+  createForm,
+  sql,
+  type Db,
+  type OutboxKind,
+} from '@quill/db';
+import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
+import { AdminCrudController } from './admin-crud.controller';
+import { AdminService } from './admin.service';
+import { AnalyticsService } from './analytics.service';
+import { EmailEffects } from './email-effects';
+import { SubmissionService } from './submission.service';
+import { AuthService } from './auth.service';
+import { LocalAuthProvider, type ReqLike } from './auth.provider';
+
+/** No identity → the local provider resolves the first seeded account + owner. */
+const asOwner = (): ReqLike => ({ headers: {} });
+
+let db: Db;
+let controller: AdminCrudController;
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db);
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: 'test',
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
+  });
+  const auth = new AuthService(db, provider);
+  controller = new AdminCrudController(
+    db,
+    auth,
+    new AdminService(db),
+    // Nothing here submits or notifies — the log-only notifier is enough to
+    // satisfy the constructor.
+    new SubmissionService(db, new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db)),
+    new AnalyticsService(db),
+  );
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+async function acmeId(): Promise<string> {
+  const account = await getAccountByCode(db, 'acme');
+  return account!.id;
+}
+
+async function seedForm(name: string, accountId: string): Promise<string> {
+  const created = await createForm(db, accountId, { name, config: { version: 1, steps: [] } });
+  if (!created.ok) throw new Error(`could not seed form ${name}`);
+  return created.value.id;
+}
+
+/** One outbox row for `formId`, in whichever end state the case needs. */
+async function seedDelivery(over: {
+  accountId: string;
+  formId: string;
+  kind?: OutboxKind;
+  action?: string;
+  landed?: boolean;
+  error?: string;
+  at?: number;
+}): Promise<string> {
+  const kind = over.kind ?? 'webhook';
+  const id = await enqueueOutbox(db, {
+    kind,
+    action: over.action ?? 'complete',
+    accountId: over.accountId,
+    payload: JSON.stringify({
+      destination: { type: kind },
+      ctx: { formId: over.formId, accountId: over.accountId },
+    }),
+    now: 1_000,
+  });
+  if (over.landed) await markOutboxDone(db, id, over.at ?? 5_000);
+  else await markOutboxFailed(db, id, { attempts: 5, error: over.error ?? 'HTTP 400', now: over.at ?? 5_000 });
+  return id;
+}
+
+/** A second tenant, for the isolation assertions. */
+async function otherAccount(): Promise<string> {
+  await insertAccountWithShortCode(db, { name: 'Other', externalId: 'ext:other' });
+  const row = await db.get<{ id: string }>(
+    sql`SELECT id FROM account WHERE external_id = ${'ext:other'} LIMIT 1`,
+  );
+  return String(row!.id);
+}
+
+describe('GET /v1/forms/:id/deliveries', () => {
+  it('answers with failures across every kind when nothing narrows it', async () => {
+    const acc = await acmeId();
+    const form = await seedForm('Lead form', acc);
+    const hook = await seedDelivery({ accountId: acc, formId: form, kind: 'webhook' });
+    const mail = await seedDelivery({
+      accountId: acc,
+      formId: form,
+      kind: 'email',
+      action: 'submission_received',
+    });
+    await seedDelivery({ accountId: acc, formId: form, kind: 'webhook', landed: true });
+
+    const res = await controller.formDeliveries(asOwner(), form);
+    expect(res.items.map((i) => i.id).sort()).toEqual([hook, mail].sort());
+  });
+
+  it('narrows to the asked-for kind', async () => {
+    const acc = await acmeId();
+    const form = await seedForm('Lead form', acc);
+    const hook = await seedDelivery({ accountId: acc, formId: form, kind: 'webhook' });
+    await seedDelivery({ accountId: acc, formId: form, kind: 'hubspot' });
+
+    const res = await controller.formDeliveries(asOwner(), form, undefined, 'webhook');
+    expect(res.items.map((i) => i.id)).toEqual([hook]);
+  });
+
+  it('accepts several kinds in one param', async () => {
+    const acc = await acmeId();
+    const form = await seedForm('Lead form', acc);
+    const crm = await seedDelivery({ accountId: acc, formId: form, kind: 'hubspot', at: 5_000 });
+    const booking = await seedDelivery({
+      accountId: acc,
+      formId: form,
+      kind: 'booking_sync',
+      action: 'crm_update',
+      at: 6_000,
+    });
+    await seedDelivery({ accountId: acc, formId: form, kind: 'webhook' });
+
+    const res = await controller.formDeliveries(asOwner(), form, undefined, 'hubspot,booking_sync');
+    expect(res.items.map((i) => i.id)).toEqual([booking, crm]);
+  });
+
+  it('returns what landed once the caller asks for it', async () => {
+    const acc = await acmeId();
+    const form = await seedForm('Lead form', acc);
+    const landed = await seedDelivery({ accountId: acc, formId: form, landed: true, at: 5_000 });
+    const failed = await seedDelivery({ accountId: acc, formId: form, at: 6_000 });
+
+    const res = await controller.formDeliveries(asOwner(), form, undefined, 'webhook', 'done,failed');
+    expect(res.items.map((i) => i.id)).toEqual([failed, landed]);
+    expect(res.items.map((i) => i.status)).toEqual(['failed', 'done']);
+  });
+
+  it('drops tokens it does not recognise instead of rejecting the request', async () => {
+    const acc = await acmeId();
+    const form = await seedForm('Lead form', acc);
+    const hook = await seedDelivery({ accountId: acc, formId: form, kind: 'webhook' });
+
+    // A newer client naming a kind this build has never heard of still gets the
+    // part of its question this build CAN answer.
+    const res = await controller.formDeliveries(asOwner(), form, undefined, 'webhook,carrier_pigeon');
+    expect(res.items.map((i) => i.id)).toEqual([hook]);
+  });
+
+  it('answers with nothing when every asked-for token is unknown', async () => {
+    const acc = await acmeId();
+    const form = await seedForm('Lead form', acc);
+    await seedDelivery({ accountId: acc, formId: form, kind: 'webhook' });
+
+    // Never "no valid kinds, so all kinds" — that would fill an integration's
+    // history with another integration's deliveries.
+    const res = await controller.formDeliveries(asOwner(), form, undefined, 'carrier_pigeon');
+    expect(res.items).toEqual([]);
+  });
+
+  it("refuses a form the caller's account does not own", async () => {
+    const other = await otherAccount();
+    const theirs = await seedForm('Not yours', other);
+    await seedDelivery({ accountId: other, formId: theirs });
+
+    await expect(controller.formDeliveries(asOwner(), theirs)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('never reads another account\'s rows, landed ones included', async () => {
+    const acc = await acmeId();
+    const other = await otherAccount();
+    const form = await seedForm('Lead form', acc);
+    // Same form id in the payload, different account column — the case the SQL
+    // tenant filter exists for.
+    await seedDelivery({ accountId: other, formId: form, landed: true });
+
+    const res = await controller.formDeliveries(asOwner(), form, undefined, 'webhook', 'done,failed');
+    expect(res.items).toEqual([]);
+  });
+});

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpCode,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   Optional,
   Param,
@@ -25,6 +26,8 @@ import {
   listIntegrationStatuses,
   resolveProviderToken,
   getFormById,
+  recordSettledDelivery,
+  WEBHOOK_PING_ACTION,
   summarizeFailedDeliveriesByForm,
   updateFormDestinations,
   upsertIntegration,
@@ -38,7 +41,7 @@ import {
   type DestinationEvent,
   type FormDestination,
 } from '@quill/types';
-import { WebhookDestination, WebhookHttpError } from '@quill/destinations';
+import { transcriptOfError, WebhookDestination, WebhookHttpError } from '@quill/destinations';
 import { syncMirrorForm } from './hubspot-mirror';
 import type { ServerEnv } from '@quill/config/env';
 import { AuthService, type ReqLike } from './auth.service';
@@ -608,6 +611,7 @@ const destinationsBodySchema = z.object({ destinations: z.array(formDestinationS
  */
 @Controller('v1')
 export class FormDestinationsController {
+  private readonly log = new Logger('FormDestinations');
   /** Injectable for tests; defaults to global fetch for the webhook ping. */
   fetchImpl: typeof fetch = fetch;
 
@@ -788,23 +792,71 @@ export class FormDestinationsController {
     );
 
     const now = Date.now();
+    const ctx = {
+      idempotencyKey: `ping:${id}:${now}`,
+      submissionId: 'test-submission',
+      formId: form.id,
+      formName: form.name,
+      accountId: p.accountId,
+      sessionId: 'test-session',
+      score: 0,
+      outcomeLabel: null,
+      phase: 'partial' as const,
+      submittedAt: now,
+      data: { ...sampleAnswers(config.steps ?? []), test: true },
+      utm: {},
+    };
+
+    /**
+     * Log the test delivery beside the real ones.
+     *
+     * A ping is synchronous — the author clicks and waits for the verdict — so
+     * it never passes through the outbox. That is a fact about HOW it is
+     * dispatched, and it was letting the delivery history stay empty during
+     * exactly the session it exists to help: wiring up an endpoint, when the
+     * test delivery is often the only one that has ever run. It IS a real signed
+     * POST to the real URL, so it belongs in the log, labelled by its `ping`
+     * action. Recorded terminal so the worker can never pick it up and send it a
+     * second time.
+     *
+     * Best-effort throughout: the author's answer is the ping result, and
+     * failing to write the log entry must not turn a successful test delivery
+     * into an error on screen.
+     */
+    const record = async (status: 'done' | 'failed', error: string | null, transcript: object) => {
+      try {
+        await recordSettledDelivery(this.db, {
+          kind: 'webhook',
+          action: WEBHOOK_PING_ACTION,
+          accountId: p.accountId,
+          subjectUid: ctx.submissionId,
+          // Same shape every destination row carries, so the per-form read finds
+          // it by `ctx.formId` like any other.
+          payload: JSON.stringify({ destination: { type: 'webhook' }, ctx }),
+          status,
+          error,
+          transcript,
+          now,
+        });
+      } catch (e) {
+        this.log.warn(`could not record the webhook test delivery: ${String(e)}`);
+      }
+    };
+
     try {
-      await dest.deliver({
-        idempotencyKey: `ping:${id}:${now}`,
-        submissionId: 'test-submission',
-        formId: form.id,
-        formName: form.name,
-        accountId: p.accountId,
-        sessionId: 'test-session',
-        score: 0,
-        outcomeLabel: null,
-        phase: 'partial',
-        submittedAt: now,
-        data: { ...sampleAnswers(config.steps ?? []), test: true },
-        utm: {},
+      const result = await dest.deliver(ctx);
+      await record('done', null, {
+        requestBody: result.requestBody,
+        responseStatus: result.responseStatus,
+        responseBody: result.responseBody,
       });
       return { ok: true };
     } catch (err) {
+      await record(
+        'failed',
+        err instanceof Error ? err.message : String(err),
+        transcriptOfError(err),
+      );
       // "HTTP 400" alone sends the author looking in the wrong place. Classify
       // it into something the UI can explain, and pass along the endpoint's own
       // response — which names the real reason far more often than the status

--- a/apps/api/src/outbox.worker.ts
+++ b/apps/api/src/outbox.worker.ts
@@ -17,6 +17,7 @@ import {
   type Db,
   type OutboxRow,
 } from '@quill/db';
+import { transcriptOfError, type DeliveryTranscript } from '@quill/destinations';
 import type { ServerEnv } from '@quill/config/env';
 import { EmailEffects, OutboxSkipError } from './email-effects';
 import { DestinationEffects } from './destination-effects';
@@ -107,8 +108,8 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
 
   private async process(row: OutboxRow, now: number): Promise<void> {
     try {
-      await this.execute(row);
-      await markOutboxDone(this.db, row.id, now);
+      const transcript = await this.execute(row);
+      await markOutboxDone(this.db, row.id, now, transcript);
     } catch (err) {
       if (err instanceof OutboxSkipError) {
         // A decision, not a failure: record the reason ONCE and stop — waiting
@@ -119,13 +120,16 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       }
       const attempts = row.attempts + 1;
       const message = err instanceof Error ? err.message : String(err);
+      // A failure is the transcript anyone actually needs to read back, and it
+      // arrives on the thrown error rather than a returned value.
+      const transcript = transcriptOfError(err);
       if (attempts >= row.maxAttempts) {
-        await markOutboxFailed(this.db, row.id, { attempts, error: message, now });
+        await markOutboxFailed(this.db, row.id, { attempts, error: message, now, transcript });
         this.log.error(
           `outbox ${row.kind}:${row.action} (${row.id}) gave up after ${attempts} attempts: ${message}`,
         );
       } else {
-        await markOutboxRetry(this.db, row.id, { attempts, error: message, now });
+        await markOutboxRetry(this.db, row.id, { attempts, error: message, now, transcript });
         this.log.warn(
           `outbox ${row.kind}:${row.action} (${row.id}) failed (attempt ${attempts}/${row.maxAttempts}), will retry: ${message}`,
         );
@@ -133,23 +137,25 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  /** Perform the row's side-effect. Throws on failure so `process` can retry. */
-  private async execute(row: OutboxRow): Promise<void> {
+  /**
+   * Perform the row's side-effect, reporting what crossed the wire when the
+   * handler can say. Throws on failure so `process` can retry.
+   */
+  private async execute(row: OutboxRow): Promise<DeliveryTranscript | undefined> {
     if (row.kind === 'email') {
       if (row.payload == null) throw new Error('email outbox row missing payload');
       await this.email.deliver(row.action, row.payload, row.accountId);
-      return;
+      return undefined;
     }
     if (row.kind === 'webhook' || row.kind === 'hubspot') {
       if (row.payload == null) throw new Error(`${row.kind} outbox row missing payload`);
-      await this.destinations.deliver(row.action, row.payload);
-      return;
+      return await this.destinations.deliver(row.action, row.payload);
     }
     if (row.kind === 'booking_sync') {
       if (row.payload == null) throw new Error('booking_sync outbox row missing payload');
       if (!this.bookingSync) throw new Error('booking_sync handler not wired');
       await this.bookingSync.deliver(row.action, row.payload);
-      return;
+      return undefined;
     }
     if (row.kind === 'analytics') {
       if (row.payload == null) throw new Error('analytics outbox row missing payload');
@@ -158,7 +164,7 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       // failures in a queue shared with emails and CRM deliveries.
       if (!this.analytics) throw new OutboxSkipError('analytics handler not wired');
       await this.analytics.deliver(row.action, row.payload);
-      return;
+      return undefined;
     }
     if (row.kind === 'dapta_sync') {
       if (row.payload == null) throw new Error('dapta_sync outbox row missing payload');
@@ -166,7 +172,7 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       // does not sync into the Dapta estate, never a delivery failure.
       if (!this.daptaSync) throw new OutboxSkipError('dapta_sync handler not wired');
       await this.daptaSync.deliver(row.action, row.payload);
-      return;
+      return undefined;
     }
     throw new Error(`unknown outbox kind: ${String(row.kind)}`);
   }

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -4,7 +4,7 @@
  * string; a status narrows the submissions filter. Kept dialect- and
  * framework-agnostic so both controllers parse identically.
  */
-import type { SubmissionStatus } from '@quill/db';
+import { OUTBOX_KINDS, OUTBOX_STATUSES, type OutboxKind, type OutboxStatus, type SubmissionStatus } from '@quill/db';
 
 /** Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. */
 export function parseBound(v: string | undefined, endOfDay: boolean): number | null {
@@ -35,4 +35,31 @@ export function parseIntParam(v: string | undefined): number | undefined {
   if (!v) return undefined;
   const n = Number(v);
   return Number.isFinite(n) ? Math.trunc(n) : undefined;
+}
+
+/**
+ * Narrow a comma-separated query param to a fixed vocabulary.
+ *
+ * Unknown tokens are DROPPED rather than rejected: these params name outbox
+ * kinds and statuses, which a future release may add to, and an older API
+ * answering "webhook,carrier_pigeon" with a 400 would break a newer client over
+ * a value it did not need. An absent param yields `undefined` (the caller's
+ * default); a param that names ONLY unknown tokens yields an empty list, and the
+ * caller is expected to answer with nothing rather than silently widen back to
+ * everything — asking for a kind that does not exist must not return every kind.
+ */
+function parseEnumList<T extends string>(v: string | undefined, allowed: readonly T[]): T[] | undefined {
+  if (v === undefined) return undefined;
+  const wanted = new Set(v.split(',').map((s) => s.trim()));
+  return allowed.filter((a) => wanted.has(a));
+}
+
+/** Narrow `?kind=webhook,hubspot` to real outbox kinds. */
+export function parseKinds(v: string | undefined): OutboxKind[] | undefined {
+  return parseEnumList(v, OUTBOX_KINDS);
+}
+
+/** Narrow `?status=done,failed` to real outbox statuses. */
+export function parseOutboxStatuses(v: string | undefined): OutboxStatus[] | undefined {
+  return parseEnumList(v, OUTBOX_STATUSES);
 }

--- a/apps/api/src/webhook-ping.spec.ts
+++ b/apps/api/src/webhook-ping.spec.ts
@@ -20,7 +20,16 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { createDb, migrate, seed, getAccountByCode, updateFormDestinations, type Db } from '@quill/db';
+import {
+  createDb,
+  migrate,
+  seed,
+  getAccountByCode,
+  listFormDeliveries,
+  updateFormDestinations,
+  WEBHOOK_PING_ACTION,
+  type Db,
+} from '@quill/db';
 import { FormDestinationsController } from './integrations.controller';
 import { AuthService } from './auth.service';
 import { LocalAuthProvider, type ReqLike } from './auth.provider';
@@ -210,6 +219,77 @@ describe('webhook ping', () => {
       await setWebhook('http://localhost:4999/hook');
       const res = await controller.pingWebhook(asOwner(), formId);
       expect(res).toEqual({ ok: true });
+    });
+  });
+
+  /**
+   * The test delivery is logged like a real one.
+   *
+   * It never passes through the outbox — the author clicks and waits — but it is
+   * a real signed POST to the real endpoint, and when someone is wiring a
+   * webhook up it is very often the ONLY delivery that has run. Leaving it out
+   * kept the history empty during exactly the session it exists to help.
+   */
+  describe('what the history records', () => {
+    const history = () =>
+      listFormDeliveries(db, accountId, formId, {
+        kinds: ['webhook'],
+        statuses: ['done', 'pending', 'failed', 'skipped'],
+      });
+
+    it('records a successful test, with what was sent and what came back', async () => {
+      await setWebhook('http://localhost:4999/hook');
+      await controller.pingWebhook(asOwner(), formId);
+
+      const [row] = await history();
+      expect(row?.status).toBe('done');
+      expect(row?.action).toBe(WEBHOOK_PING_ACTION);
+      expect(row?.responseStatus).toBe(200);
+      expect(row?.responseBody).toBe('{"ok":true}');
+      // The transcript is the delivery's own body, not the enqueued snapshot.
+      expect(JSON.parse(String(row?.requestBody)).data.test).toBe(true);
+    });
+
+    it('records a rejected test with the endpoint’s own answer', async () => {
+      await setWebhook('http://localhost:4999/hook');
+      controller.fetchImpl = (async () =>
+        new Response('{"error":"missing field"}', { status: 400 })) as unknown as typeof fetch;
+      await controller.pingWebhook(asOwner(), formId);
+
+      const [row] = await history();
+      expect(row?.status).toBe('failed');
+      expect(row?.responseStatus).toBe(400);
+      expect(row?.responseBody).toBe('{"error":"missing field"}');
+      expect(row?.lastError).toBe('webhook delivery failed: HTTP 400');
+    });
+
+    it('records the body even when nothing ever answered', async () => {
+      // "We sent THIS and the host never replied" is still the useful half.
+      await setWebhook('http://localhost:4999/hook');
+      controller.fetchImpl = (async () => {
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch;
+      await controller.pingWebhook(asOwner(), formId);
+
+      const [row] = await history();
+      expect(row?.status).toBe('failed');
+      expect(row?.requestBody).toContain('"test":true');
+      expect(row?.responseStatus).toBeNull();
+    });
+
+    it('records a refusal by the SSRF guard, with no transcript to show', async () => {
+      // Nothing crossed the wire, so there is no request or response to keep —
+      // but the author DID click Send test, and an empty history after a click
+      // is the exact complaint this panel exists to answer. The reason the guard
+      // gave is the whole record.
+      await setWebhook('https://10.0.0.5/hook');
+      await controller.pingWebhook(asOwner(), formId);
+
+      const [row] = await history();
+      expect(row?.status).toBe('failed');
+      expect(row?.lastError).toMatch(/private|reserved|blocked/i);
+      expect(row?.requestBody).toBeNull();
+      expect(row?.responseStatus).toBeNull();
     });
   });
 });

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { adminApi, ApiError, type FailedDelivery, type HubSpotPropertiesResponse } from '@/lib/admin-api';
+import { adminApi, ApiError, type HubSpotPropertiesResponse } from '@/lib/admin-api';
 import { getMessages } from '@quill/shared';
 import type { FormDestination } from '@quill/types';
 
@@ -77,17 +77,3 @@ export async function loadConnectIntegrationsAction(
   };
 }
 
-/**
- * Deliveries for this form that ended without landing.
- *
- * Degrades to an empty list rather than surfacing an error: this is a diagnostic
- * panel, and a lookup failure must never make the Connect tab look broken.
- */
-export async function loadFailedDeliveriesAction(id: string): Promise<FailedDelivery[]> {
-  try {
-    const res = await adminApi.formDeliveries(id);
-    return res.items;
-  } catch {
-    return [];
-  }
-}

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
@@ -9,14 +9,18 @@ import {
   NotificationEmailFields,
   type NotificationEmailValue,
 } from '@/components/notification-email-fields';
-import type { FormNotificationView, NotificationEmailKey } from '@/lib/admin-api';
+import type { DeliveryKind, FormNotificationView, NotificationEmailKey } from '@/lib/admin-api';
 import { interpolate, NOTIFICATION_SAMPLE as SAMPLE } from '@/lib/notification-preview';
+import { DeliveryHistory } from '../../integrations/delivery-history';
 import {
   loadFormNotificationsAction,
   resetFormNotificationAction,
   saveFormNotificationAction,
 } from './connect-emails-actions';
 import type { EditorMessages } from './messages';
+
+/** Stable identity so the history's fetch effect does not re-fire each render. */
+const EMAIL_HISTORY_KINDS: DeliveryKind[] = ['email'];
 
 /**
  * Emails on the Connect tab — PER-FORM template overrides (Typeform's per-form
@@ -47,6 +51,9 @@ export function ConnectEmailsSection({
   // The shared catalog is a plain typed object (same pattern as ConnectPanel's
   // integrations subtree) — safe to resolve in the browser.
   const nm = useMemo(() => getMessages(loc).admin.notifications, [loc]);
+  // The delivery-history copy lives with the integrations it was written for;
+  // this section reuses the same panel and therefore the same strings.
+  const im = useMemo(() => getMessages(loc).admin.integrations, [loc]);
 
   type LoadState =
     | { status: 'loading' }
@@ -103,6 +110,19 @@ export function ConnectEmailsSection({
           <FormEmailCard key={s.emailKey} formId={formId} setting={s} locale={loc} mc={m} nm={nm} />
         ))
       )}
+
+      {/* Only rows enqueued since this section shipped can be attributed to a
+          form — the email payload did not carry `formId` before. Older sends are
+          not missing, they are unattributable, and the panel cannot tell the
+          difference, so it says nothing about them. */}
+      <DeliveryHistory
+        formId={formId}
+        kinds={EMAIL_HISTORY_KINDS}
+        title={im.historyEmailTitle}
+        locale={loc}
+        m={im}
+        testId="email-history"
+      />
 
       <p className="text-xs text-muted-foreground">
         <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} /> {m.emailsGlobalNote}

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-panel.tsx
@@ -7,12 +7,7 @@ import { getMessages, type Locale } from '@quill/shared';
 import { Button } from '@/components/ui/button';
 import { awaitPendingDestinationWrite } from '@/lib/connect-sync';
 import { IntegrationsEditor, type QuestionMeta } from '../../integrations/integrations-editor';
-import {
-  loadConnectIntegrationsAction,
-  loadFailedDeliveriesAction,
-  type ConnectIntegrationsData,
-} from './connect-actions';
-import type { FailedDelivery } from '@/lib/admin-api';
+import { loadConnectIntegrationsAction, type ConnectIntegrationsData } from './connect-actions';
 import { ConnectEmailsSection } from './connect-emails-section';
 import { Field, PanelSection, TextField } from './fields';
 import type { EditorMessages } from './messages';
@@ -79,82 +74,18 @@ export function ConnectPanel({
         im={im}
         locale={loc}
       />
-      <FailedDeliveriesSection formId={formId} mc={mc} />
       <TrackingSection config={config} onTrackingChange={onTrackingChange} mc={mc} />
       <ConnectEmailsSection formId={formId} m={mc} locale={locale} />
     </div>
   );
 }
 
-// --- Failed deliveries -------------------------------------------------------
-
-/**
- * Deliveries for this form that ended without landing.
- *
- * Nothing in the admin ever surfaced the outbox, so a delivery that died — an
- * expired CRM token, a disconnected scheduling provider, a form with no
- * resolvable respondent email — existed only in server logs. From the outside
- * everything looked fine: the respondent submitted, the booking succeeded, the
- * confirmation arrived. The lead simply never reached the CRM.
- *
- * Renders nothing when there is nothing wrong: an empty panel here would be
- * noise on the overwhelming majority of forms.
- */
-function FailedDeliveriesSection({
-  formId,
-  mc,
-}: {
-  formId: string;
-  mc: EditorMessages['connect'];
-}) {
-  const [items, setItems] = useState<FailedDelivery[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    loadFailedDeliveriesAction(formId)
-      .then((rows) => {
-        if (!cancelled) setItems(rows);
-      })
-      .catch(() => {
-        // Diagnostics must never break the tab they diagnose.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [formId]);
-
-  if (items.length === 0) return null;
-
-  return (
-    <section data-testid="connect-failed-deliveries" className="flex flex-col gap-2">
-      <div className="min-w-0">
-        <h3 className="text-sm font-semibold text-foreground">{mc.deliveriesTitle}</h3>
-        <p className="mt-0.5 text-xs text-muted-foreground">{mc.deliveriesSubtitle}</p>
-      </div>
-      <ul className="flex flex-col gap-1.5">
-        {items.map((d) => (
-          <li
-            key={d.id}
-            data-testid="failed-delivery"
-            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-xs font-medium text-foreground">{d.kind}</span>
-              <span className="text-xs text-muted-foreground">
-                {new Date(d.updatedAt).toLocaleString()}
-              </span>
-            </div>
-            {/* The worker's own reason, verbatim. Paraphrasing it here would
-                lose the one detail that says what to fix. */}
-            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-              {d.lastError ?? mc.deliveriesNoReason}
-            </p>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+// A flat "Deliveries that did not land" list used to sit here, between the
+// integrations and Tracking. It mixed every outbox kind and, on a form with a
+// broken endpoint, its retries pushed the rest of the tab off the screen — the
+// diagnosis was louder than everything it was diagnosing. Each integration card
+// now carries its own collapsible history instead (`DeliveryHistory`), so a
+// webhook's failures are read next to the URL that produced them.
 
 // --- Integrations (embeds the existing IntegrationsEditor) -------------------
 

--- a/apps/web/app/admin/forms/[id]/integrations/actions.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/actions.ts
@@ -1,7 +1,12 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { adminApi, type WebhookPingResult } from '@/lib/admin-api';
+import {
+  adminApi,
+  type DeliveryKind,
+  type FormDelivery,
+  type WebhookPingResult,
+} from '@/lib/admin-api';
 import type { FormDestination } from '@quill/types';
 
 /**
@@ -49,5 +54,35 @@ export async function pingWebhookAction(id: string): Promise<WebhookPingResult> 
       reason: 'unknown',
       message: e instanceof Error ? e.message : 'Could not reach the webhook.',
     };
+  }
+}
+
+/** How many rows one integration's history shows. */
+const HISTORY_LIMIT = 25;
+
+/**
+ * One integration's delivery history for this form — what landed and what did
+ * not — newest first.
+ *
+ * `pending` is asked for alongside the rest: a row still working through its
+ * backoff is the most useful thing to see right after wiring an endpoint up, and
+ * leaving it out would show a submission that produced no delivery at all.
+ *
+ * Throws nothing. A lookup failure yields an empty list, because this is a
+ * diagnostic panel and it must never make the thing it diagnoses look broken.
+ */
+export async function loadDeliveryHistoryAction(
+  id: string,
+  kinds: DeliveryKind[],
+): Promise<FormDelivery[]> {
+  try {
+    const res = await adminApi.formDeliveries(id, {
+      kinds,
+      statuses: ['done', 'pending', 'failed', 'skipped'],
+      limit: HISTORY_LIMIT,
+    });
+    return res.items;
+  } catch {
+    return [];
   }
 }

--- a/apps/web/app/admin/forms/[id]/integrations/delivery-history.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/delivery-history.spec.tsx
@@ -1,0 +1,216 @@
+/**
+ * The per-integration delivery history.
+ *
+ * This panel replaced a flat failure list that sat loose in the Connect tab and
+ * mixed every outbox kind. The promises that made the move worth making are the
+ * ones pinned here:
+ *
+ *   1. the CARD stays a settings form. Closed, the history is one line — a count
+ *      and a button — so twenty-five rows of log can never bury the endpoint URL
+ *      the reader came for. The rows exist only in the dialog;
+ *   2. a red chip is the card's only standing signal, and it appears only when
+ *      something actually failed. There is no badge for a healthy log;
+ *   3. a failure carries the worker's reason verbatim, because that sentence is
+ *      the only thing in the UI that says what to fix;
+ *   4. a landed delivery is NOT dressed as a failure — the whole point of asking
+ *      for `done` rows was to tell a working webhook from one that never fired;
+ *   5. the ping note is always present, so "I sent a test and nothing showed up"
+ *      reads as the truth rather than as a bug in this panel.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { getMessages } from '@quill/shared';
+import type { FormDelivery } from '@/lib/admin-api';
+import { DeliveryHistoryView, isFailure, type HistoryState } from './delivery-history';
+
+const m = getMessages('en').admin.integrations;
+
+const delivery = (over: Partial<FormDelivery> = {}): FormDelivery => ({
+  id: 'row-1',
+  kind: 'webhook',
+  status: 'done',
+  action: 'complete',
+  lastError: null,
+  attempts: 1,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  requestBody: null,
+  responseStatus: null,
+  responseBody: null,
+  ...over,
+});
+
+const render = (state: HistoryState, open = true): string =>
+  renderToStaticMarkup(
+    <DeliveryHistoryView
+      state={state}
+      open={open}
+      onOpen={() => {}}
+      onClose={() => {}}
+      onRefresh={() => {}}
+      title={m.historyWebhookTitle}
+      locale="en"
+      m={m}
+      testId="webhook-history"
+    />,
+  );
+
+const ready = (items: FormDelivery[]): HistoryState => ({ status: 'ready', items });
+
+describe('isFailure', () => {
+  it('counts what did not land, and only that', () => {
+    expect(isFailure(delivery({ status: 'failed' }))).toBe(true);
+    expect(isFailure(delivery({ status: 'skipped' }))).toBe(true);
+    expect(isFailure(delivery({ status: 'done' }))).toBe(false);
+    // `pending` is progress, not a problem — a webhook mid-backoff must not
+    // paint the card red.
+    expect(isFailure(delivery({ status: 'pending' }))).toBe(false);
+  });
+});
+
+describe('DeliveryHistoryView — the card line', () => {
+  it('keeps the log out of the card entirely when closed', () => {
+    const html = render(ready([delivery(), delivery({ id: 'b' })]), false);
+    expect(html).toContain(m.historyWebhookTitle);
+    expect(html).toContain(m.historyOpen);
+    // The single promise this whole redesign rests on.
+    expect(html).not.toContain('data-testid="delivery-row"');
+    expect(html).not.toContain('webhook-history-dialog');
+  });
+
+  it('counts failures in the card, not total deliveries', () => {
+    const html = render(
+      ready([
+        delivery({ id: 'a', status: 'failed', lastError: 'HTTP 400' }),
+        delivery({ id: 'b', status: 'done' }),
+      ]),
+      false,
+    );
+    expect(html).toContain('webhook-history-failed-chip');
+    expect(html).toContain('1 failed');
+    // The neutral count is for a clean history; a failing one must not also
+    // advertise a reassuring total next to the red chip.
+    expect(html).not.toContain('webhook-history-count-chip');
+  });
+
+  it('counts deliveries neutrally when none of them failed', () => {
+    const html = render(ready([delivery({ id: 'a' }), delivery({ id: 'b' })]), false);
+    expect(html).toContain('webhook-history-count-chip');
+    expect(html).toContain('2 deliveries');
+    expect(html).not.toContain('webhook-history-failed-chip');
+  });
+
+  it('claims nothing at all when there is no history', () => {
+    const html = render(ready([]), false);
+    expect(html).not.toContain('webhook-history-count-chip');
+    expect(html).not.toContain('webhook-history-failed-chip');
+  });
+
+  it('will not open a dialog over a list it has not read yet', () => {
+    expect(render({ status: 'loading' }, false)).toContain('disabled=""');
+  });
+});
+
+describe('DeliveryHistoryView — the dialog', () => {
+  it('scrolls the list inside the panel', () => {
+    const html = render(ready([delivery()]));
+    expect(html).toContain('overflow-y-auto');
+    expect(html).toContain('aria-modal="true"');
+  });
+
+  it("shows a failure's reason verbatim", () => {
+    const html = render(
+      ready([delivery({ status: 'failed', lastError: 'webhook delivery failed: HTTP 400' })]),
+    );
+    expect(html).toContain('webhook delivery failed: HTTP 400');
+    expect(html).toContain('data-status="failed"');
+  });
+
+  it('says so when the worker recorded no reason', () => {
+    const html = render(ready([delivery({ status: 'failed', lastError: null })]));
+    expect(html).toContain(m.historyNoReason);
+  });
+
+  it('does not dress a landed delivery as a failure', () => {
+    const html = render(ready([delivery({ status: 'done' })]));
+    expect(html).toContain(m.historyDelivered);
+    expect(html).toContain('data-status="done"');
+    expect(html).not.toContain('bg-destructive/10');
+  });
+
+  it('shows the attempt count only once there has been more than one', () => {
+    expect(render(ready([delivery({ status: 'failed', attempts: 5 })]))).toContain('5 attempts');
+    expect(render(ready([delivery({ attempts: 1 })]))).not.toContain('attempts');
+  });
+
+  it('names the queue action so two rows of one kind can be told apart', () => {
+    const html = render(
+      ready([delivery({ id: 'a', action: 'partial' }), delivery({ id: 'b', action: 'complete' })]),
+    );
+    expect(html).toContain('partial');
+    expect(html).toContain('complete');
+  });
+
+  it('offers an empty state rather than an empty box', () => {
+    expect(render(ready([]))).toContain(m.historyEmpty);
+  });
+
+  it('keeps the card usable when the lookup failed', () => {
+    const html = render({ status: 'error' });
+    expect(html).toContain(m.historyLoadError);
+    expect(html).toContain('role="alert"');
+  });
+
+  it('always explains that a test delivery is not queued', () => {
+    // The question ("where is my ping?") arrives exactly when the list is empty.
+    expect(render(ready([]))).toContain(m.historyPingNote);
+    expect(render(ready([delivery()]))).toContain(m.historyPingNote);
+  });
+
+  it('offers a visible way out, not just Esc', () => {
+    expect(render(ready([delivery()]))).toContain(m.historyClose);
+  });
+});
+
+/**
+ * The transcript. A status and a one-line error say a delivery failed; only the
+ * body it carried and the answer it drew say WHY, which is the difference
+ * between a log and a debugging tool.
+ */
+describe('DeliveryHistoryView — reading a delivery back', () => {
+  const withTranscript = (over: Partial<FormDelivery> = {}) =>
+    delivery({
+      requestBody: '{"id":"sub-1","data":{"email":"a@b.test"}}',
+      responseStatus: 400,
+      responseBody: '{"error":"missing field"}',
+      ...over,
+    });
+
+  it('surfaces the response status on the row itself, unopened', () => {
+    // The one fact worth reading without a click: 400 and 500 send you to
+    // different places.
+    expect(render(ready([withTranscript()]))).toContain('HTTP 400');
+  });
+
+  it('offers a row with a transcript as expandable, and one without as not', () => {
+    expect(render(ready([withTranscript()]))).toContain('aria-expanded="false"');
+    // Nothing recorded → nothing to open. An empty code block would read as
+    // "we sent nothing", which is a different and false claim.
+    expect(render(ready([delivery()]))).toContain('disabled=""');
+  });
+
+  it('marks a test delivery as a test rather than hiding it', () => {
+    // It reaches the endpoint for real, so it belongs in the log — but it is not
+    // a respondent's lead, and reading it as one sends someone hunting for a
+    // submission that never happened.
+    const html = render(ready([delivery({ action: 'ping' })]));
+    expect(html).toContain('delivery-test-badge');
+    expect(html).toContain(m.historyTestBadge);
+    expect(html).toContain('data-action="ping"');
+  });
+
+  it('does not badge a real delivery as a test', () => {
+    const html = render(ready([delivery({ action: 'complete' })]));
+    expect(html).not.toContain('delivery-test-badge');
+  });
+});

--- a/apps/web/app/admin/forms/[id]/integrations/delivery-history.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/delivery-history.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+import type { FormsMessages, Locale } from '@quill/shared';
+import { Button } from '@/components/ui/button';
+import { Modal } from '@/components/modal';
+import { cn } from '@/lib/cn';
+import { WEBHOOK_PING_ACTION } from '@quill/types';
+import type { DeliveryKind, DeliveryStatus, FormDelivery } from '@/lib/admin-api';
+import { loadDeliveryHistoryAction } from './actions';
+
+type Msgs = FormsMessages['admin']['integrations'];
+
+/** `{n}`-style interpolation, same shape the rest of this screen uses. */
+const fill = (s: string, vars: Record<string, string | number>) =>
+  s.replace(/\{(\w+)\}/g, (_, k: string) => String(vars[k] ?? ''));
+
+/** A delivery that ended without landing — what the summary chip counts. */
+export const isFailure = (d: FormDelivery): boolean =>
+  d.status === 'failed' || d.status === 'skipped';
+
+export type HistoryState =
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'ready'; items: FormDelivery[] };
+
+/**
+ * One integration's delivery log, reachable from the card that configures it.
+ *
+ * This used to be a flat list of failures sitting loose in the Connect tab,
+ * under every card and mixing all four kinds. It answered "something is broken"
+ * without answering "which of these three integrations", and half a dozen
+ * retries of one dead webhook pushed Tracking and Emails off the screen.
+ *
+ * The log now belongs to its card — but it does not live INSIDE it. A card is a
+ * settings form, and twenty-five rows of delivery history in the middle of one
+ * buries the endpoint URL the reader came for. So the card carries a single
+ * line: a count, red when something failed, and a button. The log itself opens
+ * in a dialog, where a long list is free to be long and scrolls on its own.
+ */
+export function DeliveryHistory({
+  formId,
+  kinds,
+  title,
+  locale,
+  m,
+  testId,
+}: {
+  formId: string;
+  /** Which outbox kinds this card is responsible for. */
+  kinds: DeliveryKind[];
+  title: string;
+  locale: Locale;
+  m: Msgs;
+  testId: string;
+}) {
+  const [state, setState] = useState<HistoryState>({ status: 'loading' });
+  const [attempt, setAttempt] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading' });
+    loadDeliveryHistoryAction(formId, kinds)
+      .then((items) => {
+        if (!cancelled) setState({ status: 'ready', items });
+      })
+      .catch(() => {
+        // A diagnostic panel must never break the thing it diagnoses.
+        if (!cancelled) setState({ status: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `kinds` is a module constant at every call site; joining it keeps a fresh
+    // array identity per render from re-firing the fetch forever.
+  }, [formId, kinds.join(','), attempt]);
+
+  return (
+    <DeliveryHistoryView
+      state={state}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      onRefresh={() => setAttempt((n) => n + 1)}
+      title={title}
+      locale={locale}
+      m={m}
+      testId={testId}
+    />
+  );
+}
+
+/**
+ * The rendered half, with no data-fetching of its own — which is what makes
+ * every state below reachable from a test.
+ */
+export function DeliveryHistoryView({
+  state,
+  open,
+  onOpen,
+  onClose,
+  onRefresh,
+  title,
+  locale,
+  m,
+  testId,
+}: {
+  state: HistoryState;
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onRefresh: () => void;
+  title: string;
+  locale: Locale;
+  m: Msgs;
+  testId: string;
+}) {
+  const labelId = useId();
+  const items = state.status === 'ready' ? state.items : [];
+  const failures = items.filter(isFailure).length;
+
+  return (
+    <div
+      data-testid={testId}
+      data-open={open}
+      data-failures={failures}
+      className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border px-3 py-2.5"
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-foreground">{title}</span>
+        {/* The card's only permanent signal that something is wrong. There is no
+            badge for a healthy log: the count alone would read as an alert. */}
+        {failures > 0 ? (
+          <span
+            data-testid={`${testId}-failed-chip`}
+            className="inline-flex items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive"
+          >
+            <i aria-hidden className="pi pi-exclamation-triangle" style={{ fontSize: 11 }} />
+            {fill(m.historyFailedCount, { n: failures })}
+          </span>
+        ) : items.length > 0 ? (
+          <span
+            data-testid={`${testId}-count-chip`}
+            className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+          >
+            {fill(m.historyCount, { n: items.length })}
+          </span>
+        ) : null}
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        data-testid={`${testId}-open`}
+        onClick={onOpen}
+        disabled={state.status === 'loading'}
+      >
+        <i aria-hidden className="pi pi-history" style={{ fontSize: 12 }} />
+        {m.historyOpen}
+      </Button>
+
+      <Modal open={open} onClose={onClose} title={title} labelId={labelId} size="xl">
+        <div data-testid={`${testId}-dialog`} className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <p className="text-xs text-muted-foreground">{m.historyHelp}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid={`${testId}-refresh`}
+              disabled={state.status === 'loading'}
+              onClick={onRefresh}
+            >
+              <i aria-hidden className="pi pi-refresh" style={{ fontSize: 12 }} />
+              {m.historyRefresh}
+            </Button>
+          </div>
+
+          {/* The reason this is a dialog at all: the list scrolls INSIDE the
+              panel, so twenty-five rows cannot push anything else around. */}
+          <div className="max-h-[55vh] overflow-y-auto">
+            {state.status === 'loading' ? (
+              <div aria-hidden className="flex flex-col gap-2">
+                <div className="h-12 animate-pulse rounded-md border border-border bg-muted" />
+                <div className="h-12 animate-pulse rounded-md border border-border bg-muted" />
+              </div>
+            ) : state.status === 'error' ? (
+              <p className="text-xs text-muted-foreground" role="alert">
+                {m.historyLoadError}
+              </p>
+            ) : items.length === 0 ? (
+              <p className="text-xs text-muted-foreground">{m.historyEmpty}</p>
+            ) : (
+              <ul className="flex flex-col gap-1.5">
+                {items.map((d) => (
+                  <DeliveryRow key={d.id} delivery={d} locale={locale} m={m} />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            <i aria-hidden className="pi pi-info-circle" style={{ fontSize: 11 }} />{' '}
+            {m.historyPingNote}
+          </p>
+
+          {/* Esc and the backdrop close it too; this is the discoverable way. */}
+          <div className="flex justify-end">
+            <Button variant="outline" size="sm" data-testid={`${testId}-close`} onClick={onClose}>
+              {m.historyClose}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+/** Status pill styling. `pending` is progress, not a problem — never red. */
+const STATUS_CHIP: Record<DeliveryStatus, string> = {
+  done: 'bg-primary/20 text-foreground',
+  pending: 'bg-secondary/20 text-foreground',
+  failed: 'border border-destructive/40 bg-destructive/10 text-destructive',
+  skipped: 'bg-muted text-muted-foreground',
+};
+
+function statusLabel(status: DeliveryStatus, m: Msgs): string {
+  switch (status) {
+    case 'done':
+      return m.historyDelivered;
+    case 'pending':
+      return m.historyRetrying;
+    case 'failed':
+      return m.historyFailed;
+    case 'skipped':
+      return m.historySkipped;
+  }
+}
+
+/** Pretty-print a JSON body; anything unparseable is shown exactly as sent. */
+function formatBody(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function DeliveryRow({
+  delivery: d,
+  locale,
+  m,
+}: {
+  delivery: FormDelivery;
+  locale: Locale;
+  m: Msgs;
+}) {
+  const [open, setOpen] = useState(false);
+  const failed = isFailure(d);
+  const isTest = d.action === WEBHOOK_PING_ACTION;
+  // NULL is "not recorded", never "empty" — an older row, or a kind whose
+  // adapter reports no single request. Saying so is the honest render; showing
+  // an empty code block would read as "we sent nothing".
+  const recorded = d.requestBody !== null || d.responseStatus !== null || d.responseBody !== null;
+
+  return (
+    <li
+      data-testid="delivery-row"
+      data-status={d.status}
+      data-action={d.action}
+      className={cn(
+        'rounded-md border',
+        failed ? 'border-destructive/40 bg-destructive/10' : 'border-border bg-background/40',
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        disabled={!recorded}
+        className="flex w-full flex-wrap items-center justify-between gap-2 px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default"
+      >
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          {recorded ? (
+            <i
+              aria-hidden
+              className={`pi ${open ? 'pi-chevron-down' : 'pi-chevron-right'} text-muted-foreground`}
+              style={{ fontSize: 10 }}
+            />
+          ) : null}
+          <span
+            className={cn(
+              'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium',
+              STATUS_CHIP[d.status],
+            )}
+          >
+            {statusLabel(d.status, m)}
+          </span>
+          {/* A test delivery is a REAL signed POST to the real endpoint, so it
+              belongs in the log — but it answers "did my endpoint accept this",
+              not "did a respondent's lead arrive". Mislabelling it would send
+              someone hunting for a submission that never happened. */}
+          {isTest ? (
+            <span
+              data-testid="delivery-test-badge"
+              className="inline-flex shrink-0 items-center rounded-full bg-secondary/20 px-2 py-0.5 text-[11px] font-medium text-foreground"
+            >
+              {m.historyTestBadge}
+            </span>
+          ) : (
+            /* The queue's own action name. It is a stable identifier rather than
+               copy, and inventing a label per action would go stale the moment a
+               new one is enqueued. */
+            <span className="truncate font-mono text-[11px] text-muted-foreground">{d.action}</span>
+          )}
+          {d.responseStatus !== null ? (
+            <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+              HTTP {d.responseStatus}
+            </span>
+          ) : null}
+          {d.attempts > 1 ? (
+            <span className="text-[11px] tabular-nums text-muted-foreground">
+              {fill(m.historyAttempts, { n: d.attempts })}
+            </span>
+          ) : null}
+        </div>
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {new Date(d.updatedAt).toLocaleString(locale)}
+        </span>
+      </button>
+
+      {/* The worker's own reason, verbatim. Paraphrasing it here would lose the
+          one detail that says what to fix. */}
+      {failed ? (
+        <p className="px-3 pb-2 text-[11px] leading-relaxed text-muted-foreground">
+          {d.lastError ?? m.historyNoReason}
+        </p>
+      ) : null}
+
+      {open && recorded ? (
+        <div className="flex flex-col gap-2 border-t border-border/60 px-3 py-2">
+          <BodyBlock label={m.historyRequest} body={d.requestBody} empty={m.historyBodyNotRecorded} />
+          <BodyBlock
+            label={
+              d.responseStatus !== null
+                ? `${m.historyResponse} · HTTP ${d.responseStatus}`
+                : m.historyResponse
+            }
+            body={d.responseBody}
+            empty={d.responseStatus !== null ? m.historyBodyEmpty : m.historyBodyNotRecorded}
+          />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+/** One half of the transcript. Scrolls on its own — a payload can be long. */
+function BodyBlock({
+  label,
+  body,
+  empty,
+}: {
+  label: string;
+  body: string | null;
+  empty: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span className="text-[11px] font-medium text-foreground">{label}</span>
+      {body ? (
+        <pre className="max-h-56 overflow-auto rounded-md border border-border bg-background/60 p-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
+          {formatBody(body)}
+        </pre>
+      ) : (
+        <span className="text-[11px] italic text-muted-foreground">{empty}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-card.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-card.spec.tsx
@@ -123,6 +123,7 @@ describe('HubspotCard — where the extra-destination notice goes', () => {
         extraHubspotStored={over.extraHubspotStored}
         readiness={ready}
         questions={[{ key: 'email', type: 'email', label: 'Email' }]}
+        formId="form-1"
         m={im}
       />,
     );

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -20,6 +20,7 @@ import { useToast } from '@/components/toast';
 import { cn } from '@/lib/cn';
 import { bookingLabel } from '@/lib/booking-fields';
 import type {
+  DeliveryKind,
   HubSpotPropertiesResponse,
   HubSpotPropertyOption,
   WebhookPingReason,
@@ -27,6 +28,7 @@ import type {
 } from '@/lib/admin-api';
 import { trackDestinationWrite } from '@/lib/connect-sync';
 import { propertyLookup, suggestProperty, type QuestionMeta } from './auto-map';
+import { DeliveryHistory } from './delivery-history';
 import { Card } from './integrations-card';
 import {
   isCustomValue,
@@ -43,6 +45,10 @@ type SaveStatus = 'saved' | 'saving' | 'error' | 'partial';
 const AUTOSAVE_MS = 900;
 /** Same admin API base the server-side admin-api client uses (client-exposed). */
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+/** Module constants, not literals in JSX: the history's fetch keys off these. */
+const WEBHOOK_HISTORY_KINDS: DeliveryKind[] = ['webhook'];
+const HUBSPOT_HISTORY_KINDS: DeliveryKind[] = ['hubspot', 'booking_sync'];
 
 export type { QuestionMeta } from './auto-map';
 
@@ -623,6 +629,7 @@ export function IntegrationsEditor({
         // refetches the live config every time it is opened, so this is as
         // fresh as the array the card was seeded from.
         carriedCount={carriedWebhooks(initialDestinations).length}
+        locale={locale}
         m={m}
       />
       <LocaleContext.Provider value={locale}>
@@ -642,6 +649,7 @@ export function IntegrationsEditor({
           formActivityError={formActivityError}
           readiness={readiness}
           questions={questions}
+          formId={id}
           m={m}
         />
       </LocaleContext.Provider>
@@ -1214,6 +1222,7 @@ export function WebhookCard({
   clearUrlError,
   formId,
   carriedCount,
+  locale,
   m,
 }: {
   state: WebhookState;
@@ -1224,6 +1233,8 @@ export function WebhookCard({
   formId: string;
   /** Webhooks stored on this form that the card does not edit. */
   carriedCount: number;
+  /** Formats the delivery-history timestamps. */
+  locale: Locale;
   m: Msgs;
 }) {
   const { success, error: toastError } = useToast();
@@ -1348,6 +1359,17 @@ export function WebhookCard({
           </label>
         </div>
       </Field>
+      {/* Inside the card body, so it hides with the enable switch: a webhook
+          that is off has no deliveries to explain, and the settings it belongs
+          to are hidden alongside it. */}
+      <DeliveryHistory
+        formId={formId}
+        kinds={WEBHOOK_HISTORY_KINDS}
+        title={m.historyWebhookTitle}
+        locale={locale}
+        m={m}
+        testId="webhook-history"
+      />
     </Card>
   );
 }
@@ -1364,10 +1386,13 @@ export function HubspotCard({
   formActivityError,
   readiness,
   questions,
+  formId,
   m,
 }: {
   state: HubspotState;
   onChange: (s: HubspotState) => void;
+  /** Which form's delivery history the card reads. */
+  formId: string;
   /** Why HubSpot refused to build the mirror form on the last save, if it did. */
   formActivityError?: string | null;
   /** `options` rides along for the value pickers; absent = not an enumeration. */
@@ -1382,6 +1407,7 @@ export function HubspotCard({
   m: Msgs;
 }) {
   const { success, toast } = useToast();
+  const locale = useContext(LocaleContext);
   const emailSource = readiness.source;
   const utmValues = useMemo(() => state.utmMappings, [state.utmMappings]);
   const questionKeys = useMemo(() => new Set(questions.map((q) => q.key)), [questions]);
@@ -2070,6 +2096,19 @@ export function HubspotCard({
           {fill(m.formActivityError, { reason: formActivityError })}
         </p>
       ) : null}
+
+      {/* `booking_sync` rides along with `hubspot`: it IS a HubSpot write — the
+          contact update a scheduling callback triggers — so its failures belong
+          next to the mapping that decides what it writes, not in a section of
+          their own. */}
+      <DeliveryHistory
+        formId={formId}
+        kinds={HUBSPOT_HISTORY_KINDS}
+        title={m.historyHubspotTitle}
+        locale={locale}
+        m={m}
+        testId="hubspot-history"
+      />
     </Card>
   );
 }

--- a/apps/web/app/admin/forms/[id]/integrations/value-pickers.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/value-pickers.spec.tsx
@@ -96,6 +96,7 @@ function markup(over: Over = {}): string {
         { key: 'email', type: 'email', label: 'Email' },
         { key: 'role', type: 'dropdown', label: 'Your role' },
       ]}
+      formId="form-1"
       m={m}
     />,
   );

--- a/apps/web/app/admin/forms/[id]/integrations/webhook-carry.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/webhook-carry.spec.tsx
@@ -72,6 +72,7 @@ describe('WebhookCard — the carried-webhooks notice', () => {
         clearUrlError={() => {}}
         formId="form-1"
         carriedCount={over.carriedCount}
+        locale="en"
         m={m}
       />,
     );

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -289,17 +289,37 @@ export interface HubSpotProperty {
 }
 
 /** The property-picker response: disabled (no server token) or the property list. */
-/** One side-effect that never landed, as the admin surfaces it. */
-export interface FailedDelivery {
+/** What was being delivered. Mirrors `OutboxKind` in @quill/db. */
+export type DeliveryKind = 'webhook' | 'email' | 'hubspot' | 'booking_sync' | 'analytics' | 'dapta_sync';
+
+/**
+ * How a delivery ended. `pending` covers both "not attempted yet" and "waiting
+ * out a backoff between retries" — the queue does not distinguish them, and the
+ * UI should not pretend it does.
+ */
+export type DeliveryStatus = 'pending' | 'done' | 'failed' | 'skipped';
+
+/** One side-effect this form enqueued, as the admin surfaces it. */
+export interface FormDelivery {
   id: string;
-  kind: string;
-  /** `failed` = retries exhausted; `skipped` = a permanent gap, never retried. */
-  status: 'failed' | 'skipped';
+  kind: DeliveryKind;
+  status: DeliveryStatus;
+  /** The lifecycle moment that enqueued it (`complete`, `crm_update`, `ping`…). */
+  action: string;
   lastError: string | null;
   attempts: number;
   createdAt: number;
   updatedAt: number;
+  /**
+   * What actually crossed the wire. `null` = NOT RECORDED — a delivery from
+   * before this was captured, or a kind whose adapter has no single request to
+   * report. Never "an empty body was sent", and the UI must not imply otherwise.
+   */
+  requestBody: string | null;
+  responseStatus: number | null;
+  responseBody: string | null;
 }
+
 
 export type HubSpotPropertiesResponse =
   | { enabled: false; reason: string }
@@ -507,9 +527,21 @@ export const adminApi = {
   // Integrations
   hubspotProperties: () =>
     req<HubSpotPropertiesResponse>('GET', '/v1/integrations/hubspot/properties'),
-  /** Deliveries for this form that ended without landing (the failure log). */
-  formDeliveries: (id: string) =>
-    req<{ items: FailedDelivery[] }>('GET', `/v1/forms/${id}/deliveries`),
+  /**
+   * This form's deliveries, newest first. With no options the API answers with
+   * failures across every kind — the same list it has always answered with.
+   */
+  formDeliveries: (
+    id: string,
+    opts: { kinds?: DeliveryKind[]; statuses?: DeliveryStatus[]; limit?: number } = {},
+  ) => {
+    const qs = new URLSearchParams();
+    if (opts.kinds?.length) qs.set('kind', opts.kinds.join(','));
+    if (opts.statuses?.length) qs.set('status', opts.statuses.join(','));
+    if (opts.limit !== undefined) qs.set('limit', String(opts.limit));
+    const q = qs.toString();
+    return req<{ items: FormDelivery[] }>('GET', `/v1/forms/${id}/deliveries${q ? `?${q}` : ''}`);
+  },
   /** Calendly event types for the scheduler step's picker (per-account token). */
   calendlyEventTypes: () =>
     req<CalendlyEventTypesResponse>('GET', '/v1/integrations/calendly/event-types'),

--- a/packages/db/migrations/postgres/0013_outbox_account_kind_idx.sql
+++ b/packages/db/migrations/postgres/0013_outbox_account_kind_idx.sql
@@ -1,0 +1,19 @@
+-- An index for reading one account's delivery history — additive.
+--
+-- The only index this table had was `outbox_due_idx (status, next_attempt_at)`,
+-- which serves the worker: "what is due". Every read the ADMIN makes asks the
+-- opposite question — "what happened to this account's webhooks, newest first" —
+-- and had no index at all to answer it.
+--
+-- That was survivable while the admin only ever looked at failures: `failed` and
+-- `skipped` are a rounding error next to the rest of the table, so the planner's
+-- work stayed small even scanning for them. The per-integration history changes
+-- that. It reads `done` too, and `done` is the table: every landed email, every
+-- landed webhook, for the life of the deployment. Without this index, opening a
+-- form's Connect tab means a sequential scan of all of it.
+--
+-- (account_id, kind, updated_at) matches the read exactly: the account is the
+-- tenant boundary and always present, `kind` is what each card narrows to, and
+-- `updated_at` is the sort. Postgres reads a b-tree backwards at no cost, so a
+-- plain ASC index serves the DESC scan.
+CREATE INDEX IF NOT EXISTS outbox_account_kind_updated_idx ON outbox (account_id, kind, updated_at);

--- a/packages/db/migrations/postgres/0014_outbox_transcript.sql
+++ b/packages/db/migrations/postgres/0014_outbox_transcript.sql
@@ -1,0 +1,23 @@
+-- The delivery transcript on outbox rows — additive.
+--
+-- `payload` is the ENQUEUED snapshot: the destination config plus the context
+-- captured at submission time. It is not what went over the wire, and only what
+-- went over the wire answers the question every webhook debugging session opens
+-- with — "what did my endpoint actually receive, and what did it say back?".
+--
+-- Until now the admin could show a status and the worker's one-line error. That
+-- is enough to know a delivery failed and useless for finding out why: "HTTP
+-- 400" from a receiver that rejects one malformed field looks identical to one
+-- that rejects the whole schema. The body and the response tell them apart.
+--
+-- Three nullable columns, no rewrite, no default. NULL means NOT RECORDED — for
+-- every row that predates this, and for kinds whose adapter has no single
+-- request to report (HubSpot is a sequence of API calls). It never means empty.
+--
+-- Sensitivity: `request_body` carries the submission's answers, so these are
+-- exactly as sensitive as the submission row itself and live under the same
+-- account scope. Both bodies are truncated by the writer, so a receiver that
+-- answers with a full HTML error page cannot bloat the queue table.
+ALTER TABLE outbox ADD COLUMN IF NOT EXISTS request_body TEXT;
+ALTER TABLE outbox ADD COLUMN IF NOT EXISTS response_status INTEGER;
+ALTER TABLE outbox ADD COLUMN IF NOT EXISTS response_body TEXT;

--- a/packages/db/migrations/sqlite/0013_outbox_account_kind_idx.sql
+++ b/packages/db/migrations/sqlite/0013_outbox_account_kind_idx.sql
@@ -1,0 +1,19 @@
+-- An index for reading one account's delivery history — additive.
+--
+-- The only index this table had was `outbox_due_idx (status, next_attempt_at)`,
+-- which serves the worker: "what is due". Every read the ADMIN makes asks the
+-- opposite question — "what happened to this account's webhooks, newest first" —
+-- and had no index at all to answer it.
+--
+-- That was survivable while the admin only ever looked at failures: `failed` and
+-- `skipped` are a rounding error next to the rest of the table, so the planner's
+-- work stayed small even scanning for them. The per-integration history changes
+-- that. It reads `done` too, and `done` is the table: every landed email, every
+-- landed webhook, for the life of the deployment. Without this index, opening a
+-- form's Connect tab means a full scan of all of it.
+--
+-- (account_id, kind, updated_at) matches the read exactly: the account is the
+-- tenant boundary and always present, `kind` is what each card narrows to, and
+-- `updated_at` is the sort. SQLite walks a b-tree in either direction, so a
+-- plain ASC index serves the DESC scan.
+CREATE INDEX IF NOT EXISTS outbox_account_kind_updated_idx ON outbox (account_id, kind, updated_at);

--- a/packages/db/migrations/sqlite/0014_outbox_transcript.sql
+++ b/packages/db/migrations/sqlite/0014_outbox_transcript.sql
@@ -1,0 +1,26 @@
+-- The delivery transcript on outbox rows — additive.
+--
+-- `payload` is the ENQUEUED snapshot: the destination config plus the context
+-- captured at submission time. It is not what went over the wire, and only what
+-- went over the wire answers the question every webhook debugging session opens
+-- with — "what did my endpoint actually receive, and what did it say back?".
+--
+-- Until now the admin could show a status and the worker's one-line error. That
+-- is enough to know a delivery failed and useless for finding out why: "HTTP
+-- 400" from a receiver that rejects one malformed field looks identical to one
+-- that rejects the whole schema. The body and the response tell them apart.
+--
+-- Three nullable columns, no rewrite, no default. NULL means NOT RECORDED — for
+-- every row that predates this, and for kinds whose adapter has no single
+-- request to report (HubSpot is a sequence of API calls). It never means empty.
+--
+-- Sensitivity: `request_body` carries the submission's answers, so these are
+-- exactly as sensitive as the submission row itself and live under the same
+-- account scope. Both bodies are truncated by the writer, so a receiver that
+-- answers with a full HTML error page cannot bloat the queue table.
+--
+-- SQLite has no ADD COLUMN IF NOT EXISTS and does not need one: migrate.ts runs
+-- each numbered file exactly once, gated on the _migrations table.
+ALTER TABLE outbox ADD COLUMN request_body TEXT;
+ALTER TABLE outbox ADD COLUMN response_status INTEGER;
+ALTER TABLE outbox ADD COLUMN response_body TEXT;

--- a/packages/db/src/outbox.spec.ts
+++ b/packages/db/src/outbox.spec.ts
@@ -12,8 +12,15 @@ import {
   claimDueOutbox,
   markOutboxRetry,
   markOutboxDone,
+  markOutboxFailed,
   listFailedDeliveries,
+  listFormDeliveries,
+  listOutbox,
+  recordSettledDelivery,
   summarizeFailedDeliveriesByForm,
+  WEBHOOK_PING_ACTION,
+  type OutboxKind,
+  type OutboxStatus,
 } from './outbox';
 
 let db: Db;
@@ -212,6 +219,248 @@ describe('listFailedDeliveries', () => {
       const rows = await listFailedDeliveries(db, ACC, FORM);
       expect(rows.map((r) => r.id).sort()).toEqual([booking, webhook].sort());
     });
+  });
+});
+
+/**
+ * The delivery transcript — what crossed the wire, kept on the row.
+ *
+ * The columns are the whole reason the history can answer "why", so the cases
+ * that matter are the ones where a later write could destroy an earlier answer.
+ */
+describe('the delivery transcript', () => {
+  const ACC = 'acc-1';
+  const FORM = 'form-1';
+
+  const seedPending = () =>
+    enqueueOutbox(db, {
+      kind: 'webhook',
+      action: 'complete',
+      accountId: ACC,
+      payload: JSON.stringify({ destination: { type: 'webhook' }, ctx: { formId: FORM } }),
+      now: 1_000,
+    });
+
+  const readBack = async (id: string) =>
+    (await listOutbox(db, { accountId: ACC })).find((r) => r.id === id);
+
+  it('keeps what was sent and what came back on a delivered row', async () => {
+    const id = await seedPending();
+    await markOutboxDone(db, id, 2_000, {
+      requestBody: '{"hello":"world"}',
+      responseStatus: 200,
+      responseBody: 'ok',
+    });
+    const row = await readBack(id);
+    expect(row?.requestBody).toBe('{"hello":"world"}');
+    expect(row?.responseStatus).toBe(200);
+    expect(row?.responseBody).toBe('ok');
+  });
+
+  it('keeps them on a failed row too — the one anybody reads back', async () => {
+    const id = await seedPending();
+    await markOutboxFailed(db, id, {
+      attempts: 5,
+      error: 'webhook delivery failed: HTTP 400',
+      now: 2_000,
+      transcript: { requestBody: '{"a":1}', responseStatus: 400, responseBody: '{"error":"nope"}' },
+    });
+    const row = await readBack(id);
+    expect(row?.status).toBe('failed');
+    expect(row?.responseStatus).toBe(400);
+    expect(row?.responseBody).toBe('{"error":"nope"}');
+  });
+
+  it('does not let a later attempt with no transcript erase the earlier one', async () => {
+    // The last retry of a webhook whose host stopped resolving reports no
+    // response. Nulling the stored one would throw away the only evidence of
+    // what the endpoint used to say — which is the answer being looked for.
+    const id = await seedPending();
+    await markOutboxRetry(db, id, {
+      attempts: 1,
+      error: 'HTTP 500',
+      now: 2_000,
+      transcript: { requestBody: '{"a":1}', responseStatus: 500, responseBody: 'boom' },
+    });
+    await markOutboxFailed(db, id, { attempts: 5, error: 'getaddrinfo ENOTFOUND', now: 3_000 });
+    const row = await readBack(id);
+    expect(row?.responseStatus).toBe(500);
+    expect(row?.responseBody).toBe('boom');
+  });
+
+  it('truncates a receiver that answers with a whole page', async () => {
+    const id = await seedPending();
+    await markOutboxDone(db, id, 2_000, { responseBody: 'x'.repeat(5_000) });
+    const row = await readBack(id);
+    expect(row?.responseBody?.length).toBeLessThan(5_000);
+    expect(row?.responseBody?.endsWith('…')).toBe(true);
+  });
+});
+
+/**
+ * The admin's test delivery is synchronous — it never passes through the queue —
+ * but it IS a real POST to the real endpoint, so it is recorded like one.
+ */
+describe('recordSettledDelivery', () => {
+  const ACC = 'acc-1';
+  const FORM = 'form-1';
+
+  const record = (status: 'done' | 'failed') =>
+    recordSettledDelivery(db, {
+      kind: 'webhook',
+      action: WEBHOOK_PING_ACTION,
+      accountId: ACC,
+      payload: JSON.stringify({ destination: { type: 'webhook' }, ctx: { formId: FORM } }),
+      status,
+      error: status === 'failed' ? 'webhook delivery failed: HTTP 400' : null,
+      transcript: { requestBody: '{"test":true}', responseStatus: 400, responseBody: 'nope' },
+      now: 2_000,
+    });
+
+  it('lands in the form history like any other delivery', async () => {
+    const id = await record('failed');
+    const rows = await listFormDeliveries(db, ACC, FORM, { kinds: ['webhook'] });
+    expect(rows.map((r) => r.id)).toEqual([id]);
+    expect(rows[0]?.action).toBe(WEBHOOK_PING_ACTION);
+    expect(rows[0]?.requestBody).toBe('{"test":true}');
+  });
+
+  it('is never claimable, so a test delivery cannot be sent twice', async () => {
+    // Enqueueing and then settling would leave a window for the worker to grab
+    // the row. Inserted terminal, with nothing due, there is no window at all.
+    await record('done');
+    expect(await claimDueOutbox(db, Number.MAX_SAFE_INTEGER)).toEqual([]);
+  });
+});
+
+/**
+ * The same read, widened to answer "what happened" rather than "what broke".
+ *
+ * Every case here is about a narrowing that must hold: the per-integration
+ * history asks for `done` rows, and `done` is most of this table, so a `kinds`
+ * filter that quietly failed open would put a form's landed emails inside its
+ * webhook card.
+ */
+describe('listFormDeliveries', () => {
+  const ACC = 'acc-1';
+  const OTHER = 'acc-2';
+  const FORM = 'form-1';
+
+  async function seed(over: {
+    accountId?: string;
+    formId?: string;
+    kind?: OutboxKind;
+    action?: string;
+    status?: OutboxStatus;
+    lastError?: string | null;
+    attempts?: number;
+    updatedAt?: number;
+  }) {
+    const kind = over.kind ?? 'webhook';
+    const accountId = over.accountId ?? ACC;
+    const id = await enqueueOutbox(db, {
+      kind,
+      action: over.action ?? 'complete',
+      accountId,
+      payload: JSON.stringify({
+        destination: { type: kind, enabled: true, settings: { url: 'https://x.test/hook' } },
+        ctx: { formId: over.formId ?? FORM, submissionId: 'sub-1', accountId },
+      }),
+      now: 1_000,
+    });
+    await db.run(
+      sql`UPDATE outbox SET status = ${over.status ?? 'done'},
+                            last_error = ${over.lastError ?? null},
+                            attempts = ${over.attempts ?? 0},
+                            updated_at = ${over.updatedAt ?? 2_000}
+          WHERE id = ${id}`,
+    );
+    return id;
+  }
+
+  it('defaults to failures only, so existing callers see no change', async () => {
+    const failed = await seed({ status: 'failed', lastError: 'HTTP 400' });
+    await seed({ status: 'done' });
+    await seed({ status: 'pending' });
+
+    const rows = await listFormDeliveries(db, ACC, FORM);
+    expect(rows.map((r) => r.id)).toEqual([failed]);
+  });
+
+  it('returns what landed when asked for it, newest first', async () => {
+    const older = await seed({ status: 'done', updatedAt: 2_000 });
+    const newer = await seed({ status: 'failed', lastError: 'HTTP 400', updatedAt: 3_000 });
+
+    const rows = await listFormDeliveries(db, ACC, FORM, {
+      statuses: ['done', 'pending', 'failed', 'skipped'],
+    });
+    expect(rows.map((r) => r.id)).toEqual([newer, older]);
+    expect(rows.map((r) => r.status)).toEqual(['failed', 'done']);
+  });
+
+  it('narrows to the asked-for kinds and nothing else', async () => {
+    const hook = await seed({ kind: 'webhook', status: 'done' });
+    await seed({ kind: 'email', status: 'done', action: 'submission_received' });
+    await seed({ kind: 'hubspot', status: 'done' });
+
+    const rows = await listFormDeliveries(db, ACC, FORM, {
+      kinds: ['webhook'],
+      statuses: ['done'],
+    });
+    expect(rows.map((r) => r.id)).toEqual([hook]);
+  });
+
+  it('groups booking_sync with hubspot when both are asked for', async () => {
+    const crm = await seed({ kind: 'hubspot', status: 'done', updatedAt: 3_000 });
+    const booking = await seed({
+      kind: 'booking_sync',
+      action: 'crm_update',
+      status: 'failed',
+      lastError: 'calendly 500',
+      updatedAt: 4_000,
+    });
+    await seed({ kind: 'webhook', status: 'done' });
+
+    const rows = await listFormDeliveries(db, ACC, FORM, {
+      kinds: ['hubspot', 'booking_sync'],
+      statuses: ['done', 'failed'],
+    });
+    expect(rows.map((r) => r.id)).toEqual([booking, crm]);
+  });
+
+  it('answers with nothing when the caller narrowed to nothing', async () => {
+    // An empty list is a caller that asked for no kinds — never a caller who
+    // meant "all of them". Widening back would be the worst possible reading:
+    // a card would fill with another integration's history.
+    await seed({ status: 'done' });
+    expect(await listFormDeliveries(db, ACC, FORM, { kinds: [], statuses: ['done'] })).toEqual([]);
+    expect(await listFormDeliveries(db, ACC, FORM, { statuses: [] })).toEqual([]);
+  });
+
+  it('keeps the account boundary while reading landed rows', async () => {
+    await seed({ accountId: OTHER, status: 'done' });
+    expect(
+      await listFormDeliveries(db, ACC, FORM, { kinds: ['webhook'], statuses: ['done'] }),
+    ).toEqual([]);
+  });
+
+  it('carries the action and attempt count the row recorded', async () => {
+    await seed({ action: 'partial', status: 'failed', lastError: 'HTTP 500', attempts: 5 });
+    const [row] = await listFormDeliveries(db, ACC, FORM);
+    expect(row?.action).toBe('partial');
+    expect(row?.attempts).toBe(5);
+  });
+
+  it('bounds the answer with limit and the work with scanLimit', async () => {
+    for (let i = 0; i < 4; i++) await seed({ status: 'done', updatedAt: 2_000 + i });
+    const all = await listFormDeliveries(db, ACC, FORM, { statuses: ['done'] });
+    expect(all).toHaveLength(4);
+    expect(await listFormDeliveries(db, ACC, FORM, { statuses: ['done'], limit: 2 })).toHaveLength(2);
+    // scanLimit stops the read before the form filter ever runs, which is what
+    // keeps a busy account from paging its whole history into memory.
+    expect(
+      await listFormDeliveries(db, ACC, FORM, { statuses: ['done'], scanLimit: 1 }),
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -43,13 +43,30 @@ import type { Db } from './client';
  * the API (DestinationEffects / BookingSyncEffects / AnalyticsCapture /
  * DaptaSyncDelivery).
  */
-export type OutboxKind = 'webhook' | 'email' | 'hubspot' | 'booking_sync' | 'analytics' | 'dapta_sync';
+export const OUTBOX_KINDS = [
+  'webhook',
+  'email',
+  'hubspot',
+  'booking_sync',
+  'analytics',
+  'dapta_sync',
+] as const;
+export type OutboxKind = (typeof OUTBOX_KINDS)[number];
 /**
  * `skipped` = deliberately not performed (e.g. an email row whose tenant
  * context is unrecoverable on a transport that requires it) — recorded ONCE
  * with a reason, never retried. Distinct from `failed` (exhausted retries).
  */
-export type OutboxStatus = 'pending' | 'done' | 'failed' | 'skipped';
+export const OUTBOX_STATUSES = ['pending', 'done', 'failed', 'skipped'] as const;
+export type OutboxStatus = (typeof OUTBOX_STATUSES)[number];
+
+/**
+ * The `action` of a row written by the admin's "Send test" button.
+ *
+ * Defined in @quill/types and re-exported here so a caller already importing the
+ * queue does not need a second import for the one value that labels its rows.
+ */
+export { WEBHOOK_PING_ACTION } from '@quill/types';
 
 export interface OutboxRow {
   id: string;
@@ -70,6 +87,14 @@ export interface OutboxRow {
   claimedAt: number | null;
   /** Which worker instance holds the claim (diagnostics). */
   claimedBy: string | null;
+  /**
+   * The last attempt's transcript. `null` = not recorded — a row from before
+   * this existed, or a kind whose adapter reports no single request. Never
+   * "an empty body was sent".
+   */
+  requestBody: string | null;
+  responseStatus: number | null;
+  responseBody: string | null;
 }
 
 export interface EnqueueOutboxInput {
@@ -155,6 +180,9 @@ function mapRow(r: Record<string, unknown>): OutboxRow {
     updatedAt: Number(r.updated_at),
     claimedAt: r.claimed_at == null ? null : Number(r.claimed_at),
     claimedBy: (r.claimed_by as string | null) ?? null,
+    requestBody: (r.request_body as string | null) ?? null,
+    responseStatus: r.response_status == null ? null : Number(r.response_status),
+    responseBody: (r.response_body as string | null) ?? null,
   };
 }
 
@@ -212,11 +240,65 @@ export async function claimDueOutbox(
   return rows.map(mapRow);
 }
 
-/** Mark a row delivered. */
-export async function markOutboxDone(db: Db, id: string, now = Date.now()): Promise<void> {
-  await db.run(
-    sql`UPDATE outbox SET status = 'done', updated_at = ${now}, last_error = NULL WHERE id = ${id}`,
-  );
+/**
+ * What actually crossed the wire on an attempt, as the queue records it.
+ *
+ * Every field is optional and absent means NOT RECORDED — an adapter with no
+ * single request to report (HubSpot is a sequence of calls) writes nothing here,
+ * and a NULL column must never be read as "an empty body was sent".
+ */
+export interface DeliveryTranscript {
+  requestBody?: string;
+  responseStatus?: number;
+  responseBody?: string | null;
+}
+
+/**
+ * How much of each body survives.
+ *
+ * The request is ours and structured, so it is capped generously — a form with
+ * fifty answers still fits. The response belongs to somebody else and a failing
+ * endpoint routinely answers with an entire HTML error page, so it is capped
+ * hard: enough to carry a JSON error, not enough to bloat the queue table.
+ */
+const MAX_REQUEST_BODY = 8_000;
+const MAX_RESPONSE_BODY = 2_000;
+
+const clip = (v: string, max: number): string => (v.length > max ? `${v.slice(0, max)}…` : v);
+
+/**
+ * The transcript columns for an UPDATE, or nothing at all.
+ *
+ * An attempt that reported no transcript must LEAVE the stored one alone rather
+ * than null it: the last retry of a webhook whose host stopped resolving has no
+ * response to record, and wiping the previous attempt's would throw away the
+ * only evidence of what the endpoint used to say.
+ */
+function transcriptSets(t: DeliveryTranscript | undefined) {
+  if (!t) return [];
+  const sets = [];
+  if (t.requestBody !== undefined)
+    sets.push(sql`request_body = ${clip(t.requestBody, MAX_REQUEST_BODY)}`);
+  if (t.responseStatus !== undefined) sets.push(sql`response_status = ${t.responseStatus}`);
+  if (t.responseBody !== undefined)
+    sets.push(sql`response_body = ${t.responseBody === null ? null : clip(t.responseBody, MAX_RESPONSE_BODY)}`);
+  return sets;
+}
+
+/** Mark a row delivered, keeping what crossed the wire. */
+export async function markOutboxDone(
+  db: Db,
+  id: string,
+  now = Date.now(),
+  transcript?: DeliveryTranscript,
+): Promise<void> {
+  const sets = [
+    sql`status = 'done'`,
+    sql`updated_at = ${now}`,
+    sql`last_error = NULL`,
+    ...transcriptSets(transcript),
+  ];
+  await db.run(sql`UPDATE outbox SET ${sql.join(sets, sql`, `)} WHERE id = ${id}`);
 }
 
 /**
@@ -227,18 +309,21 @@ export async function markOutboxDone(db: Db, id: string, now = Date.now()): Prom
 export async function markOutboxRetry(
   db: Db,
   id: string,
-  args: { attempts: number; error: string; now?: number },
+  args: { attempts: number; error: string; now?: number; transcript?: DeliveryTranscript },
 ): Promise<void> {
   const now = args.now ?? Date.now();
   const nextAt = now + backoffMs(args.attempts);
   // Clear the claim so the row is reclaimable once its backoff elapses.
-  await db.run(
-    sql`UPDATE outbox
-        SET attempts = ${args.attempts}, next_attempt_at = ${nextAt},
-            last_error = ${args.error.slice(0, 1000)}, updated_at = ${now},
-            claimed_at = NULL, claimed_by = NULL
-        WHERE id = ${id}`,
-  );
+  const sets = [
+    sql`attempts = ${args.attempts}`,
+    sql`next_attempt_at = ${nextAt}`,
+    sql`last_error = ${args.error.slice(0, 1000)}`,
+    sql`updated_at = ${now}`,
+    sql`claimed_at = NULL`,
+    sql`claimed_by = NULL`,
+    ...transcriptSets(args.transcript),
+  ];
+  await db.run(sql`UPDATE outbox SET ${sql.join(sets, sql`, `)} WHERE id = ${id}`);
 }
 
 /**
@@ -262,15 +347,64 @@ export async function markOutboxSkipped(
 export async function markOutboxFailed(
   db: Db,
   id: string,
-  args: { attempts: number; error: string; now?: number },
+  args: { attempts: number; error: string; now?: number; transcript?: DeliveryTranscript },
 ): Promise<void> {
   const now = args.now ?? Date.now();
+  const sets = [
+    sql`status = 'failed'`,
+    sql`attempts = ${args.attempts}`,
+    sql`last_error = ${args.error.slice(0, 1000)}`,
+    sql`updated_at = ${now}`,
+    ...transcriptSets(args.transcript),
+  ];
+  await db.run(sql`UPDATE outbox SET ${sql.join(sets, sql`, `)} WHERE id = ${id}`);
+}
+
+/**
+ * Record a delivery that already happened, in its final state.
+ *
+ * The admin's test delivery is synchronous on purpose — the author clicks and
+ * waits for the answer — so it never passes through the queue. That does not
+ * make it any less of a delivery: it is a real signed POST to the real endpoint,
+ * and it is very often the ONLY delivery a form has when someone is wiring one
+ * up. Leaving it out of the history meant the log stayed empty during exactly
+ * the session it existed to help.
+ *
+ * Inserted TERMINAL, never `pending`: enqueueing and then settling would leave a
+ * window in which the worker could claim the row and deliver it a second time.
+ * `next_attempt_at` is set far past for the same reason — nothing due, ever.
+ */
+export async function recordSettledDelivery(
+  db: Db,
+  input: {
+    kind: OutboxKind;
+    action: string;
+    accountId: string;
+    subjectUid?: string | null;
+    payload: string;
+    status: 'done' | 'failed';
+    error?: string | null;
+    transcript?: DeliveryTranscript;
+    now?: number;
+  },
+): Promise<string> {
+  const id = randomUUID();
+  const now = input.now ?? Date.now();
+  const t = input.transcript ?? {};
   await db.run(
-    sql`UPDATE outbox
-        SET status = 'failed', attempts = ${args.attempts},
-            last_error = ${args.error.slice(0, 1000)}, updated_at = ${now}
-        WHERE id = ${id}`,
+    sql`INSERT INTO outbox
+          (id, kind, action, subject_uid, account_id, webhook_id, payload, status,
+           attempts, max_attempts, next_attempt_at, last_error, created_at, updated_at,
+           request_body, response_status, response_body)
+        VALUES (${id}, ${input.kind}, ${input.action}, ${input.subjectUid ?? null},
+                ${input.accountId}, ${null}, ${input.payload}, ${input.status},
+                ${1}, ${1}, ${Number.MAX_SAFE_INTEGER}, ${input.error?.slice(0, 1000) ?? null},
+                ${now}, ${now},
+                ${t.requestBody === undefined ? null : clip(t.requestBody, MAX_REQUEST_BODY)},
+                ${t.responseStatus ?? null},
+                ${t.responseBody == null ? null : clip(t.responseBody, MAX_RESPONSE_BODY)})`,
   );
+  return id;
 }
 
 /** Inspect the queue / delivery log (tests, the admin deliveries view). */
@@ -296,22 +430,57 @@ export async function listOutbox(
   return rows.map(mapRow);
 }
 
-/** A side-effect that did not land, in the terms the person who owns the form has. */
-export interface FailedDelivery {
+/** One delivery of this form's, in the terms the person who owns the form has. */
+export interface FormDelivery {
   id: string;
-  /** `booking_sync`, `destination`, `email`… — what was being delivered. */
+  /** `booking_sync`, `webhook`, `hubspot`, `email` — what was being delivered. */
   kind: OutboxKind;
-  /** `failed` = retries exhausted; `skipped` = a permanent gap, never retried. */
-  status: 'failed' | 'skipped';
+  /**
+   * `done` = landed; `pending` = queued or between retries; `failed` = retries
+   * exhausted; `skipped` = a permanent gap, recorded once and never retried.
+   */
+  status: OutboxStatus;
+  /**
+   * Which lifecycle moment enqueued it — `partial`/`complete` for destinations,
+   * `submission_received`/`submission_confirmed` for email, `crm_update` for a
+   * booking sync. Two rows of the same kind differ only by this and their time.
+   */
+  action: string;
   /** The reason the worker recorded. This is the whole point of the view. */
   lastError: string | null;
   attempts: number;
   createdAt: number;
   updatedAt: number;
+  /**
+   * What actually crossed the wire. `null` = not recorded (a row older than the
+   * feature, or a kind with no single request to report) — the UI must say that
+   * rather than render an empty body.
+   */
+  requestBody: string | null;
+  responseStatus: number | null;
+  responseBody: string | null;
 }
 
 /**
- * Deliveries for one form that ended without landing.
+ * Kept for the callers that only ever want what did not land. Same rows, same
+ * shape — the narrower status union is what those call sites read.
+ */
+export type FailedDelivery = FormDelivery & { status: 'failed' | 'skipped' };
+
+/** Everything a history read can narrow by. All optional; see the defaults. */
+export interface FormDeliveryQuery {
+  /** Restrict to these kinds. Empty/absent = every kind. Applied IN SQL. */
+  kinds?: OutboxKind[];
+  /** Restrict to these statuses. Absent = only what did not land. */
+  statuses?: OutboxStatus[];
+  /** How many matching rows to return. */
+  limit?: number;
+  /** How many rows to look at before giving up — see {@link DEFAULT_DELIVERY_SCAN_LIMIT}. */
+  scanLimit?: number;
+}
+
+/**
+ * One form's deliveries, newest first.
  *
  * Nothing in the admin surfaced the outbox, so a delivery that died — an expired
  * CRM token, a disconnected scheduling provider, a form with no resolvable
@@ -325,39 +494,74 @@ export interface FailedDelivery {
  * would mean a destructive migration on a table every deployment already has.
  * The account IS a column, so the scope that matters for isolation is enforced
  * in SQL; the form filter narrows within one account's own rows.
+ *
+ * `kinds` narrows IN SQL, and that is what makes asking for `done` rows viable:
+ * successful deliveries are by far the largest part of this table, so a history
+ * read that could not restrict to one integration would drag every landed email
+ * through the scan window to find a handful of webhooks.
  */
-export async function listFailedDeliveries(
+export async function listFormDeliveries(
   db: Db,
   accountId: string,
   formId: string,
-  limit = 50,
-): Promise<FailedDelivery[]> {
+  query: FormDeliveryQuery = {},
+): Promise<FormDelivery[]> {
+  const {
+    kinds,
+    statuses = ['failed', 'skipped'],
+    limit = 50,
+    scanLimit = DEFAULT_DELIVERY_SCAN_LIMIT,
+  } = query;
+  // An empty list would render as `IN ()` — a syntax error on both dialects.
+  // Absent means "every kind"; explicitly empty means the caller narrowed to
+  // nothing, and nothing is the honest answer.
+  if (kinds?.length === 0 || statuses.length === 0) return [];
+
+  const conds = [sql`account_id = ${accountId}`, sql`status IN (${bindList(statuses)})`];
+  if (kinds?.length) conds.push(sql`kind IN (${bindList(kinds)})`);
+  const where = sql.join(conds, sql` AND `);
+
   const rows = await db.all<Record<string, unknown>>(
     sql`SELECT * FROM outbox
-        WHERE account_id = ${accountId} AND status IN ('failed', 'skipped')
+        WHERE ${where}
         ORDER BY updated_at DESC
-        LIMIT ${DEFAULT_FAILURE_SCAN_LIMIT}`,
+        LIMIT ${scanLimit}`,
   );
-  const out: FailedDelivery[] = [];
+  const out: FormDelivery[] = [];
   for (const raw of rows) {
     const row = mapRow(raw);
     if (!payloadTargetsForm(row.payload, formId)) continue;
     out.push({
       id: row.id,
       kind: row.kind,
-      status: row.status as 'failed' | 'skipped',
+      status: row.status,
+      action: row.action,
       lastError: row.lastError,
       attempts: row.attempts,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
+      requestBody: row.requestBody,
+      responseStatus: row.responseStatus,
+      responseBody: row.responseBody,
     });
     if (out.length >= limit) break;
   }
   return out;
 }
 
+/** Deliveries for one form that ended without landing — the default narrowing. */
+export async function listFailedDeliveries(
+  db: Db,
+  accountId: string,
+  formId: string,
+  limit = 50,
+): Promise<FailedDelivery[]> {
+  const rows = await listFormDeliveries(db, accountId, formId, { limit });
+  return rows as FailedDelivery[];
+}
+
 /**
- * How many failed/skipped rows a single read will look at.
+ * How many rows a single read will look at.
  *
  * The form is matched in JS, so the SELECT cannot narrow to it and an account
  * with a long-broken destination would otherwise drag its entire failure history
@@ -366,7 +570,21 @@ export async function listFailedDeliveries(
  * same number or a caller asking for 50 would stop looking after 50 rows of which
  * only some match.
  */
-const DEFAULT_FAILURE_SCAN_LIMIT = 500;
+const DEFAULT_DELIVERY_SCAN_LIMIT = 500;
+
+/**
+ * One bound placeholder per value, for an `IN (…)` list.
+ *
+ * The values are a fixed vocabulary (`OutboxKind` / `OutboxStatus`), but they
+ * arrive from a query string, so they go through the driver as parameters like
+ * every other user-supplied value — never spliced into the statement text.
+ */
+function bindList(values: readonly string[]) {
+  return sql.join(
+    values.map((v) => sql`${v}`),
+    sql`, `,
+  );
+}
 
 /**
  * The form a row's payload names, across the two shapes the queue carries.
@@ -431,7 +649,7 @@ export async function summarizeFailedDeliveriesByForm(
   db: Db,
   accountId: string,
   kind: OutboxKind,
-  scanLimit = DEFAULT_FAILURE_SCAN_LIMIT,
+  scanLimit = DEFAULT_DELIVERY_SCAN_LIMIT,
 ): Promise<FormDeliveryFailures[]> {
   const rows = await db.all<Record<string, unknown>>(
     sql`SELECT * FROM outbox

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -99,6 +99,29 @@ export const outbox = pgTable('outbox', {
   // Worker claim/lease (H2): set atomically when a row is claimed for delivery.
   claimedAt: bigint('claimed_at', { mode: 'number' }),
   claimedBy: text('claimed_by'),
+  /**
+   * The delivery transcript: the request body we actually sent, and the status
+   * and body that came back.
+   *
+   * `payload` above is the ENQUEUED snapshot — the destination config plus the
+   * captured context — not the bytes that went over the wire. The two are not
+   * the same thing, and only the second one answers "what did my endpoint
+   * actually receive", which is the question every webhook debugging session
+   * starts with. Reconstructing it from `payload` would be a guess that drifts
+   * the moment an adapter changes shape.
+   *
+   * NULL on every row written before this shipped, and on kinds whose adapter
+   * reports no transcript (HubSpot is several API calls, not one request). NULL
+   * therefore means "not recorded", never "empty".
+   *
+   * These carry submission answers, so they are as sensitive as the submission
+   * itself — same account scope, and both are truncated on write (see
+   * MAX_REQUEST_BODY / MAX_RESPONSE_BODY) so one endpoint answering with an HTML
+   * error page cannot bloat the queue.
+   */
+  requestBody: text('request_body'),
+  responseStatus: integer('response_status'),
+  responseBody: text('response_body'),
 });
 
 export const notificationSetting = pgTable(

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -110,6 +110,12 @@ export const outbox = sqliteTable('outbox', {
   // Worker claim/lease (H2): set atomically when a row is claimed for delivery.
   claimedAt: integer('claimed_at'),
   claimedBy: text('claimed_by'),
+  // The delivery transcript — what we actually sent and what came back. NULL
+  // for every row written before this shipped, and for kinds whose adapter does
+  // not report one. See `schema.pg.ts` for the full rationale.
+  requestBody: text('request_body'),
+  responseStatus: integer('response_status'),
+  responseBody: text('response_body'),
 });
 
 /** Per-account (and per-form override) notification controls. */

--- a/packages/destinations/src/adapters/webhook.ts
+++ b/packages/destinations/src/adapters/webhook.ts
@@ -123,8 +123,14 @@ export class WebhookDestination implements SubmissionDestination {
         signal: controller.signal,
       });
     } catch (err) {
-      // Timeout (abort) or network error — surface so the outbox retries.
-      throw err instanceof Error ? err : new Error(`webhook delivery failed: ${String(err)}`);
+      // Timeout (abort) or network error — surface so the outbox retries. The
+      // request body rides along even though nothing answered: "we sent THIS and
+      // the host never replied" is still the useful half of the transcript.
+      const error = err instanceof Error ? err : new Error(`webhook delivery failed: ${String(err)}`);
+      // Attached rather than wrapped in a new class: the message and the error's
+      // own type are what the outbox stores and what existing tests assert on.
+      (error as Error & { requestBody?: string }).requestBody = body;
+      throw error;
     } finally {
       clearTimeout(timeout);
     }
@@ -135,6 +141,7 @@ export class WebhookDestination implements SubmissionDestination {
         `webhook delivery refused: endpoint attempted a redirect (HTTP ${res.status})`,
         res.status,
         null,
+        body,
       );
     }
     if (!res.ok) {
@@ -143,9 +150,24 @@ export class WebhookDestination implements SubmissionDestination {
       // best-effort and bounded: a failing endpoint may answer with a whole
       // HTML error page, and none of this belongs in an outbox row.
       const detail = await readErrorBody(res);
-      throw new WebhookHttpError(`webhook delivery failed: HTTP ${res.status}`, res.status, detail);
+      throw new WebhookHttpError(
+        `webhook delivery failed: HTTP ${res.status}`,
+        res.status,
+        detail,
+        body,
+      );
     }
-    return { delivered: true, driver: 'webhook' };
+    // A 2xx body too, not only a failing one. "It returned 200" and "it returned
+    // 200 saying `{"accepted":false}`" are different answers, and the second is
+    // the one that explains a lead that never arrived at a receiver we called
+    // healthy.
+    return {
+      delivered: true,
+      driver: 'webhook',
+      requestBody: body,
+      responseStatus: res.status,
+      responseBody: await readErrorBody(res),
+    };
   }
 }
 
@@ -177,6 +199,12 @@ export class WebhookHttpError extends Error {
     readonly status: number,
     /** The endpoint's own response body, trimmed and truncated, when it sent one. */
     readonly detail: string | null,
+    /**
+     * The exact request body that drew this response. Carried on the ERROR and
+     * not just the success path, because a failed delivery is the only one
+     * anybody ever needs to read back — the outbox stores it from here.
+     */
+    readonly requestBody?: string,
   ) {
     super(message);
     this.name = 'WebhookHttpError';

--- a/packages/destinations/src/destination.port.ts
+++ b/packages/destinations/src/destination.port.ts
@@ -55,7 +55,45 @@ export interface DestinationContext {
   utm: Record<string, string>;
 }
 
-export interface DestinationResult {
+/**
+ * What actually crossed the wire, for the admin's delivery history.
+ *
+ * Deliberately separate from the outbox `payload` (the enqueued snapshot): only
+ * this answers "what did my endpoint receive, and what did it say back", which
+ * is where every webhook debugging session starts. An adapter that cannot report
+ * a single request — HubSpot is a sequence of API calls — simply omits it, and
+ * the absence is rendered as "not recorded", never as an empty body.
+ *
+ * Never carries a credential: the signing secret lives in a header, not the
+ * body, and headers are not recorded.
+ */
+export interface DeliveryTranscript {
+  /** The exact request body sent, verbatim. */
+  requestBody?: string;
+  responseStatus?: number;
+  /** The receiver's own body, trimmed and truncated by the adapter. */
+  responseBody?: string | null;
+}
+
+/**
+ * The transcript a FAILED delivery left on its error.
+ *
+ * A failure is the only delivery anyone ever needs to read back, and it arrives
+ * as a thrown error rather than a returned result. Adapters attach what they
+ * have — the webhook one carries the request body even when nothing answered —
+ * and this reads it without the caller having to know any adapter's error class.
+ */
+export function transcriptOfError(err: unknown): DeliveryTranscript {
+  if (typeof err !== 'object' || err === null) return {};
+  const e = err as { requestBody?: unknown; status?: unknown; detail?: unknown };
+  return {
+    requestBody: typeof e.requestBody === 'string' ? e.requestBody : undefined,
+    responseStatus: typeof e.status === 'number' ? e.status : undefined,
+    responseBody: typeof e.detail === 'string' ? e.detail : undefined,
+  };
+}
+
+export interface DestinationResult extends DeliveryTranscript {
   /** True when actually dispatched; false for log-only / a permanent no-op. */
   delivered: boolean;
   driver: DestinationDriver;

--- a/packages/notifications/src/submission-notifier.ts
+++ b/packages/notifications/src/submission-notifier.ts
@@ -32,6 +32,13 @@ export interface SubmissionNotification {
   accountId: string;
   /** The submission id (used as the idempotency anchor). */
   submissionId: string;
+  /**
+   * Which form this is about. The notifier itself never reads it — it is here so
+   * the enqueued payload NAMES the form, which is the only way an admin reading
+   * the outbox can attribute a send to one. Optional because rows enqueued
+   * before this existed carry no form and cannot be given one retroactively.
+   */
+  formId?: string | null;
   formName: string;
   /** Where to send it — the account/team inbox and/or the respondent. */
   to: string[];

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -889,10 +889,6 @@ export interface FormsMessages {
         integrationsSubtitle: string;
         integrationsLoadError: string;
         retry: string;
-        /** Deliveries that ended without landing — hidden when there are none. */
-        deliveriesTitle: string;
-        deliveriesSubtitle: string;
-        deliveriesNoReason: string;
         trackingTitle: string;
         trackingSubtitle: string;
         /** V5-QA — these ride the draft, unlike the integrations above them. */
@@ -1186,6 +1182,40 @@ export interface FormsMessages {
       webhookEventsHelp: string;
       eventPartial: string;
       eventComplete: string;
+      // Delivery history — the collapsible log inside each integration card.
+      /** Per-card headings; the shared panel takes them as props. */
+      historyWebhookTitle: string;
+      historyHubspotTitle: string;
+      historyEmailTitle: string;
+      historyHelp: string;
+      /** How a test delivery differs from a real one, since both are listed. */
+      historyPingNote: string;
+      /** Marks a row the "Send test" button produced. */
+      historyTestBadge: string;
+      // The transcript — what we sent, what came back.
+      historyRequest: string;
+      historyResponse: string;
+      /** No transcript stored: an older delivery, or a kind that reports none. */
+      historyBodyNotRecorded: string;
+      /** The endpoint answered with no body at all. */
+      historyBodyEmpty: string;
+      historyEmpty: string;
+      historyLoadError: string;
+      historyRefresh: string;
+      /** Opens the log in a dialog — a card is a settings form, not a log view. */
+      historyOpen: string;
+      historyClose: string;
+      /** Header chips. `{n}` = a row count within the window that was read. */
+      historyCount: string;
+      historyFailedCount: string;
+      // Row status labels.
+      historyDelivered: string;
+      historyRetrying: string;
+      historyFailed: string;
+      historySkipped: string;
+      /** `{n}` = delivery attempts, shown only past the first. */
+      historyAttempts: string;
+      historyNoReason: string;
       // Google Sheets — announced, not shipped; the card is inert
       gsheetsTitle: string;
       gsheetsDesc: string;
@@ -2281,10 +2311,6 @@ export const en: FormsMessages = {
           'Send each submission to your CRM or a webhook. Delivery is durable and retried.',
         integrationsLoadError: 'Could not load integrations.',
         retry: 'Retry',
-        deliveriesTitle: 'Deliveries that did not land',
-        deliveriesSubtitle:
-          'Submissions reached this form, but these deliveries never completed. The respondent saw nothing wrong, so this is the only place it shows.',
-        deliveriesNoReason: 'No reason was recorded.',
         trackingTitle: 'Tracking & pixels',
         trackingSubtitle:
           'Measure visits and conversions on this form’s public page. Each tag loads only when its ID is set.',
@@ -2561,6 +2587,30 @@ export const en: FormsMessages = {
       webhookEventsHelp: 'Choose which submissions are sent to this webhook. Both are sent by default.',
       eventPartial: 'Partial submissions',
       eventComplete: 'Complete submissions',
+      historyWebhookTitle: 'Webhook history',
+      historyHubspotTitle: 'HubSpot history',
+      historyEmailTitle: 'Email history',
+      historyHelp: 'The last deliveries this form made, newest first. Open one to see what was sent.',
+      historyPingNote:
+        'Test deliveries are listed too, marked as tests: they reach your endpoint for real, but carry sample answers instead of a respondent’s.',
+      historyTestBadge: 'Test',
+      historyRequest: 'What we sent',
+      historyResponse: 'What came back',
+      historyBodyNotRecorded: 'Not recorded for this delivery.',
+      historyBodyEmpty: 'Your endpoint answered with no body.',
+      historyEmpty: 'Nothing has been delivered yet.',
+      historyLoadError: 'Could not load the delivery history.',
+      historyRefresh: 'Refresh',
+      historyOpen: 'View history',
+      historyClose: 'Close',
+      historyCount: '{n} deliveries',
+      historyFailedCount: '{n} failed',
+      historyDelivered: 'Delivered',
+      historyRetrying: 'In progress',
+      historyFailed: 'Failed',
+      historySkipped: 'Skipped',
+      historyAttempts: '{n} attempts',
+      historyNoReason: 'No reason was recorded.',
       gsheetsTitle: 'Google Sheets',
       gsheetsDesc: 'Append each response as a new row in a spreadsheet.',
       comingSoon: 'Coming soon',
@@ -3641,10 +3691,6 @@ export const es: FormsMessages = {
           'Envía cada respuesta a tu CRM o a un webhook. La entrega es duradera y con reintentos.',
         integrationsLoadError: 'No se pudieron cargar las integraciones.',
         retry: 'Reintentar',
-        deliveriesTitle: 'Entregas que no llegaron',
-        deliveriesSubtitle:
-          'Las respuestas llegaron al formulario, pero estas entregas nunca se completaron. Quien respondió no vio ningún problema, así que este es el único lugar donde aparece.',
-        deliveriesNoReason: 'No se registró un motivo.',
         trackingTitle: 'Seguimiento y píxeles',
         trackingSubtitle:
           'Mide visitas y conversiones en la página pública de este formulario. Cada etiqueta se carga solo cuando su ID está configurado.',
@@ -3925,6 +3971,31 @@ export const es: FormsMessages = {
       webhookEventsHelp: 'Elige qué respuestas se envían a este webhook. Por defecto se envían ambas.',
       eventPartial: 'Respuestas parciales',
       eventComplete: 'Respuestas completas',
+      historyWebhookTitle: 'Historial del webhook',
+      historyHubspotTitle: 'Historial de HubSpot',
+      historyEmailTitle: 'Historial de correos',
+      historyHelp:
+        'Las últimas entregas que hizo este formulario, de la más reciente a la más antigua. Abrí una para ver qué se envió.',
+      historyPingNote:
+        'Las entregas de prueba también aparecen, marcadas como tales: llegan de verdad a tu endpoint, pero llevan respuestas de ejemplo en lugar de las de una persona.',
+      historyTestBadge: 'Prueba',
+      historyRequest: 'Lo que enviamos',
+      historyResponse: 'Lo que respondió',
+      historyBodyNotRecorded: 'No se registró para esta entrega.',
+      historyBodyEmpty: 'Tu endpoint respondió sin cuerpo.',
+      historyEmpty: 'Todavía no se ha entregado nada.',
+      historyLoadError: 'No se pudo cargar el historial de entregas.',
+      historyRefresh: 'Actualizar',
+      historyOpen: 'Ver historial',
+      historyClose: 'Cerrar',
+      historyCount: '{n} entregas',
+      historyFailedCount: '{n} con error',
+      historyDelivered: 'Entregada',
+      historyRetrying: 'En curso',
+      historyFailed: 'Falló',
+      historySkipped: 'Omitida',
+      historyAttempts: '{n} intentos',
+      historyNoReason: 'No se registró un motivo.',
       gsheetsTitle: 'Google Sheets',
       gsheetsDesc: 'Añade cada respuesta como una fila nueva en una hoja de cálculo.',
       comingSoon: 'Muy pronto',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -795,6 +795,17 @@ export function hasExtraHubspotDestination(destinations: unknown, stored?: unkno
  */
 export const WEBHOOK_SECRET_MASK = '__DAPTA_FORMS_SECRET_KEEP__';
 
+/**
+ * The `action` a delivery gets when it came from the admin's "Send test" button
+ * rather than a respondent.
+ *
+ * Lives HERE, in the contract package, because both ends read it and neither can
+ * import the other's home: the API stamps it through @quill/db, and the admin —
+ * a browser bundle — reads it to badge the row. A test delivery mislabelled as a
+ * real one would have somebody debugging a submission that never happened.
+ */
+export const WEBHOOK_PING_ACTION = 'ping';
+
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }


### PR DESCRIPTION
## Why

The Connect tab rendered one flat **"Deliveries that did not land"** block, sitting loose between the integrations and Tracking and mixing all four outbox kinds. It said *something* was broken without saying *which of the three integrations*, and on a form with a dead endpoint its retries pushed Tracking and Emails off the screen — the diagnosis was louder than everything it was diagnosing.

## What changed

**Each card owns its own log.** `webhook` → the webhook card, `hubspot` + `booking_sync` → the HubSpot card (a booking sync *is* a HubSpot write), `email` → the Emails section. Nothing lost a surface; the reason a webhook is failing is now read beside the URL that is failing.

**The log is not *inside* the card.** A card is a settings form, and twenty-five rows of history in the middle of one buries the endpoint URL the reader came for. The card carries a single line — a count, red when something failed — and the log opens in a dialog (`components/modal.tsx`, focus trap included) where a long list is free to be long and scrolls on its own.

**A history, not a failure list.** The queue never deleted its `done` rows; nothing had ever asked for them, so a webhook that works and one that has never fired looked identical. `listFormDeliveries` takes `kinds` + `statuses` — defaulting to the original failures-only answer, so existing callers are unaffected — and `kinds` narrows **in SQL**, which is what makes reading landed rows viable at all since they are most of the table.

**Deliveries can be read back.** Expanding a row shows the request body actually sent and the status + body that came back. The enqueued `payload` is *not* those bytes, and only those bytes answer the question a webhook debugging session opens with; reconstructing it would be a guess that drifts the moment an adapter changes shape.

**Test deliveries are listed.** `Send test` is synchronous and never passed through the queue, so the log stayed empty during exactly the session it exists to help — wiring up an endpoint, when the test is often the only delivery that has run. It is a real signed POST, so it is recorded, badged as a test, and written **already-terminal** so the worker can never claim it and send it a second time.

**Email rows can be attributed to a form.** `SubmissionNotification` never carried `formId` — it resolved the template and was dropped — so no email delivery could be traced to its form. Additive; rows enqueued before this stay unattributable.

## Decisions worth reviewing

- **`NULL` means NOT RECORDED, never "an empty body was sent".** Older rows, and kinds whose adapter has no single request (HubSpot is a sequence of API calls), render as "not recorded" rather than an empty code block.
- **A later attempt with no transcript does not erase the earlier one.** The last retry of a host that stopped resolving has no response; nulling the stored one would throw away the only evidence of what the endpoint used to say. Pinned by a test.
- **An SSRF refusal IS logged**, with the guard's reason and no transcript. Nothing crossed the wire, but the author clicked Send test and an empty history after a click is the exact complaint this panel answers.
- **`request_body` carries submission answers**, so it is as sensitive as the submission row itself and lives under the same account scope. Request truncated at 8 000 chars, response at 2 000, so a receiver answering with a full HTML error page cannot bloat the queue table.
- **`WEBHOOK_PING_ACTION` lives in `@quill/types`**, not `@quill/db`: the admin is a browser bundle and cannot import the queue. Importing a runtime value from the server-only API client is what broke the client bundle on the first attempt.

## Migrations (additive, both dialects)

- `0013_outbox_account_kind_idx` — `(account_id, kind, updated_at)`. The only index this table had, `(status, next_attempt_at)`, serves the worker's opposite question. Reading `done` rows without this is a sequential scan of the largest partition on every tab open.
- `0014_outbox_transcript` — `request_body`, `response_status`, `response_body`, all nullable.

## Verification

- `pnpm typecheck` · `pnpm lint` · `pnpm test` (1 421) · `pnpm build` — all green.
- `publish-gate` passes (gitleaks clean over history and tree).
- Migrations applied on **Postgres** and `outbox.spec.ts` green there. Note: the rest of the `@quill/db` suite is flaky against a shared local Postgres on `develop` too — a different set fails each run, unrelated to this branch.
- Exercised end to end against a local catcher alternating 200/400: test deliveries land in the log with both outcomes, transcripts stored and rendered.

## Not in scope

`app/admin/integrations/webhooks-section.tsx` still shows failures only per form. Its comment about never showing a green tick because successful deliveries are not queried stops being true at the data layer with this change, but that page's health signal is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
