### PR TITLE
fix: SSRF hardening for the share card + effect-idempotent submit retry

### DIFF
--- a/.changeset/submission-effects-once.md
+++ b/.changeset/submission-effects-once.md
@@ -1,0 +1,9 @@
+---
+'@quill/db': patch
+---
+
+`upsertSubmission` now reports `wasCompletedBefore` — whether the session's row
+was already completed when the write arrived. The row was always idempotent per
+session; this flag lets callers make its downstream effects (emails, CRM
+deliveries) idempotent too, firing them only on the first completion instead of
+on every transport-retry re-landing of the same one.

--- a/apps/api/src/submission.service.spec.ts
+++ b/apps/api/src/submission.service.spec.ts
@@ -87,6 +87,48 @@ describe('submit', () => {
     expect(payload.respondentEmail).toBe('lead@acme.io');
   });
 
+  it('a re-landed complete enqueues NO second round of effects', async () => {
+    // `callActionWithRetry` cannot abort an in-flight request, so a complete
+    // that landed slowly IS retried and this method runs twice for one real
+    // submission. The row dedupes itself; the effects must too — without the
+    // gate, owner and respondent each got a duplicate email and a drained CRM
+    // delivery duplicated its activity.
+    const payload = {
+      sessionId: 'sess-retry',
+      data: { role: 'founder', team_size: 20, company: 'Acme', email: 'lead@acme.io' },
+    };
+    const first = await svc.submit('acme', 'lead-qualifier', payload);
+    const retried = await svc.submit('acme', 'lead-qualifier', payload);
+    await flushEffects();
+
+    // Same verdict both times — the retry is invisible to the visitor.
+    expect('error' in first || 'error' in retried).toBe(false);
+    if ('error' in first || 'error' in retried) return;
+    expect(retried.id).toBe(first.id);
+    expect(retried.score).toBe(first.score);
+
+    // Exactly ONE owner notice and ONE respondent receipt, not two of each.
+    const outbox = await listOutbox(db, { kind: 'email' });
+    expect(outbox.map((r) => r.action).sort()).toEqual(['submission_confirmed', 'submission_received']);
+  });
+
+  it('a partial→complete transition still fires the complete effects once', async () => {
+    // The gate must key on "was ALREADY completed", not "row existed" — the
+    // normal partial-then-final flow reuses the row and must still notify.
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-partial-then-final',
+      partial: true,
+      data: { role: 'founder' },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-partial-then-final',
+      data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+    });
+    await flushEffects();
+    const outbox = await listOutbox(db, { kind: 'email' });
+    expect(outbox.map((r) => r.action).sort()).toEqual(['submission_confirmed', 'submission_received']);
+  });
+
   it('a completed submission WITHOUT an email enqueues only the owner notice', async () => {
     await svc.submit('acme', 'lead-qualifier', {
       sessionId: 'sess-noemail',

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -126,7 +126,16 @@ export class SubmissionService {
       partial: input.partial,
     });
 
-    if (!input.partial) {
+    // A transport retry whose first attempt actually landed re-runs this whole
+    // method (`callActionWithRetry` cannot abort an in-flight request, so a
+    // slow-but-successful complete IS retried). The submission row dedupes
+    // itself; its effects do not — without this gate the owner and respondent
+    // each get a second email, and a drained CRM delivery duplicates (the
+    // HubSpot mirror activity has no idempotency key). The first landing
+    // already owes every effect, so a re-landed complete enqueues nothing.
+    const reCompleted = !input.partial && row.wasCompletedBefore;
+
+    if (!input.partial && !reCompleted) {
       const respondentEmail = pickEmail(input.data);
       // form.id lets the effect apply any per-form template override
       // (precedence form → account → stock, resolved inside the effect).
@@ -162,7 +171,11 @@ export class SubmissionService {
     // internally guarded so it cannot throw) — the actual delivery happens later
     // in the worker, so the submission is never blocked or failed by a slow/failing
     // destination. Enqueued for BOTH phases; adapters decide phase behavior.
-    await this.destinations?.enqueueSubmissionDeliveries({
+    // Skipped on a re-landed complete (same reasoning as the emails above):
+    // enqueue cancels only PENDING rows, so once the worker drained the first
+    // delivery a second enqueue is a duplicate webhook/CRM activity, not a retry.
+    if (!reCompleted)
+      await this.destinations?.enqueueSubmissionDeliveries({
       formId: form.id,
       formName: form.name,
       accountId: form.accountId,

--- a/apps/web/lib/og-remote-image.spec.ts
+++ b/apps/web/lib/og-remote-image.spec.ts
@@ -5,6 +5,9 @@
  * author URLs the server is willing to resolve and which bytes Satori is able to
  * draw. Every rejection has to come back as null, because the alternative is a
  * throw inside `ImageResponse` and a link that unfurls with no card at all.
+ *
+ * DNS is injected everywhere: the guard now resolves hostnames before fetching,
+ * and a unit test must not depend on the machine's resolver.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { remoteImageDataUri } from './og-remote-image';
@@ -13,6 +16,9 @@ function respond(type: string, bytes = Buffer.from([1, 2, 3]), status = 200) {
   return new Response(bytes, { status, headers: { 'content-type': type } });
 }
 
+/** A resolver that says every hostname lives at a public address. */
+const publicDns = { resolve: async () => ['93.184.216.34'] };
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -20,20 +26,34 @@ afterEach(() => {
 describe('remoteImageDataUri — what it will draw', () => {
   it('returns the bytes inline so Satori never re-fetches without the guards', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/png')));
-    const uri = await remoteImageDataUri('https://cdn.example.com/logo.png');
+    const uri = await remoteImageDataUri('https://cdn.example.com/logo.png', publicDns);
     expect(uri).toBe(`data:image/png;base64,${Buffer.from([1, 2, 3]).toString('base64')}`);
   });
 
   it('accepts SVG, which is how the product’s own marks reach a card', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/svg+xml')));
-    await expect(remoteImageDataUri('https://cdn.example.com/logo.svg')).resolves.toContain(
+    await expect(remoteImageDataUri('https://cdn.example.com/logo.svg', publicDns)).resolves.toContain(
       'data:image/svg+xml;base64,',
     );
   });
 
   it('tolerates a charset on the content type', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/svg+xml; charset=utf-8')));
-    await expect(remoteImageDataUri('https://cdn.example.com/logo.svg')).resolves.not.toBeNull();
+    await expect(remoteImageDataUri('https://cdn.example.com/logo.svg', publicDns)).resolves.not.toBeNull();
+  });
+
+  it('accepts a public IP literal without consulting DNS', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/png')));
+    const resolve = vi.fn();
+    await expect(remoteImageDataUri('https://93.184.216.34/logo.png', { resolve })).resolves.not.toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('refuses to follow redirects — the Location target was never validated', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(respond('image/png'));
+    vi.stubGlobal('fetch', fetchSpy);
+    await remoteImageDataUri('https://cdn.example.com/logo.png', publicDns);
+    expect(fetchSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ redirect: 'error' }));
   });
 });
 
@@ -42,28 +62,28 @@ describe('remoteImageDataUri — what it refuses', () => {
     // This is the case that made every WordPress-hosted logo a render error
     // rather than a missing logo.
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/webp')));
-    await expect(remoteImageDataUri('https://cdn.example.com/logo.webp')).resolves.toBeNull();
+    await expect(remoteImageDataUri('https://cdn.example.com/logo.webp', publicDns)).resolves.toBeNull();
   });
 
   it('drops AVIF for the same reason', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/avif')));
-    await expect(remoteImageDataUri('https://cdn.example.com/logo.avif')).resolves.toBeNull();
+    await expect(remoteImageDataUri('https://cdn.example.com/logo.avif', publicDns)).resolves.toBeNull();
   });
 
   it('drops a non-OK response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/png', Buffer.from([1]), 404)));
-    await expect(remoteImageDataUri('https://cdn.example.com/gone.png')).resolves.toBeNull();
+    await expect(remoteImageDataUri('https://cdn.example.com/gone.png', publicDns)).resolves.toBeNull();
   });
 
   it('drops a body past the size cap even when the header understated it', async () => {
     const huge = Buffer.alloc(1_600_000, 7);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(respond('image/png', huge)));
-    await expect(remoteImageDataUri('https://cdn.example.com/huge.png')).resolves.toBeNull();
+    await expect(remoteImageDataUri('https://cdn.example.com/huge.png', publicDns)).resolves.toBeNull();
   });
 
   it('swallows a fetch that throws, so a dead origin costs only the logo', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
-    await expect(remoteImageDataUri('https://cdn.example.com/slow.png')).resolves.toBeNull();
+    await expect(remoteImageDataUri('https://cdn.example.com/slow.png', publicDns)).resolves.toBeNull();
   });
 });
 
@@ -82,16 +102,62 @@ describe('remoteImageDataUri — where it will not reach', () => {
       'http://172.16.0.9/logo.png',
       'http://kubernetes.default.internal/logo.png',
     ]) {
-      await expect(remoteImageDataUri(url)).resolves.toBeNull();
+      await expect(remoteImageDataUri(url, publicDns)).resolves.toBeNull();
     }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses a public-looking hostname that RESOLVES to a private address', async () => {
+    // DNS rebinding's first half: nothing in the URL looks internal, the
+    // resolver is what aims it inward. The name check alone cannot see this.
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    for (const inward of ['10.0.0.5', '127.0.0.1', '169.254.169.254', '::1', 'fd00::2', '::ffff:192.168.1.9']) {
+      await expect(
+        remoteImageDataUri('https://logo.attacker.example/x.png', { resolve: async () => [inward] }),
+      ).resolves.toBeNull();
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses when ANY resolved address is private — one public A record is no alibi', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await expect(
+      remoteImageDataUri('https://logo.attacker.example/x.png', {
+        resolve: async () => ['93.184.216.34', '10.0.0.5'],
+      }),
+    ).resolves.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses private IP literals in v6 forms the old regexes never saw', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    for (const url of ['http://[fd00::1]/x.png', 'http://[::ffff:10.0.0.5]/x.png', 'http://[fe80::1]/x.png']) {
+      await expect(remoteImageDataUri(url, publicDns)).resolves.toBeNull();
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats a hostname that does not resolve as unreachable', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await expect(
+      remoteImageDataUri('https://nope.example/x.png', {
+        resolve: async () => {
+          throw new Error('ENOTFOUND');
+        },
+      }),
+    ).resolves.toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('refuses a non-http scheme', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    await expect(remoteImageDataUri('file:///etc/passwd')).resolves.toBeNull();
-    await expect(remoteImageDataUri('data:image/png;base64,AAAA')).resolves.toBeNull();
+    await expect(remoteImageDataUri('file:///etc/passwd', publicDns)).resolves.toBeNull();
+    await expect(remoteImageDataUri('data:image/png;base64,AAAA', publicDns)).resolves.toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -99,7 +165,7 @@ describe('remoteImageDataUri — where it will not reach', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     for (const value of [null, undefined, '', '   ', 'not a url']) {
-      await expect(remoteImageDataUri(value)).resolves.toBeNull();
+      await expect(remoteImageDataUri(value, publicDns)).resolves.toBeNull();
     }
     expect(fetchSpy).not.toHaveBeenCalled();
   });

--- a/apps/web/lib/og-remote-image.ts
+++ b/apps/web/lib/og-remote-image.ts
@@ -15,10 +15,17 @@
  *     and shows no card at all, which is worse than a card without the logo.
  *  3. **Reach.** The URL is author-controlled and we now resolve it from inside
  *     the cluster, so it is a server-side request forgery surface the `<img>`
- *     version never was. Loopback and private ranges are refused.
+ *     version never was. The hostname is checked, then RESOLVED, and any
+ *     loopback / private / link-local / unique-local address is refused —
+ *     matching the `ssrf-guard` the webhook adapter sets as this repo's
+ *     standard (a name check alone lets a public DNS name point inward).
+ *     Redirects are refused outright (`redirect: 'error'`): following one
+ *     would land on a hostname none of these checks ever saw, and a card is
+ *     better missing a logo than fetching where a Location header aims it.
  *
  * Every failure path returns null and the caller draws the card without it.
  */
+import { isIP } from 'node:net';
 
 /** Satori's decoders. WebP and AVIF are absent because it has none. */
 const DECODABLE = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml']);
@@ -40,6 +47,57 @@ const BLOCKED_HOST = [
   /\.local$/i,
 ];
 
+/** Resolve a hostname to its addresses (A/AAAA). Injectable for tests. */
+export type OgDnsResolver = (hostname: string) => Promise<string[]>;
+
+const defaultResolver: OgDnsResolver = async (hostname) => {
+  const { lookup } = await import('node:dns/promises');
+  const results = await lookup(hostname, { all: true });
+  return results.map((r) => r.address);
+};
+
+/**
+ * True for an address this server may fetch from on an author's behalf —
+ * public unicast only. Same classification as `ssrf-guard` in
+ * `@quill/destinations` (not imported: that package is API-side and carries
+ * the adapters; the web app only needs these thirty lines).
+ */
+function isPublicAddress(ip: string): boolean {
+  const kind = isIP(ip);
+  if (kind === 4) {
+    const o = ip.split('.').map(Number);
+    if (o.length !== 4 || o.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+    const [a, b] = o as [number, number, number, number];
+    if (a === 127 || a === 10 || a === 0) return false; // loopback, private, "this host"
+    if (a === 172 && b >= 16 && b <= 31) return false; // 172.16.0.0/12
+    if (a === 192 && b === 168) return false; // 192.168.0.0/16
+    if (a === 169 && b === 254) return false; // link-local incl. cloud metadata
+    if (a === 100 && b >= 64 && b <= 127) return false; // CGNAT
+    if (a >= 224) return false; // multicast + reserved
+    return true;
+  }
+  if (kind === 6) {
+    const lower = ip.toLowerCase();
+    // IPv4-mapped — classify the embedded v4. Both spellings reach here:
+    // dotted (::ffff:10.0.0.5) from DNS answers, and the hex pair the WHATWG
+    // URL parser canonicalizes hostnames to (::ffff:a00:5).
+    const mappedDotted = lower.match(/(?:::ffff:|::)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (mappedDotted) return isPublicAddress(mappedDotted[1]!);
+    const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mappedHex) {
+      const hi = parseInt(mappedHex[1]!, 16);
+      const lo = parseInt(mappedHex[2]!, 16);
+      return isPublicAddress(`${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`);
+    }
+    if (lower === '::1' || lower === '::') return false; // loopback, unspecified
+    if (/^fe[89ab]/.test(lower)) return false; // fe80::/10 link-local
+    const firstByte = parseInt(lower.split(':')[0]?.padStart(4, '0').slice(0, 2) || '0', 16);
+    if ((firstByte & 0xfe) === 0xfc) return false; // fc00::/7 unique-local
+    return true;
+  }
+  return false;
+}
+
 function isFetchable(raw: string): URL | null {
   let url: URL;
   try {
@@ -53,20 +111,44 @@ function isFetchable(raw: string): URL | null {
 }
 
 /**
+ * The hostname's real targets, all of them public — or false. An IP literal is
+ * its own target; a DNS name is looked up so a public-looking name that
+ * resolves inward (DNS rebinding's first half) is refused before any request.
+ */
+async function reachesOnlyPublicAddresses(url: URL, resolve: OgDnsResolver): Promise<boolean> {
+  const host = url.hostname.replace(/^\[|\]$/g, '');
+  if (isIP(host)) return isPublicAddress(host);
+  try {
+    const ips = await resolve(host);
+    return ips.length > 0 && ips.every(isPublicAddress);
+  } catch {
+    // NXDOMAIN / resolver failure — the fetch could not succeed anyway.
+    return false;
+  }
+}
+
+/**
  * The image as a `data:` URI Satori can draw, or null when it cannot be used.
  *
  * Returns a data URI rather than the original URL on purpose: Satori would
  * otherwise fetch it a second time itself, with none of the guards above.
  */
-export async function remoteImageDataUri(raw: string | null | undefined): Promise<string | null> {
+export async function remoteImageDataUri(
+  raw: string | null | undefined,
+  opts?: { resolve?: OgDnsResolver },
+): Promise<string | null> {
   const trimmed = raw?.trim();
   if (!trimmed) return null;
   const url = isFetchable(trimmed);
   if (!url) return null;
+  if (!(await reachesOnlyPublicAddresses(url, opts?.resolve ?? defaultResolver))) return null;
 
   try {
     const res = await fetch(url, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      // A redirect would move the request to a hostname the guards above never
+      // examined — refuse rather than re-validate hop by hop.
+      redirect: 'error',
       // The card is cached by whoever renders it; re-validating the author's
       // asset on every crawl would multiply their bandwidth by our traffic.
       cache: 'force-cache',

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -598,6 +598,13 @@ function mapSubmission(r: Record<string, unknown>): SubmissionRow {
  * Upsert THE submission for a session (one row per session). A partial save sets
  * `partial_at`; a final submit sets `completed_at`. Re-submitting the same
  * session updates the same row (idempotent per session) rather than duplicating.
+ *
+ * `wasCompletedBefore` reports whether the row was ALREADY completed when this
+ * write arrived. The row itself is safely idempotent; its downstream EFFECTS
+ * (emails, CRM deliveries) are not — a client-side transport retry whose first
+ * attempt actually landed re-runs the service, and only this flag lets it tell
+ * a first completion (fire the effects) from a re-landed one (row refreshed,
+ * effects already owed by the first landing).
  */
 export async function upsertSubmission(
   db: Db,
@@ -609,7 +616,7 @@ export async function upsertSubmission(
     partial?: boolean;
     now?: number;
   },
-): Promise<SubmissionRow> {
+): Promise<SubmissionRow & { wasCompletedBefore: boolean }> {
   const now = input.now ?? Date.now();
   const completedAt = input.partial ? null : now;
   const partialAt = input.partial ? now : null;
@@ -621,12 +628,13 @@ export async function upsertSubmission(
           WHERE form_id = ${input.formId} AND session_id = ${input.sessionId} LIMIT 1`,
     );
 
-  const applyUpdate = async (existing: ExistingRow): Promise<SubmissionRow> => {
+  const applyUpdate = async (existing: ExistingRow): Promise<SubmissionRow & { wasCompletedBefore: boolean }> => {
+    const wasCompletedBefore = existing.completed_at != null;
     // Reorder guard: a fire-and-forget partial can land AFTER the complete
     // submit. Once a row is completed, only a complete submit may update it —
     // a late partial must NOT overwrite the finalized data/score.
-    if (input.partial && existing.completed_at != null) {
-      return (await getSubmissionById(db, existing.id))!;
+    if (input.partial && wasCompletedBefore) {
+      return { ...(await getSubmissionById(db, existing.id))!, wasCompletedBefore };
     }
     await db.run(
       sql`UPDATE submission
@@ -635,7 +643,7 @@ export async function upsertSubmission(
               partial_at = COALESCE(${partialAt}, partial_at)
           WHERE id = ${existing.id}`,
     );
-    return (await getSubmissionById(db, existing.id))!;
+    return { ...(await getSubmissionById(db, existing.id))!, wasCompletedBefore };
   };
 
   const existing = await selectExisting();
@@ -653,7 +661,7 @@ export async function upsertSubmission(
           VALUES (${id}, ${input.formId}, ${input.sessionId}, ${jsonParam(input.data)}, ${input.score},
             ${now}, ${completedAt}, ${partialAt})`,
     );
-    return (await getSubmissionById(db, id))!;
+    return { ...(await getSubmissionById(db, id))!, wasCompletedBefore: false };
   } catch (err) {
     const raced = await selectExisting();
     if (raced) return applyUpdate(raced);

--- a/packages/db/src/submission.spec.ts
+++ b/packages/db/src/submission.spec.ts
@@ -80,6 +80,24 @@ describe('submission upsert', () => {
     expect(rows[0]!.completedAt).not.toBeNull();
   });
 
+  it('reports whether the row was already completed, so effects fire exactly once', async () => {
+    // The row is idempotent per session; its downstream effects (emails, CRM
+    // deliveries) are not. `wasCompletedBefore` is what lets the service tell a
+    // first completion from a transport-retry re-landing of the same one.
+    const session = 'effects-once';
+    const first = await upsertSubmission(db, { formId, sessionId: session, data: { a: 1 }, score: 3, partial: true });
+    expect(first.wasCompletedBefore).toBe(false); // fresh insert
+
+    const completed = await upsertSubmission(db, { formId, sessionId: session, data: { a: 1, b: 2 }, score: 7 });
+    expect(completed.wasCompletedBefore).toBe(false); // partial→complete: FIRST completion
+
+    const retried = await upsertSubmission(db, { formId, sessionId: session, data: { a: 1, b: 2 }, score: 7 });
+    expect(retried.wasCompletedBefore).toBe(true); // re-landed complete: effects already owed
+
+    const latePartial = await upsertSubmission(db, { formId, sessionId: session, data: { a: 1 }, score: 3, partial: true });
+    expect(latePartial.wasCompletedBefore).toBe(true); // reorder-guarded no-op
+  });
+
   it('creates distinct rows for distinct sessions', async () => {
     await upsertSubmission(db, { formId, sessionId: 'a', data: {}, score: 0 });
     await upsertSubmission(db, { formId, sessionId: 'b', data: {}, score: 0 });


### PR DESCRIPTION
Closes the two SHOULD-FIX findings from the pre-release review of #89. **Merge this before #89** — it targets `develop`, so the release train picks it up automatically.

## 1. Share card image fetch: redirect-follow SSRF bypass

`og-remote-image.ts` regex-checked only the *original* hostname and fetched with the default `redirect: follow`: an author sets their logo to `https://attacker.com/x` which 302s to `http://10.0.0.5/…` or the cloud metadata endpoint, and the server fetches it. A public DNS name resolving to a private IP also passed.

Now, mirroring the `ssrf-guard` standard from the webhook adapter (not imported — that package is API-side; the web app carries the ~30 lines it needs):

- the hostname is **resolved** and every address must be public — loopback, RFC1918, link-local (incl. `169.254.169.254`), CGNAT, multicast, IPv6 `fe80::/10` + `fc00::/7`, and **both IPv4-mapped spellings** (`::ffff:10.0.0.5` and the hex `::ffff:a00:5` the WHATWG URL parser canonicalizes to — the dotted-only check misses it, caught by test)
- `redirect: 'error'` — a redirect lands on a hostname no check ever saw; the card degrades to no logo
- resolver injectable; every failure still returns null (card renders without the image)

Spec grows 10→17 cases: rebinding, mixed public+private answers, v6 literals, NXDOMAIN, redirect refusal.

## 2. Submit retry: row-safe but not effect-safe

`callActionWithRetry` cannot abort an in-flight request, so a complete submit that **landed slowly is retried** and the service runs twice for one real submission. The row dedupes by `(form, session)`; the effects did not:

- owner + respondent each received a **duplicate email** whenever both attempts landed
- `enqueueSubmissionDeliveries` cancels only *pending* rows — once the worker drained the first delivery, the re-enqueue **duplicated the webhook/HubSpot activity** (the mirror submission has no idempotency key)

`upsertSubmission` now returns `wasCompletedBefore` (already-completed when this write arrived) and the service skips every complete-phase effect on a re-landed complete. The partial→complete transition still fires effects exactly once — pinned by test on both layers (db spec runs on both dialects, so the Postgres parity job covers it).

## Verification

`typecheck` 16/16 · `lint` clean · api 348 · db 174 (incl. the parity spec) · web 411 · changeset for `@quill/db` (additive return field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)