### PR TITLE
fix(web): multi-select choice honors the card layout

### DIFF
--- a/.changeset/multi-select-card-grid.md
+++ b/.changeset/multi-select-card-grid.md
@@ -1,0 +1,22 @@
+---
+'@quill/web': patch
+---
+
+Multi-select choice questions honor the card layout on the public form.
+
+Layout and selection mode are independent axes of a `multiple_choice` step:
+`optionLayout` picks the markup (card grid vs rows) and `selectionMode` picks
+the semantics (checkbox toggles + Continue vs radio + auto-advance). The public
+renderer collapsed them: any multi-select step fell into the checkbox ROW list
+before the layout was ever consulted, so a step configured as cards rendered as
+rows — while the builder canvas, which resolves the layout without looking at
+the selection mode, kept drawing the card grid. The published form disagreed
+with its own preview, which is a bug, not a constraint.
+
+The card grid now renders for both modes. Multi-select cards toggle in and out
+of the picked set (`role="checkbox"`, several can be selected at once) and the
+form's Continue button submits, exactly like the row list behaves; single-select
+cards keep their radio semantics and auto-advance. Option icons — emoji or
+image — reach the card in both modes. No config change: forms that stored
+`optionLayout: 'cards'` with `selectionMode: 'multiple'` simply start rendering
+what their builder preview always promised.

--- a/apps/web/components/public/step-input.spec.tsx
+++ b/apps/web/components/public/step-input.spec.tsx
@@ -1,0 +1,73 @@
+/**
+ * The `multiple_choice` render matrix: layout (`resolveOptionLayout`) and
+ * selection mode (`isMultiSelect`) are independent axes. The regression pinned
+ * here: a multi-select step configured with `optionLayout: 'cards'` silently
+ * fell back to the checkbox ROW list — the builder canvas draws the card grid
+ * for that exact config, so the published form disagreed with its own preview.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { FormStep } from '@quill/engine';
+import { StepInput } from './step-input';
+
+function render(step: FormStep, value: unknown = null) {
+  return renderToStaticMarkup(
+    <StepInput
+      step={step}
+      value={value as never}
+      answers={{}}
+      onChange={() => {}}
+      onFieldChange={() => {}}
+      onSelect={() => {}}
+      dropdownPlaceholder="Pick one"
+      dropdownEmpty="No matches"
+    />,
+  );
+}
+
+const cards: FormStep = {
+  key: 'use_case',
+  type: 'multiple_choice',
+  optionLayout: 'cards',
+  options: [
+    { label: 'Leads', value: 'leads', icon: '🧲' },
+    { label: 'Meetings', value: 'meetings', icon: '📅' },
+  ],
+};
+
+describe('multiple_choice: layout x selection mode', () => {
+  it('multi-select + cards renders the card grid with checkbox semantics', () => {
+    const html = render({ ...cards, selectionMode: 'multiple' }, ['leads']);
+    expect(html).toContain('pf-choices--icons');
+    expect(html).toContain('role="checkbox"');
+    expect(html).not.toContain('pf-choices--list');
+    // The picked card carries the selected state; the other does not.
+    expect(html).toContain('pf-choice-icon pf-choice-icon--selected');
+    expect(html).toContain('aria-checked="false"');
+  });
+
+  it('single-select + cards keeps the radio card grid', () => {
+    const html = render(cards, 'leads');
+    expect(html).toContain('pf-choices--icons');
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('role="radio"');
+    expect(html).not.toContain('role="checkbox"');
+  });
+
+  it('multi-select + list keeps the checkbox rows', () => {
+    const html = render(
+      { ...cards, optionLayout: 'list', selectionMode: 'multiple' },
+      ['meetings'],
+    );
+    expect(html).toContain('pf-choices--list');
+    expect(html).toContain('pf-choice-list--multi');
+    expect(html).toContain('role="checkbox"');
+    expect(html).not.toContain('pf-choices--icons');
+  });
+
+  it('multi-select + cards shows the option icons (emoji reach the card)', () => {
+    const html = render({ ...cards, selectionMode: 'multiple' });
+    expect(html).toContain('🧲');
+    expect(html).toContain('📅');
+  });
+});

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -194,11 +194,46 @@ export function StepInput({
         />
       );
 
-    case 'multiple_choice':
-      // Multi-select (checkboxes): toggle values in/out of an array; the form's
-      // Continue button submits. No auto-advance (you may pick several).
-      if (isMultiSelect(step)) {
-        const picked = asArray(value);
+    case 'multiple_choice': {
+      // Layout and selection mode are independent axes: `resolveOptionLayout`
+      // picks the markup (card grid vs rows) and `isMultiSelect` picks the
+      // semantics (checkbox toggles + Continue vs radio + auto-advance). The
+      // builder canvas already draws the card grid for multi-select steps, so
+      // the public renderer honoring only one axis was a preview/public
+      // disagreement, not a constraint.
+      const multi = isMultiSelect(step);
+      const picked = asArray(value);
+      const toggle = (opt: FormOption) => {
+        const on = picked.includes(opt.value);
+        onChange(on ? picked.filter((v) => v !== opt.value) : [...picked, opt.value]);
+      };
+      if (resolveOptionLayout(step) === 'cards') {
+        return (
+          <div
+            className="pf-choices--icons"
+            role={multi ? 'group' : 'radiogroup'}
+            aria-label={step.question ?? step.key}
+          >
+            {(step.options ?? []).map((opt) => {
+              const on = multi ? picked.includes(opt.value) : value === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role={multi ? 'checkbox' : 'radio'}
+                  aria-checked={on}
+                  className={`pf-choice-icon${on ? ' pf-choice-icon--selected' : ''}`}
+                  onClick={() => (multi ? toggle(opt) : onSelect(opt.value))}
+                >
+                  <OptionIcon option={opt} layout="cards" />
+                  <span className="pf-choice-icon__label">{opt.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        );
+      }
+      if (multi) {
         return (
           <div className="pf-choices--list" role="group" aria-label={step.question ?? step.key}>
             {(step.options ?? []).map((opt) => {
@@ -210,34 +245,13 @@ export function StepInput({
                   role="checkbox"
                   aria-checked={on}
                   className={`pf-choice-list pf-choice-list--multi${on ? ' pf-choice-list--selected' : ''}`}
-                  onClick={() =>
-                    onChange(on ? picked.filter((v) => v !== opt.value) : [...picked, opt.value])
-                  }
+                  onClick={() => toggle(opt)}
                 >
                   <span className="pf-choice-list__check" aria-hidden="true" />
                   <span className="pf-choice-list__text">{opt.label}</span>
                 </button>
               );
             })}
-          </div>
-        );
-      }
-      if (resolveOptionLayout(step) === 'cards') {
-        return (
-          <div className="pf-choices--icons" role="radiogroup" aria-label={step.question ?? step.key}>
-            {(step.options ?? []).map((opt) => (
-              <button
-                key={opt.value}
-                type="button"
-                role="radio"
-                aria-checked={value === opt.value}
-                className={`pf-choice-icon${value === opt.value ? ' pf-choice-icon--selected' : ''}`}
-                onClick={() => onSelect(opt.value)}
-              >
-                <OptionIcon option={opt} layout="cards" />
-                <span className="pf-choice-icon__label">{opt.label}</span>
-              </button>
-            ))}
           </div>
         );
       }
@@ -262,6 +276,7 @@ export function StepInput({
           ))}
         </div>
       );
+    }
 
     case 'slider':
       return <SliderInput step={step} value={value} onChange={onChange} onSeed={onSeed} />;


### PR DESCRIPTION
## What

A `multiple_choice` step configured with `optionLayout: 'cards'` **and** `selectionMode: 'multiple'` rendered as the checkbox ROW list on the public form, while the builder canvas — which resolves the layout without looking at the selection mode — kept drawing the card grid. The published form disagreed with its own preview.

Layout and selection mode are independent axes: `resolveOptionLayout` picks the markup, `isMultiSelect` picks the semantics. The public renderer now honors both:

- **Multi + cards**: card grid with checkbox semantics (`role="checkbox"`, several selected at once, toggle on tap), submitting through the Continue button. The existing no-auto-advance gates in both renderers already key on `isMultiSelect`, not layout, so Continue/Enter behavior needed no change.
- **Single + cards**: unchanged (radio + auto-advance).
- **Multi + list / single + list**: unchanged.

Option icons (emoji or image) reach the card in both modes. Both public layouts go through `StepInput`, so slides and vertical are covered by the one branch. No config or schema change — stored configs simply start rendering what the builder preview always promised.

## Tests

New `step-input.spec.tsx` pins the layout × mode matrix (4 cases). Full web suite 435/435, typecheck and lint clean. Verified in the browser on the seeded SQLite form: two cards selected simultaneously, toggle off works, Continue submits.

## Review

`forms-reviewer` pass: PASS. One nit acknowledged: `@quill/web` sits in the changesets ignore list, so its changeset is documentation-only — same precedent as `onboarding-step-url.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)