### PR TITLE
fix(engine): normalize inverted slider validation bounds

### DIFF
--- a/.changeset/sliders-normalize-bounds.md
+++ b/.changeset/sliders-normalize-bounds.md
@@ -1,0 +1,6 @@
+---
+'@quill/engine': patch
+---
+
+Normalize explicitly inverted slider bounds before answer validation. Missing
+bounds remain open-ended, so existing form config v1 behavior stays unchanged.

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -678,6 +678,105 @@ describe('validateAnswerCode', () => {
   });
 });
 
+describe('slider validation bounds', () => {
+  const inverted = step({ key: 's', type: 'slider', min: 90, max: 10 });
+
+  it('accepts a value inside UI-normalized inverted bounds in validateAnswer', () => {
+    expect(validateAnswer(inverted, 50)).toEqual({ ok: true });
+  });
+
+  it('accepts a value inside UI-normalized inverted bounds in validateAnswerCode', () => {
+    expect(validateAnswerCode(inverted, 50)).toEqual({ ok: true });
+  });
+
+  it('enforces the normalized inverted boundary matrix in both validators', () => {
+    const invertedBounds = step({ key: 'inverted-bounds', type: 'slider', min: 90, max: 10 });
+    const cases = [
+      [9, { ok: false, error: 'Value is too low.' }, { ok: false, code: 'too_low' }],
+      [10, { ok: true }, { ok: true }],
+      [90, { ok: true }, { ok: true }],
+      [91, { ok: false, error: 'Value is too high.' }, { ok: false, code: 'too_high' }],
+    ] as const;
+
+    for (const [value, expectedAnswer, expectedCode] of cases) {
+      expect(validateAnswer(invertedBounds, value)).toEqual(expectedAnswer);
+      expect(validateAnswerCode(invertedBounds, value)).toEqual(expectedCode);
+    }
+  });
+
+  it('enforces an equal-bound slider in both validators', () => {
+    const equalBounds = step({ key: 'equal-bounds', type: 'slider', min: 10, max: 10 });
+    const cases = [
+      [9, { ok: false, error: 'Value is too low.' }, { ok: false, code: 'too_low' }],
+      [10, { ok: true }, { ok: true }],
+      [11, { ok: false, error: 'Value is too high.' }, { ok: false, code: 'too_high' }],
+    ] as const;
+
+    for (const [value, expectedAnswer, expectedCode] of cases) {
+      expect(validateAnswer(equalBounds, value)).toEqual(expectedAnswer);
+      expect(validateAnswerCode(equalBounds, value)).toEqual(expectedCode);
+    }
+  });
+
+  it('matches displayed bounds at every present-bound edge in both validators', () => {
+    const sliders = [
+      step({ key: 'inverted-pair', type: 'slider', min: 100, max: 10 }),
+      step({ key: 'equal-pair', type: 'slider', min: 7, max: 7 }),
+      step({ key: 'normal-pair', type: 'slider', min: -20, max: 40 }),
+    ];
+
+    for (const slider of sliders) {
+      const { min, max } = sliderBounds(slider);
+      const cases = [
+        [min - 1, { ok: false, error: 'Value is too low.' }, { ok: false, code: 'too_low' }],
+        [min, { ok: true }, { ok: true }],
+        [max, { ok: true }, { ok: true }],
+        [max + 1, { ok: false, error: 'Value is too high.' }, { ok: false, code: 'too_high' }],
+      ] as const;
+
+      for (const [value, expectedAnswer, expectedCode] of cases) {
+        expect(validateAnswer(slider, value)).toEqual(expectedAnswer);
+        expect(validateAnswerCode(slider, value)).toEqual(expectedCode);
+      }
+    }
+  });
+
+  it('leaves absent, single, and normal bounds behavior unchanged', () => {
+    const cases = [
+      [step({ key: 'absent', type: 'slider' }), -1_000, true],
+      [step({ key: 'absent', type: 'slider' }), 1_000, true],
+      [step({ key: 'min-only', type: 'slider', min: 10 }), 9, false],
+      [step({ key: 'min-only', type: 'slider', min: 10 }), 10, true],
+      [step({ key: 'max-only', type: 'slider', max: 10 }), 11, false],
+      [step({ key: 'max-only', type: 'slider', max: 10 }), 10, true],
+      [step({ key: 'normal', type: 'slider', min: 10, max: 90 }), 9, false],
+      [step({ key: 'normal', type: 'slider', min: 10, max: 90 }), 50, true],
+      [step({ key: 'normal', type: 'slider', min: 10, max: 90 }), 91, false],
+    ] as const;
+
+    for (const [slider, value, expectedOk] of cases) {
+      expect(validateAnswer(slider, value).ok).toBe(expectedOk);
+      expect(validateAnswerCode(slider, value).ok).toBe(expectedOk);
+    }
+  });
+
+  it('keeps missing slider sides open in both validators', () => {
+    const minOnly = step({ key: 'min-only-open', type: 'slider', min: 10 });
+    const maxOnly = step({ key: 'max-only-open', type: 'slider', max: 10 });
+    const absent = step({ key: 'absent-open', type: 'slider' });
+
+    expect(validateAnswer(minOnly, 11)).toEqual({ ok: true });
+    expect(validateAnswerCode(minOnly, 11)).toEqual({ ok: true });
+    expect(validateAnswer(maxOnly, 9)).toEqual({ ok: true });
+    expect(validateAnswerCode(maxOnly, 9)).toEqual({ ok: true });
+
+    for (const value of [-1_000_000, 1_000_000]) {
+      expect(validateAnswer(absent, value)).toEqual({ ok: true });
+      expect(validateAnswerCode(absent, value)).toEqual({ ok: true });
+    }
+  });
+});
+
 describe('normalizeUrl / canonicalizeAnswer', () => {
   it('trims and prepends https:// only when no http(s) scheme is present', () => {
     expect(normalizeUrl('  acme.com ')).toBe('https://acme.com');

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -1319,6 +1319,17 @@ export function isInputlessStep(step: Pick<FormStep, 'type'>): boolean {
   return step.type === 'message' || step.type === 'reveal';
 }
 
+/**
+ * Keep missing v1 bounds open-ended while matching the UI's handling of an
+ * explicitly inverted pair.
+ */
+function normalizedSliderValidationBounds(
+  step: Pick<FormStep, 'min' | 'max'>,
+): { min?: number; max?: number } {
+  const { min, max } = step;
+  return min != null && max != null && min > max ? { min: max, max: min } : { min, max };
+}
+
 /** Validate one answer against its step. Pure; used on both client and server. */
 export function validateAnswer(step: FormStep, value: AnswerValue): ValidationResult {
   // Info + reveal steps never carry input.
@@ -1359,8 +1370,9 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
     case 'slider': {
       const n = Number(value);
       if (Number.isNaN(n)) return { ok: false, error: 'Enter a number.' };
-      if (step.min != null && n < step.min) return { ok: false, error: 'Value is too low.' };
-      if (step.max != null && n > step.max) return { ok: false, error: 'Value is too high.' };
+      const { min, max } = normalizedSliderValidationBounds(step);
+      if (min != null && n < min) return { ok: false, error: 'Value is too low.' };
+      if (max != null && n > max) return { ok: false, error: 'Value is too high.' };
       return { ok: true };
     }
     case 'dropdown':
@@ -1932,8 +1944,9 @@ export function validateAnswerCode(
     case 'slider': {
       const n = Number(value);
       if (Number.isNaN(n)) return { ok: false, code: 'number' };
-      if (step.min != null && n < step.min) return { ok: false, code: 'too_low' };
-      if (step.max != null && n > step.max) return { ok: false, code: 'too_high' };
+      const { min, max } = normalizedSliderValidationBounds(step);
+      if (min != null && n < min) return { ok: false, code: 'too_low' };
+      if (max != null && n > max) return { ok: false, code: 'too_high' };
       return { ok: true };
     }
     case 'dropdown':


### PR DESCRIPTION
## Problem

The slider UI normalizes inverted minimum and maximum values. The validators used the raw values instead. A slider displayed as 10 to 90 could reject every answer inside that range.

## Fix

Normalize only the provided validation bounds before comparing an answer. Keep missing bounds open-ended. Keep normal and equal bounds unchanged.

## Tests

- Cover inverted, normal, equal, single, and missing bounds.
- Compare validation boundaries with the displayed slider bounds.
- Run all 304 engine tests.
- Run engine type checking and linting.

This PR includes a patch changeset for `@quill/engine`.