### PR TITLE
fix(web): forward the visitor's X-Forwarded-For chain to the public API

### DIFF
--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -2,6 +2,7 @@
 
 import { postSubmission, postFormEvent } from '@/lib/api';
 import { postBookingCallback } from '@/lib/booking-embed';
+import { forwardedForChain } from '@/lib/forwarded-for';
 import type { BookingCallbackInput } from '@quill/types';
 
 /**
@@ -32,5 +33,5 @@ export async function recordBookingAction(
   slug: string,
   payload: BookingCallbackInput,
 ): Promise<void> {
-  await postBookingCallback(accountCode, slug, payload);
+  await postBookingCallback(accountCode, slug, payload, await forwardedForChain());
 }

--- a/apps/web/lib/api.spec.ts
+++ b/apps/web/lib/api.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPublicForm, postFormEvent, postSubmission } from './api';
 
 const headersMock = vi.hoisted(() => vi.fn());
@@ -22,6 +22,10 @@ beforeEach(() => {
   headersMock.mockResolvedValue(requestHeaders({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' }));
   fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 /**

--- a/apps/web/lib/api.spec.ts
+++ b/apps/web/lib/api.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPublicForm, postFormEvent, postSubmission } from './api';
+
+const headersMock = vi.hoisted(() => vi.fn());
+vi.mock('next/headers', () => ({ headers: headersMock }));
+
+function requestHeaders(entries: Record<string, string>) {
+  return { get: (k: string) => entries[k.toLowerCase()] ?? null };
+}
+
+function jsonResponse(status: number, body: unknown = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  headersMock.mockReset();
+  headersMock.mockResolvedValue(requestHeaders({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' }));
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+/**
+ * Every server-side call made on a visitor's behalf must carry the visitor's
+ * X-Forwarded-For chain — otherwise the API rate-limits ALL visitors as one
+ * client (the web server's IP). See `lib/forwarded-for.ts`.
+ */
+describe('visitor IP forwarding to the public API', () => {
+  it('getPublicForm forwards the chain on the config fetch', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { slug: 's', name: 'n', config: {} }));
+    await getPublicForm('acme', 'lead-qualifier');
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+  });
+
+  it('postSubmission forwards the chain alongside content-type', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(201, { id: '1', score: 0, outcome: null }));
+    await postSubmission('acme', 'lead-qualifier', { sessionId: 's1', data: {} });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.7, 10.0.0.2',
+    });
+  });
+
+  it('postFormEvent forwards the chain', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200));
+    await postFormEvent('acme', 'lead-qualifier', { sessionId: 's1', type: 'view' });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+  });
+
+  it('sends no forwarding header when the incoming request has none', async () => {
+    headersMock.mockResolvedValue(requestHeaders({}));
+    fetchMock.mockResolvedValue(jsonResponse(200));
+    await postFormEvent('acme', 'lead-qualifier', { sessionId: 's1', type: 'view' });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty('x-forwarded-for');
+  });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -6,11 +6,15 @@
 import { cache } from 'react';
 import type { PublicForm, PublicProfile } from '@quill/types';
 import { serverApiUrl } from './api-url';
+import { forwardedForHeader } from './forwarded-for';
 
 const API_URL = serverApiUrl;
 
 async function getJson<T>(path: string): Promise<T | null> {
-  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  const res = await fetch(`${API_URL}${path}`, {
+    cache: 'no-store',
+    headers: await forwardedForHeader(),
+  });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`API ${path} failed: ${res.status}`);
   return (await res.json()) as T;
@@ -55,7 +59,7 @@ export async function postSubmission(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/submissions`,
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', ...(await forwardedForHeader()) },
       body: JSON.stringify(body),
       cache: 'no-store',
     },
@@ -82,7 +86,7 @@ export async function postFormEvent(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/events`,
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', ...(await forwardedForHeader()) },
       body: JSON.stringify(body),
       cache: 'no-store',
     },

--- a/apps/web/lib/booking-embed.spec.ts
+++ b/apps/web/lib/booking-embed.spec.ts
@@ -216,4 +216,22 @@ describe('postBookingCallback', () => {
       postBookingCallback('acme', 'lead-qualifier', { sessionId: 's', provider: 'calendly' }),
     ).resolves.toBeUndefined();
   });
+
+  it('forwards the visitor chain when given one, and omits the header when not', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postBookingCallback(
+      'acme',
+      'lead-qualifier',
+      { sessionId: 's', provider: 'calendly' },
+      '203.0.113.7, 10.0.0.2',
+    );
+    let [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+
+    await postBookingCallback('acme', 'lead-qualifier', { sessionId: 's', provider: 'calendly' });
+    [, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty('x-forwarded-for');
+  });
 });

--- a/apps/web/lib/booking-embed.ts
+++ b/apps/web/lib/booking-embed.ts
@@ -244,12 +244,22 @@ export async function postBookingCallback(
   accountCode: string,
   slug: string,
   body: BookingCallbackInput,
+  /**
+   * The visitor's X-Forwarded-For chain, when calling from the server on a
+   * visitor's behalf (see `lib/forwarded-for.ts`). A parameter — not a
+   * `next/headers` import — because this module also ships to the browser,
+   * where the visitor IS the socket peer and no forwarding is needed.
+   */
+  forwardedFor?: string | null,
 ): Promise<void> {
   await fetch(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/booking`,
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        ...(forwardedFor ? { 'x-forwarded-for': forwardedFor } : {}),
+      },
       body: JSON.stringify(body),
       cache: 'no-store',
     },

--- a/apps/web/lib/forwarded-for.spec.ts
+++ b/apps/web/lib/forwarded-for.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { forwardedForChain, forwardedForHeader } from './forwarded-for';
+
+const headersMock = vi.hoisted(() => vi.fn());
+vi.mock('next/headers', () => ({ headers: headersMock }));
+
+function requestHeaders(entries: Record<string, string>) {
+  return { get: (k: string) => entries[k.toLowerCase()] ?? null };
+}
+
+beforeEach(() => {
+  headersMock.mockReset();
+});
+
+describe('forwardedForChain', () => {
+  it('returns the incoming chain verbatim — proxy hop math belongs to the API', async () => {
+    headersMock.mockResolvedValue(
+      requestHeaders({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' }),
+    );
+    await expect(forwardedForChain()).resolves.toBe('203.0.113.7, 10.0.0.2');
+  });
+
+  it('returns null when the request has no chain (direct-exposed self-host)', async () => {
+    headersMock.mockResolvedValue(requestHeaders({}));
+    await expect(forwardedForChain()).resolves.toBeNull();
+  });
+
+  it('returns null outside a request scope instead of throwing', async () => {
+    headersMock.mockRejectedValue(new Error('headers called outside a request scope'));
+    await expect(forwardedForChain()).resolves.toBeNull();
+  });
+});
+
+describe('forwardedForHeader', () => {
+  it('spreads into fetch headers when a chain exists', async () => {
+    headersMock.mockResolvedValue(requestHeaders({ 'x-forwarded-for': '203.0.113.7' }));
+    await expect(forwardedForHeader()).resolves.toEqual({ 'x-forwarded-for': '203.0.113.7' });
+  });
+
+  it('is empty when there is nothing to forward — no empty-string header sent', async () => {
+    headersMock.mockResolvedValue(requestHeaders({}));
+    await expect(forwardedForHeader()).resolves.toEqual({});
+  });
+});

--- a/apps/web/lib/forwarded-for.ts
+++ b/apps/web/lib/forwarded-for.ts
@@ -1,0 +1,34 @@
+/**
+ * The visitor's `X-Forwarded-For` chain, for server-side calls made to the
+ * public API on a visitor's behalf.
+ *
+ * The public API rate-limits per client IP (`apps/api/src/rate-limit.ts`). When
+ * the web app fetches on behalf of a visitor (RSC page render, Server Actions),
+ * the API's socket peer is the web server — so without this header every
+ * visitor of every form shares ONE rate-limit bucket, and a burst of visitors
+ * (a conference QR moment) exhausts it for everyone at once.
+ *
+ * The chain is forwarded VERBATIM, never rebuilt: the API resolves the real
+ * client entry from the right by its own `TRUST_PROXY_HOPS`, so the header must
+ * reach it exactly as the web app's fronting proxy produced it. Appending or
+ * reordering entries here would silently shift that math.
+ */
+import { headers } from 'next/headers';
+
+/** The incoming request's XFF chain, or null outside a request / no proxy. */
+export async function forwardedForChain(): Promise<string | null> {
+  try {
+    const h = await headers();
+    return h.get('x-forwarded-for');
+  } catch {
+    // Outside a request scope (build-time render, tests) there is no visitor
+    // to attribute — the caller sends no header and the API keys on the peer.
+    return null;
+  }
+}
+
+/** The chain as ready-to-spread fetch headers ({} when there is none). */
+export async function forwardedForHeader(): Promise<Record<string, string>> {
+  const chain = await forwardedForChain();
+  return chain ? { 'x-forwarded-for': chain } : {};
+}

--- a/apps/web/lib/forwarded-for.ts
+++ b/apps/web/lib/forwarded-for.ts
@@ -11,7 +11,11 @@
  * The chain is forwarded VERBATIM, never rebuilt: the API resolves the real
  * client entry from the right by its own `TRUST_PROXY_HOPS`, so the header must
  * reach it exactly as the web app's fronting proxy produced it. Appending or
- * reordering entries here would silently shift that math.
+ * reordering entries here would silently shift that math. For the same reason
+ * the web→API call itself must not traverse an XFF-appending proxy (call the
+ * API directly / in-cluster) — such a hop would append the web server's IP and
+ * the API would resolve back to it, silently re-merging every visitor into one
+ * bucket.
  */
 import { headers } from 'next/headers';
 


### PR DESCRIPTION
## Problem

During Colombia Tech Week (2026-08-14), QR-scan stampedes took the public form down twice (10:18 and 10:48 COT): visitors got the *"This page didn't load"* error boundary while the service itself was healthy.

Root cause: every server-side call the web app makes on a visitor's behalf — the RSC config fetch and the submission/event/booking Server Actions — reaches the API from the **web server's own IP**. The API's per-IP rate limiter (`RATE_LIMIT_CAPACITY=60`, `RATE_LIMIT_REFILL_PER_SEC=1`) therefore keyed **all visitors of all forms into one shared token bucket**. ~100 visitors/minute × ~10 requests each exhausted it platform-wide, and any one customer's traffic spike throttled every other customer.

(Production was stabilized the same day by raising the limits via ConfigMap; this PR is the real fix.)

## Change

Forward the incoming request's `X-Forwarded-For` chain **verbatim** on those calls, so the API's existing `clientKey()` + `TRUST_PROXY_HOPS` resolution sees the real visitor and limits per visitor, as the limiter was designed to.

- `apps/web/lib/forwarded-for.ts` (new): reads the chain from `next/headers`; resolves to nothing outside a request scope (build-time render, tests) or when there is no proxy.
- `apps/web/lib/api.ts`: `getJson`, `postSubmission`, `postFormEvent` send the chain.
- `apps/web/lib/booking-embed.ts`: `postBookingCallback` takes the chain as an optional parameter — this module also ships to the browser, so it cannot import `next/headers`; the Server Action passes it.
- No API-side change: spoofing stays defeated because the fronting ALB always appends the true peer and `clientKey()` resolves from the right.

## Verification

- 26 unit tests across 3 specs (new: `forwarded-for.spec.ts`, `api.spec.ts`; extended: `booking-embed.spec.ts`); full `@quill/web` suite green (441 tests), typecheck + lint clean.
- End-to-end against a header-logging mock API through a real `next dev` SSR render: single IP, multi-hop chain (`203.0.113.7, 10.0.0.2`), and no-proxy requests all arrive with the correct chain (Next supplies the socket peer when no proxy is present, so direct-exposed self-hosts also get per-visitor limiting).

## Deploy note

Once this reaches production, the temporary ConfigMap values (`RATE_LIMIT_CAPACITY=10000`, `RATE_LIMIT_REFILL_PER_SEC=200`) protect per-IP rather than platform-wide. Venue Wi-Fi / CGNAT still put whole crowds behind one IP, so keep capacity generous (thousands, not 60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)