### PR TITLE
fix(engine): outcome redirect delay of 0 held the thank-you screen anyway

### DIFF
--- a/.changeset/outcome-delay-pairing.md
+++ b/.changeset/outcome-delay-pairing.md
@@ -1,0 +1,11 @@
+---
+'@quill/engine': patch
+---
+
+`resolveEnding`: the redirect delay now inherits from the form-level ending only
+when the redirect URL itself was inherited. An outcome that brings its own URL
+with no delay of its own resolves to 0 (redirect immediately) — which is what
+the outcomes dialog has always displayed for an untouched field. Previously the
+form-level delay leaked under an outcome-level URL, so the public form held the
+thank-you screen that the editor said it would skip; a delay orphaned by a
+cleared form-level URL leaked the same way.

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -1512,6 +1512,55 @@ describe('resolveEnding (V5-B1 — outcome → form → built-in)', () => {
     expect(resolveEnding(cfg, null).redirectDelayMs).toBe(0);
   });
 
+  it('an outcome with its OWN url never inherits the form-level delay', () => {
+    // The reported bug: the outcomes dialog renders an untouched delay as "0"
+    // and promises "0 = redirect immediately", but the stored value is absent,
+    // and absent used to fall through to the form-level delay — so the public
+    // form held the thank-you the dialog said it would skip. The delay belongs
+    // to the URL pairing: an outcome that brings its own destination without
+    // its own delay redirects immediately, as displayed.
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [],
+      ending: { redirectUrl: 'https://example.com/all', redirectDelayMs: 1500 },
+    };
+    const own = resolveEnding(cfg, outcome({ redirectUrl: 'https://example.com/vip' }));
+    expect(own.redirectUrl).toBe('https://example.com/vip');
+    expect(own.redirectDelayMs).toBe(0);
+    // Its own delay still wins when it has one...
+    expect(
+      resolveEnding(cfg, outcome({ redirectUrl: 'https://example.com/vip', redirectDelayMs: 500 }))
+        .redirectDelayMs,
+    ).toBe(500);
+    // ...and an outcome that inherits the URL keeps inheriting the delay with it.
+    expect(resolveEnding(cfg, outcome()).redirectDelayMs).toBe(1500);
+  });
+
+  it('a form-level delay orphaned by a cleared form URL cannot leak into an outcome', () => {
+    // The ending panel keeps the stored delay when its URL is cleared; before
+    // the pairing rule, that orphan re-attached to any outcome-level URL.
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [],
+      ending: { redirectUrl: null, redirectDelayMs: 2000 },
+    };
+    const out = resolveEnding(cfg, outcome({ redirectUrl: 'https://example.com/vip' }));
+    expect(out.redirectUrl).toBe('https://example.com/vip');
+    expect(out.redirectDelayMs).toBe(0);
+  });
+
+  it('a whitespace-only outcome url is not an OWN url — same rule as pick()', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [],
+      ending: { redirectUrl: 'https://example.com/all', redirectDelayMs: 1500 },
+    };
+    // The URL falls back to the form's, so the delay travels with it.
+    const out = resolveEnding(cfg, outcome({ redirectUrl: '   ' }));
+    expect(out.redirectUrl).toBe('https://example.com/all');
+    expect(out.redirectDelayMs).toBe(1500);
+  });
+
   it('with scoring off there is no outcome, so the form-level ending is what shows', () => {
     // The V4 complaint end to end: scoring off must not let a range hijack the ending.
     const cfg: FormConfig = {

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -1793,7 +1793,19 @@ export function resolveEnding(config: FormConfig, outcome: FormOutcome | null): 
   const redirectUrl = pick(outcome?.redirectUrl, e?.redirectUrl);
   // A delay without a destination is meaningless — report 0 so the renderer
   // never holds the screen waiting for a redirect that is not coming.
-  const delaySource = outcome?.redirectDelayMs ?? e?.redirectDelayMs ?? 0;
+  //
+  // The delay inherits from the form-level ending ONLY when the URL itself was
+  // inherited. It describes how long to hold the thank-you before going to a
+  // specific destination — it belongs to that pairing, not to the outcome in
+  // the abstract. An outcome that brings its own URL with no delay of its own
+  // therefore resolves 0, which is exactly what the outcomes dialog shows its
+  // author for an untouched field ("0 = redirect immediately"). The old rule
+  // (`outcome ?? form ?? 0`) let a form-level delay leak under an
+  // outcome-level URL, so a dialog reading 0 held the screen anyway — and a
+  // form whose URL had been cleared could leak its orphaned delay the same
+  // way.
+  const ownUrl = typeof outcome?.redirectUrl === 'string' && outcome.redirectUrl.trim() !== '';
+  const delaySource = outcome?.redirectDelayMs ?? (ownUrl ? 0 : (e?.redirectDelayMs ?? 0));
   return {
     headline: pick(outcome?.label, e?.headline),
     body: pick(outcome?.message, e?.body),

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -300,7 +300,10 @@ export interface FormOutcome {
   overrides?: OutcomeOverrideRule[];
   /**
    * Hold the thank-you screen this long before this outcome's redirect fires
-   * (additive — V5-B1). Absent = inherit `config.ending.redirectDelayMs`.
+   * (additive — V5-B1). Absent = 0 when this outcome has its own
+   * `redirectUrl`; `config.ending.redirectDelayMs` is inherited only when the
+   * URL is inherited too — the delay belongs to the URL pairing (see
+   * `resolveEnding`).
    */
   redirectDelayMs?: number;
 }
@@ -1804,7 +1807,9 @@ export function resolveEnding(config: FormConfig, outcome: FormOutcome | null): 
   // outcome-level URL, so a dialog reading 0 held the screen anyway — and a
   // form whose URL had been cleared could leak its orphaned delay the same
   // way.
-  const ownUrl = typeof outcome?.redirectUrl === 'string' && outcome.redirectUrl.trim() !== '';
+  // "Own" by the same definition `pick` uses for the URL itself, so the two
+  // can never disagree about whether the outcome brought a destination.
+  const ownUrl = pick(outcome?.redirectUrl, null) !== null;
   const delaySource = outcome?.redirectDelayMs ?? (ownUrl ? 0 : (e?.redirectDelayMs ?? 0));
   return {
     headline: pick(outcome?.label, e?.headline),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -514,7 +514,10 @@ export const formOutcomeSchema = z.object({
   booking: outcomeBookingSchema.nullable().optional(),
   /**
    * Hold the thank-you screen this long before this outcome's redirect fires
-   * (ADDITIVE — V5-B1). Absent = inherit the form-level ending's delay.
+   * (ADDITIVE — V5-B1). Absent = 0 when this outcome has its own
+   * `redirectUrl`; the form-level ending's delay is inherited only when the
+   * URL is inherited too — the delay belongs to the URL pairing (the engine's
+   * `resolveEnding` is the resolver).
    */
   redirectDelayMs: z.number().int().min(0).max(60_000).optional(),
   /**


### PR DESCRIPTION
## The bug

In the Outcomes dialog, the "Show the thank-you first (ms)" field renders an untouched delay as **0**, and its hint promises **"0 = redirect immediately"**. But the stored value is *absent*, and `resolveEnding` let absent fall through to the form-level ending's delay:

```ts
const delaySource = outcome?.redirectDelayMs ?? e?.redirectDelayMs ?? 0;
```

So an outcome with its own redirect URL and a dialog reading 0 still held the thank-you screen on the public form — for exactly the length of a delay configured on a *different* pairing. Worse, leaving the field at 0 could not store a real 0: the input already shows 0, nothing fires `onChange`, and `undefined` persists. There was no way to get the promised behavior without typing 0 over some other value first.

Proven against the engine before fixing:

```
outcome URL propia, dialog muestra 0 (stored: undefined) → delay resuelto: 1500  ← el bug
outcome URL propia, 0 tipeado de verdad                  → delay resuelto: 0
form URL borrada, delay huérfano 2000 + outcome URL      → delay resuelto: 2000  ← fuga
```

## The fix

One rule: **the delay inherits only when the URL does.** It describes how long to hold the thank-you before going to a specific destination — it belongs to that pairing, not to the outcome in the abstract.

- Outcome with its own URL, no delay of its own → **0**, which is what its author has been shown all along.
- Outcome that inherits the form URL → keeps inheriting the form delay with it. Unchanged.
- Own delay always wins when present. Unchanged.
- The orphan case closes for free: a form-level delay whose URL was cleared can no longer re-attach under an outcome-level URL.

"Own" is derived from the same `pick()` that resolves the URL, so the two definitions of "set" cannot drift (whitespace-only = not set, pinned by a spec case).

Fixed at resolution, not by rewriting configs: every already-saved form gets the corrected behavior at render, and no stored blob changes shape.

## Behavior change, stated plainly

A form with a form-level URL+delay whose outcome overrides *only* the URL used to wait the form's delay; it now redirects immediately. The dialog always displayed 0 for that outcome, so the new behavior is the one its author was being promised. The i18n hint ("0 = redirect immediately", en+es) is now simply true.

## Verification

- 4 new spec cases pin the three proven scenarios plus the whitespace edge; engine suite 200/200.
- Both public renderers consume `redirectDelayMs` opaquely (`> 0` = hold, else immediate) — no renderer change needed; builder preview renders through the same components, so preview and public form agree automatically. Nothing in `apps/api` calls `resolveEnding`.
- Full suite green (engine 200, api 25 files, web 37 files, db 15 files), typecheck, lint, build, publish-gate.
- Changeset: `@quill/engine` patch.
- forms-reviewer: **PASS** — its two should-fixes (both doc comments still described the old inheritance, re-documenting the bug) and one nit (inline own-URL check could drift from `pick()`) are fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
