### PR TITLE
fix(web): forward autoFocus to the phone step's number input

### DIFF
--- a/apps/web/components/public/phone-input.tsx
+++ b/apps/web/components/public/phone-input.tsx
@@ -66,6 +66,7 @@ export function PhoneInput({
   locale = 'en',
   ariaLabel,
   defaultCountry,
+  autoFocus = true,
 }: {
   /** Full number including the dial code ('+525512345678'), or ''. */
   value: string;
@@ -76,6 +77,13 @@ export function PhoneInput({
   ariaLabel?: string;
   /** Per-form default country (ISO alpha-2, e.g. "CO"); falls back to locale. */
   defaultCountry?: string | null;
+  /**
+   * Focus the number input on mount. Default `true` — the slides layout shows
+   * one question per screen, so focusing it is always right. The vertical
+   * layout renders every question at once and passes `false`: competing
+   * autofocused inputs would fight, and the winner would scroll the page.
+   */
+  autoFocus?: boolean;
 }) {
   const m = getMessages(locale).renderer.phonePicker;
   const listId = useId();
@@ -210,7 +218,7 @@ export function PhoneInput({
           placeholder={formatPhoneDigits(country.dial, '0'.repeat(minLen))}
           aria-label={ariaLabel}
           aria-invalid={tooShort || undefined}
-          autoFocus
+          autoFocus={autoFocus}
         />
       </div>
 

--- a/apps/web/components/public/step-input.spec.tsx
+++ b/apps/web/components/public/step-input.spec.tsx
@@ -10,7 +10,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import type { FormStep } from '@quill/engine';
 import { StepInput } from './step-input';
 
-function render(step: FormStep, value: unknown = null) {
+function render(step: FormStep, value: unknown = null, autoFocus?: boolean) {
   return renderToStaticMarkup(
     <StepInput
       step={step}
@@ -21,6 +21,7 @@ function render(step: FormStep, value: unknown = null) {
       onSelect={() => {}}
       dropdownPlaceholder="Pick one"
       dropdownEmpty="No matches"
+      autoFocus={autoFocus}
     />,
   );
 }
@@ -69,6 +70,57 @@ describe('multiple_choice: layout x selection mode', () => {
     const html = render({ ...cards, selectionMode: 'multiple' });
     expect(html).toContain('🧲');
     expect(html).toContain('📅');
+  });
+});
+
+/**
+ * `autoFocus` must reach EVERY text-entry step, including `phone`. The
+ * regression pinned here: the `phone` case dropped the prop and PhoneInput
+ * focused its number field unconditionally, so the vertical layout — which
+ * renders every question at once and passes `autoFocus={false}` precisely to
+ * stop this — still had its phone field grab focus and scroll the page.
+ *
+ * Focus oracle: these tests assert on the `autofocus` attribute of the rendered
+ * `type="tel"` field — the browser's declarative "focus me" directive, i.e. the
+ * behavior a respondent actually experiences — never on component source text.
+ * The web suite runs in `environment: 'node'` (see vitest.config.ts), so there
+ * is no `document.activeElement`; the rendered directive is the observable.
+ */
+const phone: FormStep = {
+  key: 'mobile',
+  type: 'phone',
+  question: 'What is your phone number?',
+};
+
+/** The rendered phone number field, isolated so the assertion cannot be
+ *  satisfied by an `autofocus` belonging to some other element. */
+function telField(html: string): string {
+  const tag = html.match(/<input\b[^>]*\btype="tel"[^>]*>/)?.[0];
+  if (!tag) throw new Error(`no tel input rendered:\n${html}`);
+  return tag;
+}
+
+describe('phone: autoFocus reaches the number field', () => {
+  it('autoFocus={false} leaves the phone field unfocused', () => {
+    expect(telField(render(phone, '', false))).not.toContain('autofocus');
+  });
+
+  it('autoFocus={true} focuses the phone field', () => {
+    expect(telField(render(phone, '', true))).toContain('autofocus');
+  });
+
+  it('the default still focuses the phone field (slides layout)', () => {
+    expect(telField(render(phone, ''))).toContain('autofocus');
+  });
+
+  it('other text steps are unchanged by the fix', () => {
+    const text: FormStep = { key: 'company', type: 'text', question: 'Company?' };
+    expect(render(text, '', false)).not.toContain('autofocus');
+    expect(render(text, '')).toContain('autofocus');
+    // `name` renders two inputs: only the FIRST one ever autofocuses.
+    const name: FormStep = { key: 'full_name', type: 'name', question: 'Your name?' };
+    expect(render(name, '', false)).not.toContain('autofocus');
+    expect(render(name, '').match(/autofocus/g)).toHaveLength(1);
   });
 });
 

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -154,6 +154,7 @@ export function StepInput({
           locale={locale}
           ariaLabel={step.question ?? step.key}
           defaultCountry={step.phoneDefaultCountry ?? undefined}
+          autoFocus={autoFocus}
         />
       );
 


### PR DESCRIPTION
## Problem

Vertical forms pass `autoFocus={false}` so their inputs do not compete for focus. The phone input ignored this value and always focused its number field. This could scroll the page away from the first question and open the mobile keyboard.

## Fix

- Add an optional `autoFocus` prop to `PhoneInput`.
- Forward the existing `StepInput` value to the phone field.
- Keep the previous default autofocus behavior for other layouts.

## Tests

- Add regression coverage for `false`, `true`, and the default value.
- Confirm text and name inputs keep their existing behavior.
- Run all 471 web tests.
- Run web type checking and linting.