### PR TITLE
fix(db): claim concurrent submission completion atomically

### DIFF
--- a/.changeset/atomic-submission-completion.md
+++ b/.changeset/atomic-submission-completion.md
@@ -1,0 +1,5 @@
+---
+'@quill/db': patch
+---
+
+Make concurrent final submissions claim completion atomically so only one caller reports the first completion.

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -636,6 +636,18 @@ export async function upsertSubmission(
     if (input.partial && wasCompletedBefore) {
       return { ...(await getSubmissionById(db, existing.id))!, wasCompletedBefore };
     }
+    if (!input.partial && !wasCompletedBefore) {
+      // The SELECT above routes partials and retries, but cannot decide a
+      // completion claim: another finalization may commit after it read NULL.
+      const completed = await db.get<Record<string, unknown>>(
+        sql`UPDATE submission
+            SET data = ${jsonParam(input.data)}, score = ${input.score}, completed_at = ${completedAt}
+            WHERE id = ${existing.id} AND completed_at IS NULL
+            RETURNING *`,
+      );
+      if (completed) return { ...mapSubmission(completed), wasCompletedBefore: false };
+      return { ...(await getSubmissionById(db, existing.id))!, wasCompletedBefore: true };
+    }
     await db.run(
       sql`UPDATE submission
           SET data = ${jsonParam(input.data)}, score = ${input.score},
@@ -705,4 +717,3 @@ export async function recordFormEvent(
           ${input.stepIndex ?? null}, ${input.stepKey ?? null}, ${input.now ?? Date.now()})`,
   );
 }
-

--- a/packages/db/src/submission.spec.ts
+++ b/packages/db/src/submission.spec.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import { createDb, type Db } from './client';
 import { migrate } from './migrate';
 import { upsertSubmission, listSubmissions } from './forms';
@@ -15,6 +15,32 @@ import { upsertSubmission, listSubmissions } from './forms';
 let db: Db;
 let accountId: string;
 let formId: string;
+
+/**
+ * Hold the two reads that begin concurrent finalizations until both have
+ * observed the same partial row. This stays test-local: production code has no
+ * testing hook or scheduling concern.
+ */
+function interleaveFirstTwoReads(source: Db): Db {
+  let reached = 0;
+  let release!: () => void;
+  const bothReadsReached = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    ...source,
+    get: async <T>(query: SQL): Promise<T | undefined> => {
+      const row = await source.get<T>(query);
+      if (reached < 2) {
+        reached += 1;
+        if (reached === 2) release();
+        await bothReadsReached;
+      }
+      return row;
+    },
+  };
+}
 
 beforeEach(async () => {
   // Honors DATABASE_URL so CI re-runs this same suite against real Postgres
@@ -96,6 +122,19 @@ describe('submission upsert', () => {
 
     const latePartial = await upsertSubmission(db, { formId, sessionId: session, data: { a: 1 }, score: 3, partial: true });
     expect(latePartial.wasCompletedBefore).toBe(true); // reorder-guarded no-op
+  });
+
+  it('reports exactly one first completion when finalizations race', async () => {
+    const session = 'concurrent-finalization';
+    await upsertSubmission(db, { formId, sessionId: session, data: { a: 1 }, score: 3, partial: true });
+
+    const racingDb = interleaveFirstTwoReads(db);
+    const results = await Promise.all([
+      upsertSubmission(racingDb, { formId, sessionId: session, data: { a: 1, b: 2 }, score: 7 }),
+      upsertSubmission(racingDb, { formId, sessionId: session, data: { a: 1, b: 3 }, score: 8 }),
+    ]);
+
+    expect(results.filter((row) => !row.wasCompletedBefore)).toHaveLength(1);
   });
 
   it('creates distinct rows for distinct sessions', async () => {


### PR DESCRIPTION
## Problem

Two final requests can complete the same partial submission at the same time. Both requests can report that they completed it first. The API can then enqueue completion effects twice.

## Fix

Claim the partial-to-complete transition with one guarded database update. Only the request that changes `completed_at` reports the first completion. Other requests keep the existing completed state.

## Tests

- Add a deterministic concurrent completion regression test.
- Run the test repeatedly on SQLite and Postgres.
- Run the complete SQLite database suite.
- Run focused Postgres submission tests.
- Run database type checking and linting.

The unrelated full Postgres baseline failures reproduce on both the base and this branch.