### PR TITLE
feat(web): first-touch attribution in the platform dataLayer + landing PostHog alias

### DIFF
--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -7,6 +7,7 @@ import { AdminShell } from '@/components/admin-shell';
 import { getLocale } from '@/lib/locale';
 import { getThemePref } from '@/lib/theme.server';
 import { ToastProvider } from '@/components/toast';
+import { PH_ID_COOKIE, sanitizeLandingDistinctId } from '@/lib/attribution';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
 import { ProductAnalytics } from '@/components/analytics/product-analytics';
 import { PlatformGtm, resolvePlatformGtmId } from '@/components/analytics/platform-gtm';
@@ -71,6 +72,10 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           // Passing them only on the wizard would leave every funnel that starts
           // after onboarding un-sliceable by campaign, which is most of them.
           attribution: me.attribution,
+          // The landing's PostHog id, if this login started on a landing CTA.
+          // Re-sanitized on read — the cookie is ours, but the ten minutes
+          // between write and read are not a chain of custody.
+          landingDistinctId: sanitizeLandingDistinctId(jar.get(PH_ID_COOKIE)?.value),
         }}
       />
       <AdminShell

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -53,7 +53,10 @@ export default async function AdminLayout({ children }: { children: ReactNode })
 
   return (
     <ToastProvider>
-      <PlatformGtm gtmId={resolvePlatformGtmId()} />
+      {/* Same tags GTM gets on the wizard, minus the signup event: this layout
+          wraps every dashboard page, so the campaign is available to any tag
+          the container fires later — but the account here is of any age. */}
+      <PlatformGtm gtmId={resolvePlatformGtmId()} attribution={me.attribution} />
       <ProductAnalytics
         analytics={analytics}
         identity={{

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import { parseAttribution } from '@quill/types';
+import { PH_ID_COOKIE, PH_ID_QUERY_KEY, sanitizeLandingDistinctId } from '@/lib/attribution';
 import { authProvider } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
@@ -60,6 +61,22 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // back from campaign B inside ten minutes, and last-wins would credit B.
   if (attribution && !jar.get(ATTRIBUTION_COOKIE)) {
     jar.set(ATTRIBUTION_COOKIE, JSON.stringify(attribution), {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 600,
+    });
+  }
+
+  // The landing's PostHog anonymous id, parked beside the tags with the same
+  // rules: sanitized (this query is composable by anyone), first attempt wins
+  // (the id of the visit that STARTED the login is the one worth joining), and
+  // absent sets nothing. Unlike the tags it never touches the API or the
+  // database — its whole life is browser-side, ending in one `alias` call.
+  const landingId = sanitizeLandingDistinctId(sp.getAll(PH_ID_QUERY_KEY));
+  if (landingId && !jar.get(PH_ID_COOKIE)) {
+    jar.set(PH_ID_COOKIE, landingId, {
       path: '/',
       httpOnly: true,
       sameSite: 'lax',

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -25,6 +25,13 @@ export default async function LoginPage({
 
   return (
     <>
+      {/* No tags to hand the container here, and that is not an oversight. On a
+          Dapta build this page only renders as an ERROR landing or after a
+          sign-out (the redirect above takes every other visit straight to the
+          hosted login), so it is not a step of the acquisition funnel. The tags
+          exist at this point — parked in the httpOnly attribution cookie — but
+          publishing a campaign on a failed login would file the same click under
+          two different pages. */}
       <PlatformGtm gtmId={resolvePlatformGtmId()} />
       <main className="flex min-h-dvh flex-col items-center justify-center gap-8 px-6">
         {/* Sign-in is an entrance, so it gets the full company lockup at display

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -63,7 +63,15 @@ export default async function OnboardingPage({
 
   return (
     <>
-      <PlatformGtm gtmId={resolvePlatformGtmId()} />
+      {/* The only surface that passes `signupAccountId`: this page renders once
+          per brand-new workspace, and its first paint is the conversion the ad
+          platforms are optimizing for. The tags come from `account.attribution`
+          — written by the callback moments ago, before this page ever ran. */}
+      <PlatformGtm
+        gtmId={resolvePlatformGtmId()}
+        attribution={me.attribution}
+        signupAccountId={me.accountId}
+      />
       <ProductAnalytics
         analytics={resolveProductAnalytics()}
         identity={{

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,6 +1,8 @@
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { PH_ID_COOKIE, sanitizeLandingDistinctId } from '@/lib/attribution';
 import { preferredLocale } from '@/lib/locale';
 import { currentOnboardingCohort } from '@/lib/dapta-onboarding';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
@@ -81,6 +83,13 @@ export default async function OnboardingPage({
           accountCode: me.accountCode,
           role: me.role,
           attribution: me.attribution,
+          // This is the page that usually spends the ph_id cookie: a fresh
+          // signup lands HERE, not on the dashboard. Wired in both places
+          // because which one renders first is the API's `onboardingRequired`
+          // decision, not ours.
+          landingDistinctId: sanitizeLandingDistinctId(
+            (await cookies()).get(PH_ID_COOKIE)?.value,
+          ),
         }}
       />
       <OnboardingWizard messages={messages} locale={locale} cohort={cohort} />

--- a/apps/web/components/analytics/platform-gtm.spec.tsx
+++ b/apps/web/components/analytics/platform-gtm.spec.tsx
@@ -4,6 +4,9 @@ import Script from 'next/script';
 import {
   DAPTA_PLATFORM_GTM_ID,
   PlatformGtm,
+  SIGNUP_DATALAYER_EVENT,
+  buildPlatformPrelude,
+  platformDataLayerVars,
   resolvePlatformGtmId,
   type PlatformGtmEnv,
 } from './platform-gtm';
@@ -121,5 +124,125 @@ describe('PlatformGtm', () => {
     expect((iframe!.props as AnyProps).src).toBe(
       `https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(hostile)}`,
     );
+  });
+});
+
+describe('platformDataLayerVars — the stored blob as container variables', () => {
+  it('re-keys to the snake_case names the container declares', () => {
+    expect(
+      platformDataLayerVars({
+        utmSource: 'google',
+        utmMedium: 'cpc',
+        utmCampaign: 'forms_launch',
+        utmContent: 'variant_a',
+        utmTerm: 'formularios',
+        gclid: 'Cj0KCQ',
+        fbclid: 'IwAR1',
+      }),
+    ).toEqual({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'forms_launch',
+      utm_content: 'variant_a',
+      utm_term: 'formularios',
+      gclid: 'Cj0KCQ',
+      fbclid: 'IwAR1',
+    });
+  });
+
+  it('publishes referrer and landing path under the FIRST-TOUCH names', () => {
+    // These two are a cross-domain contract: daptaforms.ai pushes the same
+    // variables under these names. Renaming one side alone does not fail — the
+    // container variable just resolves undefined and the tags go quiet.
+    expect(
+      platformDataLayerVars({ referrer: 'https://example.test/x', landingPath: '/precios' }),
+    ).toEqual({ first_touch_referrer: 'https://example.test/x', first_touch_path: '/precios' });
+  });
+
+  it('says nothing at all for an account with no tags', () => {
+    // `{}` and not keys-with-empty-values: a blank utm_source in the layer reads
+    // as "this signup was untagged", which is a different claim from "unknown".
+    expect(platformDataLayerVars(null)).toEqual({});
+    expect(platformDataLayerVars(undefined)).toEqual({});
+    expect(platformDataLayerVars({})).toEqual({});
+    expect(platformDataLayerVars({ utmSource: '', gclid: null })).toEqual({});
+  });
+
+  it('drops what a tag cannot read: unknown keys and non-strings', () => {
+    expect(
+      platformDataLayerVars({ utmSource: 'google', firstSeenAt: 1_700_000_000_000, nope: 'x' }),
+    ).toEqual({ utm_source: 'google' });
+  });
+});
+
+describe('buildPlatformPrelude — what the container sees when it boots', () => {
+  it('initializes the layer even with nothing to push', () => {
+    const out = buildPlatformPrelude({});
+    expect(out).toBe('window.dataLayer=window.dataLayer||[];');
+    expect(out).not.toContain('push');
+  });
+
+  it('emits the signup event only when an account id is passed', () => {
+    expect(buildPlatformPrelude({}, 'acc_123')).toContain(SIGNUP_DATALAYER_EVENT);
+    expect(buildPlatformPrelude({ utm_source: 'google' })).not.toContain(SIGNUP_DATALAYER_EVENT);
+    expect(buildPlatformPrelude({}, null)).not.toContain(SIGNUP_DATALAYER_EVENT);
+  });
+
+  it('latches the signup event per account, and fires when storage is blocked', () => {
+    const out = buildPlatformPrelude({}, 'acc_123');
+    expect(out).toContain('"dapta_forms_signup:acc_123"');
+    // The push sits OUTSIDE the try: a private-mode browser that throws on
+    // localStorage must still report the conversion. Counted twice is
+    // recoverable; never counted is not.
+    const tryEnd = out.indexOf('catch(e){}');
+    expect(tryEnd).toBeGreaterThan(-1);
+    expect(out.indexOf('w.dataLayer.push')).toBeGreaterThan(tryEnd);
+  });
+});
+
+describe('PlatformGtm — attribution reaches the layer before the container', () => {
+  const snippetOf = (el: ReturnType<typeof PlatformGtm>) =>
+    (byTestId(collect(el), 'platform-gtm').props as AnyProps).children as string;
+
+  it('pushes the tags BEFORE gtm.js loads', () => {
+    // The ordering IS the fix. A tag firing on container initialization reads
+    // the layer as it stands at that moment, so a push that lands afterwards
+    // produces a conversion with no campaign on it.
+    const snippet = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: { utmSource: 'google' } }),
+    );
+    expect(snippet).toContain('"utm_source":"google"');
+    expect(snippet.indexOf('"utm_source"')).toBeLessThan(snippet.indexOf('gtm.js'));
+  });
+
+  it('fires the signup event on the wizard and nowhere else', () => {
+    const wizard = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: null, signupAccountId: 'acc_9' }),
+    );
+    expect(wizard).toContain(SIGNUP_DATALAYER_EVENT);
+    // The dashboard passes the same tags without an id — an account signing in
+    // three years later still wants its funnel sliced, and wants no new signup.
+    const dashboard = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: { utmSource: 'google' } }),
+    );
+    expect(dashboard).not.toContain(SIGNUP_DATALAYER_EVENT);
+  });
+
+  it('neutralizes a hostile tag — no </script> breakout out of a utm value', () => {
+    // `utm_source` is whatever the last person to compose a link typed, it is
+    // stored verbatim, and it lands inside an inline <script>.
+    const hostile = `</script><script>alert(1)//`;
+    const snippet = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: { utmSource: hostile } }),
+    );
+    expect(snippet).not.toContain('</script>');
+    expect(snippet).toContain('\\u003c/script>');
+  });
+
+  it('writes no dataLayer at all on a bare fork', () => {
+    // No container means no reader. A fork stays at zero third-party anything.
+    expect(
+      PlatformGtm({ gtmId: null, attribution: { utmSource: 'google' }, signupAccountId: 'acc_1' }),
+    ).toBeNull();
   });
 });

--- a/apps/web/components/analytics/platform-gtm.tsx
+++ b/apps/web/components/analytics/platform-gtm.tsx
@@ -1,5 +1,6 @@
 import Script from 'next/script';
-import { buildGtmSnippet } from '@/components/tracking/tracking-scripts';
+import { attributionEventProps, attributionSchema } from '@quill/types';
+import { buildGtmSnippet, js } from '@/components/tracking/tracking-scripts';
 
 /**
  * Dapta's own Google Tag Manager container for PLATFORM pages — login,
@@ -51,15 +52,127 @@ export function resolvePlatformGtmId(
 }
 
 /**
- * Renders the GTM loader + its no-JS iframe. Returns null when no container is
- * resolved (every bare fork) — no markup, no request.
+ * The two tags whose `dataLayer` names do NOT match the stored field.
+ *
+ * The marketing container declares its variables once and reads them on both
+ * domains, so these names are a CONTRACT with daptaforms.ai — which publishes
+ * `first_touch_referrer` / `first_touch_path` to say plainly that they describe
+ * the visit that started everything, not the page the tag fired on. Renaming
+ * either side alone does not fail: the variable simply resolves undefined and
+ * every tag reading it goes quiet.
  */
-export function PlatformGtm({ gtmId }: { gtmId: string | null }) {
+const DATALAYER_RENAMES: Record<string, string> = {
+  referrer: 'first_touch_referrer',
+  landing_path: 'first_touch_path',
+};
+
+/** Event name, shared with the server-side product-analytics capture. */
+export const SIGNUP_DATALAYER_EVENT = 'forms_signup_completed';
+
+/**
+ * `Me.attribution` as `dataLayer` variables.
+ *
+ * These are FIRST-touch tags read back from `account.attribution`, not the query
+ * string of the current URL — which is exactly the part GA4 cannot reconstruct on
+ * its own here. The signup round-trip leaves our origin for the identity provider
+ * and comes back with a bare URL and a third-party referrer, so by the time any
+ * platform page renders, the campaign exists only in our own column.
+ *
+ * Returns `{}` — never keys with empty values — when there is nothing to say. A
+ * blank `utm_source` in the layer is worse than an absent one: it overwrites a
+ * value a previous push may have set, and reads in the container as "we know this
+ * signup was untagged" rather than "we do not know".
+ */
+export function platformDataLayerVars(
+  attribution: Record<string, string | number | null | undefined> | null | undefined,
+): Record<string, string> {
+  if (!attribution) return {};
+  // Parse rather than trust: the value crosses the API as loose JSON, and
+  // `attributionEventProps` promises a validated `Attribution`. A drifted row
+  // yields `{}` here, which degrades to "no campaign" instead of injecting
+  // whatever shape the column happens to hold into an inline script.
+  const parsed = attributionSchema.safeParse(attribution);
+  if (!parsed.success) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attributionEventProps(parsed.data))) {
+    out[DATALAYER_RENAMES[key] ?? key] = value;
+  }
+  return out;
+}
+
+/**
+ * The `dataLayer` writes that must happen BEFORE the container boots.
+ *
+ * Ordering is the whole point, and it is why this is concatenated into the GTM
+ * script tag rather than rendered as a sibling `<Script>`: a tag that fires on
+ * container initialization reads the layer as it stands at that moment, so a push
+ * that lands afterwards produces an event with no campaign on it — which is the
+ * shape of the bug this fixes. Keeping both in one snippet makes the order a fact
+ * of the string, not a behavior of the framework's script scheduler.
+ *
+ * Every interpolated value is escaped through `js()`. They originate in a query
+ * string: `utm_source` is whatever the last person to compose a link typed, it is
+ * stored verbatim, and it lands inside an inline `<script>`.
+ */
+export function buildPlatformPrelude(
+  vars: Record<string, string>,
+  signupAccountId?: string | null,
+): string {
+  let out = 'window.dataLayer=window.dataLayer||[];';
+  if (Object.keys(vars).length > 0) out += `window.dataLayer.push(${js(vars)});`;
+  if (signupAccountId) out += buildSignupEventSnippet(signupAccountId);
+  return out;
+}
+
+/**
+ * One `forms_signup_completed` per account, per browser.
+ *
+ * The wizard's first paint IS the moment the account came into being — it is the
+ * first page a new workspace ever renders — but it is not a moment that happens
+ * only once: a reload, or coming back tomorrow to an abandoned wizard, renders it
+ * again. Hence the `localStorage` latch, which is the honest bound on this: it is
+ * per browser, so the same person finishing signup on their phone would count
+ * twice. Ad platforms de-duplicate conversions on their own side, and the
+ * alternative — a server-side latch — cannot be read here: the cookie that would
+ * carry it is httpOnly and a Server Component cannot clear it.
+ *
+ * A blocked `localStorage` (private mode) FIRES rather than stays silent. Given
+ * the choice between a conversion counted twice and a real signup never counted,
+ * the double is the recoverable one.
+ */
+function buildSignupEventSnippet(accountId: string): string {
+  const key = `dapta_forms_signup:${accountId}`;
+  return (
+    `(function(w,k){try{if(w.localStorage.getItem(k))return;w.localStorage.setItem(k,'1')}catch(e){}` +
+    `w.dataLayer.push({event:${js(SIGNUP_DATALAYER_EVENT)}})})(window,${js(key)});`
+  );
+}
+
+/**
+ * Renders the GTM loader + its no-JS iframe. Returns null when no container is
+ * resolved (every bare fork) — no markup, no request, and with it no `dataLayer`
+ * write either: a fork has no container to read one.
+ *
+ * `attribution` is the caller's `me.attribution`; `signupAccountId` is passed by
+ * the ONE surface that represents a brand-new workspace (the wizard). The
+ * dashboard passes the tags without it — an account signing in three years later
+ * still wants its funnel sliced by campaign, and does not want a second signup.
+ */
+export function PlatformGtm({
+  gtmId,
+  attribution,
+  signupAccountId,
+}: {
+  gtmId: string | null;
+  attribution?: Record<string, string | number | null | undefined> | null;
+  signupAccountId?: string | null;
+}) {
   if (!gtmId) return null;
+  const prelude = buildPlatformPrelude(platformDataLayerVars(attribution), signupAccountId);
   return (
     <>
       <Script id="platform-gtm" data-testid="platform-gtm" strategy="afterInteractive">
-        {buildGtmSnippet(gtmId)}
+        {prelude + buildGtmSnippet(gtmId)}
       </Script>
       <noscript data-testid="platform-gtm-noscript">
         <iframe

--- a/apps/web/components/analytics/product-analytics.tsx
+++ b/apps/web/components/analytics/product-analytics.tsx
@@ -29,7 +29,7 @@ export function ProductAnalytics({
   identity: AnalyticsIdentity;
 }) {
   const { key, host } = analytics;
-  const { email, memberId, accountId, accountCode, role, attribution } = identity;
+  const { email, memberId, accountId, accountCode, role, attribution, landingDistinctId } = identity;
 
   // `attribution` is an OBJECT, re-created by every RSC payload, so depending on
   // it directly would re-run the effect — and re-identify the session — on every
@@ -52,13 +52,18 @@ export function ProductAnalytics({
       accountCode,
       role,
       attribution: attributionRef.current,
+      // The landing's anonymous id, when a `quill_ph_id` cookie was parked by
+      // the login. A plain string, so it sits in the deps without the object
+      // dance above; re-running with the same id is a no-op behind
+      // `identifyMember`'s localStorage latch.
+      landingDistinctId,
     });
     // Re-runs on a workspace switch: `account_id` is a super property and a
     // group, so it has to follow the member into the workspace they are
     // actually looking at, or every event after a switch is filed under the
     // wrong account. The campaign tags are a property of that same WORKSPACE and
     // change with it, which is why `attributionKey` is here too.
-  }, [key, email, memberId, accountId, accountCode, role, attributionKey]);
+  }, [key, email, memberId, accountId, accountCode, role, attributionKey, landingDistinctId]);
 
   if (!key) return null;
 

--- a/apps/web/components/tracking/tracking-scripts.tsx
+++ b/apps/web/components/tracking/tracking-scripts.tsx
@@ -22,11 +22,21 @@ import { hasAnyTracking, type ResolvedTracking } from './resolve-tracking';
  */
 
 /**
- * Serialize an id for interpolation inside an inline JS snippet. JSON encoding
+ * Serialize a value for interpolation inside an inline JS snippet. JSON encoding
  * neutralizes quotes/backslashes; escaping `<` prevents `</script>` breakout.
  * Ids are loosely validated strings from form config/env — treat as data.
+ *
+ * Exported for `components/analytics/platform-gtm.tsx`, which inlines a snippet
+ * of its own. ONE escaper for every inline script in the app, deliberately: a
+ * second copy is a second thing to remember to fix, and the values it guards
+ * against there come off a query string anyone can compose.
+ *
+ * Objects are accepted as well as strings — the platform snippet serializes a
+ * whole `dataLayer` payload. `undefined` is not: `JSON.stringify` returns the
+ * value `undefined` rather than a string, which would interpolate the bare word
+ * into the snippet. Callers pass a value or skip the call.
  */
-function js(value: string): string {
+export function js(value: string | Record<string, string>): string {
   return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 

--- a/apps/web/lib/attribution.spec.ts
+++ b/apps/web/lib/attribution.spec.ts
@@ -10,7 +10,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { parseAttribution, attributionSchema, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
-import { attributionHandoffQuery, crossOriginReferer } from './attribution';
+import {
+  attributionHandoffQuery,
+  crossOriginReferer,
+  sanitizeLandingDistinctId,
+} from './attribution';
 
 describe('parseAttribution — snake_case URL in, camelCase blob out', () => {
   it('maps the UTM set and the paid-click ids onto the stored field names', () => {
@@ -138,6 +142,53 @@ describe('attributionHandoffQuery — hop 1, the seam that already broke', () =>
   it('caps a forwarded value so the redirect cannot carry a huge Location header', () => {
     const query = attributionHandoffQuery({ utm_source: 'a'.repeat(4096) }, null, null);
     expect(new URLSearchParams(query).get('utm_source')).toHaveLength(512);
+  });
+
+  it('carries the landing PostHog id beside the tags', () => {
+    const query = attributionHandoffQuery(
+      { utm_source: 'google', ph_id: '0198a1b2-c3d4-7e89' },
+      null,
+      null,
+    );
+    expect(new URLSearchParams(query).get('ph_id')).toBe('0198a1b2-c3d4-7e89');
+    // ...and it never leaks into the attribution parse on the far side.
+    expect(receive(query)).toEqual({ utmSource: 'google' });
+  });
+
+  it('an id alone is still worth a hop — it spends no claim', () => {
+    // parseAttribution over an id-only query stays null, so the login route
+    // parks no attribution cookie: nothing here can burn first touch.
+    const query = attributionHandoffQuery({ ph_id: 'ph-abc' }, null, null);
+    expect(query).toBe('ph_id=ph-abc');
+    expect(receive(query)).toBeNull();
+  });
+
+  it('drops a hostile id rather than forwarding it', () => {
+    expect(attributionHandoffQuery({ ph_id: '"><script>x' }, null, null)).toBe('');
+    const query = attributionHandoffQuery({ utm_source: 'g', ph_id: '"><script>x' }, null, null);
+    expect(new URLSearchParams(query).get('ph_id')).toBeNull();
+  });
+});
+
+describe('sanitizeLandingDistinctId — attacker-composable, vendor-shaped', () => {
+  it('accepts the shapes the landing snippet can actually mint', () => {
+    expect(sanitizeLandingDistinctId('0198a1b2-c3d4-7e89-a1b2-c3d4e5f60718')).toBe(
+      '0198a1b2-c3d4-7e89-a1b2-c3d4e5f60718',
+    );
+    expect(sanitizeLandingDistinctId('$device:0198a1b2-c3d4')).toBe('$device:0198a1b2-c3d4');
+    expect(sanitizeLandingDistinctId('  ph-abc  ')).toBe('ph-abc');
+  });
+
+  it('refuses everything else', () => {
+    expect(sanitizeLandingDistinctId(undefined)).toBeNull();
+    expect(sanitizeLandingDistinctId('')).toBeNull();
+    expect(sanitizeLandingDistinctId('a b')).toBeNull();
+    expect(sanitizeLandingDistinctId('"><img src=x>')).toBeNull();
+    expect(sanitizeLandingDistinctId('x'.repeat(201))).toBeNull();
+  });
+
+  it('takes the first of a repeated param, like every other inbound key', () => {
+    expect(sanitizeLandingDistinctId(['real', 'injected'])).toBe('real');
   });
 });
 

--- a/apps/web/lib/attribution.ts
+++ b/apps/web/lib/attribution.ts
@@ -39,12 +39,60 @@ export function crossOriginReferer(
 }
 
 /**
+ * The query key the landing uses to hand over its PostHog anonymous id.
+ *
+ * `daptaforms.ai` and this app are different origins, so the vendor's cookie
+ * does not cross: without this the same human is two unrelated people and the
+ * "visited the landing → signed up" funnel does not exist. The landing appends
+ * its `distinct_id` to the CTA under this name; it rides the same hops as the
+ * campaign tags and is aliased onto the identified person once, in
+ * `identifyMember`.
+ */
+export const PH_ID_QUERY_KEY = 'ph_id';
+
+/**
+ * Where the login route parks that id for the round-trip. Unlike the
+ * attribution cookie its reader is NOT the callback but the first
+ * analytics-bearing page after login (admin layout / onboarding), which hands
+ * it to `identifyMember` to alias onto the identified person. Nothing deletes
+ * it — a Server Component cannot clear a cookie — so it simply expires with
+ * the login attempt, and the alias itself is latched client-side.
+ *
+ * Lives here rather than in the route file because route files may only export
+ * handlers, and both the route (writer) and the pages (readers) need the name.
+ */
+export const PH_ID_COOKIE = 'quill_ph_id';
+
+/**
+ * A landing distinct id fit to carry, or null.
+ *
+ * Strict on purpose: this value is attacker-composable (anyone can put anything
+ * after `?ph_id=`), and the only legitimate producer is the landing's own
+ * vendor snippet, whose ids are UUID-shaped. The allowlist covers every id that
+ * snippet can mint — hex, dashes, and the vendor's occasional `$device:` prefix
+ * — and refuses everything else. Losing the identity join for an exotic id is
+ * a shrug; forwarding arbitrary text into cookies and analytics calls is not.
+ */
+export function sanitizeLandingDistinctId(raw: string | string[] | undefined | null): string | null {
+  // First of a repeated param, same first-wins rule as the attribution parser.
+  const value = (Array.isArray(raw) ? raw[0] : raw) ?? '';
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 200) return null;
+  return /^[A-Za-z0-9$:._-]+$/.test(trimmed) ? trimmed : null;
+}
+
+/**
  * The query string to hand `/api/auth/login`, or `''` when there is nothing to
  * carry.
  *
  * `''` rather than an empty object is what keeps an untagged visit from spending
  * the claim: no query means the login route sets no cookie, so the callback has
  * nothing to POST.
+ *
+ * `ph_id` counts as something to carry on its own. It spends nothing — the
+ * write-once claim is decided by `parseAttribution` over the attribution keys,
+ * which an id-only query still leaves empty — and in practice it never arrives
+ * alone anyway: the landing CTA that appends it also guarantees a `utm_source`.
  */
 export function attributionHandoffQuery(
   params: Readonly<Record<string, string | string[] | undefined>>,
@@ -55,10 +103,11 @@ export function attributionHandoffQuery(
     ...params,
     referrer: crossOriginReferer(referer, self),
   };
+  const landingId = sanitizeLandingDistinctId(params[PH_ID_QUERY_KEY]);
 
   // Decide with the SAME parser the login route will use, so the two can never
   // disagree about what counts as "nothing to carry".
-  if (!parseAttribution(candidate)) return '';
+  if (!parseAttribution(candidate) && !landingId) return '';
 
   const qs = new URLSearchParams();
   for (const key of ATTRIBUTION_QUERY_KEYS) {
@@ -67,5 +116,6 @@ export function attributionHandoffQuery(
     const value = Array.isArray(raw) ? raw[0] : raw;
     if (typeof value === 'string' && value.trim()) qs.set(key, value.trim().slice(0, FORWARD_MAX));
   }
+  if (landingId) qs.set(PH_ID_QUERY_KEY, landingId);
   return qs.toString();
 }

--- a/apps/web/lib/product-analytics.spec.ts
+++ b/apps/web/lib/product-analytics.spec.ts
@@ -3,11 +3,13 @@
  * test is mostly a NEGATIVE one: with nothing configured the admin must load no
  * script and make no request, so a bare fork runs untouched.
  */
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   resolveProductAnalytics,
   buildAnalyticsSnippet,
+  identifyMember,
   DEFAULT_ANALYTICS_HOST,
+  type AnalyticsIdentity,
 } from './product-analytics';
 
 describe('resolveProductAnalytics', () => {
@@ -71,5 +73,89 @@ describe('buildAnalyticsSnippet', () => {
     const snippet = buildAnalyticsSnippet('</script><script>alert(1)</script>', 'https://x.example');
     expect(snippet).not.toContain('</script>');
     expect(snippet).toContain('\\u003c');
+  });
+});
+
+describe('identifyMember — the landing-visit alias', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** A window with a call-recording posthog and a real-enough localStorage. */
+  function stubWindow(opts: { storageThrows?: boolean } = {}) {
+    const calls: Array<[string, ...unknown[]]> = [];
+    const record =
+      (name: string) =>
+      (...args: unknown[]) =>
+        void calls.push([name, ...args]);
+    const store = new Map<string, string>();
+    vi.stubGlobal('window', {
+      posthog: {
+        identify: record('identify'),
+        alias: record('alias'),
+        register: record('register'),
+        group: record('group'),
+      },
+      localStorage: opts.storageThrows
+        ? {
+            getItem() {
+              throw new Error('blocked');
+            },
+            setItem() {
+              throw new Error('blocked');
+            },
+          }
+        : {
+            getItem: (k: string) => store.get(k) ?? null,
+            setItem: (k: string, v: string) => void store.set(k, v),
+          },
+    });
+    return calls;
+  }
+
+  const identity = (extra?: Partial<AnalyticsIdentity>): AnalyticsIdentity => ({
+    email: 'ana@example.com',
+    memberId: 'mem_1',
+    accountId: 'acc_1',
+    accountCode: 'ACME1',
+    role: 'owner',
+    ...extra,
+  });
+
+  it('aliases the landing id AFTER identify, so it lands on the person', () => {
+    // Before identify, the current distinct id is this origin's anonymous id —
+    // the landing visit would chain to a session instead of pinning to the
+    // person. The order is the contract.
+    const calls = stubWindow();
+    identifyMember(identity({ landingDistinctId: '0198a1b2-c3d4' }));
+    const names = calls.map(([n]) => n);
+    expect(names.indexOf('alias')).toBeGreaterThan(names.indexOf('identify'));
+    expect(calls.find(([n]) => n === 'alias')).toEqual(['alias', '0198a1b2-c3d4']);
+  });
+
+  it('makes no alias call at all without a landing id', () => {
+    const calls = stubWindow();
+    identifyMember(identity());
+    identifyMember(identity({ landingDistinctId: null }));
+    expect(calls.filter(([n]) => n === 'alias')).toHaveLength(0);
+  });
+
+  it('latches: the same landing id aliases once per browser', () => {
+    // The cookie carrying the id lives ten minutes and cannot be deleted
+    // server-side, so every render inside that window re-offers the id.
+    const calls = stubWindow();
+    identifyMember(identity({ landingDistinctId: 'ph-abc' }));
+    identifyMember(identity({ landingDistinctId: 'ph-abc' }));
+    expect(calls.filter(([n]) => n === 'alias')).toHaveLength(1);
+  });
+
+  it('fires anyway when localStorage is blocked — a repeat beats a never', () => {
+    const calls = stubWindow({ storageThrows: true });
+    identifyMember(identity({ landingDistinctId: 'ph-abc' }));
+    expect(calls.filter(([n]) => n === 'alias')).toHaveLength(1);
+  });
+
+  it('does nothing without an email — no identify means nothing to pin to', () => {
+    const calls = stubWindow();
+    identifyMember(identity({ email: null, landingDistinctId: 'ph-abc' }));
+    expect(calls).toHaveLength(0);
   });
 });

--- a/apps/web/lib/product-analytics.ts
+++ b/apps/web/lib/product-analytics.ts
@@ -52,6 +52,14 @@ export interface AnalyticsIdentity {
    * only registered when present (see `identifyMember`).
    */
   attribution?: Record<string, string | number | null | undefined> | null;
+  /**
+   * The landing's PostHog anonymous id, read back from the `quill_ph_id` cookie
+   * the login route parked. Present only in the minutes after a login that
+   * started on a landing CTA; aliased onto the person exactly once (see
+   * `identifyMember`) so the landing visit and the platform session stop being
+   * two unrelated people.
+   */
+  landingDistinctId?: string | null;
 }
 
 /**
@@ -127,6 +135,7 @@ export function buildAnalyticsSnippet(key: string, host: string): string {
  */
 interface PosthogBrowser {
   identify(distinctId: string, properties?: Record<string, unknown>): void;
+  alias(alias: string, original?: string): void;
   register(properties: Record<string, unknown>): void;
   group(type: string, key: string, properties?: Record<string, unknown>): void;
   capture(event: string, properties?: Record<string, unknown>): void;
@@ -166,6 +175,11 @@ export function identifyMember(identity: AnalyticsIdentity): void {
     account_id: identity.accountId,
     role: identity.role,
   });
+  // AFTER identify, never before: `alias` links its argument to the CURRENT
+  // distinct id, and before identify that is this origin's anonymous id — the
+  // landing visit would be chained to a session that identify then merges,
+  // instead of pinned to the person directly.
+  aliasLandingVisit(ph, identity.landingDistinctId);
   ph.register({
     product: 'forms',
     account_id: identity.accountId,
@@ -183,6 +197,32 @@ export function identifyMember(identity: AnalyticsIdentity): void {
     // answerable across the handful of events we hand-instrument.
     ...groupAttribution(identity.attribution),
   });
+}
+
+/**
+ * Join the landing visit to the person, once per landing id per browser.
+ *
+ * `alias(landingId)` files the landing's anonymous id under the person the
+ * session just identified as — the cross-domain stitch the vendor's cookie
+ * cannot make on its own. The landing id is never an identified id (the landing
+ * has nobody to identify), which is exactly the case alias exists for.
+ *
+ * The latch is `localStorage`, keyed by the landing id itself: the cookie that
+ * carries the id lives ten minutes and nothing can delete it server-side, so
+ * every render inside that window would otherwise re-send the merge. When
+ * storage is blocked the alias fires anyway — the vendor drops a repeated
+ * merge on the floor, and a join that never happens is the only real loss.
+ */
+function aliasLandingVisit(ph: PosthogBrowser, landingId: string | null | undefined): void {
+  if (!landingId) return;
+  try {
+    const key = `dapta_forms_ph_alias:${landingId}`;
+    if (window.localStorage.getItem(key)) return;
+    window.localStorage.setItem(key, '1');
+  } catch {
+    // Private mode: fall through and alias anyway.
+  }
+  ph.alias(landingId);
 }
 
 /** The campaign subset of the attribution blob, snake_cased. Empty when absent. */


### PR DESCRIPTION
## What this fixes

Marketing reported campaign data not arriving on platform events. The suspected cause was the cross-domain hop through the identity provider; the real one was on the browser side: the platform mounts the marketing GTM container (`platform-gtm.tsx`) but **nothing in the app ever wrote to `dataLayer`**, so every campaign variable the container declares resolved `undefined` on our pages. Tags fired; they carried no campaign.

(The cross-domain hop was never broken: the tags survive it in the httpOnly `quill_attribution` cookie — first-party, `SameSite=Lax`, and the IAM return is a top-level GET navigation, so the browser sends it. No change to that chain, and nothing needed from clone-services.)

## Commit 1 — dataLayer prelude + signup event

- `platformDataLayerVars(me.attribution)` re-keys the stored first-touch blob to the snake_case names the container already reads on daptaforms.ai (`utm_*`, `gclid`, `fbclid`, `first_touch_referrer`, `first_touch_path`). Those last two names are a cross-domain contract with the landing — renaming either side alone doesn't fail, the variable just resolves undefined.
- The push is **concatenated into the same inline script as the GTM snippet**, before it. A tag firing on container initialization reads the layer as it stands at that moment; ordering has to be a fact of the string, not a behavior of the framework's script scheduler.
- The wizard (and only the wizard) also emits `forms_signup_completed` — same name as the server-side capture — latched in `localStorage` per account. The latch is per browser, which is the honest bound: a second device counts twice, and ad platforms de-dup on their side. Blocked storage **fires anyway**: counted twice is recoverable, never counted is not.
- `js()` (the inline-script escaper) becomes a shared export instead of a second copy. Every interpolated value originates in a query string someone else composed.

## Commit 2 — the landing's PostHog id, aliased onto the person

The landing appends its anonymous `distinct_id` to the CTA as `ph_id` so the two origins can be stitched into one person. The platform dropped it twice over: the root redirect forwards only the attribution allowlist, and nothing read the value — same human, two unrelated PostHog people, no landing→signup funnel.

It now rides the same road as the tags: root handoff → ten-minute httpOnly `quill_ph_id` cookie at `/api/auth/login` (first-wins, same flags as its siblings) → read back by the admin layout and the wizard → `posthog.alias(landingId)` **after** `identify()` in `identifyMember`. Before identify, the current distinct id is this origin's anonymous session — the landing visit would chain to that instead of pinning to the person. Latched in `localStorage`; the cookie cannot be deleted server-side.

The value is attacker-composable, so it is sanitized at every boundary: 200-char cap, charset limited to what the vendor snippet can mint (`/^[A-Za-z0-9$:._-]+$/`). A hostile id is dropped, not forwarded. Residual accepted risk (also in the commit message): a crafted login link can merge an attacker-chosen *conforming* anonymous id into the person — analytics-graph pollution only, no authz or rendering surface.

## What stays true for a bare fork

No container id resolves → `PlatformGtm` returns null → **no markup, no dataLayer, no cookie, no alias**. The login route bails to `/login` before the ph_id block on the local provider. Zero third-party requests, unchanged.

## Verification

- 31 new/extended tests: variable mapping and renames, empty-attribution pushes nothing, hostile values cannot break out of the inline script, signup event only on the wizard, prelude-before-gtm.js ordering, sanitizer accept/refuse, alias-after-identify ordering, latch, blocked-storage behavior.
- Live browser (production build, Playwright): dataLayer shows the tags **before** `gtm.js`; `forms_signup_completed` on first wizard paint, absent on reload and on `/admin`; `identify → alias` in order with the queue as the record (analytics host pointed at a dead port so the loader stub's queue is inspectable); reload emits no second alias.
- Full suite (453 web + 360 api), typecheck, lint, build, publish-gate: green.
- forms-reviewer: PASS, no blockers. Two nits on record: the route's cookie-parking glue is untested (mirrors the pre-existing attribution block), and the accepted-risk note above.

## Companion change (separate repo, not in this PR)

`dapta-forms-landing` now captures `gclid`/`fbclid` into first-touch and the CTA decorator (512-char cap — a real fbclid exceeds 200 and a truncated one matches nothing). Already committed there; needs its own deploy.

## Out of scope, known

- GA4 container config (marketing): `auth.dapta.ai` in unwanted referrals + cross-domain `daptaforms.ai` ↔ `forms.dapta.ai`. Without it GA4 still splits the session at the hop.
- Existing landing visitors keep their stored first-touch blob without click ids — by design; corrects itself with new traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
