### PR TITLE
release: campaign attribution end-to-end, per-visitor rate limiting, multi-select cards, outcome redirect fix

### DIFF
--- a/.changeset/multi-select-card-grid.md
+++ b/.changeset/multi-select-card-grid.md
@@ -1,0 +1,22 @@
+---
+'@quill/web': patch
+---
+
+Multi-select choice questions honor the card layout on the public form.
+
+Layout and selection mode are independent axes of a `multiple_choice` step:
+`optionLayout` picks the markup (card grid vs rows) and `selectionMode` picks
+the semantics (checkbox toggles + Continue vs radio + auto-advance). The public
+renderer collapsed them: any multi-select step fell into the checkbox ROW list
+before the layout was ever consulted, so a step configured as cards rendered as
+rows — while the builder canvas, which resolves the layout without looking at
+the selection mode, kept drawing the card grid. The published form disagreed
+with its own preview, which is a bug, not a constraint.
+
+The card grid now renders for both modes. Multi-select cards toggle in and out
+of the picked set (`role="checkbox"`, several can be selected at once) and the
+form's Continue button submits, exactly like the row list behaves; single-select
+cards keep their radio semantics and auto-advance. Option icons — emoji or
+image — reach the card in both modes. No config change: forms that stored
+`optionLayout: 'cards'` with `selectionMode: 'multiple'` simply start rendering
+what their builder preview always promised.

--- a/.changeset/outcome-delay-pairing.md
+++ b/.changeset/outcome-delay-pairing.md
@@ -1,0 +1,11 @@
+---
+'@quill/engine': patch
+---
+
+`resolveEnding`: the redirect delay now inherits from the form-level ending only
+when the redirect URL itself was inherited. An outcome that brings its own URL
+with no delay of its own resolves to 0 (redirect immediately) — which is what
+the outcomes dialog has always displayed for an untouched field. Previously the
+form-level delay leaked under an outcome-level URL, so the public form held the
+thank-you screen that the editor said it would skip; a delay orphaned by a
+cleared form-level URL leaked the same way.

--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -2,6 +2,7 @@
 
 import { postSubmission, postFormEvent } from '@/lib/api';
 import { postBookingCallback } from '@/lib/booking-embed';
+import { forwardedForChain } from '@/lib/forwarded-for';
 import type { BookingCallbackInput } from '@quill/types';
 
 /**
@@ -32,5 +33,5 @@ export async function recordBookingAction(
   slug: string,
   payload: BookingCallbackInput,
 ): Promise<void> {
-  await postBookingCallback(accountCode, slug, payload);
+  await postBookingCallback(accountCode, slug, payload, await forwardedForChain());
 }

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -7,6 +7,7 @@ import { AdminShell } from '@/components/admin-shell';
 import { getLocale } from '@/lib/locale';
 import { getThemePref } from '@/lib/theme.server';
 import { ToastProvider } from '@/components/toast';
+import { PH_ID_COOKIE, sanitizeLandingDistinctId } from '@/lib/attribution';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
 import { ProductAnalytics } from '@/components/analytics/product-analytics';
 import { PlatformGtm, resolvePlatformGtmId } from '@/components/analytics/platform-gtm';
@@ -71,6 +72,10 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           // Passing them only on the wizard would leave every funnel that starts
           // after onboarding un-sliceable by campaign, which is most of them.
           attribution: me.attribution,
+          // The landing's PostHog id, if this login started on a landing CTA.
+          // Re-sanitized on read — the cookie is ours, but the ten minutes
+          // between write and read are not a chain of custody.
+          landingDistinctId: sanitizeLandingDistinctId(jar.get(PH_ID_COOKIE)?.value),
         }}
       />
       <AdminShell

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -53,7 +53,10 @@ export default async function AdminLayout({ children }: { children: ReactNode })
 
   return (
     <ToastProvider>
-      <PlatformGtm gtmId={resolvePlatformGtmId()} />
+      {/* Same tags GTM gets on the wizard, minus the signup event: this layout
+          wraps every dashboard page, so the campaign is available to any tag
+          the container fires later — but the account here is of any age. */}
+      <PlatformGtm gtmId={resolvePlatformGtmId()} attribution={me.attribution} />
       <ProductAnalytics
         analytics={analytics}
         identity={{

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import { parseAttribution } from '@quill/types';
+import { PH_ID_COOKIE, PH_ID_QUERY_KEY, sanitizeLandingDistinctId } from '@/lib/attribution';
 import { authProvider } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
@@ -60,6 +61,22 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // back from campaign B inside ten minutes, and last-wins would credit B.
   if (attribution && !jar.get(ATTRIBUTION_COOKIE)) {
     jar.set(ATTRIBUTION_COOKIE, JSON.stringify(attribution), {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 600,
+    });
+  }
+
+  // The landing's PostHog anonymous id, parked beside the tags with the same
+  // rules: sanitized (this query is composable by anyone), first attempt wins
+  // (the id of the visit that STARTED the login is the one worth joining), and
+  // absent sets nothing. Unlike the tags it never touches the API or the
+  // database — its whole life is browser-side, ending in one `alias` call.
+  const landingId = sanitizeLandingDistinctId(sp.getAll(PH_ID_QUERY_KEY));
+  if (landingId && !jar.get(PH_ID_COOKIE)) {
+    jar.set(PH_ID_COOKIE, landingId, {
       path: '/',
       httpOnly: true,
       sameSite: 'lax',

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -25,6 +25,13 @@ export default async function LoginPage({
 
   return (
     <>
+      {/* No tags to hand the container here, and that is not an oversight. On a
+          Dapta build this page only renders as an ERROR landing or after a
+          sign-out (the redirect above takes every other visit straight to the
+          hosted login), so it is not a step of the acquisition funnel. The tags
+          exist at this point — parked in the httpOnly attribution cookie — but
+          publishing a campaign on a failed login would file the same click under
+          two different pages. */}
       <PlatformGtm gtmId={resolvePlatformGtmId()} />
       <main className="flex min-h-dvh flex-col items-center justify-center gap-8 px-6">
         {/* Sign-in is an entrance, so it gets the full company lockup at display

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -63,7 +63,15 @@ export default async function OnboardingPage({
 
   return (
     <>
-      <PlatformGtm gtmId={resolvePlatformGtmId()} />
+      {/* The only surface that passes `signupAccountId`: this page renders once
+          per brand-new workspace, and its first paint is the conversion the ad
+          platforms are optimizing for. The tags come from `account.attribution`
+          — written by the callback moments ago, before this page ever ran. */}
+      <PlatformGtm
+        gtmId={resolvePlatformGtmId()}
+        attribution={me.attribution}
+        signupAccountId={me.accountId}
+      />
       <ProductAnalytics
         analytics={resolveProductAnalytics()}
         identity={{

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,6 +1,8 @@
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { PH_ID_COOKIE, sanitizeLandingDistinctId } from '@/lib/attribution';
 import { preferredLocale } from '@/lib/locale';
 import { currentOnboardingCohort } from '@/lib/dapta-onboarding';
 import { resolveProductAnalytics } from '@/lib/product-analytics';
@@ -81,6 +83,13 @@ export default async function OnboardingPage({
           accountCode: me.accountCode,
           role: me.role,
           attribution: me.attribution,
+          // This is the page that usually spends the ph_id cookie: a fresh
+          // signup lands HERE, not on the dashboard. Wired in both places
+          // because which one renders first is the API's `onboardingRequired`
+          // decision, not ours.
+          landingDistinctId: sanitizeLandingDistinctId(
+            (await cookies()).get(PH_ID_COOKIE)?.value,
+          ),
         }}
       />
       <OnboardingWizard messages={messages} locale={locale} cohort={cohort} />

--- a/apps/web/components/analytics/platform-gtm.spec.tsx
+++ b/apps/web/components/analytics/platform-gtm.spec.tsx
@@ -4,6 +4,9 @@ import Script from 'next/script';
 import {
   DAPTA_PLATFORM_GTM_ID,
   PlatformGtm,
+  SIGNUP_DATALAYER_EVENT,
+  buildPlatformPrelude,
+  platformDataLayerVars,
   resolvePlatformGtmId,
   type PlatformGtmEnv,
 } from './platform-gtm';
@@ -121,5 +124,125 @@ describe('PlatformGtm', () => {
     expect((iframe!.props as AnyProps).src).toBe(
       `https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(hostile)}`,
     );
+  });
+});
+
+describe('platformDataLayerVars — the stored blob as container variables', () => {
+  it('re-keys to the snake_case names the container declares', () => {
+    expect(
+      platformDataLayerVars({
+        utmSource: 'google',
+        utmMedium: 'cpc',
+        utmCampaign: 'forms_launch',
+        utmContent: 'variant_a',
+        utmTerm: 'formularios',
+        gclid: 'Cj0KCQ',
+        fbclid: 'IwAR1',
+      }),
+    ).toEqual({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'forms_launch',
+      utm_content: 'variant_a',
+      utm_term: 'formularios',
+      gclid: 'Cj0KCQ',
+      fbclid: 'IwAR1',
+    });
+  });
+
+  it('publishes referrer and landing path under the FIRST-TOUCH names', () => {
+    // These two are a cross-domain contract: daptaforms.ai pushes the same
+    // variables under these names. Renaming one side alone does not fail — the
+    // container variable just resolves undefined and the tags go quiet.
+    expect(
+      platformDataLayerVars({ referrer: 'https://example.test/x', landingPath: '/precios' }),
+    ).toEqual({ first_touch_referrer: 'https://example.test/x', first_touch_path: '/precios' });
+  });
+
+  it('says nothing at all for an account with no tags', () => {
+    // `{}` and not keys-with-empty-values: a blank utm_source in the layer reads
+    // as "this signup was untagged", which is a different claim from "unknown".
+    expect(platformDataLayerVars(null)).toEqual({});
+    expect(platformDataLayerVars(undefined)).toEqual({});
+    expect(platformDataLayerVars({})).toEqual({});
+    expect(platformDataLayerVars({ utmSource: '', gclid: null })).toEqual({});
+  });
+
+  it('drops what a tag cannot read: unknown keys and non-strings', () => {
+    expect(
+      platformDataLayerVars({ utmSource: 'google', firstSeenAt: 1_700_000_000_000, nope: 'x' }),
+    ).toEqual({ utm_source: 'google' });
+  });
+});
+
+describe('buildPlatformPrelude — what the container sees when it boots', () => {
+  it('initializes the layer even with nothing to push', () => {
+    const out = buildPlatformPrelude({});
+    expect(out).toBe('window.dataLayer=window.dataLayer||[];');
+    expect(out).not.toContain('push');
+  });
+
+  it('emits the signup event only when an account id is passed', () => {
+    expect(buildPlatformPrelude({}, 'acc_123')).toContain(SIGNUP_DATALAYER_EVENT);
+    expect(buildPlatformPrelude({ utm_source: 'google' })).not.toContain(SIGNUP_DATALAYER_EVENT);
+    expect(buildPlatformPrelude({}, null)).not.toContain(SIGNUP_DATALAYER_EVENT);
+  });
+
+  it('latches the signup event per account, and fires when storage is blocked', () => {
+    const out = buildPlatformPrelude({}, 'acc_123');
+    expect(out).toContain('"dapta_forms_signup:acc_123"');
+    // The push sits OUTSIDE the try: a private-mode browser that throws on
+    // localStorage must still report the conversion. Counted twice is
+    // recoverable; never counted is not.
+    const tryEnd = out.indexOf('catch(e){}');
+    expect(tryEnd).toBeGreaterThan(-1);
+    expect(out.indexOf('w.dataLayer.push')).toBeGreaterThan(tryEnd);
+  });
+});
+
+describe('PlatformGtm — attribution reaches the layer before the container', () => {
+  const snippetOf = (el: ReturnType<typeof PlatformGtm>) =>
+    (byTestId(collect(el), 'platform-gtm').props as AnyProps).children as string;
+
+  it('pushes the tags BEFORE gtm.js loads', () => {
+    // The ordering IS the fix. A tag firing on container initialization reads
+    // the layer as it stands at that moment, so a push that lands afterwards
+    // produces a conversion with no campaign on it.
+    const snippet = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: { utmSource: 'google' } }),
+    );
+    expect(snippet).toContain('"utm_source":"google"');
+    expect(snippet.indexOf('"utm_source"')).toBeLessThan(snippet.indexOf('gtm.js'));
+  });
+
+  it('fires the signup event on the wizard and nowhere else', () => {
+    const wizard = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: null, signupAccountId: 'acc_9' }),
+    );
+    expect(wizard).toContain(SIGNUP_DATALAYER_EVENT);
+    // The dashboard passes the same tags without an id — an account signing in
+    // three years later still wants its funnel sliced, and wants no new signup.
+    const dashboard = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: { utmSource: 'google' } }),
+    );
+    expect(dashboard).not.toContain(SIGNUP_DATALAYER_EVENT);
+  });
+
+  it('neutralizes a hostile tag — no </script> breakout out of a utm value', () => {
+    // `utm_source` is whatever the last person to compose a link typed, it is
+    // stored verbatim, and it lands inside an inline <script>.
+    const hostile = `</script><script>alert(1)//`;
+    const snippet = snippetOf(
+      PlatformGtm({ gtmId: 'GTM-TEST123', attribution: { utmSource: hostile } }),
+    );
+    expect(snippet).not.toContain('</script>');
+    expect(snippet).toContain('\\u003c/script>');
+  });
+
+  it('writes no dataLayer at all on a bare fork', () => {
+    // No container means no reader. A fork stays at zero third-party anything.
+    expect(
+      PlatformGtm({ gtmId: null, attribution: { utmSource: 'google' }, signupAccountId: 'acc_1' }),
+    ).toBeNull();
   });
 });

--- a/apps/web/components/analytics/platform-gtm.tsx
+++ b/apps/web/components/analytics/platform-gtm.tsx
@@ -1,5 +1,6 @@
 import Script from 'next/script';
-import { buildGtmSnippet } from '@/components/tracking/tracking-scripts';
+import { attributionEventProps, attributionSchema } from '@quill/types';
+import { buildGtmSnippet, js } from '@/components/tracking/tracking-scripts';
 
 /**
  * Dapta's own Google Tag Manager container for PLATFORM pages — login,
@@ -51,15 +52,127 @@ export function resolvePlatformGtmId(
 }
 
 /**
- * Renders the GTM loader + its no-JS iframe. Returns null when no container is
- * resolved (every bare fork) — no markup, no request.
+ * The two tags whose `dataLayer` names do NOT match the stored field.
+ *
+ * The marketing container declares its variables once and reads them on both
+ * domains, so these names are a CONTRACT with daptaforms.ai — which publishes
+ * `first_touch_referrer` / `first_touch_path` to say plainly that they describe
+ * the visit that started everything, not the page the tag fired on. Renaming
+ * either side alone does not fail: the variable simply resolves undefined and
+ * every tag reading it goes quiet.
  */
-export function PlatformGtm({ gtmId }: { gtmId: string | null }) {
+const DATALAYER_RENAMES: Record<string, string> = {
+  referrer: 'first_touch_referrer',
+  landing_path: 'first_touch_path',
+};
+
+/** Event name, shared with the server-side product-analytics capture. */
+export const SIGNUP_DATALAYER_EVENT = 'forms_signup_completed';
+
+/**
+ * `Me.attribution` as `dataLayer` variables.
+ *
+ * These are FIRST-touch tags read back from `account.attribution`, not the query
+ * string of the current URL — which is exactly the part GA4 cannot reconstruct on
+ * its own here. The signup round-trip leaves our origin for the identity provider
+ * and comes back with a bare URL and a third-party referrer, so by the time any
+ * platform page renders, the campaign exists only in our own column.
+ *
+ * Returns `{}` — never keys with empty values — when there is nothing to say. A
+ * blank `utm_source` in the layer is worse than an absent one: it overwrites a
+ * value a previous push may have set, and reads in the container as "we know this
+ * signup was untagged" rather than "we do not know".
+ */
+export function platformDataLayerVars(
+  attribution: Record<string, string | number | null | undefined> | null | undefined,
+): Record<string, string> {
+  if (!attribution) return {};
+  // Parse rather than trust: the value crosses the API as loose JSON, and
+  // `attributionEventProps` promises a validated `Attribution`. A drifted row
+  // yields `{}` here, which degrades to "no campaign" instead of injecting
+  // whatever shape the column happens to hold into an inline script.
+  const parsed = attributionSchema.safeParse(attribution);
+  if (!parsed.success) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attributionEventProps(parsed.data))) {
+    out[DATALAYER_RENAMES[key] ?? key] = value;
+  }
+  return out;
+}
+
+/**
+ * The `dataLayer` writes that must happen BEFORE the container boots.
+ *
+ * Ordering is the whole point, and it is why this is concatenated into the GTM
+ * script tag rather than rendered as a sibling `<Script>`: a tag that fires on
+ * container initialization reads the layer as it stands at that moment, so a push
+ * that lands afterwards produces an event with no campaign on it — which is the
+ * shape of the bug this fixes. Keeping both in one snippet makes the order a fact
+ * of the string, not a behavior of the framework's script scheduler.
+ *
+ * Every interpolated value is escaped through `js()`. They originate in a query
+ * string: `utm_source` is whatever the last person to compose a link typed, it is
+ * stored verbatim, and it lands inside an inline `<script>`.
+ */
+export function buildPlatformPrelude(
+  vars: Record<string, string>,
+  signupAccountId?: string | null,
+): string {
+  let out = 'window.dataLayer=window.dataLayer||[];';
+  if (Object.keys(vars).length > 0) out += `window.dataLayer.push(${js(vars)});`;
+  if (signupAccountId) out += buildSignupEventSnippet(signupAccountId);
+  return out;
+}
+
+/**
+ * One `forms_signup_completed` per account, per browser.
+ *
+ * The wizard's first paint IS the moment the account came into being — it is the
+ * first page a new workspace ever renders — but it is not a moment that happens
+ * only once: a reload, or coming back tomorrow to an abandoned wizard, renders it
+ * again. Hence the `localStorage` latch, which is the honest bound on this: it is
+ * per browser, so the same person finishing signup on their phone would count
+ * twice. Ad platforms de-duplicate conversions on their own side, and the
+ * alternative — a server-side latch — cannot be read here: the cookie that would
+ * carry it is httpOnly and a Server Component cannot clear it.
+ *
+ * A blocked `localStorage` (private mode) FIRES rather than stays silent. Given
+ * the choice between a conversion counted twice and a real signup never counted,
+ * the double is the recoverable one.
+ */
+function buildSignupEventSnippet(accountId: string): string {
+  const key = `dapta_forms_signup:${accountId}`;
+  return (
+    `(function(w,k){try{if(w.localStorage.getItem(k))return;w.localStorage.setItem(k,'1')}catch(e){}` +
+    `w.dataLayer.push({event:${js(SIGNUP_DATALAYER_EVENT)}})})(window,${js(key)});`
+  );
+}
+
+/**
+ * Renders the GTM loader + its no-JS iframe. Returns null when no container is
+ * resolved (every bare fork) — no markup, no request, and with it no `dataLayer`
+ * write either: a fork has no container to read one.
+ *
+ * `attribution` is the caller's `me.attribution`; `signupAccountId` is passed by
+ * the ONE surface that represents a brand-new workspace (the wizard). The
+ * dashboard passes the tags without it — an account signing in three years later
+ * still wants its funnel sliced by campaign, and does not want a second signup.
+ */
+export function PlatformGtm({
+  gtmId,
+  attribution,
+  signupAccountId,
+}: {
+  gtmId: string | null;
+  attribution?: Record<string, string | number | null | undefined> | null;
+  signupAccountId?: string | null;
+}) {
   if (!gtmId) return null;
+  const prelude = buildPlatformPrelude(platformDataLayerVars(attribution), signupAccountId);
   return (
     <>
       <Script id="platform-gtm" data-testid="platform-gtm" strategy="afterInteractive">
-        {buildGtmSnippet(gtmId)}
+        {prelude + buildGtmSnippet(gtmId)}
       </Script>
       <noscript data-testid="platform-gtm-noscript">
         <iframe

--- a/apps/web/components/analytics/product-analytics.tsx
+++ b/apps/web/components/analytics/product-analytics.tsx
@@ -29,7 +29,7 @@ export function ProductAnalytics({
   identity: AnalyticsIdentity;
 }) {
   const { key, host } = analytics;
-  const { email, memberId, accountId, accountCode, role, attribution } = identity;
+  const { email, memberId, accountId, accountCode, role, attribution, landingDistinctId } = identity;
 
   // `attribution` is an OBJECT, re-created by every RSC payload, so depending on
   // it directly would re-run the effect — and re-identify the session — on every
@@ -52,13 +52,18 @@ export function ProductAnalytics({
       accountCode,
       role,
       attribution: attributionRef.current,
+      // The landing's anonymous id, when a `quill_ph_id` cookie was parked by
+      // the login. A plain string, so it sits in the deps without the object
+      // dance above; re-running with the same id is a no-op behind
+      // `identifyMember`'s localStorage latch.
+      landingDistinctId,
     });
     // Re-runs on a workspace switch: `account_id` is a super property and a
     // group, so it has to follow the member into the workspace they are
     // actually looking at, or every event after a switch is filed under the
     // wrong account. The campaign tags are a property of that same WORKSPACE and
     // change with it, which is why `attributionKey` is here too.
-  }, [key, email, memberId, accountId, accountCode, role, attributionKey]);
+  }, [key, email, memberId, accountId, accountCode, role, attributionKey, landingDistinctId]);
 
   if (!key) return null;
 

--- a/apps/web/components/public/step-input.spec.tsx
+++ b/apps/web/components/public/step-input.spec.tsx
@@ -1,0 +1,73 @@
+/**
+ * The `multiple_choice` render matrix: layout (`resolveOptionLayout`) and
+ * selection mode (`isMultiSelect`) are independent axes. The regression pinned
+ * here: a multi-select step configured with `optionLayout: 'cards'` silently
+ * fell back to the checkbox ROW list — the builder canvas draws the card grid
+ * for that exact config, so the published form disagreed with its own preview.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { FormStep } from '@quill/engine';
+import { StepInput } from './step-input';
+
+function render(step: FormStep, value: unknown = null) {
+  return renderToStaticMarkup(
+    <StepInput
+      step={step}
+      value={value as never}
+      answers={{}}
+      onChange={() => {}}
+      onFieldChange={() => {}}
+      onSelect={() => {}}
+      dropdownPlaceholder="Pick one"
+      dropdownEmpty="No matches"
+    />,
+  );
+}
+
+const cards: FormStep = {
+  key: 'use_case',
+  type: 'multiple_choice',
+  optionLayout: 'cards',
+  options: [
+    { label: 'Leads', value: 'leads', icon: '🧲' },
+    { label: 'Meetings', value: 'meetings', icon: '📅' },
+  ],
+};
+
+describe('multiple_choice: layout x selection mode', () => {
+  it('multi-select + cards renders the card grid with checkbox semantics', () => {
+    const html = render({ ...cards, selectionMode: 'multiple' }, ['leads']);
+    expect(html).toContain('pf-choices--icons');
+    expect(html).toContain('role="checkbox"');
+    expect(html).not.toContain('pf-choices--list');
+    // The picked card carries the selected state; the other does not.
+    expect(html).toContain('pf-choice-icon pf-choice-icon--selected');
+    expect(html).toContain('aria-checked="false"');
+  });
+
+  it('single-select + cards keeps the radio card grid', () => {
+    const html = render(cards, 'leads');
+    expect(html).toContain('pf-choices--icons');
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('role="radio"');
+    expect(html).not.toContain('role="checkbox"');
+  });
+
+  it('multi-select + list keeps the checkbox rows', () => {
+    const html = render(
+      { ...cards, optionLayout: 'list', selectionMode: 'multiple' },
+      ['meetings'],
+    );
+    expect(html).toContain('pf-choices--list');
+    expect(html).toContain('pf-choice-list--multi');
+    expect(html).toContain('role="checkbox"');
+    expect(html).not.toContain('pf-choices--icons');
+  });
+
+  it('multi-select + cards shows the option icons (emoji reach the card)', () => {
+    const html = render({ ...cards, selectionMode: 'multiple' });
+    expect(html).toContain('🧲');
+    expect(html).toContain('📅');
+  });
+});

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -194,11 +194,46 @@ export function StepInput({
         />
       );
 
-    case 'multiple_choice':
-      // Multi-select (checkboxes): toggle values in/out of an array; the form's
-      // Continue button submits. No auto-advance (you may pick several).
-      if (isMultiSelect(step)) {
-        const picked = asArray(value);
+    case 'multiple_choice': {
+      // Layout and selection mode are independent axes: `resolveOptionLayout`
+      // picks the markup (card grid vs rows) and `isMultiSelect` picks the
+      // semantics (checkbox toggles + Continue vs radio + auto-advance). The
+      // builder canvas already draws the card grid for multi-select steps, so
+      // the public renderer honoring only one axis was a preview/public
+      // disagreement, not a constraint.
+      const multi = isMultiSelect(step);
+      const picked = asArray(value);
+      const toggle = (opt: FormOption) => {
+        const on = picked.includes(opt.value);
+        onChange(on ? picked.filter((v) => v !== opt.value) : [...picked, opt.value]);
+      };
+      if (resolveOptionLayout(step) === 'cards') {
+        return (
+          <div
+            className="pf-choices--icons"
+            role={multi ? 'group' : 'radiogroup'}
+            aria-label={step.question ?? step.key}
+          >
+            {(step.options ?? []).map((opt) => {
+              const on = multi ? picked.includes(opt.value) : value === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role={multi ? 'checkbox' : 'radio'}
+                  aria-checked={on}
+                  className={`pf-choice-icon${on ? ' pf-choice-icon--selected' : ''}`}
+                  onClick={() => (multi ? toggle(opt) : onSelect(opt.value))}
+                >
+                  <OptionIcon option={opt} layout="cards" />
+                  <span className="pf-choice-icon__label">{opt.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        );
+      }
+      if (multi) {
         return (
           <div className="pf-choices--list" role="group" aria-label={step.question ?? step.key}>
             {(step.options ?? []).map((opt) => {
@@ -210,34 +245,13 @@ export function StepInput({
                   role="checkbox"
                   aria-checked={on}
                   className={`pf-choice-list pf-choice-list--multi${on ? ' pf-choice-list--selected' : ''}`}
-                  onClick={() =>
-                    onChange(on ? picked.filter((v) => v !== opt.value) : [...picked, opt.value])
-                  }
+                  onClick={() => toggle(opt)}
                 >
                   <span className="pf-choice-list__check" aria-hidden="true" />
                   <span className="pf-choice-list__text">{opt.label}</span>
                 </button>
               );
             })}
-          </div>
-        );
-      }
-      if (resolveOptionLayout(step) === 'cards') {
-        return (
-          <div className="pf-choices--icons" role="radiogroup" aria-label={step.question ?? step.key}>
-            {(step.options ?? []).map((opt) => (
-              <button
-                key={opt.value}
-                type="button"
-                role="radio"
-                aria-checked={value === opt.value}
-                className={`pf-choice-icon${value === opt.value ? ' pf-choice-icon--selected' : ''}`}
-                onClick={() => onSelect(opt.value)}
-              >
-                <OptionIcon option={opt} layout="cards" />
-                <span className="pf-choice-icon__label">{opt.label}</span>
-              </button>
-            ))}
           </div>
         );
       }
@@ -262,6 +276,7 @@ export function StepInput({
           ))}
         </div>
       );
+    }
 
     case 'slider':
       return <SliderInput step={step} value={value} onChange={onChange} onSeed={onSeed} />;

--- a/apps/web/components/tracking/tracking-scripts.tsx
+++ b/apps/web/components/tracking/tracking-scripts.tsx
@@ -22,11 +22,21 @@ import { hasAnyTracking, type ResolvedTracking } from './resolve-tracking';
  */
 
 /**
- * Serialize an id for interpolation inside an inline JS snippet. JSON encoding
+ * Serialize a value for interpolation inside an inline JS snippet. JSON encoding
  * neutralizes quotes/backslashes; escaping `<` prevents `</script>` breakout.
  * Ids are loosely validated strings from form config/env — treat as data.
+ *
+ * Exported for `components/analytics/platform-gtm.tsx`, which inlines a snippet
+ * of its own. ONE escaper for every inline script in the app, deliberately: a
+ * second copy is a second thing to remember to fix, and the values it guards
+ * against there come off a query string anyone can compose.
+ *
+ * Objects are accepted as well as strings — the platform snippet serializes a
+ * whole `dataLayer` payload. `undefined` is not: `JSON.stringify` returns the
+ * value `undefined` rather than a string, which would interpolate the bare word
+ * into the snippet. Callers pass a value or skip the call.
  */
-function js(value: string): string {
+export function js(value: string | Record<string, string>): string {
   return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 

--- a/apps/web/lib/api.spec.ts
+++ b/apps/web/lib/api.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPublicForm, postFormEvent, postSubmission } from './api';
 
 const headersMock = vi.hoisted(() => vi.fn());
@@ -22,6 +22,10 @@ beforeEach(() => {
   headersMock.mockResolvedValue(requestHeaders({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' }));
   fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 /**

--- a/apps/web/lib/api.spec.ts
+++ b/apps/web/lib/api.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPublicForm, postFormEvent, postSubmission } from './api';
+
+const headersMock = vi.hoisted(() => vi.fn());
+vi.mock('next/headers', () => ({ headers: headersMock }));
+
+function requestHeaders(entries: Record<string, string>) {
+  return { get: (k: string) => entries[k.toLowerCase()] ?? null };
+}
+
+function jsonResponse(status: number, body: unknown = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  headersMock.mockReset();
+  headersMock.mockResolvedValue(requestHeaders({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' }));
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+/**
+ * Every server-side call made on a visitor's behalf must carry the visitor's
+ * X-Forwarded-For chain — otherwise the API rate-limits ALL visitors as one
+ * client (the web server's IP). See `lib/forwarded-for.ts`.
+ */
+describe('visitor IP forwarding to the public API', () => {
+  it('getPublicForm forwards the chain on the config fetch', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { slug: 's', name: 'n', config: {} }));
+    await getPublicForm('acme', 'lead-qualifier');
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+  });
+
+  it('postSubmission forwards the chain alongside content-type', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(201, { id: '1', score: 0, outcome: null }));
+    await postSubmission('acme', 'lead-qualifier', { sessionId: 's1', data: {} });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.7, 10.0.0.2',
+    });
+  });
+
+  it('postFormEvent forwards the chain', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200));
+    await postFormEvent('acme', 'lead-qualifier', { sessionId: 's1', type: 'view' });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+  });
+
+  it('sends no forwarding header when the incoming request has none', async () => {
+    headersMock.mockResolvedValue(requestHeaders({}));
+    fetchMock.mockResolvedValue(jsonResponse(200));
+    await postFormEvent('acme', 'lead-qualifier', { sessionId: 's1', type: 'view' });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty('x-forwarded-for');
+  });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -6,11 +6,15 @@
 import { cache } from 'react';
 import type { PublicForm, PublicProfile } from '@quill/types';
 import { serverApiUrl } from './api-url';
+import { forwardedForHeader } from './forwarded-for';
 
 const API_URL = serverApiUrl;
 
 async function getJson<T>(path: string): Promise<T | null> {
-  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  const res = await fetch(`${API_URL}${path}`, {
+    cache: 'no-store',
+    headers: await forwardedForHeader(),
+  });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`API ${path} failed: ${res.status}`);
   return (await res.json()) as T;
@@ -55,7 +59,7 @@ export async function postSubmission(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/submissions`,
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', ...(await forwardedForHeader()) },
       body: JSON.stringify(body),
       cache: 'no-store',
     },
@@ -82,7 +86,7 @@ export async function postFormEvent(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/events`,
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', ...(await forwardedForHeader()) },
       body: JSON.stringify(body),
       cache: 'no-store',
     },

--- a/apps/web/lib/attribution.spec.ts
+++ b/apps/web/lib/attribution.spec.ts
@@ -10,7 +10,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { parseAttribution, attributionSchema, ATTRIBUTION_QUERY_KEYS } from '@quill/types';
-import { attributionHandoffQuery, crossOriginReferer } from './attribution';
+import {
+  attributionHandoffQuery,
+  crossOriginReferer,
+  sanitizeLandingDistinctId,
+} from './attribution';
 
 describe('parseAttribution — snake_case URL in, camelCase blob out', () => {
   it('maps the UTM set and the paid-click ids onto the stored field names', () => {
@@ -138,6 +142,53 @@ describe('attributionHandoffQuery — hop 1, the seam that already broke', () =>
   it('caps a forwarded value so the redirect cannot carry a huge Location header', () => {
     const query = attributionHandoffQuery({ utm_source: 'a'.repeat(4096) }, null, null);
     expect(new URLSearchParams(query).get('utm_source')).toHaveLength(512);
+  });
+
+  it('carries the landing PostHog id beside the tags', () => {
+    const query = attributionHandoffQuery(
+      { utm_source: 'google', ph_id: '0198a1b2-c3d4-7e89' },
+      null,
+      null,
+    );
+    expect(new URLSearchParams(query).get('ph_id')).toBe('0198a1b2-c3d4-7e89');
+    // ...and it never leaks into the attribution parse on the far side.
+    expect(receive(query)).toEqual({ utmSource: 'google' });
+  });
+
+  it('an id alone is still worth a hop — it spends no claim', () => {
+    // parseAttribution over an id-only query stays null, so the login route
+    // parks no attribution cookie: nothing here can burn first touch.
+    const query = attributionHandoffQuery({ ph_id: 'ph-abc' }, null, null);
+    expect(query).toBe('ph_id=ph-abc');
+    expect(receive(query)).toBeNull();
+  });
+
+  it('drops a hostile id rather than forwarding it', () => {
+    expect(attributionHandoffQuery({ ph_id: '"><script>x' }, null, null)).toBe('');
+    const query = attributionHandoffQuery({ utm_source: 'g', ph_id: '"><script>x' }, null, null);
+    expect(new URLSearchParams(query).get('ph_id')).toBeNull();
+  });
+});
+
+describe('sanitizeLandingDistinctId — attacker-composable, vendor-shaped', () => {
+  it('accepts the shapes the landing snippet can actually mint', () => {
+    expect(sanitizeLandingDistinctId('0198a1b2-c3d4-7e89-a1b2-c3d4e5f60718')).toBe(
+      '0198a1b2-c3d4-7e89-a1b2-c3d4e5f60718',
+    );
+    expect(sanitizeLandingDistinctId('$device:0198a1b2-c3d4')).toBe('$device:0198a1b2-c3d4');
+    expect(sanitizeLandingDistinctId('  ph-abc  ')).toBe('ph-abc');
+  });
+
+  it('refuses everything else', () => {
+    expect(sanitizeLandingDistinctId(undefined)).toBeNull();
+    expect(sanitizeLandingDistinctId('')).toBeNull();
+    expect(sanitizeLandingDistinctId('a b')).toBeNull();
+    expect(sanitizeLandingDistinctId('"><img src=x>')).toBeNull();
+    expect(sanitizeLandingDistinctId('x'.repeat(201))).toBeNull();
+  });
+
+  it('takes the first of a repeated param, like every other inbound key', () => {
+    expect(sanitizeLandingDistinctId(['real', 'injected'])).toBe('real');
   });
 });
 

--- a/apps/web/lib/attribution.ts
+++ b/apps/web/lib/attribution.ts
@@ -39,12 +39,60 @@ export function crossOriginReferer(
 }
 
 /**
+ * The query key the landing uses to hand over its PostHog anonymous id.
+ *
+ * `daptaforms.ai` and this app are different origins, so the vendor's cookie
+ * does not cross: without this the same human is two unrelated people and the
+ * "visited the landing → signed up" funnel does not exist. The landing appends
+ * its `distinct_id` to the CTA under this name; it rides the same hops as the
+ * campaign tags and is aliased onto the identified person once, in
+ * `identifyMember`.
+ */
+export const PH_ID_QUERY_KEY = 'ph_id';
+
+/**
+ * Where the login route parks that id for the round-trip. Unlike the
+ * attribution cookie its reader is NOT the callback but the first
+ * analytics-bearing page after login (admin layout / onboarding), which hands
+ * it to `identifyMember` to alias onto the identified person. Nothing deletes
+ * it — a Server Component cannot clear a cookie — so it simply expires with
+ * the login attempt, and the alias itself is latched client-side.
+ *
+ * Lives here rather than in the route file because route files may only export
+ * handlers, and both the route (writer) and the pages (readers) need the name.
+ */
+export const PH_ID_COOKIE = 'quill_ph_id';
+
+/**
+ * A landing distinct id fit to carry, or null.
+ *
+ * Strict on purpose: this value is attacker-composable (anyone can put anything
+ * after `?ph_id=`), and the only legitimate producer is the landing's own
+ * vendor snippet, whose ids are UUID-shaped. The allowlist covers every id that
+ * snippet can mint — hex, dashes, and the vendor's occasional `$device:` prefix
+ * — and refuses everything else. Losing the identity join for an exotic id is
+ * a shrug; forwarding arbitrary text into cookies and analytics calls is not.
+ */
+export function sanitizeLandingDistinctId(raw: string | string[] | undefined | null): string | null {
+  // First of a repeated param, same first-wins rule as the attribution parser.
+  const value = (Array.isArray(raw) ? raw[0] : raw) ?? '';
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 200) return null;
+  return /^[A-Za-z0-9$:._-]+$/.test(trimmed) ? trimmed : null;
+}
+
+/**
  * The query string to hand `/api/auth/login`, or `''` when there is nothing to
  * carry.
  *
  * `''` rather than an empty object is what keeps an untagged visit from spending
  * the claim: no query means the login route sets no cookie, so the callback has
  * nothing to POST.
+ *
+ * `ph_id` counts as something to carry on its own. It spends nothing — the
+ * write-once claim is decided by `parseAttribution` over the attribution keys,
+ * which an id-only query still leaves empty — and in practice it never arrives
+ * alone anyway: the landing CTA that appends it also guarantees a `utm_source`.
  */
 export function attributionHandoffQuery(
   params: Readonly<Record<string, string | string[] | undefined>>,
@@ -55,10 +103,11 @@ export function attributionHandoffQuery(
     ...params,
     referrer: crossOriginReferer(referer, self),
   };
+  const landingId = sanitizeLandingDistinctId(params[PH_ID_QUERY_KEY]);
 
   // Decide with the SAME parser the login route will use, so the two can never
   // disagree about what counts as "nothing to carry".
-  if (!parseAttribution(candidate)) return '';
+  if (!parseAttribution(candidate) && !landingId) return '';
 
   const qs = new URLSearchParams();
   for (const key of ATTRIBUTION_QUERY_KEYS) {
@@ -67,5 +116,6 @@ export function attributionHandoffQuery(
     const value = Array.isArray(raw) ? raw[0] : raw;
     if (typeof value === 'string' && value.trim()) qs.set(key, value.trim().slice(0, FORWARD_MAX));
   }
+  if (landingId) qs.set(PH_ID_QUERY_KEY, landingId);
   return qs.toString();
 }

--- a/apps/web/lib/booking-embed.spec.ts
+++ b/apps/web/lib/booking-embed.spec.ts
@@ -216,4 +216,22 @@ describe('postBookingCallback', () => {
       postBookingCallback('acme', 'lead-qualifier', { sessionId: 's', provider: 'calendly' }),
     ).resolves.toBeUndefined();
   });
+
+  it('forwards the visitor chain when given one, and omits the header when not', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postBookingCallback(
+      'acme',
+      'lead-qualifier',
+      { sessionId: 's', provider: 'calendly' },
+      '203.0.113.7, 10.0.0.2',
+    );
+    let [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+
+    await postBookingCallback('acme', 'lead-qualifier', { sessionId: 's', provider: 'calendly' });
+    [, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty('x-forwarded-for');
+  });
 });

--- a/apps/web/lib/booking-embed.ts
+++ b/apps/web/lib/booking-embed.ts
@@ -244,12 +244,22 @@ export async function postBookingCallback(
   accountCode: string,
   slug: string,
   body: BookingCallbackInput,
+  /**
+   * The visitor's X-Forwarded-For chain, when calling from the server on a
+   * visitor's behalf (see `lib/forwarded-for.ts`). A parameter — not a
+   * `next/headers` import — because this module also ships to the browser,
+   * where the visitor IS the socket peer and no forwarding is needed.
+   */
+  forwardedFor?: string | null,
 ): Promise<void> {
   await fetch(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/booking`,
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        ...(forwardedFor ? { 'x-forwarded-for': forwardedFor } : {}),
+      },
       body: JSON.stringify(body),
       cache: 'no-store',
     },

--- a/apps/web/lib/forwarded-for.spec.ts
+++ b/apps/web/lib/forwarded-for.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { forwardedForChain, forwardedForHeader } from './forwarded-for';
+
+const headersMock = vi.hoisted(() => vi.fn());
+vi.mock('next/headers', () => ({ headers: headersMock }));
+
+function requestHeaders(entries: Record<string, string>) {
+  return { get: (k: string) => entries[k.toLowerCase()] ?? null };
+}
+
+beforeEach(() => {
+  headersMock.mockReset();
+});
+
+describe('forwardedForChain', () => {
+  it('returns the incoming chain verbatim — proxy hop math belongs to the API', async () => {
+    headersMock.mockResolvedValue(
+      requestHeaders({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' }),
+    );
+    await expect(forwardedForChain()).resolves.toBe('203.0.113.7, 10.0.0.2');
+  });
+
+  it('returns null when the request has no chain (direct-exposed self-host)', async () => {
+    headersMock.mockResolvedValue(requestHeaders({}));
+    await expect(forwardedForChain()).resolves.toBeNull();
+  });
+
+  it('returns null outside a request scope instead of throwing', async () => {
+    headersMock.mockRejectedValue(new Error('headers called outside a request scope'));
+    await expect(forwardedForChain()).resolves.toBeNull();
+  });
+});
+
+describe('forwardedForHeader', () => {
+  it('spreads into fetch headers when a chain exists', async () => {
+    headersMock.mockResolvedValue(requestHeaders({ 'x-forwarded-for': '203.0.113.7' }));
+    await expect(forwardedForHeader()).resolves.toEqual({ 'x-forwarded-for': '203.0.113.7' });
+  });
+
+  it('is empty when there is nothing to forward — no empty-string header sent', async () => {
+    headersMock.mockResolvedValue(requestHeaders({}));
+    await expect(forwardedForHeader()).resolves.toEqual({});
+  });
+});

--- a/apps/web/lib/forwarded-for.ts
+++ b/apps/web/lib/forwarded-for.ts
@@ -1,0 +1,34 @@
+/**
+ * The visitor's `X-Forwarded-For` chain, for server-side calls made to the
+ * public API on a visitor's behalf.
+ *
+ * The public API rate-limits per client IP (`apps/api/src/rate-limit.ts`). When
+ * the web app fetches on behalf of a visitor (RSC page render, Server Actions),
+ * the API's socket peer is the web server — so without this header every
+ * visitor of every form shares ONE rate-limit bucket, and a burst of visitors
+ * (a conference QR moment) exhausts it for everyone at once.
+ *
+ * The chain is forwarded VERBATIM, never rebuilt: the API resolves the real
+ * client entry from the right by its own `TRUST_PROXY_HOPS`, so the header must
+ * reach it exactly as the web app's fronting proxy produced it. Appending or
+ * reordering entries here would silently shift that math.
+ */
+import { headers } from 'next/headers';
+
+/** The incoming request's XFF chain, or null outside a request / no proxy. */
+export async function forwardedForChain(): Promise<string | null> {
+  try {
+    const h = await headers();
+    return h.get('x-forwarded-for');
+  } catch {
+    // Outside a request scope (build-time render, tests) there is no visitor
+    // to attribute — the caller sends no header and the API keys on the peer.
+    return null;
+  }
+}
+
+/** The chain as ready-to-spread fetch headers ({} when there is none). */
+export async function forwardedForHeader(): Promise<Record<string, string>> {
+  const chain = await forwardedForChain();
+  return chain ? { 'x-forwarded-for': chain } : {};
+}

--- a/apps/web/lib/forwarded-for.ts
+++ b/apps/web/lib/forwarded-for.ts
@@ -11,7 +11,11 @@
  * The chain is forwarded VERBATIM, never rebuilt: the API resolves the real
  * client entry from the right by its own `TRUST_PROXY_HOPS`, so the header must
  * reach it exactly as the web app's fronting proxy produced it. Appending or
- * reordering entries here would silently shift that math.
+ * reordering entries here would silently shift that math. For the same reason
+ * the web→API call itself must not traverse an XFF-appending proxy (call the
+ * API directly / in-cluster) — such a hop would append the web server's IP and
+ * the API would resolve back to it, silently re-merging every visitor into one
+ * bucket.
  */
 import { headers } from 'next/headers';
 

--- a/apps/web/lib/product-analytics.spec.ts
+++ b/apps/web/lib/product-analytics.spec.ts
@@ -3,11 +3,13 @@
  * test is mostly a NEGATIVE one: with nothing configured the admin must load no
  * script and make no request, so a bare fork runs untouched.
  */
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   resolveProductAnalytics,
   buildAnalyticsSnippet,
+  identifyMember,
   DEFAULT_ANALYTICS_HOST,
+  type AnalyticsIdentity,
 } from './product-analytics';
 
 describe('resolveProductAnalytics', () => {
@@ -71,5 +73,89 @@ describe('buildAnalyticsSnippet', () => {
     const snippet = buildAnalyticsSnippet('</script><script>alert(1)</script>', 'https://x.example');
     expect(snippet).not.toContain('</script>');
     expect(snippet).toContain('\\u003c');
+  });
+});
+
+describe('identifyMember — the landing-visit alias', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** A window with a call-recording posthog and a real-enough localStorage. */
+  function stubWindow(opts: { storageThrows?: boolean } = {}) {
+    const calls: Array<[string, ...unknown[]]> = [];
+    const record =
+      (name: string) =>
+      (...args: unknown[]) =>
+        void calls.push([name, ...args]);
+    const store = new Map<string, string>();
+    vi.stubGlobal('window', {
+      posthog: {
+        identify: record('identify'),
+        alias: record('alias'),
+        register: record('register'),
+        group: record('group'),
+      },
+      localStorage: opts.storageThrows
+        ? {
+            getItem() {
+              throw new Error('blocked');
+            },
+            setItem() {
+              throw new Error('blocked');
+            },
+          }
+        : {
+            getItem: (k: string) => store.get(k) ?? null,
+            setItem: (k: string, v: string) => void store.set(k, v),
+          },
+    });
+    return calls;
+  }
+
+  const identity = (extra?: Partial<AnalyticsIdentity>): AnalyticsIdentity => ({
+    email: 'ana@example.com',
+    memberId: 'mem_1',
+    accountId: 'acc_1',
+    accountCode: 'ACME1',
+    role: 'owner',
+    ...extra,
+  });
+
+  it('aliases the landing id AFTER identify, so it lands on the person', () => {
+    // Before identify, the current distinct id is this origin's anonymous id —
+    // the landing visit would chain to a session instead of pinning to the
+    // person. The order is the contract.
+    const calls = stubWindow();
+    identifyMember(identity({ landingDistinctId: '0198a1b2-c3d4' }));
+    const names = calls.map(([n]) => n);
+    expect(names.indexOf('alias')).toBeGreaterThan(names.indexOf('identify'));
+    expect(calls.find(([n]) => n === 'alias')).toEqual(['alias', '0198a1b2-c3d4']);
+  });
+
+  it('makes no alias call at all without a landing id', () => {
+    const calls = stubWindow();
+    identifyMember(identity());
+    identifyMember(identity({ landingDistinctId: null }));
+    expect(calls.filter(([n]) => n === 'alias')).toHaveLength(0);
+  });
+
+  it('latches: the same landing id aliases once per browser', () => {
+    // The cookie carrying the id lives ten minutes and cannot be deleted
+    // server-side, so every render inside that window re-offers the id.
+    const calls = stubWindow();
+    identifyMember(identity({ landingDistinctId: 'ph-abc' }));
+    identifyMember(identity({ landingDistinctId: 'ph-abc' }));
+    expect(calls.filter(([n]) => n === 'alias')).toHaveLength(1);
+  });
+
+  it('fires anyway when localStorage is blocked — a repeat beats a never', () => {
+    const calls = stubWindow({ storageThrows: true });
+    identifyMember(identity({ landingDistinctId: 'ph-abc' }));
+    expect(calls.filter(([n]) => n === 'alias')).toHaveLength(1);
+  });
+
+  it('does nothing without an email — no identify means nothing to pin to', () => {
+    const calls = stubWindow();
+    identifyMember(identity({ email: null, landingDistinctId: 'ph-abc' }));
+    expect(calls).toHaveLength(0);
   });
 });

--- a/apps/web/lib/product-analytics.ts
+++ b/apps/web/lib/product-analytics.ts
@@ -52,6 +52,14 @@ export interface AnalyticsIdentity {
    * only registered when present (see `identifyMember`).
    */
   attribution?: Record<string, string | number | null | undefined> | null;
+  /**
+   * The landing's PostHog anonymous id, read back from the `quill_ph_id` cookie
+   * the login route parked. Present only in the minutes after a login that
+   * started on a landing CTA; aliased onto the person exactly once (see
+   * `identifyMember`) so the landing visit and the platform session stop being
+   * two unrelated people.
+   */
+  landingDistinctId?: string | null;
 }
 
 /**
@@ -127,6 +135,7 @@ export function buildAnalyticsSnippet(key: string, host: string): string {
  */
 interface PosthogBrowser {
   identify(distinctId: string, properties?: Record<string, unknown>): void;
+  alias(alias: string, original?: string): void;
   register(properties: Record<string, unknown>): void;
   group(type: string, key: string, properties?: Record<string, unknown>): void;
   capture(event: string, properties?: Record<string, unknown>): void;
@@ -166,6 +175,11 @@ export function identifyMember(identity: AnalyticsIdentity): void {
     account_id: identity.accountId,
     role: identity.role,
   });
+  // AFTER identify, never before: `alias` links its argument to the CURRENT
+  // distinct id, and before identify that is this origin's anonymous id — the
+  // landing visit would be chained to a session that identify then merges,
+  // instead of pinned to the person directly.
+  aliasLandingVisit(ph, identity.landingDistinctId);
   ph.register({
     product: 'forms',
     account_id: identity.accountId,
@@ -183,6 +197,32 @@ export function identifyMember(identity: AnalyticsIdentity): void {
     // answerable across the handful of events we hand-instrument.
     ...groupAttribution(identity.attribution),
   });
+}
+
+/**
+ * Join the landing visit to the person, once per landing id per browser.
+ *
+ * `alias(landingId)` files the landing's anonymous id under the person the
+ * session just identified as — the cross-domain stitch the vendor's cookie
+ * cannot make on its own. The landing id is never an identified id (the landing
+ * has nobody to identify), which is exactly the case alias exists for.
+ *
+ * The latch is `localStorage`, keyed by the landing id itself: the cookie that
+ * carries the id lives ten minutes and nothing can delete it server-side, so
+ * every render inside that window would otherwise re-send the merge. When
+ * storage is blocked the alias fires anyway — the vendor drops a repeated
+ * merge on the floor, and a join that never happens is the only real loss.
+ */
+function aliasLandingVisit(ph: PosthogBrowser, landingId: string | null | undefined): void {
+  if (!landingId) return;
+  try {
+    const key = `dapta_forms_ph_alias:${landingId}`;
+    if (window.localStorage.getItem(key)) return;
+    window.localStorage.setItem(key, '1');
+  } catch {
+    // Private mode: fall through and alias anyway.
+  }
+  ph.alias(landingId);
 }
 
 /** The campaign subset of the attribution blob, snake_cased. Empty when absent. */

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -1512,6 +1512,55 @@ describe('resolveEnding (V5-B1 — outcome → form → built-in)', () => {
     expect(resolveEnding(cfg, null).redirectDelayMs).toBe(0);
   });
 
+  it('an outcome with its OWN url never inherits the form-level delay', () => {
+    // The reported bug: the outcomes dialog renders an untouched delay as "0"
+    // and promises "0 = redirect immediately", but the stored value is absent,
+    // and absent used to fall through to the form-level delay — so the public
+    // form held the thank-you the dialog said it would skip. The delay belongs
+    // to the URL pairing: an outcome that brings its own destination without
+    // its own delay redirects immediately, as displayed.
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [],
+      ending: { redirectUrl: 'https://example.com/all', redirectDelayMs: 1500 },
+    };
+    const own = resolveEnding(cfg, outcome({ redirectUrl: 'https://example.com/vip' }));
+    expect(own.redirectUrl).toBe('https://example.com/vip');
+    expect(own.redirectDelayMs).toBe(0);
+    // Its own delay still wins when it has one...
+    expect(
+      resolveEnding(cfg, outcome({ redirectUrl: 'https://example.com/vip', redirectDelayMs: 500 }))
+        .redirectDelayMs,
+    ).toBe(500);
+    // ...and an outcome that inherits the URL keeps inheriting the delay with it.
+    expect(resolveEnding(cfg, outcome()).redirectDelayMs).toBe(1500);
+  });
+
+  it('a form-level delay orphaned by a cleared form URL cannot leak into an outcome', () => {
+    // The ending panel keeps the stored delay when its URL is cleared; before
+    // the pairing rule, that orphan re-attached to any outcome-level URL.
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [],
+      ending: { redirectUrl: null, redirectDelayMs: 2000 },
+    };
+    const out = resolveEnding(cfg, outcome({ redirectUrl: 'https://example.com/vip' }));
+    expect(out.redirectUrl).toBe('https://example.com/vip');
+    expect(out.redirectDelayMs).toBe(0);
+  });
+
+  it('a whitespace-only outcome url is not an OWN url — same rule as pick()', () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [],
+      ending: { redirectUrl: 'https://example.com/all', redirectDelayMs: 1500 },
+    };
+    // The URL falls back to the form's, so the delay travels with it.
+    const out = resolveEnding(cfg, outcome({ redirectUrl: '   ' }));
+    expect(out.redirectUrl).toBe('https://example.com/all');
+    expect(out.redirectDelayMs).toBe(1500);
+  });
+
   it('with scoring off there is no outcome, so the form-level ending is what shows', () => {
     // The V4 complaint end to end: scoring off must not let a range hijack the ending.
     const cfg: FormConfig = {

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -1793,7 +1793,19 @@ export function resolveEnding(config: FormConfig, outcome: FormOutcome | null): 
   const redirectUrl = pick(outcome?.redirectUrl, e?.redirectUrl);
   // A delay without a destination is meaningless — report 0 so the renderer
   // never holds the screen waiting for a redirect that is not coming.
-  const delaySource = outcome?.redirectDelayMs ?? e?.redirectDelayMs ?? 0;
+  //
+  // The delay inherits from the form-level ending ONLY when the URL itself was
+  // inherited. It describes how long to hold the thank-you before going to a
+  // specific destination — it belongs to that pairing, not to the outcome in
+  // the abstract. An outcome that brings its own URL with no delay of its own
+  // therefore resolves 0, which is exactly what the outcomes dialog shows its
+  // author for an untouched field ("0 = redirect immediately"). The old rule
+  // (`outcome ?? form ?? 0`) let a form-level delay leak under an
+  // outcome-level URL, so a dialog reading 0 held the screen anyway — and a
+  // form whose URL had been cleared could leak its orphaned delay the same
+  // way.
+  const ownUrl = typeof outcome?.redirectUrl === 'string' && outcome.redirectUrl.trim() !== '';
+  const delaySource = outcome?.redirectDelayMs ?? (ownUrl ? 0 : (e?.redirectDelayMs ?? 0));
   return {
     headline: pick(outcome?.label, e?.headline),
     body: pick(outcome?.message, e?.body),

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -300,7 +300,10 @@ export interface FormOutcome {
   overrides?: OutcomeOverrideRule[];
   /**
    * Hold the thank-you screen this long before this outcome's redirect fires
-   * (additive — V5-B1). Absent = inherit `config.ending.redirectDelayMs`.
+   * (additive — V5-B1). Absent = 0 when this outcome has its own
+   * `redirectUrl`; `config.ending.redirectDelayMs` is inherited only when the
+   * URL is inherited too — the delay belongs to the URL pairing (see
+   * `resolveEnding`).
    */
   redirectDelayMs?: number;
 }
@@ -1804,7 +1807,9 @@ export function resolveEnding(config: FormConfig, outcome: FormOutcome | null): 
   // outcome-level URL, so a dialog reading 0 held the screen anyway — and a
   // form whose URL had been cleared could leak its orphaned delay the same
   // way.
-  const ownUrl = typeof outcome?.redirectUrl === 'string' && outcome.redirectUrl.trim() !== '';
+  // "Own" by the same definition `pick` uses for the URL itself, so the two
+  // can never disagree about whether the outcome brought a destination.
+  const ownUrl = pick(outcome?.redirectUrl, null) !== null;
   const delaySource = outcome?.redirectDelayMs ?? (ownUrl ? 0 : (e?.redirectDelayMs ?? 0));
   return {
     headline: pick(outcome?.label, e?.headline),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -514,7 +514,10 @@ export const formOutcomeSchema = z.object({
   booking: outcomeBookingSchema.nullable().optional(),
   /**
    * Hold the thank-you screen this long before this outcome's redirect fires
-   * (ADDITIVE — V5-B1). Absent = inherit the form-level ending's delay.
+   * (ADDITIVE — V5-B1). Absent = 0 when this outcome has its own
+   * `redirectUrl`; the form-level ending's delay is inherited only when the
+   * URL is inherited too — the delay belongs to the URL pairing (the engine's
+   * `resolveEnding` is the resolver).
    */
   redirectDelayMs: z.number().int().min(0).max(60_000).optional(),
   /**


### PR DESCRIPTION
Release `develop` → `main`: 4 PRs, 7 non-merge commits, 26 files (+948/−48).

> ⚠️ **Merge with a merge commit, never squash** (repo release flow). Merging this deploys nothing by itself — prd is a manual gate in `dapta-forms-deploy`.

## [#98](https://github.com/Dapta-Tech/dapta-forms/pull/98) — Per-visitor rate limiting on public forms

The Colombia Tech Week outage fix (form down twice on 2026-08-14 under QR-scan stampedes). Every server-side call the web makes on a visitor's behalf reached the API from the web server's own IP, so the per-IP limiter keyed **all visitors of all forms into one bucket** — any customer's spike throttled every other customer. The web now forwards the `X-Forwarded-For` chain verbatim on the RSC config fetch and the submission/event/booking actions, so the API limits per real visitor. Spoofing stays defeated: the ALB appends the true peer and `clientKey()` resolves from the right. (Production was stabilized same-day via ConfigMap; this is the real fix.)

## [#99](https://github.com/Dapta-Tech/dapta-forms/pull/99) — Campaign attribution reaches GTM + PostHog cross-domain identity

Marketing's "events arrive without campaign" issue. The platform mounts the marketing GTM container but never wrote to `dataLayer` — every variable the container declares resolved `undefined` on our pages.

- First-touch attribution (`utm_*`, `gclid`, `fbclid`, `first_touch_*`) read from `account.attribution` and pushed **inside the same inline script, before** the GTM snippet, on login/onboarding/admin — ordering is a fact of the string, so tags firing on container init always see the campaign.
- `forms_signup_completed` dataLayer event on the wizard only (localStorage-latched per account) — a real conversion trigger for Google Ads/Meta instead of a URL match.
- The landing's PostHog anonymous id (`ph_id`) now survives the login round-trip (root handoff → httpOnly cookie → `alias()` after `identify()`), so the landing visit and the platform session are one person and the landing → signup funnel exists.
- Bare fork: zero third-party anything, unchanged.

**Still needed outside this repo:** GTM/GA4 container config (Jefferson) — `forms_signup_completed` trigger, `auth.dapta.ai` in unwanted referrals, cross-domain `daptaforms.ai` ↔ `forms.dapta.ai`; and the landing's own deploy (gclid/fbclid capture, separate repo).

## [#100](https://github.com/Dapta-Tech/dapta-forms/pull/100) — Multi-select honors the card layout

`multiple_choice` with cards + multiple selection rendered as the checkbox row list on the public form while the builder preview drew the card grid. The public renderer now honors both axes: card grid with checkbox semantics, Continue to submit, icons intact. Stored configs start rendering what the preview always promised — no schema change.

## [#101](https://github.com/Dapta-Tech/dapta-forms/pull/101) — Outcome redirect delay of 0 held the thank-you anyway

The Outcomes dialog shows an untouched delay as **0** ("0 = redirect immediately"), but the stored value is absent and absent inherited the form-level delay — so the public form held the thank-you screen the editor said it would skip, and leaving the field at 0 could not even store a real 0. Fix in the engine: **the delay inherits only when the URL does**. An outcome with its own URL and no delay redirects immediately, as displayed; inheriting the URL keeps inheriting the delay. Also closes the orphaned-delay leak (form URL cleared, its delay re-attached under outcome URLs). Resolved at render — no stored config changes shape.

*Deliberate behavior change:* form-level URL+delay with an outcome overriding only the URL used to wait; it now redirects immediately — the dialog always displayed 0 for that case.

## Verification

Every PR came in with forms-reviewer PASS, full suites green (engine 200, api 360, web 453+, db), typecheck/lint/build, publish-gate. #99 and #101 additionally verified in a live browser (dataLayer ordering, signup latch, identify→alias order). #98 verified under load semantics per its own PR. Changesets: `@quill/engine` patch (#101); web changesets documentation-only (ignore list).

## Post-merge checklist

1. prd release: manual gate in `dapta-forms-deploy` (merging here ships nothing).
2. Landing deploy (separate repo) for gclid/fbclid.
3. Jefferson: container + GA4 config above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
