### PR TITLE
fix(web): match Orbit's logout contract — revoke server-side, never visit WorkOS

### DIFF
--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -1,11 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 const getSession = vi.fn();
 const clearSession = vi.fn();
+const revokeUpstreamSession = vi.fn();
 vi.mock('@/lib/auth-session', () => ({
   getSession: (...a: unknown[]) => getSession(...a),
   clearSession: (...a: unknown[]) => clearSession(...a),
+  revokeUpstreamSession: (...a: unknown[]) => revokeUpstreamSession(...a),
 }));
 
 import { GET } from './route';
@@ -14,80 +16,32 @@ const req = () => new NextRequest('https://forms.example.com/api/auth/logout');
 const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
 
 describe('GET /api/auth/logout', () => {
-  const fetchMock = vi.fn();
-
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubGlobal('fetch', fetchMock);
-    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
     vi.stubEnv('PUBLIC_APP_URL', '');
+    revokeUpstreamSession.mockResolvedValue(undefined);
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.unstubAllEnvs();
-  });
-
-  it('appends return_to to the IAM logoutUrl so WorkOS sends the browser back', async () => {
+  it('reads the session, clears the cookie, revokes upstream, lands locally', async () => {
     getSession.mockResolvedValue(workosSession);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ logoutUrl: 'https://api.workos.com/user_management/sessions/logout?session_id=sess_123' }),
-    });
 
     const res = await GET(req());
 
-    const target = new URL(res.headers.get('location')!);
-    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
-    expect(target.searchParams.get('session_id')).toBe('sess_123');
-    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
-    // The session id travels to the IAM, and the cookie is cleared after reading it.
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://iam.example.com/iam/auth/logout',
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ workos_session_id: 'sess_123' }) }),
-    );
+    // Read-then-clear: the revoke needs the session id the cookie carried.
+    expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
+    expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
-  });
-
-  it('keeps a preexisting return_to out of the way by overwriting it', async () => {
-    getSession.mockResolvedValue(workosSession);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        logoutUrl: 'https://api.workos.com/user_management/sessions/logout?session_id=s&return_to=https%3A%2F%2Felsewhere.example',
-      }),
-    });
-
-    const res = await GET(req());
-
-    const target = new URL(res.headers.get('location')!);
-    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
-  });
-
-  it('lands locally on an unparseable logoutUrl instead of failing the sign-out', async () => {
-    getSession.mockResolvedValue(workosSession);
-    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ logoutUrl: '/relative-not-a-url' }) });
-
-    const res = await GET(req());
-
+    // Never WorkOS — the browser stays on our origin (skipIdpRedirect contract).
     expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
   });
 
-  it('falls back to /login?signedout=1 when the IAM call fails', async () => {
-    getSession.mockResolvedValue(workosSession);
-    fetchMock.mockResolvedValue({ ok: false });
+  it('cleans up and lands locally even when there is no session at all', async () => {
+    getSession.mockResolvedValue(null);
 
     const res = await GET(req());
 
-    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
-  });
-
-  it('skips the IAM entirely without a workos session id', async () => {
-    getSession.mockResolvedValue({ provider: 'local', email: 'a@b.c' });
-
-    const res = await GET(req());
-
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(clearSession).toHaveBeenCalled();
+    expect(revokeUpstreamSession).toHaveBeenCalledWith(null);
     expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
   });
 });

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,49 +1,25 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { clearSession, getSession } from '@/lib/auth-session';
+import { clearSession, getSession, revokeUpstreamSession } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
 /**
- * Logout — full single-logout, platform-consistent (verified contract):
- * POST {IAM}/auth/logout { workos_session_id } -> { logoutUrl }, then send the
- * browser through WorkOS logout so the next login does NOT silently re-auth.
- * Fallbacks (no session id / IAM error): clear our cookie and land on
- * /login?signedout=1 — the login page suppresses its auto-redirect for that
- * param, otherwise logout would bounce straight back into /admin.
+ * Logout — Orbit-parity contract (skipIdpRedirect = true): revoke upstream
+ * best-effort (see `revokeUpstreamSession`), ALWAYS clear our cookie, land on
+ * /login?signedout=1 — the browser never visits WorkOS. The login page
+ * suppresses its auto-redirect for that param, otherwise logout would bounce
+ * straight back into /admin.
+ *
+ * Server ACTIONS don't come through here — `signOutAction` and `hostFetch`
+ * revoke + clear inline, because an action `redirect()` into a route handler
+ * soft-navigates and strands the URL bar on /api/auth/logout. This route serves
+ * the contexts that cannot touch the cookie themselves: the 401 path inside a
+ * Server Component render (`admin-api.ts`, where `cookies().delete()` throws)
+ * and direct navigation.
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const origin = requestOrigin(req);
   const session = await getSession();
   await clearSession();
-
-  const iam = process.env.IAM_BASE_URL?.replace(/\/$/, '');
-  const sessionId = session?.provider === 'workos' ? session.sessionId : undefined;
-  if (iam && sessionId) {
-    const res = await fetch(`${iam}/auth/logout`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ workos_session_id: sessionId }),
-      cache: 'no-store',
-    }).catch(() => null);
-    const out = res && res.ok ? ((await res.json().catch(() => ({}))) as { logoutUrl?: string }) : null;
-    if (out?.logoutUrl) {
-      // The IAM's logoutUrl carries no destination, and the WorkOS environment
-      // has no default logout redirect — followed as-is it ends the session and
-      // then strands the browser on a blank api.workos.com page. `return_to`
-      // must land on the same URL as the fallback branch below: the login page
-      // only suppresses its auto-redirect for `?signedout=1`, so any other
-      // destination would bounce a just-signed-out user straight back into
-      // the login flow. The URL must be allowlisted in WorkOS ("Logout
-      // redirect URIs") for WorkOS to honor it.
-      try {
-        const target = new URL(out.logoutUrl);
-        target.searchParams.set('return_to', new URL('/login?signedout=1', origin).toString());
-        return NextResponse.redirect(target);
-      } catch {
-        // Unparseable logoutUrl — NextResponse.redirect would throw on it too,
-        // so fall through to the local landing below.
-      }
-    }
-  }
-
+  await revokeUpstreamSession(session);
   return NextResponse.redirect(new URL('/login?signedout=1', origin));
 }

--- a/apps/web/app/login/actions.spec.ts
+++ b/apps/web/app/login/actions.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSession = vi.fn();
+const clearSession = vi.fn();
+const revokeUpstreamSession = vi.fn();
+const setSession = vi.fn();
+const authProvider = vi.fn();
+vi.mock('@/lib/auth-session', () => ({
+  getSession: (...a: unknown[]) => getSession(...a),
+  clearSession: (...a: unknown[]) => clearSession(...a),
+  revokeUpstreamSession: (...a: unknown[]) => revokeUpstreamSession(...a),
+  setSession: (...a: unknown[]) => setSession(...a),
+  authProvider: () => authProvider(),
+}));
+
+const redirect = vi.fn((url: string) => {
+  // Mirror Next's real behavior: redirect() throws, ending the action.
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+vi.mock('next/navigation', () => ({ redirect: (url: string) => redirect(url) }));
+
+import { signOutAction } from './actions';
+
+const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+
+describe('signOutAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('workos: reads the session before clearing, revokes upstream, lands on /login?signedout=1', async () => {
+    authProvider.mockReturnValue('workos');
+    getSession.mockResolvedValue(workosSession);
+
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    // Read-then-clear: clearing first hands the revoke a null session (the
+    // pre-#82 bug that left the upstream WorkOS session alive).
+    expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
+    expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
+    expect(clearSession).toHaveBeenCalled();
+  });
+
+  it('workos: still clears and lands locally when the session is already gone', async () => {
+    authProvider.mockReturnValue('workos');
+    getSession.mockResolvedValue(null);
+
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    expect(clearSession).toHaveBeenCalled();
+    expect(revokeUpstreamSession).toHaveBeenCalledWith(null);
+  });
+
+  it('local: clears and lands on plain /login without touching the IAM helper contract', async () => {
+    authProvider.mockReturnValue('local');
+    getSession.mockResolvedValue({ provider: 'local', email: 'a@b.c' });
+
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login');
+
+    expect(clearSession).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/login/actions.ts
+++ b/apps/web/app/login/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { setSession, clearSession, authProvider } from '@/lib/auth-session';
+import { setSession, clearSession, getSession, authProvider, revokeUpstreamSession } from '@/lib/auth-session';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -22,21 +22,24 @@ export async function signInAction(
 }
 
 /**
- * Logout (AUTH-WEB-CONTRACT §2/§3.5). Clearing the cookie is what makes logout
- * real in AUTH_LOCAL_STRICT mode (the next /v1/me is a 401 → /login). For workos
- * a cookie-only clear leaves the WorkOS session alive, so we must also redirect
- * through the IAM/WorkOS logout — handled by /api/auth/logout.
+ * Logout (AUTH-WEB-CONTRACT §2/§3.5) — Orbit-parity contract: read the session,
+ * clear the cookie, tell the IAM to revoke upstream (best-effort, see
+ * `revokeUpstreamSession`), and land on /login?signedout=1. The order matters:
+ * the session must be READ before `clearSession()` lands its Set-Cookie, or the
+ * revoke has no session id — that gap once left the upstream WorkOS session
+ * alive and "sign in" silently re-authenticated the same person into /admin.
  *
- * On workos we must NOT clear the cookie here. `delete()` lands as a Set-Cookie
- * on THIS response, so the browser drops the session before it navigates to
- * /api/auth/logout — which then reads a null session, finds no `sessionId`, and
- * skips the IAM single-logout entirely. That left the upstream WorkOS session
- * alive: sign out looked like it worked, and the next "sign in" silently
- * re-authenticated the same person straight back into /admin. The route reads
- * the session id and then clears the cookie itself, in that order.
+ * Inline rather than via /api/auth/logout: an action `redirect()` into a route
+ * handler soft-navigates, leaving the URL bar stranded on /api/auth/logout
+ * while the login page renders. The browser never visits WorkOS
+ * (skipIdpRedirect = true in Orbit's terms) — /login?signedout=1 is the landing,
+ * and its param is what suppresses the login page's auto-redirect.
  */
 export async function signOutAction(): Promise<void> {
-  if (authProvider() === 'workos') redirect('/api/auth/logout');
+  const session = await getSession();
   await clearSession();
-  redirect('/login');
+  await revokeUpstreamSession(session);
+  // Keyed on the configured provider, not the (possibly already-null) session:
+  // in workos mode a bare /login auto-redirects straight back into the IAM.
+  redirect(authProvider() === 'workos' ? '/login?signedout=1' : '/login');
 }

--- a/apps/web/lib/auth-session-revoke.spec.ts
+++ b/apps/web/lib/auth-session-revoke.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+
+import { revokeUpstreamSession, type Session } from './auth-session';
+
+const workosSession: Session = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+
+describe('revokeUpstreamSession', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('POSTs redirect=false with both ids and no Authorization header', async () => {
+    await revokeUpstreamSession(workosSession);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://iam.example.com/iam/auth/logout?redirect=false',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ workos_session_id: 'sess_123', session_id: 'sess_123' }),
+      }),
+    );
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('authorization');
+  });
+
+  it('still POSTs an empty body when the workos session has no session id', async () => {
+    await revokeUpstreamSession({ provider: 'workos', accessToken: 'tok' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://iam.example.com/iam/auth/logout?redirect=false',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({}) }),
+    );
+  });
+
+  it('swallows a rejected fetch — local cleanup must never be hostage to the IAM', async () => {
+    fetchMock.mockRejectedValue(new Error('iam down'));
+
+    await expect(revokeUpstreamSession(workosSession)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the IAM for a local session', async () => {
+    await revokeUpstreamSession({ provider: 'local', email: 'a@b.c' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the IAM when IAM_BASE_URL is not configured', async () => {
+    vi.stubEnv('IAM_BASE_URL', '');
+
+    await revokeUpstreamSession(workosSession);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -75,6 +75,32 @@ export async function getSession(): Promise<Session | null> {
 }
 
 /**
+ * Best-effort upstream revoke — Orbit-parity contract (skipIdpRedirect = true):
+ * POST {IAM}/auth/logout?redirect=false so the IAM revokes the WorkOS session
+ * server-side. Deliberately unauthenticated: /auth/logout is a public IAM route
+ * (like login/refresh), and sending an expired Bearer is what creates
+ * logout -> 401 -> logout loops. Fired even without a session id ({} body) —
+ * the IAM can still invalidate server-side state. The response's
+ * logoutUrl/logoutURL is the WorkOS single-logout URL — unused by design; a
+ * future "switch account" flow (skipIdpRedirect = false) is the only consumer.
+ * Never throws and never hangs past its timeout: the caller's local cleanup
+ * must not be hostage to the IAM being up.
+ */
+export async function revokeUpstreamSession(session: Session | null): Promise<void> {
+  const iam = process.env.IAM_BASE_URL?.replace(/\/$/, '');
+  if (!iam || session?.provider !== 'workos') return;
+  const sessionId = session.sessionId;
+  const body = sessionId ? { workos_session_id: sessionId, session_id: sessionId } : {};
+  await fetch(`${iam}/auth/logout?redirect=false`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(5000),
+  }).catch(() => null);
+}
+
+/**
  * Identity headers for a raw host `fetch()` that doesn't route through
  * admin-api's `req()` (a few server actions post directly). Same contract as
  * admin-api (§1): Bearer for workos, x-quill-email for local, nothing when
@@ -137,13 +163,15 @@ export async function hostFetch(path: string, init?: RequestInit): Promise<Respo
     cache: 'no-store',
   });
   if (res.status === 401) {
-    // Workos goes through /api/auth/logout, which needs the cookie STILL PRESENT
-    // to read the session id and revoke upstream — clearing it here would land a
-    // Set-Cookie on this response and hand that route a null session (see
-    // `signOutAction`). The route clears it itself, unconditionally.
-    if (authProvider() === 'workos') redirect('/api/auth/logout');
+    // Same shape as `signOutAction` (Orbit-parity): read the session BEFORE
+    // clearing (the revoke needs its id), clear unconditionally, revoke
+    // best-effort. Inline rather than via /api/auth/logout — an action
+    // `redirect()` into a route handler strands the URL bar there. And per the
+    // contract, a 401 anywhere never re-enters logout: one revoke, then /login.
+    const session = await getSession();
     await clearSession();
-    redirect('/login');
+    await revokeUpstreamSession(session);
+    redirect(authProvider() === 'workos' ? '/login?signedout=1' : '/login');
   }
   return res;
 }


### PR DESCRIPTION
## What

Adopts Orbit's logout contract (per Karen's specs and `Dapta-Tech/dapta-orbit`'s `iam-auth.service.ts`, `skipIdpRedirect = true`) in place of the WorkOS single-logout redirect:

- `POST {IAM}/auth/logout?redirect=false` — public route, **no Bearer** (an expired token here is what creates logout → 401 → logout loops).
- Body `{ workos_session_id, session_id }` (same id in both fields, as Orbit sends it), or `{}` when the session carries no id — the POST always fires so the IAM can invalidate server-side state.
- Local cleanup runs **unconditionally**, whatever the IAM call does (5s timeout, errors swallowed).
- The browser **never visits WorkOS**: every sign-out lands on `/login?signedout=1`. The response's `logoutUrl`/`logoutURL` is deliberately unused — a future "switch account" flow (`skipIdpRedirect = false`) is its only consumer.

## How

- New `revokeUpstreamSession()` in `apps/web/lib/auth-session.ts` owns the IAM call.
- `signOutAction` and `hostFetch`'s 401 path revoke + clear **inline** and redirect straight to the login page. Routing them through `/api/auth/logout` left the URL bar stranded on `/api/auth/logout` (an action `redirect()` into a route handler soft-navigates).
- `/api/auth/logout` stays for the contexts that can't touch the cookie: the 401 path inside a Server Component render (`admin-api.ts`, where `cookies().delete()` throws) and direct navigation.
- Read-then-clear ordering is preserved and now unit-tested — clearing first is the pre-#82 bug that left the upstream session alive.

## Consequences

- The "Logout redirect URIs" allowlist entry in the WorkOS dashboard (added for #86) is no longer needed — safe to clean up, not urgent.
- `local` provider path unchanged.

## Verification

- 10 unit tests across `route.spec.ts`, `actions.spec.ts`, `auth-session-revoke.spec.ts`; full `pnpm test` (16 workspaces), `typecheck`, `lint`, publish-gate green.
- Offline E2E against a stub IAM signing with the API's `JWT_SECRET`: login → admin → sign out. Stub log records `POST /auth/logout?redirect=false`, `hasAuthorizationHeader: false`, body `{"workos_session_id":"workos_session_STUB_123","session_id":"workos_session_STUB_123"}`; a sentinel IdP-logout URL in the stub's response is never visited; browser ends on `/login?signedout=1` and a follow-up `/admin` bounces back to login.
