### PR TITLE
fix(web): settle ambiguous public page saves with a revision fence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,14 @@ MAIL_FROM_NAME=Forms
 # OUTBOX_POLL_MS=5000
 # OUTBOX_MAX_ATTEMPTS=5
 
+# --- Public page write shim (DEPRECATED — remove after the rollout) ---------
+# The public page write moved to PUT /v2/me/profile, which requires the
+# revision the client read (compare-and-set). PUT /v1/me/profile stays only so
+# a web build from before that change keeps working while the deploy rolls.
+# Order: migration -> API (this flag ON) -> web. Then set it to false and remove
+# the route. Roll web back before the API. With it false, /v1 writes answer 410.
+# PROFILE_V1_WRITE_SHIM=true
+
 # --- CORS / rate limiting (public surface) ----------------------------------
 # Comma-separated origin allowlist; unset -> the app's own web origin only.
 # CORS_ORIGINS=https://acme.com,https://foo.io

--- a/.env.example
+++ b/.env.example
@@ -231,12 +231,20 @@ MAIL_FROM_NAME=Forms
 # OUTBOX_POLL_MS=5000
 # OUTBOX_MAX_ATTEMPTS=5
 
-# --- Public page write shim (DEPRECATED — remove after the rollout) ---------
-# The public page write moved to PUT /v2/me/profile, which requires the
-# revision the client read (compare-and-set). PUT /v1/me/profile stays only so
-# a web build from before that change keeps working while the deploy rolls.
-# Order: migration -> API (this flag ON) -> web. Then set it to false and remove
-# the route. Roll web back before the API. With it false, /v1 writes answer 410.
+# --- Public page writes (revision-guarded) ---------------------------------
+# PUT /v2/me/profile requires the revision the client read (compare-and-set),
+# and its fence settles a save whose answer never arrived. OFF by default: turn
+# it on only after every API instance in the fleet increments the revision, or a
+# pre-revision writer beside an enabled one makes the fence undecidable. While
+# false, reads report the capability as unavailable and the dashboard blocks
+# editing instead of failing one save at a time. Disabling this is the FIRST
+# step of a rollback. Full contract + rollout order: SELF-HOSTING.md.
+# PROFILE_V2_WRITES_ENABLED=false
+#
+# DEPRECATED — remove after the rollout. PUT /v1/me/profile stays only so a web
+# build from before the v2 contract keeps working while the deploy rolls; it
+# still increments the revision atomically. Set false once every web pod is on
+# v2 (then /v1 writes answer 410), and remove the route with the flags.
 # PROFILE_V1_WRITE_SHIM=true
 
 # --- CORS / rate limiting (public surface) ----------------------------------

--- a/.env.example
+++ b/.env.example
@@ -232,20 +232,30 @@ MAIL_FROM_NAME=Forms
 # OUTBOX_MAX_ATTEMPTS=5
 
 # --- Public page writes (revision-guarded) ---------------------------------
-# PUT /v2/me/profile requires the revision the client read (compare-and-set),
-# and its fence settles a save whose answer never arrived. OFF by default: turn
-# it on only after every API instance in the fleet increments the revision, or a
-# pre-revision writer beside an enabled one makes the fence undecidable. While
-# false, reads report the capability as unavailable and the dashboard blocks
-# editing instead of failing one save at a time. Disabling this is the FIRST
-# step of a rollback. Full contract + rollout order: SELF-HOSTING.md.
+# PUT /v2/me/profile requires the revision the client read (compare-and-set).
+# This flag admits NEW guarded saves. OFF by default: turn it on only after every
+# API instance in the fleet increments the revision. While false, reads report
+# write admission as unavailable and the dashboard blocks editing instead of
+# failing one save at a time.
+#
+# It does NOT gate the fence (POST /v2/me/profile/fence), which settles a save
+# whose answer never arrived. Recovery stays available on every revision-aware
+# build, so closing the write gate never strands a browser mid-ambiguity —
+# closing it is the FIRST step of an emergency rollback.
+#
+# Once this has ever been true against a database, rolling the API back below
+# revision awareness is NOT supported: only a revision-aware API can settle an
+# expectation a browser is still holding. Full contract, rollout and rollback:
+# SELF-HOSTING.md.
 # PROFILE_V2_WRITES_ENABLED=false
 #
-# DEPRECATED — remove after the rollout. PUT /v1/me/profile stays only so a web
-# build from before the v2 contract keeps working while the deploy rolls; it
-# still increments the revision atomically. Set false once every web pod is on
-# v2 (then /v1 writes answer 410), and remove the route with the flags.
-# PROFILE_V1_WRITE_SHIM=true
+# DEPRECATED — remove after the rollout. PUT /v1/me/profile is the non-CAS
+# writer, kept only so a web build from before the v2 contract keeps working
+# during the transition; it still increments the revision atomically. OFF by
+# default, so it is never left alive by omission: set it true for the bounded
+# window, then false once every web pod is on v2 (then /v1 writes answer 410),
+# then remove the route and the flags together.
+# PROFILE_V1_WRITE_SHIM=false
 
 # --- CORS / rate limiting (public surface) ----------------------------------
 # Comma-separated origin allowlist; unset -> the app's own web origin only.

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -337,6 +337,81 @@ through the same outbox with retry + backoff).
   compatible with the newer schema — roll back by redeploying the previous image
   tags. Keep old images available (don't prune the tag you might revert to).
 
+### Migration numbering
+
+Migrations are recorded by **filename** in the `_migrations` table, not by a
+highest-number watermark. Two consequences, both deliberate:
+
+- A gap in the numbering is not a missing migration. Branches claim numbers
+  before they merge, and they do not merge in order.
+- A lower-numbered file that arrives in a later release still applies on its own,
+  after a higher-numbered one has already run.
+
+So `0016_member_profile_revision.sql` (the member write counter below) applies
+independently of whatever occupies the `0015` slot; it adds one column to
+`member` and depends on nothing else.
+
+## Public page write compatibility contract
+
+The public member page is written with a per-member revision
+(`member.profile_revision`, migration `0016`). A save whose answer never reaches
+the browser is ambiguous, because a client timeout does not abort the write, so
+the write path is compare-and-set and the client settles ambiguity with a fence.
+These are the normative invariants — change any of them and the ambiguity
+becomes undecidable again.
+
+- **N1 Scope.** `accountId` **and** `memberId` scope every profile read, write and
+  fence. A member is never addressed by id alone.
+- **N2 Rollout gate.** `PROFILE_V2_WRITES_ENABLED` stays false until every API
+  instance in the fleet increments the revision. `PROFILE_V1_WRITE_SHIM` keeps a
+  pre-v2 web build working for a bounded window and still increments the revision
+  atomically with its write.
+- **N3 Zero rows.** A write that changed no rows is disambiguated by an
+  account-scoped re-read: absent member is `404`, a moved revision is `409`.
+- **N4 Abort budget.** The server-side call budget is strictly shorter than the
+  client's Server Action timeout, and an abort never proves the API did not
+  commit.
+- **N5 Legacy rows.** A `NULL` revision is logical 0. Predicates and increments
+  use `coalesce(profile_revision, 0)`, never the bare column.
+- **N6 Draft safety.** Adopting authoritative state updates stored fields (links,
+  listed forms, branding, published state) and never erases the headline or bio
+  the member is typing.
+- **N7 Fence outcomes.** A fence conflict distinguishes a genuinely changed page
+  from a revision that advanced with identical content, and neither is reported
+  as a successful save.
+- **N8 Reconciliation route.** Reconciliation is an authenticated, same-origin
+  `POST` whose body carries only `expectedRevision`; authentication failures come
+  back as JSON status codes, never as a login page with a 200.
+- **N9 After settling.** A resolved reconciliation revalidates `/admin/settings`
+  and refreshes the router, and a remount keeps the reconciled revision instead
+  of regressing to the revision the page was first rendered with.
+- **N10 Dedicated fence.** The fence advances the revision without touching
+  content. A same-value write is not a substitute (schema normalization can
+  change stored bytes), and neither content comparison nor a mutation id inside
+  the profile blob is used.
+
+### Rollout order
+
+1. Run `pnpm db:migrate` (adds `member.profile_revision`, nullable).
+2. Deploy the new API with `PROFILE_V2_WRITES_ENABLED=false` and
+   `PROFILE_V1_WRITE_SHIM=true`. Old web keeps working through `/v1`.
+3. Confirm every API instance is the new build.
+4. Set `PROFILE_V2_WRITES_ENABLED=true` and roll the API.
+5. Deploy the new web. It uses `/v2` only and never falls back to `/v1`.
+6. When no old web pod remains, set `PROFILE_V1_WRITE_SHIM=false` (the `/v1`
+   write then answers `410`). Once that has held for a release, remove the `/v1`
+   route, its writer, and both flags together.
+
+### Rollback order
+
+1. **First** set `PROFILE_V2_WRITES_ENABLED=false` and roll the API, so web
+   sessions already loaded in browsers cannot mutate.
+2. **Then** roll web back.
+3. **Only then** roll the API back below revision awareness.
+
+Never run a v2-enabled API beside an instance that writes the profile without
+incrementing the revision.
+
 ## Troubleshooting
 
 - **API won't boot: `Refusing to boot: AUTH_PROVIDER=local …`** — you set

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -362,6 +362,12 @@ becomes undecidable again.
 
 - **N1 Scope.** `accountId` **and** `memberId` scope every profile read, write and
   fence. A member is never addressed by id alone.
+- **N1b Gate posture is private.** Whether guarded writes are admitted, and
+  whether the `/v1` compatibility window is still open, are answered only to an
+  authenticated caller. Both save handlers resolve the principal before their
+  gate, so an anonymous request gets the ordinary authentication refusal and
+  learns nothing about the rollout. For an authenticated caller the gate still
+  comes first, before revision and schema validation and before any write.
 - **N2 Write admission, and forward-only compatibility.**
   `PROFILE_V2_WRITES_ENABLED` admits NEW guarded saves and stays false until
   every API instance in the fleet increments the revision. It does **not** gate

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -362,9 +362,15 @@ becomes undecidable again.
 
 - **N1 Scope.** `accountId` **and** `memberId` scope every profile read, write and
   fence. A member is never addressed by id alone.
-- **N2 Rollout gate.** `PROFILE_V2_WRITES_ENABLED` stays false until every API
-  instance in the fleet increments the revision. `PROFILE_V1_WRITE_SHIM` keeps a
-  pre-v2 web build working for a bounded window and still increments the revision
+- **N2 Write admission, and forward-only compatibility.**
+  `PROFILE_V2_WRITES_ENABLED` admits NEW guarded saves and stays false until
+  every API instance in the fleet increments the revision. It does **not** gate
+  the fence: a browser holding an expectation from an earlier save can always
+  settle it, on any revision-aware build. Once guarded writes have been enabled
+  against a database, running an API that predates the revision is
+  **unsupported** — the migration and the revision-aware API are forward-only
+  compatibility infrastructure. `PROFILE_V1_WRITE_SHIM` is off by default and is
+  turned on only for the bounded old-web window; it still increments the revision
   atomically with its write.
 - **N3 Zero rows.** A write that changed no rows is disambiguated by an
   account-scoped re-read: absent member is `404`, a moved revision is `409`.
@@ -402,14 +408,36 @@ becomes undecidable again.
    write then answers `410`). Once that has held for a release, remove the `/v1`
    route, its writer, and both flags together.
 
-### Rollback order
+### Rollback
 
-1. **First** set `PROFILE_V2_WRITES_ENABLED=false` and roll the API, so web
-   sessions already loaded in browsers cannot mutate.
-2. **Then** roll web back.
-3. **Only then** roll the API back below revision awareness.
+**Before guarded writes have ever been enabled** (step 4 above has not run on
+this database), the previous API is still a supported rollback target: no
+guarded write exists, so no browser holds an expectation to settle.
 
-Never run a v2-enabled API beside an instance that writes the profile without
+**After guarded writes have been enabled, rolling the API below revision
+awareness is not supported.** A browser can be holding an expectation from a
+save whose answer it never received, and only a revision-aware API can settle
+it. An API without the fence cannot answer that question at all, so the session
+is left unable to distinguish "not applied" from "applied", which is the defect
+this contract exists to remove. There is no way to drain those expectations
+first: they live in open browser tabs, not in the server.
+
+The supported emergency rollback is:
+
+1. Set `PROFILE_V2_WRITES_ENABLED=false` and roll the API. New saves stop being
+   admitted immediately; the fence keeps working, so sessions in an ambiguous
+   state can still resolve.
+2. Roll web back if the web build is the problem.
+3. Keep the revision-aware API. It is compatible with older web builds through
+   the `/v1` shim (`PROFILE_V1_WRITE_SHIM=true`), which still increments the
+   revision.
+
+A hard reload remains the last resort for a client that cannot settle: it drops
+the pending expectation and re-reads stored state. That is a client recovery, not
+a licence to downgrade the API, because the reload shows what is stored without
+ever establishing what the ambiguous save did.
+
+Never run a write-enabled API beside an instance that writes the profile without
 incrementing the revision.
 
 ## Troubleshooting

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -135,7 +135,9 @@ export class AdminCrudController {
      * working; absent means the `/v1` profile write shim is CLOSED, which is the
      * safe default for anything that did not deliberately turn it on.
      */
-    @Optional() @Inject(ENV) private readonly env?: Pick<ServerEnv, 'PROFILE_V1_WRITE_SHIM'>,
+    @Optional()
+    @Inject(ENV)
+    private readonly env?: Pick<ServerEnv, 'PROFILE_V1_WRITE_SHIM' | 'PROFILE_V2_WRITES_ENABLED'>,
   ) {}
 
   // --- Identity ----------------------------------------------------------
@@ -192,7 +194,13 @@ export class AdminCrudController {
     const first = await claimAccountAttribution(this.db, p.accountId, tags).catch((err) => {
       // Same shape as the activation claim: a lock or a dead connection must not
       // turn a completed login into a 500 on the way to the dashboard.
-      this.log.warn(`attribution claim failed for account ${p.accountId}: ${String(err)}`);
+      // Deliberately opaque: this line is about a claim that did not stick, not
+      // about who tried it or what the driver said. The account id identifies a
+      // customer and the raw error can carry a connection string, a row, or a
+      // vendor message, and none of that belongs in an operational log.
+      this.log.warn(
+        `attribution_claim_failed (error_class=${err instanceof Error ? err.constructor.name : 'unknown'})`,
+      );
       return false;
     });
     if (first && this.productAnalytics?.enabled) {
@@ -312,10 +320,16 @@ export class AdminCrudController {
     if (!member) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
     const state = await getMemberProfileState(this.db, p.accountId, p.memberId);
     if (!state) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    // `revision` is ADDITIVE and is also the capability signal: a web build that
-    // does not get a number here knows it is talking to a pre-CAS API and must
-    // block writes rather than send an unguarded one.
-    return { handle: member.handle, profile: state.profile, revision: state.revision };
+    // `revision` is ADDITIVE and is half of the capability signal: a web build
+    // that does not get a number here knows it is talking to a pre-CAS API.
+    // `writesEnabled` is the other half — an API that CAN guard writes but has
+    // not been switched on yet must not be written to either.
+    return {
+      handle: member.handle,
+      profile: state.profile,
+      revision: state.revision,
+      writesEnabled: this.env?.PROFILE_V2_WRITES_ENABLED === true,
+    };
   }
 
   /**

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -5,6 +5,7 @@ import {
   Controller,
   Delete,
   Get,
+  GoneException,
   HttpCode,
   Inject,
   Logger,
@@ -43,8 +44,8 @@ import {
   updateForm,
   upsertNotificationSetting,
   type CrudResult,
-  getMemberProfileRaw,
-  setMemberProfile,
+  getMemberProfileState,
+  overwriteMemberProfileLegacy,
 } from '@quill/db';
 import {
   defaultSubmissionTemplate,
@@ -76,7 +77,8 @@ import { EmailEffects } from './email-effects';
 import { AnalyticsEffects } from './analytics-effects';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
 import { parseBound, parseIntParam, parseKinds, parseOutboxStatuses, parseStatus } from './query-params';
-import { DB } from './tokens';
+import { DB, ENV } from './tokens';
+import type { ServerEnv } from '@quill/config/env';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
   try {
@@ -128,6 +130,12 @@ export class AdminCrudController {
     // service (per-question drop-off shown to a form owner). This one is our own
     // telemetry about the people using the builder. Different audience entirely.
     @Optional() @Inject(AnalyticsEffects) private readonly productAnalytics?: AnalyticsEffects,
+    /**
+     * Optional like the effects above so direct constructions in tests keep
+     * working; absent means the `/v1` profile write shim is CLOSED, which is the
+     * safe default for anything that did not deliberately turn it on.
+     */
+    @Optional() @Inject(ENV) private readonly env?: Pick<ServerEnv, 'PROFILE_V1_WRITE_SHIM'>,
   ) {}
 
   // --- Identity ----------------------------------------------------------
@@ -296,31 +304,50 @@ export class AdminCrudController {
     return this.auth.listWorkspaces(req);
   }
 
-  /** This member's public page config (the raw blob, or null). */
+  /** This member's public page config (the raw blob, or null) + its revision. */
   @Get('me/profile')
   async myProfile(@Req() req: ReqLike) {
     const p = await this.auth.resolveHost(req);
     const member = await getAccountMember(this.db, p.accountId, p.memberId);
     if (!member) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
-    const raw = await getMemberProfileRaw(this.db, p.accountId, p.memberId);
-    return { handle: member.handle, profile: raw };
+    const state = await getMemberProfileState(this.db, p.accountId, p.memberId);
+    if (!state) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    // `revision` is ADDITIVE and is also the capability signal: a web build that
+    // does not get a number here knows it is talking to a pre-CAS API and must
+    // block writes rather than send an unguarded one.
+    return { handle: member.handle, profile: state.profile, revision: state.revision };
   }
 
   /**
-   * Replace this member's public page. A null body removes it entirely, which is
-   * the same thing as never having had one — the page goes back to 404-ing.
+   * DEPRECATED — the last-write-wins public page write, kept ONLY so a web build
+   * from before the v2 contract keeps working during a rolling deploy. Remove
+   * this route, `overwriteMemberProfileLegacy` and `PROFILE_V1_WRITE_SHIM`
+   * together once no old web pod can reach this API.
    *
-   * Scoped to the CALLER's own member row, never an id from the request: your
-   * public page is yours, and an admin editing a teammate's bio is a different
-   * feature with different consent.
+   * Gated by configuration and off by 410 when the gate is closed, so a
+   * deployment that has finished rolling cannot keep an unguarded writer alive
+   * by accident. It cannot compare-and-set (its callers know nothing about
+   * revisions) but it DOES increment the revision in the same statement as the
+   * write, which is what keeps the fence monotonic while an old tab saves.
+   *
+   * Scoped to the CALLER's own member row, never an id from the request.
    */
   @Put('me/profile')
   async saveMyProfile(@Req() req: ReqLike, @Body() body: unknown) {
+    if (!this.env?.PROFILE_V1_WRITE_SHIM) {
+      throw new GoneException({
+        error: 'V1_WRITE_RETIRED',
+        message: 'This endpoint is retired. Use PUT /v2/me/profile with expectedRevision.',
+      });
+    }
     const p = await this.auth.resolveHost(req);
     const raw = (body as { profile?: unknown } | null)?.profile ?? null;
     const profile = raw == null ? null : parse(memberProfileSchema, raw);
-    await setMemberProfile(this.db, p.accountId, p.memberId, profile);
-    return { ok: true, profile };
+    const result = await overwriteMemberProfileLegacy(this.db, p.accountId, p.memberId, profile);
+    if (result.status === 'not_found') {
+      throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    }
+    return { ok: true, profile: result.profile, revision: result.revision };
   }
 
   @Get('vanity')

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -194,13 +194,12 @@ export class AdminCrudController {
     const first = await claimAccountAttribution(this.db, p.accountId, tags).catch((err) => {
       // Same shape as the activation claim: a lock or a dead connection must not
       // turn a completed login into a 500 on the way to the dashboard.
-      // Deliberately opaque: this line is about a claim that did not stick, not
-      // about who tried it or what the driver said. The account id identifies a
-      // customer and the raw error can carry a connection string, a row, or a
-      // vendor message, and none of that belongs in an operational log.
-      this.log.warn(
-        `attribution_claim_failed (error_class=${err instanceof Error ? err.constructor.name : 'unknown'})`,
-      );
+      // One fixed event, and nothing else. Not the account id, not the raw
+      // error, and not the error's class either: a class name is still derived
+      // from an attacker- or vendor-influenced object, and a custom error class
+      // can carry data in its own name. Operators need to know that claims are
+      // failing; the value of the failure is in the metric, not in this line.
+      this.log.warn('attribution_claim_failed');
       return false;
     });
     if (first && this.productAnalytics?.enabled) {
@@ -328,7 +327,10 @@ export class AdminCrudController {
       handle: member.handle,
       profile: state.profile,
       revision: state.revision,
+      /** May a NEW save start here? */
       writesEnabled: this.env?.PROFILE_V2_WRITES_ENABLED === true,
+      /** May an ambiguous save be settled here? Any revision-aware build can. */
+      fenceSupported: true,
     };
   }
 

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -350,13 +350,16 @@ export class AdminCrudController {
    */
   @Put('me/profile')
   async saveMyProfile(@Req() req: ReqLike, @Body() body: unknown) {
+    // Identify the caller first: whether the compatibility window is still open
+    // is rollout posture, and it is answered only to someone we can name. The
+    // retirement refusal then comes before any validation or persistence.
+    const p = await this.auth.resolveHost(req);
     if (!this.env?.PROFILE_V1_WRITE_SHIM) {
       throw new GoneException({
         error: 'V1_WRITE_RETIRED',
         message: 'This endpoint is retired. Use PUT /v2/me/profile with expectedRevision.',
       });
     }
-    const p = await this.auth.resolveHost(req);
     const raw = (body as { profile?: unknown } | null)?.profile ?? null;
     const profile = raw == null ? null : parse(memberProfileSchema, raw);
     const result = await overwriteMemberProfileLegacy(this.db, p.accountId, p.memberId, profile);

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -32,6 +32,7 @@ import type { Db } from '@quill/db';
 import { HealthController, DocsController } from './controllers';
 import { PublicController } from './public.controller';
 import { AdminCrudController } from './admin-crud.controller';
+import { ProfileV2Controller } from './profile-v2.controller';
 import { BrandingController } from './branding.controller';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
@@ -48,6 +49,7 @@ import {
     DocsController,
     PublicController,
     AdminCrudController,
+    ProfileV2Controller,
     BrandingController,
     AnalyticsController,
     IntegrationsController,

--- a/apps/api/src/attribution-logging.spec.ts
+++ b/apps/api/src/attribution-logging.spec.ts
@@ -40,18 +40,18 @@ describe('attribution claim logging', () => {
     await db.close();
   });
 
-  /** A controller whose attribution claim always fails with a chatty error. */
-  function controller(): AdminCrudController {
+  /** A controller whose attribution claim always fails with `error`. */
+  function controller(error: unknown = new TypeError(SECRET_MESSAGE)): AdminCrudController {
     const failing = {
       dialect: db.dialect,
       all: async () => {
-        throw new TypeError(SECRET_MESSAGE);
+        throw error;
       },
       get: async () => {
-        throw new TypeError(SECRET_MESSAGE);
+        throw error;
       },
       run: async () => {
-        throw new TypeError(SECRET_MESSAGE);
+        throw error;
       },
       execRaw: async () => undefined,
       close: async () => undefined,
@@ -79,12 +79,42 @@ describe('attribution claim logging', () => {
     expect(line).not.toContain(SECRET_MESSAGE);
   });
 
-  it('still says a claim failed, with a stable name and the error class', async () => {
+  it('still says a claim failed, as one fixed event', async () => {
     await controller().recordAttribution({} as ReqLike, { utmSource: 'newsletter' });
 
-    const line = warnings.join('\n');
-    expect(line).toContain('attribution_claim_failed');
-    expect(line).toContain('TypeError');
+    expect(warnings).toEqual(['attribution_claim_failed']);
+  });
+
+  it('says exactly the same thing whatever was thrown', async () => {
+    // The error's CLASS is derived from the thrown object too, and a custom
+    // class can carry data in its own name. Nothing about the error survives.
+    class LeakyPostgresError extends Error {
+      constructor() {
+        super(SECRET_MESSAGE);
+        this.name = 'LeakyPostgresError:alex@example.com';
+      }
+    }
+    const thrown: unknown[] = [
+      new TypeError(SECRET_MESSAGE),
+      new Error(SECRET_MESSAGE),
+      new LeakyPostgresError(),
+      'a bare string with hunter2 in it',
+      { code: '28P01', detail: SECRET_MESSAGE },
+    ];
+
+    for (const err of thrown) {
+      warnings = [];
+      await controller(err).recordAttribution({} as ReqLike, { utmSource: 'newsletter' });
+      expect(warnings, String(err)).toEqual(['attribution_claim_failed']);
+    }
+  });
+
+  it('never names the error class', async () => {
+    await controller(new TypeError(SECRET_MESSAGE)).recordAttribution({} as ReqLike, {
+      utmSource: 'newsletter',
+    });
+
+    expect(warnings.join('\n')).not.toContain('TypeError');
   });
 
   it('keeps the login working — a failed claim is not a failed request', async () => {

--- a/apps/api/src/attribution-logging.spec.ts
+++ b/apps/api/src/attribution-logging.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * What the attribution failure path is allowed to write to the log.
+ *
+ * A login that could not record where it came from must not become a 500, so
+ * the claim is caught and swallowed. The line it leaves behind used to carry the
+ * account id and the raw driver error — a customer identifier plus whatever the
+ * dependency felt like saying, which for a database driver can be a row, a
+ * connection string, or a vendor message.
+ *
+ * The line stays (operators need to know claims are failing), but it says only
+ * that: a stable event name and the error's class.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { createDb, migrate, sql, type Db } from '@quill/db';
+import { AdminCrudController } from './admin-crud.controller';
+import type { AuthService, ReqLike } from './auth.service';
+
+const SECRET_MESSAGE =
+  'connect ECONNREFUSED postgres://quill:hunter2@db.internal:5432 — row {"email":"alex@example.com"}';
+
+describe('attribution claim logging', () => {
+  let db: Db;
+  let accountId: string;
+  let warnings: string[];
+
+  beforeEach(async () => {
+    warnings = [];
+    vi.spyOn(Logger.prototype, 'warn').mockImplementation((message: unknown) => {
+      warnings.push(String(message));
+    });
+    db = await createDb('file::memory:');
+    await migrate(db);
+    accountId = randomUUID();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await db.close();
+  });
+
+  /** A controller whose attribution claim always fails with a chatty error. */
+  function controller(): AdminCrudController {
+    const failing = {
+      dialect: db.dialect,
+      all: async () => {
+        throw new TypeError(SECRET_MESSAGE);
+      },
+      get: async () => {
+        throw new TypeError(SECRET_MESSAGE);
+      },
+      run: async () => {
+        throw new TypeError(SECRET_MESSAGE);
+      },
+      execRaw: async () => undefined,
+      close: async () => undefined,
+    } as unknown as Db;
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: randomUUID(), role: 'owner' }),
+    } as unknown as AuthService;
+    return new AdminCrudController(failing, auth, {} as never, {} as never, {} as never);
+  }
+
+  it('does not put the account identifier in the log', async () => {
+    await controller().recordAttribution({} as ReqLike, { utmSource: 'newsletter' });
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.join('\n')).not.toContain(accountId);
+  });
+
+  it('does not repeat what the dependency said', async () => {
+    await controller().recordAttribution({} as ReqLike, { utmSource: 'newsletter' });
+
+    const line = warnings.join('\n');
+    expect(line).not.toContain('hunter2');
+    expect(line).not.toContain('postgres://');
+    expect(line).not.toContain('alex@example.com');
+    expect(line).not.toContain(SECRET_MESSAGE);
+  });
+
+  it('still says a claim failed, with a stable name and the error class', async () => {
+    await controller().recordAttribution({} as ReqLike, { utmSource: 'newsletter' });
+
+    const line = warnings.join('\n');
+    expect(line).toContain('attribution_claim_failed');
+    expect(line).toContain('TypeError');
+  });
+
+  it('keeps the login working — a failed claim is not a failed request', async () => {
+    const res = await controller().recordAttribution({} as ReqLike, { utmSource: 'newsletter' });
+
+    expect(res).toMatchObject({ recorded: false });
+  });
+});

--- a/apps/api/src/profile-contract.spec.ts
+++ b/apps/api/src/profile-contract.spec.ts
@@ -14,6 +14,7 @@
  * otherwise.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import { createDb, migrate, sql, getMemberProfileState, type Db } from '@quill/db';
 import { serverEnvSchema } from '@quill/config/env';
@@ -35,6 +36,19 @@ const statusOf = async (run: () => Promise<unknown>): Promise<number> => {
     return (e as { getStatus?: () => number }).getStatus?.() ?? 0;
   }
   return 200;
+};
+
+/** Status + body of a refusal, together, so two refusals can be compared whole. */
+const outcomeOf = async (
+  run: () => Promise<unknown>,
+): Promise<{ status: number; body: unknown }> => {
+  try {
+    await run();
+  } catch (e) {
+    const err = e as { getStatus?: () => number; getResponse?: () => unknown };
+    return { status: err.getStatus?.() ?? 0, body: err.getResponse?.() ?? null };
+  }
+  return { status: 200, body: null };
 };
 
 const bodyOf = async (run: () => Promise<unknown>): Promise<Record<string, unknown>> => {
@@ -448,5 +462,210 @@ describe('configuration defaults', () => {
       expect(env.PROFILE_V1_WRITE_SHIM, raw).toBe(false);
       expect(env.PROFILE_V2_WRITES_ENABLED, raw).toBe(false);
     }
+  });
+});
+
+/**
+ * Write-gate posture is private.
+ *
+ * `PROFILE_V2_WRITES_ENABLED` and `PROFILE_V1_WRITE_SHIM` describe how far along
+ * an operator's rollout is. Answering them before knowing who is asking hands
+ * that to anyone who can reach the port: `V2_WRITES_DISABLED` says a
+ * revision-aware API is deployed but not switched on, and `V1_WRITE_RETIRED`
+ * says the compatibility window has closed. Both are useful to somebody timing
+ * a rollout, and neither is any of an anonymous caller's business.
+ *
+ * So each gate now sits behind `resolveHost`, and an unauthenticated caller gets
+ * the same refusal it would get from any other authenticated route — the same
+ * status and the same body, byte for byte, whichever way the flags are set.
+ *
+ * The gates stay in front of everything else. An authenticated caller whose
+ * write is not admitted learns only that, never whether its revision or its
+ * profile would have been acceptable, and nothing is persisted.
+ */
+describe('write-gate posture is only visible after authentication', () => {
+  let db: Db;
+  let accountId: string;
+  let memberId: string;
+  let auth: AuthService;
+  const req = {} as ReqLike;
+
+  /** Refuses exactly as the auth provider does when there is no session. */
+  const rejecting = {
+    resolveHost: async () => {
+      throw new UnauthorizedException({ error: 'UNAUTHENTICATED', message: 'No session.' });
+    },
+  } as unknown as AuthService;
+
+  const v2With = (writes: boolean, service: AuthService = auth) =>
+    new ProfileV2Controller(db, service, { PROFILE_V2_WRITES_ENABLED: writes });
+
+  const v1With = (shim: boolean, service: AuthService = auth) =>
+    new AdminCrudController(db, service, {} as never, {} as never, {} as never, undefined, undefined, {
+      PROFILE_V1_WRITE_SHIM: shim,
+      PROFILE_V2_WRITES_ENABLED: false,
+    });
+
+  const revision = async (): Promise<number> =>
+    (await getMemberProfileState(db, accountId, memberId))!.revision;
+
+  beforeEach(async () => {
+    db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+    await migrate(db);
+    accountId = randomUUID();
+    memberId = randomUUID();
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${accountId}, ${'t' + accountId.slice(0, 8)}, ${'Test'}, ${Date.now()})`,
+    );
+    await db.run(
+      sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, created_at)
+          VALUES (${memberId}, ${accountId}, ${memberId + '@e.com'}, ${'Alex'},
+                  ${'h' + memberId.slice(0, 8)}, ${'owner'}, ${'active'}, ${Date.now()})`,
+    );
+    auth = {
+      resolveHost: async () => ({ accountId, memberId, role: 'owner' }),
+    } as unknown as AuthService;
+  });
+
+  afterEach(async () => {
+    await db.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+    await db.close();
+  });
+
+  // Case 1
+  it('answers an unauthenticated v2 write identically whether writes are on or off', async () => {
+    // The baseline: what an unauthenticated caller gets from a route with no
+    // gate at all.
+    const baseline = await outcomeOf(() => v2With(true, rejecting).read(req));
+
+    const gateOn = await outcomeOf(() =>
+      v2With(true, rejecting).save(req, { profile: page(true), expectedRevision: 0 }),
+    );
+    const gateOff = await outcomeOf(() =>
+      v2With(false, rejecting).save(req, { profile: page(true), expectedRevision: 0 }),
+    );
+
+    expect(gateOn.status).toBe(401);
+    expect(gateOff.status).toBe(401);
+    // Byte for byte: the two refusals are indistinguishable from each other and
+    // from the ungated route's refusal.
+    expect(JSON.stringify(gateOff.body)).toBe(JSON.stringify(gateOn.body));
+    expect(JSON.stringify(gateOff.body)).toBe(JSON.stringify(baseline.body));
+  });
+
+  it('never leaks V2_WRITES_DISABLED to a caller it has not identified', async () => {
+    for (const writes of [true, false]) {
+      const out = await outcomeOf(() =>
+        v2With(writes, rejecting).save(req, { profile: page(true), expectedRevision: 0 }),
+      );
+      expect(JSON.stringify(out), `writes=${writes}`).not.toContain('V2_WRITES_DISABLED');
+    }
+  });
+
+  // Case 2
+  it('answers an unauthenticated v1 write identically whether the shim is on or off', async () => {
+    const baseline = await outcomeOf(() => v1With(true, rejecting).myProfile(req));
+
+    const shimOn = await outcomeOf(() =>
+      v1With(true, rejecting).saveMyProfile(req, { profile: page(true) }),
+    );
+    const shimOff = await outcomeOf(() =>
+      v1With(false, rejecting).saveMyProfile(req, { profile: page(true) }),
+    );
+
+    expect(shimOn.status).toBe(401);
+    expect(shimOff.status).toBe(401);
+    expect(JSON.stringify(shimOff.body)).toBe(JSON.stringify(shimOn.body));
+    expect(JSON.stringify(shimOff.body)).toBe(JSON.stringify(baseline.body));
+  });
+
+  it('never leaks V1_WRITE_RETIRED to a caller it has not identified', async () => {
+    for (const shim of [true, false]) {
+      const out = await outcomeOf(() =>
+        v1With(shim, rejecting).saveMyProfile(req, { profile: page(true) }),
+      );
+      expect(JSON.stringify(out), `shim=${shim}`).not.toContain('V1_WRITE_RETIRED');
+    }
+  });
+
+  // Case 3
+  it('tells an authenticated caller only that writes are closed, whatever the body says', async () => {
+    const before = await revision();
+
+    // A missing revision, a malformed one, and a profile the schema would
+    // reject: all of them stop at the gate, so none of them reveals whether the
+    // payload would have been accepted.
+    const bodies: unknown[] = [
+      { profile: page(true) },
+      { profile: page(true), expectedRevision: '0' },
+      { profile: page(true), expectedRevision: -1 },
+      { profile: { version: 1, enabled: 'yes' }, expectedRevision: 0 },
+      { profile: { version: 2 }, expectedRevision: 0 },
+      {},
+    ];
+
+    for (const body of bodies) {
+      const out = await outcomeOf(() => v2With(false).save(req, body));
+      expect(out.status, JSON.stringify(body)).toBe(501);
+      expect(out.body).toMatchObject({ error: 'V2_WRITES_DISABLED' });
+      expect(JSON.stringify(out.body)).not.toContain('REVISION_REQUIRED');
+      expect(JSON.stringify(out.body)).not.toContain('BAD_REQUEST');
+    }
+    expect(await revision()).toBe(before);
+  });
+
+  // Case 4
+  it('retires the v1 write after authentication, and persists nothing', async () => {
+    const before = await revision();
+
+    const out = await outcomeOf(() => v1With(false).saveMyProfile(req, { profile: page(true) }));
+
+    expect(out.status).toBe(410);
+    expect(out.body).toMatchObject({ error: 'V1_WRITE_RETIRED' });
+    // Only the profile and its revision are asserted: resolving a principal may
+    // legitimately touch the member row (activation, last seen).
+    expect(await revision()).toBe(before);
+    expect((await getMemberProfileState(db, accountId, memberId))!.profile).toBeNull();
+  });
+
+  // Case 5
+  it('keeps the fence working with writes closed, for this principal only', async () => {
+    const won = await v2With(false).fence(req, { expectedRevision: 0 });
+    expect(won).toMatchObject({ ok: true, revision: 1 });
+
+    // Same expectation again: a conflict, and no second burn.
+    expect(await statusOf(() => v2With(false).fence(req, { expectedRevision: 0 }))).toBe(409);
+    expect(await revision()).toBe(1);
+
+    // Another account asking about this member gets nothing, gate or no gate.
+    const stranger = {
+      resolveHost: async () => ({ accountId: randomUUID(), memberId, role: 'owner' }),
+    } as unknown as AuthService;
+    expect(await statusOf(() => v2With(false, stranger).fence(req, { expectedRevision: 1 }))).toBe(
+      404,
+    );
+    expect(await revision()).toBe(1);
+  });
+
+  // Case 6
+  it('writes normally when the gate is open, and never answers disabled', async () => {
+    const out = await outcomeOf(() =>
+      v2With(true).save(req, { profile: page(true), expectedRevision: 0 }),
+    );
+
+    expect(out.status).toBe(200);
+    expect(await revision()).toBe(1);
+    expect((await getMemberProfileState(db, accountId, memberId))!.profile).toMatchObject({
+      enabled: true,
+    });
+
+    // And a refusal after that still leaves the revision exactly where it is.
+    const refused = await outcomeOf(() =>
+      v2With(false).save(req, { profile: page(false), expectedRevision: 1 }),
+    );
+    expect(refused.status).toBe(501);
+    expect(await revision()).toBe(1);
   });
 });

--- a/apps/api/src/profile-contract.spec.ts
+++ b/apps/api/src/profile-contract.spec.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { createDb, migrate, sql, getMemberProfileState, type Db } from '@quill/db';
+import { serverEnvSchema } from '@quill/config/env';
 import { ProfileV2Controller } from './profile-v2.controller';
 import { AdminCrudController } from './admin-crud.controller';
 import type { AuthService, ReqLike } from './auth.service';
@@ -219,6 +220,25 @@ describe('public page write contract', () => {
       );
 
       expect(await statusOf(() => noEnv.saveMyProfile(req, { profile: page(true) }))).toBe(410);
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
+    });
+
+    it('is closed when the flag is simply unset, not just when it is false', async () => {
+      // The default must not leave a non-CAS writer alive for anyone who never
+      // heard of the flag: it takes an explicit true to open it.
+      const unset = new AdminCrudController(
+        db,
+        auth,
+        {} as never,
+        {} as never,
+        {} as never,
+        undefined,
+        undefined,
+        { PROFILE_V2_WRITES_ENABLED: true } as never,
+      );
+
+      expect(await statusOf(() => unset.saveMyProfile(req, { profile: page(true) }))).toBe(410);
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
     });
 
     it('reports the revision on the v1 read, which is how a client detects v2', async () => {
@@ -280,15 +300,40 @@ describe('the v2 write gate', () => {
     expect((await getMemberProfileState(db, accountId, memberId))!.profile).toBeNull();
   });
 
-  it('refuses a fence too, so no revision is burned while disabled', async () => {
-    expect(await statusOf(() => off().fence(req, { expectedRevision: 0 }))).toBe(501);
-    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
+  it('still fences, because recovery is not a new write', async () => {
+    // A browser holding an expectation from a save that WAS admitted must be
+    // able to settle it. Gating this would strand exactly the sessions that are
+    // already in trouble, and closing the gate is the first step of a rollback.
+    const won = await off().fence(req, { expectedRevision: 0 });
+
+    expect(won).toMatchObject({ ok: true, revision: 1 });
+    // And the losing direction works too, with no extra burn.
+    expect(await statusOf(() => off().fence(req, { expectedRevision: 0 }))).toBe(409);
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(1);
   });
 
-  it('still answers reads, and reports the capability as unavailable', async () => {
-    const read = (await off().read(req)) as { revision: number; writesEnabled: boolean };
+  it('fences a conflict against a write that landed before the gate closed', async () => {
+    await new ProfileV2Controller(db, auth, { PROFILE_V2_WRITES_ENABLED: true }).save(req, {
+      profile: page(true),
+      expectedRevision: 0,
+    });
 
-    expect(read).toMatchObject({ revision: 0, writesEnabled: false });
+    const body = await bodyOf(() => off().fence(req, { expectedRevision: 0 }));
+
+    expect(body).toMatchObject({ error: 'REVISION_CONFLICT', revision: 1 });
+    expect((body.profile as { enabled: boolean }).enabled).toBe(true);
+  });
+
+  it('still answers reads: no new saves, but recovery is available', async () => {
+    const read = (await off().read(req)) as {
+      revision: number;
+      writesEnabled: boolean;
+      fenceSupported: boolean;
+    };
+
+    // Two separate answers. Fence support must never be inferred from write
+    // admission — that is what made closing the gate strand a session.
+    expect(read).toMatchObject({ revision: 0, writesEnabled: false, fenceSupported: true });
   });
 
   it('reports the capability as available once switched on, and then writes', async () => {
@@ -299,6 +344,21 @@ describe('the v2 write gate', () => {
       ok: true,
       revision: 1,
     });
+  });
+
+  it('reports fence support through the v1 read too', async () => {
+    const shim = new AdminCrudController(
+      db,
+      auth,
+      {} as never,
+      {} as never,
+      {} as never,
+      undefined,
+      undefined,
+      { PROFILE_V1_WRITE_SHIM: false, PROFILE_V2_WRITES_ENABLED: false },
+    );
+
+    expect(await shim.myProfile(req)).toMatchObject({ writesEnabled: false, fenceSupported: true });
   });
 
   it('is reported through the v1 read as well, so an old route cannot mislead a new client', async () => {
@@ -347,5 +407,46 @@ describe('an unresolved write', () => {
     expect(await bodyOf(() => controller.fence(req, { expectedRevision: 4 }))).toMatchObject({
       error: 'WRITE_UNRESOLVED',
     });
+  });
+});
+
+describe('configuration defaults', () => {
+  /** Parse a minimal environment, as a fresh deployment would have. */
+  const parsed = () =>
+    serverEnvSchema.parse({ DATABASE_URL: 'file:./.data/dev.db', PUBLIC_APP_URL: 'http://localhost:3000' });
+
+  it('admits no guarded writes until someone turns them on', () => {
+    expect(parsed().PROFILE_V2_WRITES_ENABLED).toBe(false);
+  });
+
+  it('leaves the deprecated v1 writer OFF when nothing sets it', () => {
+    // The unguarded writer must be something a deployment switches on for a
+    // bounded window, never something left alive by omission.
+    expect(parsed().PROFILE_V1_WRITE_SHIM).toBe(false);
+  });
+
+  it('takes an explicit true to open either one', () => {
+    const env = serverEnvSchema.parse({
+      DATABASE_URL: 'file:./.data/dev.db',
+      PUBLIC_APP_URL: 'http://localhost:3000',
+      PROFILE_V1_WRITE_SHIM: 'true',
+      PROFILE_V2_WRITES_ENABLED: 'true',
+    });
+
+    expect(env.PROFILE_V1_WRITE_SHIM).toBe(true);
+    expect(env.PROFILE_V2_WRITES_ENABLED).toBe(true);
+  });
+
+  it('treats anything that is not a truthy string as off', () => {
+    for (const raw of ['false', '0', 'no', 'maybe', '']) {
+      const env = serverEnvSchema.parse({
+        DATABASE_URL: 'file:./.data/dev.db',
+        PUBLIC_APP_URL: 'http://localhost:3000',
+        PROFILE_V1_WRITE_SHIM: raw,
+        PROFILE_V2_WRITES_ENABLED: raw,
+      });
+      expect(env.PROFILE_V1_WRITE_SHIM, raw).toBe(false);
+      expect(env.PROFILE_V2_WRITES_ENABLED, raw).toBe(false);
+    }
   });
 });

--- a/apps/api/src/profile-contract.spec.ts
+++ b/apps/api/src/profile-contract.spec.ts
@@ -70,7 +70,8 @@ describe('public page write contract', () => {
     auth = {
       resolveHost: async () => ({ accountId, memberId, role: 'owner' }),
     } as unknown as AuthService;
-    v2 = new ProfileV2Controller(db, auth);
+    // Writes ON for the contract tests below; the gate has its own describe.
+    v2 = new ProfileV2Controller(db, auth, { PROFILE_V2_WRITES_ENABLED: true });
   });
 
   afterEach(async () => {
@@ -181,16 +182,10 @@ describe('public page write contract', () => {
 
   describe('the deprecated /v1 write shim', () => {
     const shim = (db: Db, auth: AuthService, on: boolean) =>
-      new AdminCrudController(
-        db,
-        auth,
-        {} as never,
-        {} as never,
-        {} as never,
-        undefined,
-        undefined,
-        { PROFILE_V1_WRITE_SHIM: on },
-      );
+      new AdminCrudController(db, auth, {} as never, {} as never, {} as never, undefined, undefined, {
+        PROFILE_V1_WRITE_SHIM: on,
+        PROFILE_V2_WRITES_ENABLED: true,
+      });
 
     it('still increments the revision atomically, so fences stay decidable', async () => {
       const res = (await shim(db, auth, true).saveMyProfile(req, { profile: page(true) })) as {
@@ -230,6 +225,127 @@ describe('public page write contract', () => {
       const read = (await shim(db, auth, true).myProfile(req)) as { revision: number };
 
       expect(typeof read.revision).toBe('number');
+    });
+  });
+});
+
+describe('the v2 write gate', () => {
+  let db: Db;
+  let accountId: string;
+  let memberId: string;
+  let auth: AuthService;
+  const req = {} as ReqLike;
+
+  beforeEach(async () => {
+    db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+    await migrate(db);
+    accountId = randomUUID();
+    memberId = randomUUID();
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${accountId}, ${'t' + accountId.slice(0, 8)}, ${'Test'}, ${Date.now()})`,
+    );
+    await db.run(
+      sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, created_at)
+          VALUES (${memberId}, ${accountId}, ${memberId + '@e.com'}, ${'Alex'},
+                  ${'h' + memberId.slice(0, 8)}, ${'owner'}, ${'active'}, ${Date.now()})`,
+    );
+    auth = {
+      resolveHost: async () => ({ accountId, memberId, role: 'owner' }),
+    } as unknown as AuthService;
+  });
+
+  afterEach(async () => {
+    await db.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+    await db.close();
+  });
+
+  const off = () => new ProfileV2Controller(db, auth, { PROFILE_V2_WRITES_ENABLED: false });
+
+  it('is closed when nothing configured it, so a fresh deploy cannot write', async () => {
+    const unconfigured = new ProfileV2Controller(db, auth);
+
+    expect(await statusOf(() => unconfigured.save(req, { profile: page(true), expectedRevision: 0 }))).toBe(
+      501,
+    );
+  });
+
+  it('refuses a CAS before it can touch the row', async () => {
+    const status = await statusOf(() => off().save(req, { profile: page(true), expectedRevision: 0 }));
+
+    expect(status).toBe(501);
+    // Nothing written, and nothing spent: the revision is exactly where it was.
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
+    expect((await getMemberProfileState(db, accountId, memberId))!.profile).toBeNull();
+  });
+
+  it('refuses a fence too, so no revision is burned while disabled', async () => {
+    expect(await statusOf(() => off().fence(req, { expectedRevision: 0 }))).toBe(501);
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
+  });
+
+  it('still answers reads, and reports the capability as unavailable', async () => {
+    const read = (await off().read(req)) as { revision: number; writesEnabled: boolean };
+
+    expect(read).toMatchObject({ revision: 0, writesEnabled: false });
+  });
+
+  it('reports the capability as available once switched on, and then writes', async () => {
+    const on = new ProfileV2Controller(db, auth, { PROFILE_V2_WRITES_ENABLED: true });
+
+    expect(await on.read(req)).toMatchObject({ writesEnabled: true });
+    expect(await on.save(req, { profile: page(true), expectedRevision: 0 })).toMatchObject({
+      ok: true,
+      revision: 1,
+    });
+  });
+
+  it('is reported through the v1 read as well, so an old route cannot mislead a new client', async () => {
+    const shim = new AdminCrudController(
+      db,
+      auth,
+      {} as never,
+      {} as never,
+      {} as never,
+      undefined,
+      undefined,
+      { PROFILE_V1_WRITE_SHIM: true, PROFILE_V2_WRITES_ENABLED: false },
+    );
+
+    expect(await shim.myProfile(req)).toMatchObject({ writesEnabled: false });
+    // The deprecated writer is still available for an OLD web build in the
+    // bounded window, and still increments.
+    expect(await shim.saveMyProfile(req, { profile: page(true) })).toMatchObject({
+      ok: true,
+      revision: 1,
+    });
+  });
+});
+
+describe('an unresolved write', () => {
+  it('is 503 with its own code — never a 409 a client would adopt', async () => {
+    const stubDb = {
+      dialect: 'postgres',
+      all: async () => {
+        throw Object.assign(new Error('could not serialize access'), { code: '40001' });
+      },
+      get: async () => ({ profile: null, profile_revision: 4 }),
+      run: async () => undefined,
+      execRaw: async () => undefined,
+      close: async () => undefined,
+    } as unknown as Db;
+    const auth = {
+      resolveHost: async () => ({ accountId: 'a', memberId: 'm', role: 'owner' }),
+    } as unknown as AuthService;
+    const controller = new ProfileV2Controller(stubDb, auth, { PROFILE_V2_WRITES_ENABLED: true });
+    const req = {} as ReqLike;
+
+    expect(await statusOf(() => controller.save(req, { profile: page(true), expectedRevision: 4 }))).toBe(
+      503,
+    );
+    expect(await bodyOf(() => controller.fence(req, { expectedRevision: 4 }))).toMatchObject({
+      error: 'WRITE_UNRESOLVED',
     });
   });
 });

--- a/apps/api/src/profile-contract.spec.ts
+++ b/apps/api/src/profile-contract.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * The public page write contract at the HTTP boundary.
+ *
+ * v2 is mandatory and versioned in the PATH: an API that predates it answers
+ * 404, so a new web build cannot have an unguarded write quietly accepted by an
+ * old pod. Every mutation names the revision it expects; a missing or malformed
+ * one is refused rather than defaulted.
+ *
+ * The `/v1` writer stays exactly long enough for a rolling deploy, behind a
+ * flag, and even then it increments the revision atomically with its write —
+ * otherwise a fence could not decide anything while an old tab is saving.
+ *
+ * Runs against DATABASE_URL when set (Postgres parity), in-memory SQLite
+ * otherwise.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createDb, migrate, sql, getMemberProfileState, type Db } from '@quill/db';
+import { ProfileV2Controller } from './profile-v2.controller';
+import { AdminCrudController } from './admin-crud.controller';
+import type { AuthService, ReqLike } from './auth.service';
+
+const page = (enabled: boolean, headline = 'Growth partner') => ({
+  version: 1 as const,
+  enabled,
+  headline,
+});
+
+/** Status carried by a Nest HttpException. */
+const statusOf = async (run: () => Promise<unknown>): Promise<number> => {
+  try {
+    await run();
+  } catch (e) {
+    return (e as { getStatus?: () => number }).getStatus?.() ?? 0;
+  }
+  return 200;
+};
+
+const bodyOf = async (run: () => Promise<unknown>): Promise<Record<string, unknown>> => {
+  try {
+    await run();
+  } catch (e) {
+    return (e as { getResponse?: () => Record<string, unknown> }).getResponse?.() ?? {};
+  }
+  return {};
+};
+
+describe('public page write contract', () => {
+  let db: Db;
+  let accountId: string;
+  let memberId: string;
+  let v2: ProfileV2Controller;
+  let auth: AuthService;
+  const req = {} as ReqLike;
+
+  beforeEach(async () => {
+    db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+    await migrate(db);
+    accountId = randomUUID();
+    memberId = randomUUID();
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${accountId}, ${'t' + accountId.slice(0, 8)}, ${'Test'}, ${Date.now()})`,
+    );
+    await db.run(
+      sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, created_at)
+          VALUES (${memberId}, ${accountId}, ${memberId + '@e.com'}, ${'Alex'},
+                  ${'h' + memberId.slice(0, 8)}, ${'owner'}, ${'active'}, ${Date.now()})`,
+    );
+    auth = {
+      resolveHost: async () => ({ accountId, memberId, role: 'owner' }),
+    } as unknown as AuthService;
+    v2 = new ProfileV2Controller(db, auth);
+  });
+
+  afterEach(async () => {
+    await db.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+    await db.close();
+  });
+
+  describe('GET — the capability signal', () => {
+    it('carries the revision to write against', async () => {
+      const read = (await v2.read(req)) as { revision: number; profile: unknown };
+
+      expect(typeof read.revision).toBe('number');
+      expect(read).toMatchObject({ revision: 0, profile: null });
+    });
+  });
+
+  describe('PUT /v2/me/profile', () => {
+    it('writes when the expectation matches, and returns the new revision', async () => {
+      const res = (await v2.save(req, { profile: page(true), expectedRevision: 0 })) as {
+        ok: boolean;
+        revision: number;
+      };
+
+      expect(res).toMatchObject({ ok: true, revision: 1 });
+      expect((await getMemberProfileState(db, accountId, memberId))!.profile).toMatchObject({
+        enabled: true,
+      });
+    });
+
+    it('fails closed when the revision is missing', async () => {
+      expect(await statusOf(() => v2.save(req, { profile: page(true) }))).toBe(400);
+      // Nothing was written by the refusal.
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
+    });
+
+    it('fails closed on a revision that is not a plain non-negative integer', async () => {
+      for (const bad of [null, '0', 1.5, -1, Number.MAX_SAFE_INTEGER + 1]) {
+        expect(
+          await statusOf(() => v2.save(req, { profile: page(true), expectedRevision: bad })),
+          String(bad),
+        ).toBe(400);
+      }
+    });
+
+    it('answers a stale expectation with 409 and the authoritative state', async () => {
+      await v2.save(req, { profile: page(true, 'first'), expectedRevision: 0 });
+
+      const status = await statusOf(() =>
+        v2.save(req, { profile: page(false, 'second'), expectedRevision: 0 }),
+      );
+      const body = await bodyOf(() =>
+        v2.save(req, { profile: page(false, 'second'), expectedRevision: 0 }),
+      );
+
+      expect(status).toBe(409);
+      expect(body).toMatchObject({ error: 'REVISION_CONFLICT', revision: 1 });
+      expect((body.profile as { headline: string }).headline).toBe('first');
+      // Two refusals, and the revision is still 1: a conflict burns nothing.
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(1);
+    });
+
+    it('removes the page when the profile is null', async () => {
+      await v2.save(req, { profile: page(true), expectedRevision: 0 });
+      const res = (await v2.save(req, { profile: null, expectedRevision: 1 })) as {
+        profile: unknown;
+      };
+
+      expect(res.profile).toBeNull();
+    });
+  });
+
+  describe('POST /v2/me/profile/fence', () => {
+    it('advances the revision without touching the page', async () => {
+      await v2.save(req, { profile: page(true, 'kept'), expectedRevision: 0 });
+
+      const res = (await v2.fence(req, { expectedRevision: 1 })) as {
+        revision: number;
+        profile: { headline: string };
+      };
+
+      expect(res).toMatchObject({ ok: true, revision: 2 });
+      expect(res.profile.headline).toBe('kept');
+    });
+
+    it('requires a revision too — a fence with no expectation orders nothing', async () => {
+      expect(await statusOf(() => v2.fence(req, {}))).toBe(400);
+      expect(await statusOf(() => v2.fence(req, { expectedRevision: '1' }))).toBe(400);
+    });
+
+    it('conflicts, without burning a revision, when repeated with the same expectation', async () => {
+      await v2.fence(req, { expectedRevision: 0 });
+
+      expect(await statusOf(() => v2.fence(req, { expectedRevision: 0 }))).toBe(409);
+      expect(await statusOf(() => v2.fence(req, { expectedRevision: 0 }))).toBe(409);
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(1);
+    });
+
+    it('blocks the write it fenced', async () => {
+      await v2.fence(req, { expectedRevision: 0 });
+
+      expect(await statusOf(() => v2.save(req, { profile: page(true), expectedRevision: 0 }))).toBe(
+        409,
+      );
+      expect((await getMemberProfileState(db, accountId, memberId))!.profile).toBeNull();
+    });
+  });
+
+  describe('the deprecated /v1 write shim', () => {
+    const shim = (db: Db, auth: AuthService, on: boolean) =>
+      new AdminCrudController(
+        db,
+        auth,
+        {} as never,
+        {} as never,
+        {} as never,
+        undefined,
+        undefined,
+        { PROFILE_V1_WRITE_SHIM: on },
+      );
+
+    it('still increments the revision atomically, so fences stay decidable', async () => {
+      const res = (await shim(db, auth, true).saveMyProfile(req, { profile: page(true) })) as {
+        revision: number;
+      };
+
+      expect(res).toMatchObject({ ok: true, revision: 1 });
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(1);
+      // A fence that expected the pre-write revision now conflicts, which is
+      // what tells a v2 client that something else wrote.
+      expect(await statusOf(() => v2.fence(req, { expectedRevision: 0 }))).toBe(409);
+    });
+
+    it('is 410 once the gate is closed, so no unguarded writer survives the rollout', async () => {
+      expect(
+        await statusOf(() => shim(db, auth, false).saveMyProfile(req, { profile: page(true) })),
+      ).toBe(410);
+      expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(0);
+    });
+
+    it('is closed by default when nothing configured it', async () => {
+      const noEnv = new AdminCrudController(
+        db,
+        auth,
+        {} as never,
+        {} as never,
+        {} as never,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(await statusOf(() => noEnv.saveMyProfile(req, { profile: page(true) }))).toBe(410);
+    });
+
+    it('reports the revision on the v1 read, which is how a client detects v2', async () => {
+      const read = (await shim(db, auth, true).myProfile(req)) as { revision: number };
+
+      expect(typeof read.revision).toBe('number');
+    });
+  });
+});

--- a/apps/api/src/profile-v2.controller.ts
+++ b/apps/api/src/profile-v2.controller.ts
@@ -177,8 +177,16 @@ export class ProfileV2Controller {
    */
   @Put()
   async save(@Req() req: ReqLike, @Body() body: unknown) {
-    if (!this.writesEnabled) return writesDisabled();
+    // Identify the caller BEFORE deciding anything else, including whether this
+    // deployment admits guarded writes at all. Write-gate posture describes how
+    // far along an operator's rollout is, and an anonymous caller has no
+    // business learning it — so an unauthenticated request gets the ordinary
+    // auth refusal here, exactly as it would from any other admin route.
     const p = await this.auth.resolveHost(req);
+    // Still the FIRST decision after identity: an admitted caller learns only
+    // that writes are closed, never whether its revision or its profile would
+    // have been acceptable, and nothing reaches the row.
+    if (!this.writesEnabled) return writesDisabled();
     const expectedRevision = requireExpectedRevision(body);
     const raw = (body as { profile?: unknown } | null)?.profile ?? null;
     let profile: unknown = null;

--- a/apps/api/src/profile-v2.controller.ts
+++ b/apps/api/src/profile-v2.controller.ts
@@ -1,0 +1,147 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  Get,
+  Inject,
+  NotFoundException,
+  Post,
+  Put,
+  Req,
+} from '@nestjs/common';
+import type { Db } from '@quill/db';
+import {
+  casSetMemberProfile,
+  fenceMemberProfile,
+  getAccountMember,
+  getMemberProfileState,
+  type ProfileWriteResult,
+} from '@quill/db';
+import { memberProfileSchema } from '@quill/types';
+import { ZodError } from 'zod';
+import { DB } from './tokens';
+import { AuthService, type ReqLike } from './auth.service';
+
+/**
+ * The public page write contract, v2 — compare-and-set plus a fence.
+ *
+ * v1 could only say "the write was accepted". That is not enough for a browser
+ * whose request timed out: the timeout does not abort the write, so the client
+ * cannot tell "never applied" from "applied, answer lost", and rereading can
+ * return pre-write state while the write is still in flight. Every mutation
+ * here therefore names the revision it expects, and the fence lets a client
+ * settle one ambiguous write by ordering itself after it.
+ *
+ * The version lives in the PATH, not in an optional field: an older API build
+ * cannot recognise `/v2`, so it answers 404 rather than silently accepting a
+ * new-web mutation without the guard. Missing or invalid revisions fail closed.
+ */
+
+/** A successful write: what is stored now, and the revision behind it. */
+interface ProfileStateBody {
+  ok: true;
+  profile: unknown;
+  revision: number;
+}
+
+const conflict = (r: { profile: unknown; revision: number }): never => {
+  throw new ConflictException({
+    error: 'REVISION_CONFLICT',
+    message: 'The public page moved on. Reload the current state and try again.',
+    profile: r.profile,
+    revision: r.revision,
+  });
+};
+
+const notFound = (): never => {
+  throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+};
+
+/**
+ * `expectedRevision` is REQUIRED and must be a safe non-negative integer.
+ * Absent, null, "3", 3.5 and -1 are all rejected: a mutation that cannot name
+ * its baseline is exactly the unguarded write this contract exists to stop.
+ */
+function requireExpectedRevision(body: unknown): number {
+  const raw = (body as { expectedRevision?: unknown } | null | undefined)?.expectedRevision;
+  if (typeof raw !== 'number' || !Number.isSafeInteger(raw) || raw < 0) {
+    throw new BadRequestException({
+      error: 'REVISION_REQUIRED',
+      message: 'expectedRevision must be a non-negative integer.',
+    });
+  }
+  return raw;
+}
+
+/** Turn a repository outcome into the HTTP contract. */
+function respond(result: ProfileWriteResult): ProfileStateBody {
+  if (result.status === 'not_found') return notFound();
+  if (result.status === 'conflict') return conflict(result);
+  return { ok: true, profile: result.profile, revision: result.revision };
+}
+
+@Controller('v2/me/profile')
+export class ProfileV2Controller {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AuthService) private readonly auth: AuthService,
+  ) {}
+
+  /**
+   * The caller's own public page plus the revision to write against. The same
+   * body as `GET /v1/me/profile`; a client that gets no numeric `revision` from
+   * either route is talking to an API that cannot guard writes, and must not
+   * write at all.
+   */
+  @Get()
+  async read(@Req() req: ReqLike) {
+    const p = await this.auth.resolveHost(req);
+    const member = await getAccountMember(this.db, p.accountId, p.memberId);
+    if (!member) return notFound();
+    const state = await getMemberProfileState(this.db, p.accountId, p.memberId);
+    if (!state) return notFound();
+    return { handle: member.handle, profile: state.profile, revision: state.revision };
+  }
+
+  /**
+   * Replace the caller's own public page if the row is still at
+   * `expectedRevision`. Scoped to the CALLER's member row, never an id from the
+   * request. A stale expectation is a 409 carrying authoritative state and
+   * burns no revision, so retrying after adopting it is safe.
+   */
+  @Put()
+  async save(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const expectedRevision = requireExpectedRevision(body);
+    const raw = (body as { profile?: unknown } | null)?.profile ?? null;
+    let profile: unknown = null;
+    try {
+      profile = raw == null ? null : memberProfileSchema.parse(raw);
+    } catch (err) {
+      if (err instanceof ZodError) {
+        throw new BadRequestException({ error: 'BAD_REQUEST', message: err.issues[0]?.message });
+      }
+      throw err;
+    }
+    return respond(
+      await casSetMemberProfile(this.db, p.accountId, p.memberId, profile, expectedRevision),
+    );
+  }
+
+  /**
+   * Order one ambiguous save. Advances the revision without touching content:
+   * winning proves the ambiguous write never landed and never can, losing
+   * returns the state that beat it.
+   *
+   * POST, not GET: it mutates. Repeating it with the SAME original expectation
+   * is naturally idempotent — the first call spends that revision, so every
+   * repeat conflicts instead of advancing the counter again.
+   */
+  @Post('fence')
+  async fence(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const expectedRevision = requireExpectedRevision(body);
+    return respond(await fenceMemberProfile(this.db, p.accountId, p.memberId, expectedRevision));
+  }
+}

--- a/apps/api/src/profile-v2.controller.ts
+++ b/apps/api/src/profile-v2.controller.ts
@@ -78,10 +78,15 @@ const unresolved = (): never => {
 };
 
 /**
- * v2 writes are OFF until an operator confirms every API writer in the fleet
- * increments the revision. Until then a v2 mutation is refused BEFORE it can
- * touch the row, and the read below advertises the capability as unavailable so
- * a new web build blocks instead of discovering it one failed save at a time.
+ * NEW v2 writes are OFF until an operator confirms every API writer in the fleet
+ * increments the revision. Until then a save is refused BEFORE it can touch the
+ * row, and the read below advertises write admission as unavailable so a new web
+ * build blocks instead of discovering it one failed save at a time.
+ *
+ * This gates saves ONLY. The fence is recovery, not a new write: a browser
+ * holding an expectation from a save that was admitted earlier must still be
+ * able to settle it, or turning the flag off would strand exactly the sessions
+ * that are already in trouble.
  */
 const writesDisabled = (): never => {
   throw new HttpException(
@@ -153,7 +158,14 @@ export class ProfileV2Controller {
       handle: member.handle,
       profile: state.profile,
       revision: state.revision,
+      /** May a NEW save start here? */
       writesEnabled: this.writesEnabled,
+      /**
+       * May an ambiguous save be settled here? True on every revision-aware
+       * build, independently of write admission. An older API reports neither
+       * field and supports neither.
+       */
+      fenceSupported: true,
     };
   }
 
@@ -194,7 +206,7 @@ export class ProfileV2Controller {
    */
   @Post('fence')
   async fence(@Req() req: ReqLike, @Body() body: unknown) {
-    if (!this.writesEnabled) return writesDisabled();
+    // Deliberately NOT gated by write admission — see `writesDisabled`.
     const p = await this.auth.resolveHost(req);
     const expectedRevision = requireExpectedRevision(body);
     return respond(await fenceMemberProfile(this.db, p.accountId, p.memberId, expectedRevision));

--- a/apps/api/src/profile-v2.controller.ts
+++ b/apps/api/src/profile-v2.controller.ts
@@ -4,8 +4,11 @@ import {
   ConflictException,
   Controller,
   Get,
+  HttpException,
+  HttpStatus,
   Inject,
   NotFoundException,
+  Optional,
   Post,
   Put,
   Req,
@@ -20,7 +23,8 @@ import {
 } from '@quill/db';
 import { memberProfileSchema } from '@quill/types';
 import { ZodError } from 'zod';
-import { DB } from './tokens';
+import { DB, ENV } from './tokens';
+import type { ServerEnv } from '@quill/config/env';
 import { AuthService, type ReqLike } from './auth.service';
 
 /**
@@ -59,6 +63,37 @@ const notFound = (): never => {
 };
 
 /**
+ * The write neither landed nor lost. Distinct from a conflict on purpose: the
+ * caller must keep writing blocked and ask again, and must not adopt state or
+ * announce anything about the attempt.
+ */
+const unresolved = (): never => {
+  throw new HttpException(
+    {
+      error: 'WRITE_UNRESOLVED',
+      message: 'The write could not be resolved. Ask again before writing.',
+    },
+    HttpStatus.SERVICE_UNAVAILABLE,
+  );
+};
+
+/**
+ * v2 writes are OFF until an operator confirms every API writer in the fleet
+ * increments the revision. Until then a v2 mutation is refused BEFORE it can
+ * touch the row, and the read below advertises the capability as unavailable so
+ * a new web build blocks instead of discovering it one failed save at a time.
+ */
+const writesDisabled = (): never => {
+  throw new HttpException(
+    {
+      error: 'V2_WRITES_DISABLED',
+      message: 'Revision-guarded writes are not enabled on this server.',
+    },
+    HttpStatus.NOT_IMPLEMENTED,
+  );
+};
+
+/**
  * `expectedRevision` is REQUIRED and must be a safe non-negative integer.
  * Absent, null, "3", 3.5 and -1 are all rejected: a mutation that cannot name
  * its baseline is exactly the unguarded write this contract exists to stop.
@@ -77,6 +112,7 @@ function requireExpectedRevision(body: unknown): number {
 /** Turn a repository outcome into the HTTP contract. */
 function respond(result: ProfileWriteResult): ProfileStateBody {
   if (result.status === 'not_found') return notFound();
+  if (result.status === 'unresolved') return unresolved();
   if (result.status === 'conflict') return conflict(result);
   return { ok: true, profile: result.profile, revision: result.revision };
 }
@@ -86,7 +122,17 @@ export class ProfileV2Controller {
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(AuthService) private readonly auth: AuthService,
+    /**
+     * Optional so direct constructions in tests keep working; absent means the
+     * gate is CLOSED, which is the safe default for anything that did not
+     * deliberately turn revision-guarded writes on.
+     */
+    @Optional() @Inject(ENV) private readonly env?: Pick<ServerEnv, 'PROFILE_V2_WRITES_ENABLED'>,
   ) {}
+
+  private get writesEnabled(): boolean {
+    return this.env?.PROFILE_V2_WRITES_ENABLED === true;
+  }
 
   /**
    * The caller's own public page plus the revision to write against. The same
@@ -101,7 +147,14 @@ export class ProfileV2Controller {
     if (!member) return notFound();
     const state = await getMemberProfileState(this.db, p.accountId, p.memberId);
     if (!state) return notFound();
-    return { handle: member.handle, profile: state.profile, revision: state.revision };
+    // Reads are never gated: a client must be able to see its page, and to see
+    // that it may not write to it.
+    return {
+      handle: member.handle,
+      profile: state.profile,
+      revision: state.revision,
+      writesEnabled: this.writesEnabled,
+    };
   }
 
   /**
@@ -112,6 +165,7 @@ export class ProfileV2Controller {
    */
   @Put()
   async save(@Req() req: ReqLike, @Body() body: unknown) {
+    if (!this.writesEnabled) return writesDisabled();
     const p = await this.auth.resolveHost(req);
     const expectedRevision = requireExpectedRevision(body);
     const raw = (body as { profile?: unknown } | null)?.profile ?? null;
@@ -140,6 +194,7 @@ export class ProfileV2Controller {
    */
   @Post('fence')
   async fence(@Req() req: ReqLike, @Body() body: unknown) {
+    if (!this.writesEnabled) return writesDisabled();
     const p = await this.auth.resolveHost(req);
     const expectedRevision = requireExpectedRevision(body);
     return respond(await fenceMemberProfile(this.db, p.accountId, p.memberId, expectedRevision));

--- a/apps/api/src/public-profile.spec.ts
+++ b/apps/api/src/public-profile.spec.ts
@@ -21,7 +21,7 @@ import {
   migrate,
   seed,
   getAccountByCode,
-  setMemberProfile,
+  overwriteMemberProfileLegacy,
   sql,
   type Db,
 } from '@quill/db';
@@ -58,14 +58,14 @@ describe('public member profile', () => {
   });
 
   const enable = (extra: Record<string, unknown> = {}) =>
-    setMemberProfile(db, accountId, memberId, { version: 1, enabled: true, ...extra });
+    overwriteMemberProfileLegacy(db, accountId, memberId, { version: 1, enabled: true, ...extra });
 
   it('is 404 for a member who never set one up', async () => {
     expect(await svc.publicProfile(accountCode, handle)).toBeNull();
   });
 
   it('is 404 while the page is disabled', async () => {
-    await setMemberProfile(db, accountId, memberId, { version: 1, enabled: false, bio: 'hi' });
+    await overwriteMemberProfileLegacy(db, accountId, memberId, { version: 1, enabled: false, bio: 'hi' });
     expect(await svc.publicProfile(accountCode, handle)).toBeNull();
   });
 

--- a/apps/web/app/admin/settings/actions.spec.ts
+++ b/apps/web/app/admin/settings/actions.spec.ts
@@ -1,89 +1,86 @@
 /**
- * `saveMyProfileAction` is the only authority the public page screen has over
- * what is stored: the browser cannot see the member row, so whatever this
- * returns is what the switch and the "View page" link render. A bare `ok: true`
- * left the screen reconciling against the boolean it had just sent — fine while
- * saves succeed, wrong the moment one is refused. Success therefore carries the
- * persisted profile back, the same contract `saveNotificationAction` already
- * uses for a notification setting.
+ * `saveMyProfileAction` is the only way this screen writes, and the only thing
+ * that can tell it what is stored. Three things are pinned here:
+ *
+ *  - it always sends the revision it read (there is no unguarded overload, and
+ *    no fallback to the deprecated `/v1` writer),
+ *  - an aborted or dropped call comes back as `unknown` — never as a failure,
+ *    because the write may have landed,
+ *  - only outcomes that actually moved stored state revalidate the page.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MemberProfile } from '@quill/types';
 
-const saveMyProfile = vi.fn();
-const myProfile = vi.fn();
+const saveMyProfileV2 = vi.fn();
 const revalidatePath = vi.fn();
 
 vi.mock('@/lib/admin-api', () => ({
-  adminApi: {
-    saveMyProfile: (...a: unknown[]) => saveMyProfile(...a),
-    myProfile: (...a: unknown[]) => myProfile(...a),
-  },
+  adminApi: {},
   ApiError: class ApiError extends Error {},
   isAdminRole: () => true,
+  saveMyProfileV2: (...a: unknown[]) => saveMyProfileV2(...a),
 }));
 vi.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => revalidatePath(...a) }));
 vi.mock('next/navigation', () => ({ unstable_rethrow: () => undefined }));
 
-import { myProfileAction, saveMyProfileAction } from './actions';
+import { saveMyProfileAction } from './actions';
 
-const profile: MemberProfile = {
-  version: 1,
-  enabled: true,
-  headline: 'Growth partner',
-  bio: null,
-};
+const profile: MemberProfile = { version: 1, enabled: true, headline: 'Growth partner', bio: null };
+const stored: MemberProfile = { ...profile, headline: null };
 
 describe('saveMyProfileAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('hands back the profile the API says it stored, not the request', async () => {
-    // The API's copy differs from what was sent (it applies the schema's
-    // defaults). Echoing the request back would hide that, and would claim a
-    // stored state on a response that never carried one.
-    const stored = { ...profile, headline: null };
-    saveMyProfile.mockResolvedValue({ ok: true, profile: stored });
+  it('sends the expected revision with every write', async () => {
+    saveMyProfileV2.mockResolvedValue({ status: 'ok', profile: stored, revision: 5 });
 
-    const res = await saveMyProfileAction(profile);
+    const res = await saveMyProfileAction(profile, 4);
 
-    expect(res).toEqual({ ok: true, profile: stored });
-    expect(saveMyProfile).toHaveBeenCalledWith(profile);
+    expect(saveMyProfileV2).toHaveBeenCalledWith(profile, 4);
+    expect(res).toEqual({ status: 'ok', profile: stored, revision: 5 });
     expect(revalidatePath).toHaveBeenCalledWith('/admin/settings');
   });
 
-  it('carries a removed page back as the stored null', async () => {
-    saveMyProfile.mockResolvedValue({ ok: true, profile: null });
+  it('hands back the API’s stored copy, not the request', async () => {
+    saveMyProfileV2.mockResolvedValue({ status: 'ok', profile: stored, revision: 2 });
 
-    expect(await saveMyProfileAction(null)).toEqual({ ok: true, profile: null });
+    const res = await saveMyProfileAction(profile, 1);
+
+    expect(res).toMatchObject({ profile: stored });
   });
 
-  it('reports a refusal with the reason and no profile to adopt', async () => {
-    saveMyProfile.mockRejectedValue(new Error('Handle taken.'));
+  it('passes a conflict through with the authoritative state to adopt', async () => {
+    saveMyProfileV2.mockResolvedValue({ status: 'conflict', profile: stored, revision: 9 });
 
-    const res = await saveMyProfileAction(profile);
+    expect(await saveMyProfileAction(profile, 4)).toEqual({
+      status: 'conflict',
+      profile: stored,
+      revision: 9,
+    });
+    // Stored state moved (somebody else's write), so the render is stale too.
+    expect(revalidatePath).toHaveBeenCalledWith('/admin/settings');
+  });
 
-    expect(res).toEqual({ ok: false, message: 'Handle taken.' });
-    // Nothing changed server-side, so nothing is revalidated.
+  it('reports an aborted call as unknown, never as a failure', async () => {
+    saveMyProfileV2.mockResolvedValue({ status: 'unknown' });
+
+    expect(await saveMyProfileAction(profile, 4)).toEqual({ status: 'unknown' });
+    // Nothing is known to have changed, so nothing is revalidated.
     expect(revalidatePath).not.toHaveBeenCalled();
   });
-});
 
-describe('myProfileAction', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  it('reports an invocation that threw as unknown too', async () => {
+    saveMyProfileV2.mockRejectedValue(new Error('socket hang up'));
+
+    expect(await saveMyProfileAction(profile, 4)).toEqual({ status: 'unknown' });
   });
 
-  it('reads the stored profile back, which is the only authority after a timeout', async () => {
-    myProfile.mockResolvedValue({ handle: 'alex-rivera', profile });
+  it('surfaces an API that cannot guard writes instead of writing anyway', async () => {
+    saveMyProfileV2.mockResolvedValue({ status: 'unsupported' });
 
-    expect(await myProfileAction()).toEqual({ ok: true, profile });
-  });
-
-  it('reports a still-unknown state rather than inventing one', async () => {
-    myProfile.mockRejectedValue(new Error('offline'));
-
-    expect(await myProfileAction()).toEqual({ ok: false });
+    expect(await saveMyProfileAction(profile, 4)).toEqual({ status: 'unsupported' });
+    expect(revalidatePath).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/admin/settings/actions.spec.ts
+++ b/apps/web/app/admin/settings/actions.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * `saveMyProfileAction` is the only authority the public page screen has over
+ * what is stored: the browser cannot see the member row, so whatever this
+ * returns is what the switch and the "View page" link render. A bare `ok: true`
+ * left the screen reconciling against the boolean it had just sent — fine while
+ * saves succeed, wrong the moment one is refused. Success therefore carries the
+ * persisted profile back, the same contract `saveNotificationAction` already
+ * uses for a notification setting.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MemberProfile } from '@quill/types';
+
+const saveMyProfile = vi.fn();
+const revalidatePath = vi.fn();
+
+vi.mock('@/lib/admin-api', () => ({
+  adminApi: { saveMyProfile: (...a: unknown[]) => saveMyProfile(...a) },
+  ApiError: class ApiError extends Error {},
+  isAdminRole: () => true,
+}));
+vi.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => revalidatePath(...a) }));
+vi.mock('next/navigation', () => ({ unstable_rethrow: () => undefined }));
+
+import { saveMyProfileAction } from './actions';
+
+const profile: MemberProfile = {
+  version: 1,
+  enabled: true,
+  headline: 'Growth partner',
+  bio: null,
+};
+
+describe('saveMyProfileAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hands back the profile that was persisted, not just an ok flag', async () => {
+    saveMyProfile.mockResolvedValue({ ok: true, profile });
+
+    const res = await saveMyProfileAction(profile);
+
+    expect(res).toEqual({ ok: true, profile });
+    expect(saveMyProfile).toHaveBeenCalledWith(profile);
+    expect(revalidatePath).toHaveBeenCalledWith('/admin/settings');
+  });
+
+  it('carries a removed page back as the persisted null', async () => {
+    saveMyProfile.mockResolvedValue({ ok: true, profile: null });
+
+    expect(await saveMyProfileAction(null)).toEqual({ ok: true, profile: null });
+  });
+
+  it('reports a refusal with the reason and no profile to adopt', async () => {
+    saveMyProfile.mockRejectedValue(new Error('Handle taken.'));
+
+    const res = await saveMyProfileAction(profile);
+
+    expect(res).toEqual({ ok: false, message: 'Handle taken.' });
+    // Nothing changed server-side, so nothing is revalidated.
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/admin/settings/actions.spec.ts
+++ b/apps/web/app/admin/settings/actions.spec.ts
@@ -11,17 +11,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MemberProfile } from '@quill/types';
 
 const saveMyProfile = vi.fn();
+const myProfile = vi.fn();
 const revalidatePath = vi.fn();
 
 vi.mock('@/lib/admin-api', () => ({
-  adminApi: { saveMyProfile: (...a: unknown[]) => saveMyProfile(...a) },
+  adminApi: {
+    saveMyProfile: (...a: unknown[]) => saveMyProfile(...a),
+    myProfile: (...a: unknown[]) => myProfile(...a),
+  },
   ApiError: class ApiError extends Error {},
   isAdminRole: () => true,
 }));
 vi.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => revalidatePath(...a) }));
 vi.mock('next/navigation', () => ({ unstable_rethrow: () => undefined }));
 
-import { saveMyProfileAction } from './actions';
+import { myProfileAction, saveMyProfileAction } from './actions';
 
 const profile: MemberProfile = {
   version: 1,
@@ -35,17 +39,21 @@ describe('saveMyProfileAction', () => {
     vi.clearAllMocks();
   });
 
-  it('hands back the profile that was persisted, not just an ok flag', async () => {
-    saveMyProfile.mockResolvedValue({ ok: true, profile });
+  it('hands back the profile the API says it stored, not the request', async () => {
+    // The API's copy differs from what was sent (it applies the schema's
+    // defaults). Echoing the request back would hide that, and would claim a
+    // stored state on a response that never carried one.
+    const stored = { ...profile, headline: null };
+    saveMyProfile.mockResolvedValue({ ok: true, profile: stored });
 
     const res = await saveMyProfileAction(profile);
 
-    expect(res).toEqual({ ok: true, profile });
+    expect(res).toEqual({ ok: true, profile: stored });
     expect(saveMyProfile).toHaveBeenCalledWith(profile);
     expect(revalidatePath).toHaveBeenCalledWith('/admin/settings');
   });
 
-  it('carries a removed page back as the persisted null', async () => {
+  it('carries a removed page back as the stored null', async () => {
     saveMyProfile.mockResolvedValue({ ok: true, profile: null });
 
     expect(await saveMyProfileAction(null)).toEqual({ ok: true, profile: null });
@@ -59,5 +67,23 @@ describe('saveMyProfileAction', () => {
     expect(res).toEqual({ ok: false, message: 'Handle taken.' });
     // Nothing changed server-side, so nothing is revalidated.
     expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe('myProfileAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads the stored profile back, which is the only authority after a timeout', async () => {
+    myProfile.mockResolvedValue({ handle: 'alex-rivera', profile });
+
+    expect(await myProfileAction()).toEqual({ ok: true, profile });
+  });
+
+  it('reports a still-unknown state rather than inventing one', async () => {
+    myProfile.mockRejectedValue(new Error('offline'));
+
+    expect(await myProfileAction()).toEqual({ ok: false });
   });
 });

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -7,6 +7,7 @@ import type { MemberProfile } from '@quill/types';
 import {
   adminApi,
   ApiError,
+  saveMyProfileV2,
   isAdminRole,
   type NotificationEmailKey,
   type NotificationPatch,
@@ -171,53 +172,46 @@ export async function resetNotificationAction(
 }
 
 /**
- * Outcome of a public page write. Success carries the profile the API says is
- * now stored — its copy, never the request echoed back — so the client
- * reconciles against storage instead of against what it hoped to store. The
- * same contract `NotificationSaveState` uses. A refusal carries the reason and
- * no profile: nothing changed.
+ * Outcome of a public page write, as the screen sees it.
+ *
+ * `unknown` is the one that matters: the call was aborted or dropped, so the
+ * write may still have landed. It is never reported as success or as failure —
+ * the fence Route Handler settles it.
  */
 export type ProfileSaveState =
-  | { ok: true; profile: MemberProfile | null }
-  | { ok: false; message?: string };
-
-/** Outcome of a public page reread. `ok: false` means the state is still unknown. */
-export type ProfileReadState = { ok: true; profile: MemberProfile | null } | { ok: false };
+  | { status: 'ok'; profile: MemberProfile | null; revision: number }
+  | { status: 'conflict'; profile: MemberProfile | null; revision: number }
+  | { status: 'unsupported' }
+  | { status: 'unknown' }
+  | { status: 'failed'; message?: string };
 
 /**
- * Save (or clear) the caller's own public page. Scoped server-side to the
- * authenticated member — the id is never taken from the request.
+ * Save the caller's own public page against the revision it was read at.
+ *
+ * Scoped server-side to the authenticated member — the id is never taken from
+ * the request. `expectedRevision` is required: a save that cannot name its
+ * baseline is the unguarded write this contract exists to stop, so there is no
+ * overload without it and no fallback to the deprecated `/v1` writer.
  */
 export async function saveMyProfileAction(
   profile: MemberProfile | null,
+  expectedRevision: number,
 ): Promise<ProfileSaveState> {
   try {
-    const stored = await adminApi.saveMyProfile(profile);
-    revalidatePath('/admin/settings');
-    return { ok: true, profile: stored.profile ?? null };
+    const result = await saveMyProfileV2(profile, expectedRevision);
+    if (result.status === 'ok' || result.status === 'conflict') {
+      // Stored state moved (ours, or somebody else's) — the rendered page is stale.
+      revalidatePath('/admin/settings');
+      return result;
+    }
+    if (result.status === 'unsupported') return { status: 'unsupported' };
+    if (result.status === 'unknown') return { status: 'unknown' };
+    if (result.status === 'unauthorized') return { status: 'failed' };
+    if (result.status === 'not_found') return { status: 'failed' };
+    return { status: 'failed', message: result.message };
   } catch (e) {
     unstable_rethrow(e);
-    return {
-      ok: false,
-      message: e instanceof Error ? e.message : 'Could not save.',
-    };
-  }
-}
-
-/**
- * Reread the caller's own public page.
- *
- * The authority after a save the browser never got an answer to: a client-side
- * timeout does not abort the PUT, so the write may well have landed. Neither
- * the value that was sent nor the value held before it is evidence of what is
- * stored — only asking is.
- */
-export async function myProfileAction(): Promise<ProfileReadState> {
-  try {
-    const { profile } = await adminApi.myProfile();
-    return { ok: true, profile };
-  } catch (e) {
-    unstable_rethrow(e);
-    return { ok: false };
+    // A throw here is the invocation failing, not a verdict about the write.
+    return { status: 'unknown' };
   }
 }

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -171,16 +171,29 @@ export async function resetNotificationAction(
 }
 
 /**
+ * Outcome of a public page write. Success carries the profile that is now
+ * persisted so the client reconciles against stored state rather than against
+ * the boolean it just sent — the same contract `NotificationSaveState` uses.
+ * A refusal carries the reason and no profile: nothing changed.
+ */
+export type ProfileSaveState =
+  | { ok: true; profile: MemberProfile | null }
+  | { ok: false; message?: string };
+
+/**
  * Save (or clear) the caller's own public page. Scoped server-side to the
  * authenticated member — the id is never taken from the request.
+ *
+ * The API replaces the whole blob, so a resolved call means exactly this
+ * profile is what a reader would now get — that is what comes back.
  */
 export async function saveMyProfileAction(
   profile: MemberProfile | null,
-): Promise<{ ok: boolean; message?: string }> {
+): Promise<ProfileSaveState> {
   try {
     await adminApi.saveMyProfile(profile);
     revalidatePath('/admin/settings');
-    return { ok: true };
+    return { ok: true, profile };
   } catch (e) {
     unstable_rethrow(e);
     return {

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -171,34 +171,53 @@ export async function resetNotificationAction(
 }
 
 /**
- * Outcome of a public page write. Success carries the profile that is now
- * persisted so the client reconciles against stored state rather than against
- * the boolean it just sent — the same contract `NotificationSaveState` uses.
- * A refusal carries the reason and no profile: nothing changed.
+ * Outcome of a public page write. Success carries the profile the API says is
+ * now stored — its copy, never the request echoed back — so the client
+ * reconciles against storage instead of against what it hoped to store. The
+ * same contract `NotificationSaveState` uses. A refusal carries the reason and
+ * no profile: nothing changed.
  */
 export type ProfileSaveState =
   | { ok: true; profile: MemberProfile | null }
   | { ok: false; message?: string };
 
+/** Outcome of a public page reread. `ok: false` means the state is still unknown. */
+export type ProfileReadState = { ok: true; profile: MemberProfile | null } | { ok: false };
+
 /**
  * Save (or clear) the caller's own public page. Scoped server-side to the
  * authenticated member — the id is never taken from the request.
- *
- * The API replaces the whole blob, so a resolved call means exactly this
- * profile is what a reader would now get — that is what comes back.
  */
 export async function saveMyProfileAction(
   profile: MemberProfile | null,
 ): Promise<ProfileSaveState> {
   try {
-    await adminApi.saveMyProfile(profile);
+    const stored = await adminApi.saveMyProfile(profile);
     revalidatePath('/admin/settings');
-    return { ok: true, profile };
+    return { ok: true, profile: stored.profile ?? null };
   } catch (e) {
     unstable_rethrow(e);
     return {
       ok: false,
       message: e instanceof Error ? e.message : 'Could not save.',
     };
+  }
+}
+
+/**
+ * Reread the caller's own public page.
+ *
+ * The authority after a save the browser never got an answer to: a client-side
+ * timeout does not abort the PUT, so the write may well have landed. Neither
+ * the value that was sent nor the value held before it is evidence of what is
+ * stored — only asking is.
+ */
+export async function myProfileAction(): Promise<ProfileReadState> {
+  try {
+    const { profile } = await adminApi.myProfile();
+    return { ok: true, profile };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
   }
 }

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -8,7 +8,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { InviteMember } from './invite-member';
 import { MemberRowActions } from './member-row-actions';
 import { NotificationSettings } from './notification-settings';
-import { PublicPageSettings } from './public-page';
+import { PublicPageSettings, type PublicPageLoad } from './public-page';
 import { ThemeSettings } from './theme-settings';
 
 export const dynamic = 'force-dynamic';
@@ -38,13 +38,26 @@ export default async function SettingsPage() {
   };
   const publicPath = me.handle ? `/${me.accountCode}/${me.handle}` : null;
   // Every member edits their OWN page, so this is not admin-gated.
-  const myProfile = await adminApi.myProfile().catch(() => null);
+  //
+  // A failed read is NOT an empty page. Swallowing it into `null` handed the
+  // editor a blank form whose first save would have written that blankness over
+  // stored links, form choices and branding. The three outcomes stay distinct:
+  // loaded (with the revision to write against), unreadable, or an API too old
+  // to guard writes at all. Only the first one may be edited.
+  const publicPageState: PublicPageLoad = await adminApi
+    .myProfile()
+    .then((r): PublicPageLoad =>
+      typeof r.revision === 'number'
+        ? { status: 'ok', profile: r.profile, revision: r.revision }
+        : { status: 'unsupported' },
+    )
+    .catch(() => ({ status: 'failed' }) as PublicPageLoad);
 
   return (
     <div className="mx-auto max-w-[1520px] px-6 py-10 sm:px-8">
       <PageHeader title={s.title} subtitle={s.subtitle} />
 
-      <PublicPageSettings publicPath={publicPath} initial={myProfile?.profile ?? null} m={s} />
+      <PublicPageSettings publicPath={publicPath} load={publicPageState} m={s} />
 
       <ThemeSettings pref={await getThemePref()} s={s} m={getMessages(locale).admin.chrome.theme} />
 

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -42,12 +42,15 @@ export default async function SettingsPage() {
   // A failed read is NOT an empty page. Swallowing it into `null` handed the
   // editor a blank form whose first save would have written that blankness over
   // stored links, form choices and branding. The three outcomes stay distinct:
-  // loaded (with the revision to write against), unreadable, or an API too old
-  // to guard writes at all. Only the first one may be edited.
+  // loaded (with the revision to write against), unreadable, or a server that
+  // cannot guard writes — too old, or not switched on yet. Only the first one
+  // may be edited.
   const publicPageState: PublicPageLoad = await adminApi
     .myProfile()
     .then((r): PublicPageLoad =>
-      typeof r.revision === 'number'
+      // Two things must both hold to edit: the server speaks revisions at all,
+      // and revision-guarded writes are switched on. Either one missing blocks.
+      typeof r.revision === 'number' && r.writesEnabled === true
         ? { status: 'ok', profile: r.profile, revision: r.revision }
         : { status: 'unsupported' },
     )

--- a/apps/web/app/admin/settings/public-page.spec.tsx
+++ b/apps/web/app/admin/settings/public-page.spec.tsx
@@ -1,22 +1,24 @@
 /**
- * The public page switch must never claim a state the server did not persist.
+ * The public page switch must never claim a state the server did not store.
  *
  * Enabling used to move the switch on click and leave it there: when the save
  * came back rejected, the toggle stayed on — and so did the "View page" link
  * next to it — advertising a page that is still a 404. Disabling had the mirror
  * bug: the switch went off and the link disappeared while the page stayed
- * published. Both directions now render the profile the save came back with,
- * and a call that never reached the server settles nothing at all.
+ * published.
  *
+ * `readSaveVerdict` is what the screen is allowed to conclude from one save.
  * The web app's vitest runs in plain node (no jsdom), so the switch and the link
- * are read out of `renderToStaticMarkup` for the profile the reconciler settles
- * on, rather than by clicking. Playwright drives the real DOM.
+ * are read out of `renderToStaticMarkup` for the profile a verdict settles on.
+ * The transport case — where the write may still land after the client stops
+ * waiting — needs a real click and a real request in flight, so it is driven in
+ * a browser by `qa/e2e/public-page-transport.spec.ts`.
  */
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { getMessages } from '@quill/shared';
 import type { MemberProfile } from '@quill/types';
-import { PublicPageSettings, reconcileProfileSave } from './public-page';
+import { PublicPageSettings, readSaveVerdict } from './public-page';
 
 const m = getMessages('en').admin.settings;
 const publicPath = '/acme/alex-rivera';
@@ -36,103 +38,69 @@ const timedOut = {
   message: 'timed out after 15000ms',
 };
 
-/** The section as the screen actually renders it for a persisted profile. */
+/** The section as the screen actually renders it for a stored profile. */
 const screen = (profile: MemberProfile | null): string =>
   renderToStaticMarkup(<PublicPageSettings publicPath={publicPath} initial={profile} m={m} />);
 
 const switchIsOn = (html: string): boolean => html.includes('aria-checked="true"');
 const hasViewLink = (html: string): boolean => html.includes(`>${m.publicPageView}</a>`);
 
-describe('public page — a rejected save leaves persisted state on screen', () => {
-  it('keeps the page hidden, and the View link gone, when an enable is rejected', () => {
-    const next = reconcileProfileSave(hidden, { ok: false, message: 'Could not save.' });
-
-    expect(next.saved).toBe(false);
-    expect(next.profile).toEqual(hidden);
-
-    const html = screen(next.profile);
-    expect(switchIsOn(html)).toBe(false);
-    expect(hasViewLink(html)).toBe(false);
+describe('readSaveVerdict — what one save proves about stored state', () => {
+  it('adopts the server’s copy of the profile on success', () => {
+    expect(readSaveVerdict({ ok: true, profile: published })).toEqual({
+      status: 'saved',
+      profile: published,
+    });
   });
 
-  it('keeps the page published, and the View link visible, when a disable is rejected', () => {
-    const next = reconcileProfileSave(published, { ok: false, message: 'Could not save.' });
-
-    expect(next.saved).toBe(false);
-    expect(next.profile).toEqual(published);
-
-    const html = screen(next.profile);
-    expect(switchIsOn(html)).toBe(true);
-    expect(hasViewLink(html)).toBe(true);
+  it('reads a removed page as stored too', () => {
+    expect(readSaveVerdict({ ok: true, profile: null })).toEqual({
+      status: 'saved',
+      profile: null,
+    });
   });
 
-  it('surfaces the server’s own reason so the screen need not guess', () => {
-    expect(reconcileProfileSave(hidden, { ok: false, message: 'Handle taken.' }).message).toBe(
-      'Handle taken.',
-    );
-  });
-});
-
-describe('public page — a call that never landed claims nothing', () => {
-  it('leaves a hidden page hidden when the enable never reached the server', () => {
-    const next = reconcileProfileSave(hidden, timedOut);
-
-    // Not a success: no server verdict came back, so nothing may be announced
-    // as saved — and the transport message is plumbing, not an answer about the
-    // profile, so the screen falls back to its own copy instead of quoting it.
-    expect(next.saved).toBe(false);
-    expect(next.message).toBeNull();
-    expect(next.profile).toEqual(hidden);
-    expect(switchIsOn(screen(next.profile))).toBe(false);
+  it('carries the server’s reason when the save is refused, and no profile', () => {
+    expect(readSaveVerdict({ ok: false, message: 'Handle taken.' })).toEqual({
+      status: 'rejected',
+      message: 'Handle taken.',
+    });
   });
 
-  it('leaves a published page published when the disable never reached the server', () => {
-    const next = reconcileProfileSave(published, timedOut);
+  it('concludes nothing at all when the call produced no verdict', () => {
+    // Deliberately profile-free: a timeout does not abort the PUT, so neither
+    // the value sent nor the one held before it is evidence of what is stored.
+    const verdict = readSaveVerdict(timedOut);
 
-    expect(next.saved).toBe(false);
-    expect(next.profile).toEqual(published);
-
-    const html = screen(next.profile);
-    expect(switchIsOn(html)).toBe(true);
-    expect(hasViewLink(html)).toBe(true);
+    expect(verdict).toEqual({ status: 'unknown' });
+    expect(verdict).not.toHaveProperty('profile');
   });
 });
 
-describe('public page — a successful save renders what the server stored', () => {
-  it('turns the switch on and offers the link once the server confirms the publish', () => {
-    const next = reconcileProfileSave(hidden, { ok: true, profile: published });
+describe('the section renders the stored profile, both directions', () => {
+  it('shows the switch on and offers the link for a published page', () => {
+    const html = screen(published);
 
-    expect(next.saved).toBe(true);
-    expect(next.profile).toEqual(published);
-
-    const html = screen(next.profile);
     expect(switchIsOn(html)).toBe(true);
     expect(hasViewLink(html)).toBe(true);
     expect(html).toContain(`href="${publicPath}"`);
   });
 
-  it('turns the switch off and drops the link once the server confirms the unpublish', () => {
-    const next = reconcileProfileSave(published, { ok: true, profile: hidden });
+  it('shows the switch off and no link for a page that is not published', () => {
+    const html = screen(hidden);
 
-    expect(next.saved).toBe(true);
-    expect(next.profile).toEqual(hidden);
-
-    const html = screen(next.profile);
     expect(switchIsOn(html)).toBe(false);
     expect(hasViewLink(html)).toBe(false);
   });
 
-  it('takes a removed page (a null profile) as the persisted answer too', () => {
-    const next = reconcileProfileSave(published, { ok: true, profile: null });
+  it('treats a member with no profile as not published', () => {
+    const html = screen(null);
 
-    expect(next.saved).toBe(true);
-    expect(next.profile).toBeNull();
-    expect(switchIsOn(screen(next.profile))).toBe(false);
+    expect(switchIsOn(html)).toBe(false);
+    expect(hasViewLink(html)).toBe(false);
   });
-});
 
-describe('public page — the screen without a handle', () => {
-  it('explains the missing handle instead of offering a URL to publish at', () => {
+  it('explains a missing handle instead of offering a URL to publish at', () => {
     const html = renderToStaticMarkup(
       <PublicPageSettings publicPath={null} initial={published} m={m} />,
     );

--- a/apps/web/app/admin/settings/public-page.spec.tsx
+++ b/apps/web/app/admin/settings/public-page.spec.tsx
@@ -1,0 +1,143 @@
+/**
+ * The public page switch must never claim a state the server did not persist.
+ *
+ * Enabling used to move the switch on click and leave it there: when the save
+ * came back rejected, the toggle stayed on — and so did the "View page" link
+ * next to it — advertising a page that is still a 404. Disabling had the mirror
+ * bug: the switch went off and the link disappeared while the page stayed
+ * published. Both directions now render the profile the save came back with,
+ * and a call that never reached the server settles nothing at all.
+ *
+ * The web app's vitest runs in plain node (no jsdom), so the switch and the link
+ * are read out of `renderToStaticMarkup` for the profile the reconciler settles
+ * on, rather than by clicking. Playwright drives the real DOM.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { getMessages } from '@quill/shared';
+import type { MemberProfile } from '@quill/types';
+import { PublicPageSettings, reconcileProfileSave } from './public-page';
+
+const m = getMessages('en').admin.settings;
+const publicPath = '/acme/alex-rivera';
+
+const published: MemberProfile = {
+  version: 1,
+  enabled: true,
+  headline: 'Growth partner',
+  bio: null,
+};
+const hidden: MemberProfile = { ...published, enabled: false };
+
+/** A transport failure: the call produced no server verdict, ok or not. */
+const timedOut = {
+  ok: false as const,
+  transport: true as const,
+  message: 'timed out after 15000ms',
+};
+
+/** The section as the screen actually renders it for a persisted profile. */
+const screen = (profile: MemberProfile | null): string =>
+  renderToStaticMarkup(<PublicPageSettings publicPath={publicPath} initial={profile} m={m} />);
+
+const switchIsOn = (html: string): boolean => html.includes('aria-checked="true"');
+const hasViewLink = (html: string): boolean => html.includes(`>${m.publicPageView}</a>`);
+
+describe('public page — a rejected save leaves persisted state on screen', () => {
+  it('keeps the page hidden, and the View link gone, when an enable is rejected', () => {
+    const next = reconcileProfileSave(hidden, { ok: false, message: 'Could not save.' });
+
+    expect(next.saved).toBe(false);
+    expect(next.profile).toEqual(hidden);
+
+    const html = screen(next.profile);
+    expect(switchIsOn(html)).toBe(false);
+    expect(hasViewLink(html)).toBe(false);
+  });
+
+  it('keeps the page published, and the View link visible, when a disable is rejected', () => {
+    const next = reconcileProfileSave(published, { ok: false, message: 'Could not save.' });
+
+    expect(next.saved).toBe(false);
+    expect(next.profile).toEqual(published);
+
+    const html = screen(next.profile);
+    expect(switchIsOn(html)).toBe(true);
+    expect(hasViewLink(html)).toBe(true);
+  });
+
+  it('surfaces the server’s own reason so the screen need not guess', () => {
+    expect(reconcileProfileSave(hidden, { ok: false, message: 'Handle taken.' }).message).toBe(
+      'Handle taken.',
+    );
+  });
+});
+
+describe('public page — a call that never landed claims nothing', () => {
+  it('leaves a hidden page hidden when the enable never reached the server', () => {
+    const next = reconcileProfileSave(hidden, timedOut);
+
+    // Not a success: no server verdict came back, so nothing may be announced
+    // as saved — and the transport message is plumbing, not an answer about the
+    // profile, so the screen falls back to its own copy instead of quoting it.
+    expect(next.saved).toBe(false);
+    expect(next.message).toBeNull();
+    expect(next.profile).toEqual(hidden);
+    expect(switchIsOn(screen(next.profile))).toBe(false);
+  });
+
+  it('leaves a published page published when the disable never reached the server', () => {
+    const next = reconcileProfileSave(published, timedOut);
+
+    expect(next.saved).toBe(false);
+    expect(next.profile).toEqual(published);
+
+    const html = screen(next.profile);
+    expect(switchIsOn(html)).toBe(true);
+    expect(hasViewLink(html)).toBe(true);
+  });
+});
+
+describe('public page — a successful save renders what the server stored', () => {
+  it('turns the switch on and offers the link once the server confirms the publish', () => {
+    const next = reconcileProfileSave(hidden, { ok: true, profile: published });
+
+    expect(next.saved).toBe(true);
+    expect(next.profile).toEqual(published);
+
+    const html = screen(next.profile);
+    expect(switchIsOn(html)).toBe(true);
+    expect(hasViewLink(html)).toBe(true);
+    expect(html).toContain(`href="${publicPath}"`);
+  });
+
+  it('turns the switch off and drops the link once the server confirms the unpublish', () => {
+    const next = reconcileProfileSave(published, { ok: true, profile: hidden });
+
+    expect(next.saved).toBe(true);
+    expect(next.profile).toEqual(hidden);
+
+    const html = screen(next.profile);
+    expect(switchIsOn(html)).toBe(false);
+    expect(hasViewLink(html)).toBe(false);
+  });
+
+  it('takes a removed page (a null profile) as the persisted answer too', () => {
+    const next = reconcileProfileSave(published, { ok: true, profile: null });
+
+    expect(next.saved).toBe(true);
+    expect(next.profile).toBeNull();
+    expect(switchIsOn(screen(next.profile))).toBe(false);
+  });
+});
+
+describe('public page — the screen without a handle', () => {
+  it('explains the missing handle instead of offering a URL to publish at', () => {
+    const html = renderToStaticMarkup(
+      <PublicPageSettings publicPath={null} initial={published} m={m} />,
+    );
+
+    expect(html).toContain(m.publicPageNoHandle);
+    expect(hasViewLink(html)).toBe(false);
+  });
+});

--- a/apps/web/app/admin/settings/public-page.spec.tsx
+++ b/apps/web/app/admin/settings/public-page.spec.tsx
@@ -1,26 +1,35 @@
 /**
- * The public page switch must never claim a state the server did not store.
+ * What the public page section is allowed to claim, and when.
  *
- * Enabling used to move the switch on click and leave it there: when the save
- * came back rejected, the toggle stayed on — and so did the "View page" link
- * next to it — advertising a page that is still a 404. Disabling had the mirror
- * bug: the switch went off and the link disappeared while the page stayed
- * published.
+ * The switch and the "View page" link render only from authoritative state —
+ * something the server said it stores, at a revision. Three failures used to be
+ * collapsed into one: a page that could not be read looked like an empty page,
+ * a save with no answer looked like a failed save, and a save that lost a race
+ * looked like a save that worked.
  *
- * `readSaveVerdict` is what the screen is allowed to conclude from one save.
- * The web app's vitest runs in plain node (no jsdom), so the switch and the link
- * are read out of `renderToStaticMarkup` for the profile a verdict settles on.
- * The transport case — where the write may still land after the client stops
- * waiting — needs a real click and a real request in flight, so it is driven in
- * a browser by `qa/e2e/public-page-transport.spec.ts`.
+ * The web app's vitest runs in plain node (no jsdom), so the rendered markup is
+ * read out of `renderToStaticMarkup`, and the fence decision is checked as a
+ * pure function. The click-through orderings — a real timed-out action, the
+ * off-queue fence, repeated "Check again" — need a browser and live in
+ * `qa/e2e/public-page-transport.spec.ts`.
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
+
+// `useRouter` needs a mounted app router; these tests render the section on its
+// own, outside one. Refreshing is exercised in the browser suite.
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: () => undefined }) }));
 import { getMessages } from '@quill/shared';
 import type { MemberProfile } from '@quill/types';
-import { PublicPageSettings, readSaveVerdict } from './public-page';
+import {
+  PublicPageSettings,
+  readFenceOutcome,
+  sameStoredProfile,
+  type PublicPageLoad,
+} from './public-page';
 
 const m = getMessages('en').admin.settings;
+const es = getMessages('es').admin.settings;
 const publicPath = '/acme/alex-rivera';
 
 const published: MemberProfile = {
@@ -28,58 +37,55 @@ const published: MemberProfile = {
   enabled: true,
   headline: 'Growth partner',
   bio: null,
+  links: [{ label: 'Site', url: 'https://example.com' }],
 };
 const hidden: MemberProfile = { ...published, enabled: false };
 
-/** A transport failure: the call produced no server verdict, ok or not. */
-const timedOut = {
-  ok: false as const,
-  transport: true as const,
-  message: 'timed out after 15000ms',
-};
-
-/** The section as the screen actually renders it for a stored profile. */
-const screen = (profile: MemberProfile | null): string =>
-  renderToStaticMarkup(<PublicPageSettings publicPath={publicPath} initial={profile} m={m} />);
+const screen = (load: PublicPageLoad): string =>
+  renderToStaticMarkup(<PublicPageSettings publicPath={publicPath} load={load} m={m} />);
 
 const switchIsOn = (html: string): boolean => html.includes('aria-checked="true"');
+const hasSwitch = (html: string): boolean => html.includes('role="switch"');
 const hasViewLink = (html: string): boolean => html.includes(`>${m.publicPageView}</a>`);
 
-describe('readSaveVerdict — what one save proves about stored state', () => {
-  it('adopts the server’s copy of the profile on success', () => {
-    expect(readSaveVerdict({ ok: true, profile: published })).toEqual({
-      status: 'saved',
-      profile: published,
-    });
+describe('the fence decides what a timed-out save did', () => {
+  it('reports "not applied" when the fence wins, because that save can never land', () => {
+    // Fence won: it spent the revision the ambiguous save expected.
+    const out = readFenceOutcome(hidden, { status: 'ok', profile: hidden, revision: 8 });
+
+    expect(out.notice).toBe('not-applied');
+    expect(out.adopt).toEqual({ profile: hidden, revision: 8 });
   });
 
-  it('reads a removed page as stored too', () => {
-    expect(readSaveVerdict({ ok: true, profile: null })).toEqual({
-      status: 'saved',
-      profile: null,
-    });
+  it('adopts the winner and says the state changed, never that we saved it', () => {
+    const out = readFenceOutcome(hidden, { status: 'conflict', profile: published, revision: 9 });
+
+    expect(out.notice).toBe('latest-loaded');
+    expect(out.adopt).toEqual({ profile: published, revision: 9 });
   });
 
-  it('carries the server’s reason when the save is refused, and no profile', () => {
-    expect(readSaveVerdict({ ok: false, message: 'Handle taken.' })).toEqual({
-      status: 'rejected',
-      message: 'Handle taken.',
-    });
+  it('separates a no-op revision advance from a change made elsewhere', () => {
+    // Someone advanced the revision without changing content (a second fence,
+    // or a write that stored the same thing). Saying "changed elsewhere" here
+    // would be false; so would "Saved".
+    const out = readFenceOutcome(hidden, { status: 'conflict', profile: { ...hidden }, revision: 9 });
+
+    expect(out.notice).toBe('no-op-advance');
   });
 
-  it('concludes nothing at all when the call produced no verdict', () => {
-    // Deliberately profile-free: a timeout does not abort the PUT, so neither
-    // the value sent nor the one held before it is evidence of what is stored.
-    const verdict = readSaveVerdict(timedOut);
+  it('compares stored pages by content, not by key order', () => {
+    const reordered = { enabled: true, headline: 'Growth partner', bio: null, version: 1, links: published.links } as MemberProfile;
 
-    expect(verdict).toEqual({ status: 'unknown' });
-    expect(verdict).not.toHaveProperty('profile');
+    expect(sameStoredProfile(published, reordered)).toBe(true);
+    expect(sameStoredProfile(published, hidden)).toBe(false);
+    expect(sameStoredProfile(null, null)).toBe(true);
+    expect(sameStoredProfile(null, hidden)).toBe(false);
   });
 });
 
-describe('the section renders the stored profile, both directions', () => {
+describe('the section renders stored state, and only stored state', () => {
   it('shows the switch on and offers the link for a published page', () => {
-    const html = screen(published);
+    const html = screen({ status: 'ok', profile: published, revision: 3 });
 
     expect(switchIsOn(html)).toBe(true);
     expect(hasViewLink(html)).toBe(true);
@@ -87,25 +93,94 @@ describe('the section renders the stored profile, both directions', () => {
   });
 
   it('shows the switch off and no link for a page that is not published', () => {
-    const html = screen(hidden);
+    const html = screen({ status: 'ok', profile: hidden, revision: 3 });
 
     expect(switchIsOn(html)).toBe(false);
     expect(hasViewLink(html)).toBe(false);
   });
 
-  it('treats a member with no profile as not published', () => {
-    const html = screen(null);
+  it('offers no toggle at all when the page could not be read', () => {
+    // A failed read is not an empty page: rendering an editable blank form here
+    // is what would let the next save overwrite stored links and branding.
+    const html = screen({ status: 'failed' });
 
-    expect(switchIsOn(html)).toBe(false);
+    expect(hasSwitch(html)).toBe(false);
     expect(hasViewLink(html)).toBe(false);
+    expect(html).toContain(m.publicPageLoadFailed);
+    expect(html).toContain(m.publicPageReload);
+  });
+
+  it('offers no toggle when the server cannot guard writes', () => {
+    const html = screen({ status: 'unsupported' });
+
+    expect(hasSwitch(html)).toBe(false);
+    expect(html).toContain(m.publicPageUnsupported);
+    // No silent fall back to the unguarded write path.
+    expect(html).not.toContain(m.publicPageSaved);
+  });
+
+  it('never dresses an unreadable page up as "Saving" or "Could not save"', () => {
+    const html = screen({ status: 'failed' });
+
+    expect(html).not.toContain(m.publicPageSaving);
+    expect(html).not.toContain(m.publicPageError);
   });
 
   it('explains a missing handle instead of offering a URL to publish at', () => {
     const html = renderToStaticMarkup(
-      <PublicPageSettings publicPath={null} initial={published} m={m} />,
+      <PublicPageSettings publicPath={null} load={{ status: 'ok', profile: published, revision: 1 }} m={m} />,
     );
 
     expect(html).toContain(m.publicPageNoHandle);
     expect(hasViewLink(html)).toBe(false);
+  });
+});
+
+describe('every state family has its own copy, in both locales', () => {
+  const families = [
+    'publicPageLoadFailed',
+    'publicPageUnsupported',
+    'publicPageReconciling',
+    'publicPageTimedOutNotApplied',
+    'publicPageLatestLoaded',
+    'publicPageChangedElsewhere',
+    'publicPageUnresolved',
+    'publicPageCheckAgain',
+    'publicPageReload',
+    'publicPageNoOpAdvance',
+    'publicPageSaved',
+    'publicPageError',
+  ] as const;
+
+  it('is filled in for en and es', () => {
+    for (const key of families) {
+      expect(m[key], `en.${key}`).toBeTruthy();
+      expect(es[key], `es.${key}`).toBeTruthy();
+    }
+  });
+
+  it('keeps ambiguity out of the save/failure copy', () => {
+    // "Saving…" and "Could not save" are claims. An unknown outcome is neither.
+    for (const key of [
+      'publicPageReconciling',
+      'publicPageTimedOutNotApplied',
+      'publicPageUnresolved',
+      'publicPageNoOpAdvance',
+      'publicPageLatestLoaded',
+    ] as const) {
+      expect(m[key]).not.toBe(m.publicPageSaving);
+      expect(m[key]).not.toBe(m.publicPageError);
+      expect(m[key]).not.toBe(m.publicPageSaved);
+      expect(es[key]).not.toBe(es.publicPageSaving);
+      expect(es[key]).not.toBe(es.publicPageError);
+      expect(es[key]).not.toBe(es.publicPageSaved);
+    }
+  });
+
+  it('distinguishes a no-op advance from a change made elsewhere', () => {
+    expect(m.publicPageNoOpAdvance).not.toBe(m.publicPageChangedElsewhere);
+    expect(m.publicPageNoOpAdvance).not.toBe(m.publicPageLatestLoaded);
+    expect(es.publicPageNoOpAdvance).not.toBe(es.publicPageChangedElsewhere);
+    expect(es.publicPageNoOpAdvance).not.toBe(es.publicPageLatestLoaded);
   });
 });

--- a/apps/web/app/admin/settings/public-page.tsx
+++ b/apps/web/app/admin/settings/public-page.tsx
@@ -1,40 +1,87 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 import type { MemberProfile } from '@quill/types';
 import type { FormsMessages } from '@quill/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/toast';
-import { saveMyProfileAction, myProfileAction, type ProfileSaveState } from './actions';
-import {
-  callAction,
-  callActionWithRetry,
-  isTransportError,
-  type TransportError,
-} from '@/lib/call-action';
+import { saveMyProfileAction } from './actions';
+import { callAction, isTransportError } from '@/lib/call-action';
 
 type Msgs = FormsMessages['admin']['settings'];
 
-/**
- * What a save attempt proves about the STORED profile.
- *
- * `saved` is the server's own copy. `rejected` means the server refused and
- * stored nothing. `unknown` is the dangerous one: the call never produced a
- * verdict, and a client-side timeout does not abort the PUT — the write may
- * have landed. Neither the value that was sent nor the one held before it is
- * evidence of what is stored, so this outcome carries no profile at all.
- */
-export type SaveVerdict =
-  | { status: 'saved'; profile: MemberProfile | null }
-  | { status: 'rejected'; message: string | null }
-  | { status: 'unknown' };
+/** What the server render found: the page, or why it cannot be edited. */
+export type PublicPageLoad =
+  | { status: 'ok'; profile: MemberProfile | null; revision: number }
+  | { status: 'failed' }
+  | { status: 'unsupported' };
 
-export function readSaveVerdict(res: ProfileSaveState | TransportError): SaveVerdict {
-  if (isTransportError(res)) return { status: 'unknown' };
-  if (!res.ok) return { status: 'rejected', message: res.message ?? null };
-  return { status: 'saved', profile: res.profile };
+/** The stored page and the revision it was read at — the only editable baseline. */
+interface Authoritative {
+  profile: MemberProfile | null;
+  revision: number;
+}
+
+/**
+ * Every state this section can be in. `reconciling` and `unresolved` are the
+ * ones worth naming: a save whose answer never arrived is not a success and not
+ * a failure, and until it is settled nothing may be written and no on/off state
+ * may be claimed.
+ */
+type Phase =
+  | { kind: 'ready' }
+  | { kind: 'blocked'; reason: 'load' | 'capability' }
+  | { kind: 'reconciling' }
+  | { kind: 'unresolved' };
+
+/** What the fence Route Handler answers. */
+type FenceResponse =
+  | { status: 'ok'; profile: MemberProfile | null; revision: number }
+  | { status: 'conflict'; profile: MemberProfile | null; revision: number }
+  | { status: 'unauthorized' | 'not_found' | 'unsupported' | 'unknown' | 'failed' };
+
+const RECONCILE_URL = '/api/settings/public-page/reconcile';
+
+/**
+ * Are two stored pages the same page? Compared on normalized JSON, because the
+ * server re-parses the blob on every write: key order, and absent optional
+ * keys, are not a change the member made.
+ */
+export function sameStoredProfile(a: MemberProfile | null, b: MemberProfile | null): boolean {
+  const norm = (p: MemberProfile | null): string =>
+    p == null
+      ? 'null'
+      : JSON.stringify(
+          Object.fromEntries(
+            Object.entries(p as Record<string, unknown>)
+              .filter(([, v]) => v !== undefined)
+              .sort(([x], [y]) => x.localeCompare(y)),
+          ),
+        );
+  return norm(a) === norm(b);
+}
+
+/**
+ * Read a settled fence as a statement about the ambiguous save.
+ *
+ * The fence won  -> that save never landed and never can: nothing was applied.
+ * The fence lost -> something else got there first. We adopt what came back but
+ *   never claim authorship: "changed" and "unchanged" get different copy, and
+ *   neither of them is "Saved".
+ */
+export function readFenceOutcome(
+  baseline: MemberProfile | null,
+  result: { status: 'ok' | 'conflict'; profile: MemberProfile | null; revision: number },
+): { adopt: Authoritative; notice: 'not-applied' | 'latest-loaded' | 'no-op-advance' } {
+  const adopt = { profile: result.profile, revision: result.revision };
+  if (result.status === 'ok') return { adopt, notice: 'not-applied' };
+  return {
+    adopt,
+    notice: sameStoredProfile(baseline, result.profile) ? 'no-op-advance' : 'latest-loaded',
+  };
 }
 
 /**
@@ -45,49 +92,115 @@ export function readSaveVerdict(res: ProfileSaveState | TransportError): SaveVer
  * teammate the moment the migration ran — the switch is what makes it a
  * decision rather than a side-effect. Turning it off again removes the page
  * entirely; it goes straight back to the 404 it was.
+ *
+ * The switch and the "View page" link render ONLY from `authoritative`: state
+ * the server said it stores, at a revision. The headline and bio being typed
+ * live separately and are never thrown away by a reconciliation.
  */
 export function PublicPageSettings({
   publicPath,
-  initial,
+  load,
   m,
 }: {
   /** The URL this page will live at, or null when the member has no handle. */
   publicPath: string | null;
-  initial: MemberProfile | null;
+  load: PublicPageLoad;
   m: Msgs;
 }) {
   const { success, error } = useToast();
+  const router = useRouter();
   const [pending, start] = useTransition();
-  // The last profile the server told us it stores — what the switch and the
-  // View link render. It moves only when the server answers, never on click.
-  const [saved, setSaved] = useState<MemberProfile | null>(initial);
-  // `false` while a save's outcome is unknown: the screen has no authority to
-  // show a state or to write one, so it shows neither until the reread lands.
-  const [settled, setSettled] = useState(true);
-  const [headline, setHeadline] = useState(initial?.headline ?? '');
-  const [bio, setBio] = useState(initial?.bio ?? '');
-  const enabled = saved?.enabled ?? false;
 
-  /** Ask the server what it stores. The only way out of an unknown state. */
-  function reread() {
-    start(async () => {
-      // A read is idempotent, so a few in-place attempts are safe and spare the
-      // member a reload to escape a blocked section.
-      const res = await callActionWithRetry(() => myProfileAction());
-      if (isTransportError(res) || !res.ok) {
-        // Still nothing authoritative: stay blocked rather than guess.
-        error(m.publicPageError);
+  const [authoritative, setAuthoritative] = useState<Authoritative | null>(
+    load.status === 'ok' ? { profile: load.profile, revision: load.revision } : null,
+  );
+  const [phase, setPhase] = useState<Phase>(
+    load.status === 'ok'
+      ? { kind: 'ready' }
+      : { kind: 'blocked', reason: load.status === 'failed' ? 'load' : 'capability' },
+  );
+  /** The revision the ambiguous save expected. Every retry re-uses THIS one. */
+  const [ambiguous, setAmbiguous] = useState<{
+    revision: number;
+    baseline: MemberProfile | null;
+  } | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // The member's own text, kept apart from stored state so adopting an
+  // authoritative profile never deletes what they are in the middle of writing.
+  const [headline, setHeadline] = useState(load.status === 'ok' ? (load.profile?.headline ?? '') : '');
+  const [bio, setBio] = useState(load.status === 'ok' ? (load.profile?.bio ?? '') : '');
+
+  // A refresh after a settled save re-renders this page with newer stored state.
+  // Adopt it only when it is actually newer, so a remount cannot walk the
+  // reconciled revision backwards.
+  useEffect(() => {
+    if (load.status !== 'ok') return;
+    setAuthoritative((prev) =>
+      prev && prev.revision >= load.revision
+        ? prev
+        : { profile: load.profile, revision: load.revision },
+    );
+  }, [load]);
+
+  const settled = phase.kind === 'ready';
+  const canWrite = settled && !pending && !!publicPath && authoritative !== null;
+  const enabled = settled ? (authoritative?.profile?.enabled ?? false) : false;
+
+  function adopt(next: Authoritative, message: string) {
+    setAuthoritative(next);
+    setAmbiguous(null);
+    setPhase({ kind: 'ready' });
+    setNotice(message);
+    // The server already revalidated; pull the fresh render so a later remount
+    // starts from the state we just reconciled to.
+    router.refresh();
+  }
+
+  /**
+   * Settle the ambiguous save with the ORIGINAL expected revision, off the
+   * Server Action queue. Repeating this is safe: the first fence spends that
+   * revision, so every repeat conflicts instead of advancing the counter again.
+   */
+  function reconcile(pin: { revision: number; baseline: MemberProfile | null }) {
+    setPhase({ kind: 'reconciling' });
+    setNotice(m.publicPageReconciling);
+    void (async () => {
+      let result: FenceResponse;
+      try {
+        const res = await fetch(RECONCILE_URL, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ expectedRevision: pin.revision }),
+          cache: 'no-store',
+        });
+        result = (await res.json()) as FenceResponse;
+      } catch {
+        result = { status: 'unknown' };
+      }
+
+      if (result.status === 'ok' || result.status === 'conflict') {
+        const outcome = readFenceOutcome(pin.baseline, result);
+        adopt(
+          outcome.adopt,
+          outcome.notice === 'not-applied'
+            ? m.publicPageTimedOutNotApplied
+            : outcome.notice === 'no-op-advance'
+              ? m.publicPageNoOpAdvance
+              : m.publicPageLatestLoaded,
+        );
         return;
       }
-      setSaved(res.profile);
-      setSettled(true);
-    });
+      // Still undecided — including an expired session, which comes back as a
+      // JSON status rather than a login page. Editing stays off.
+      setPhase({ kind: 'unresolved' });
+      setNotice(m.publicPageUnresolved);
+    })();
   }
 
   function save(nextEnabled = enabled) {
-    // Blocked while the stored state is unknown: any payload built here would
-    // carry a pre-save value over whatever the server ended up storing.
-    if (!settled) return;
+    if (!canWrite || !authoritative) return;
+    const baseline = authoritative;
     start(async () => {
       const profile: MemberProfile = {
         version: 1,
@@ -96,25 +209,49 @@ export function PublicPageSettings({
         bio: bio.trim() || null,
         // Preserve what this screen does not edit yet rather than dropping it —
         // a save here must not silently wipe links or a palette set elsewhere.
-        links: saved?.links,
-        formSlugs: saved?.formSlugs,
-        branding: saved?.branding,
+        links: baseline.profile?.links,
+        formSlugs: baseline.profile?.formSlugs,
+        branding: baseline.profile?.branding,
       };
-      const verdict = readSaveVerdict(await callAction(() => saveMyProfileAction(profile)));
-      if (verdict.status === 'unknown') {
-        setSettled(false);
-        error(m.publicPageError);
-        reread();
+      const res = await callAction(() => saveMyProfileAction(profile, baseline.revision));
+
+      // A transport failure and a server "unknown" mean the same thing: the
+      // write may have landed. Neither may be announced either way.
+      if (isTransportError(res) || res.status === 'unknown') {
+        const pin = { revision: baseline.revision, baseline: baseline.profile };
+        setAmbiguous(pin);
+        reconcile(pin);
         return;
       }
-      if (verdict.status === 'rejected') {
-        error(verdict.message ?? m.publicPageError);
+      if (res.status === 'ok') {
+        setAuthoritative({ profile: res.profile, revision: res.revision });
+        setNotice(null);
+        success(m.publicPageSaved);
         return;
       }
-      setSaved(verdict.profile);
-      success(m.publicPageSaved);
+      if (res.status === 'conflict') {
+        // Somebody else's write won. Adopt what is stored — including the fields
+        // this screen only carries — while the draft text stays untouched.
+        setAuthoritative({ profile: res.profile, revision: res.revision });
+        setNotice(m.publicPageChangedElsewhere);
+        error(m.publicPageChangedElsewhere);
+        return;
+      }
+      if (res.status === 'unsupported') {
+        setPhase({ kind: 'blocked', reason: 'capability' });
+        setNotice(m.publicPageUnsupported);
+        return;
+      }
+      error(m.publicPageError);
     });
   }
+
+  const blockedMessage =
+    phase.kind === 'blocked'
+      ? phase.reason === 'load'
+        ? m.publicPageLoadFailed
+        : m.publicPageUnsupported
+      : null;
 
   return (
     <section
@@ -132,20 +269,57 @@ export function PublicPageSettings({
               <Switch
                 checked={enabled}
                 onCheckedChange={(v) => save(v)}
-                disabled={pending || !publicPath}
+                disabled={!canWrite}
                 aria-label={m.publicPageEnable}
               />
               {m.publicPageEnable}
             </>
           ) : (
-            // Nothing is known about the stored page: no toggle to click, and
-            // no on/off claim to read, until the reread answers.
-            <span aria-live="polite" className="text-muted-foreground">
-              {m.publicPageSaving}
+            // Nothing authoritative to show: no toggle to click and no on/off
+            // claim to read until the state is known again.
+            <span
+              data-testid="public-page-status"
+              aria-live="polite"
+              className="text-muted-foreground"
+            >
+              {phase.kind === 'reconciling'
+                ? m.publicPageReconciling
+                : (blockedMessage ?? m.publicPageUnresolved)}
             </span>
           )}
         </label>
       </div>
+
+      {notice ? (
+        <p data-testid="public-page-notice" className="mt-3 text-sm text-muted-foreground">
+          {notice}
+        </p>
+      ) : null}
+
+      {phase.kind === 'unresolved' || phase.kind === 'blocked' ? (
+        <div className="mt-3 flex items-center gap-3">
+          {ambiguous ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              data-testid="public-page-check-again"
+              onClick={() => reconcile(ambiguous)}
+            >
+              {m.publicPageCheckAgain}
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            data-testid="public-page-reload"
+            onClick={() => router.refresh()}
+          >
+            {m.publicPageReload}
+          </Button>
+        </div>
+      ) : null}
 
       {!publicPath ? (
         <p className="mt-4 text-sm text-muted-foreground">{m.publicPageNoHandle}</p>
@@ -163,6 +337,7 @@ export function PublicPageSettings({
                 maxLength={120}
                 placeholder={m.publicPageHeadlinePlaceholder}
                 onChange={(e) => setHeadline(e.target.value)}
+                disabled={!settled}
               />
             </label>
             <label className="flex flex-col gap-1.5">
@@ -173,11 +348,12 @@ export function PublicPageSettings({
                 rows={4}
                 placeholder={m.publicPageBioPlaceholder}
                 onChange={(e) => setBio(e.target.value)}
-                className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                disabled={!settled}
+                className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
               />
             </label>
             <div className="flex items-center gap-3">
-              <Button onClick={() => save()} disabled={pending || !settled} size="sm">
+              <Button onClick={() => save()} disabled={!canWrite} size="sm">
                 {pending ? m.publicPageSaving : m.publicPageSave}
               </Button>
               {settled && enabled ? (

--- a/apps/web/app/admin/settings/public-page.tsx
+++ b/apps/web/app/admin/settings/public-page.tsx
@@ -7,10 +7,31 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/toast';
-import { saveMyProfileAction } from './actions';
-import { callAction, isTransportError } from '@/lib/call-action';
+import { saveMyProfileAction, type ProfileSaveState } from './actions';
+import { callAction, isTransportError, type TransportError } from '@/lib/call-action';
 
 type Msgs = FormsMessages['admin']['settings'];
+
+/**
+ * Read a save attempt as a statement about PERSISTED state.
+ *
+ * The switch used to move on click and stay there, so a refused save left the
+ * toggle — and the "View page" link beside it — describing a page the server
+ * had declined to publish, or hiding one it had declined to take down. Only a
+ * server verdict may move the screen: a success adopts the profile that came
+ * back, a refusal keeps the last confirmed one, and a transport failure (no
+ * verdict at all) settles nothing rather than promoting a hope to a fact.
+ */
+export function reconcileProfileSave(
+  confirmed: MemberProfile | null,
+  res: ProfileSaveState | TransportError,
+): { profile: MemberProfile | null; saved: boolean; message: string | null } {
+  // Never reached the server: the write may or may not have landed, so the only
+  // honest thing on screen is the last state the server did confirm.
+  if (isTransportError(res)) return { profile: confirmed, saved: false, message: null };
+  if (!res.ok) return { profile: confirmed, saved: false, message: res.message ?? null };
+  return { profile: res.profile, saved: true, message: null };
+}
 
 /**
  * The public member page editor.
@@ -33,26 +54,31 @@ export function PublicPageSettings({
 }) {
   const { success, error } = useToast();
   const [pending, start] = useTransition();
-  const [enabled, setEnabled] = useState(initial?.enabled ?? false);
+  // The last profile the server confirmed — what the switch and the View link
+  // render. It moves only when a save comes back, never on click.
+  const [saved, setSaved] = useState<MemberProfile | null>(initial);
   const [headline, setHeadline] = useState(initial?.headline ?? '');
   const [bio, setBio] = useState(initial?.bio ?? '');
+  const enabled = saved?.enabled ?? false;
 
   function save(nextEnabled = enabled) {
     start(async () => {
-      const profile: MemberProfile | null = {
+      const profile: MemberProfile = {
         version: 1,
         enabled: nextEnabled,
         headline: headline.trim() || null,
         bio: bio.trim() || null,
         // Preserve what this screen does not edit yet rather than dropping it —
         // a save here must not silently wipe links or a palette set elsewhere.
-        links: initial?.links,
-        formSlugs: initial?.formSlugs,
-        branding: initial?.branding,
+        links: saved?.links,
+        formSlugs: saved?.formSlugs,
+        branding: saved?.branding,
       };
       const res = await callAction(() => saveMyProfileAction(profile));
-      if (res.ok) success(m.publicPageSaved);
-      else error((isTransportError(res) ? null : res.message) ?? m.publicPageError);
+      const next = reconcileProfileSave(saved, res);
+      setSaved(next.profile);
+      if (next.saved) success(m.publicPageSaved);
+      else error(next.message ?? m.publicPageError);
     });
   }
 
@@ -69,10 +95,7 @@ export function PublicPageSettings({
         <label className="flex shrink-0 items-center gap-2 text-sm">
           <Switch
             checked={enabled}
-            onCheckedChange={(v) => {
-              setEnabled(v);
-              save(v);
-            }}
+            onCheckedChange={(v) => save(v)}
             disabled={pending || !publicPath}
             aria-label={m.publicPageEnable}
           />

--- a/apps/web/app/admin/settings/public-page.tsx
+++ b/apps/web/app/admin/settings/public-page.tsx
@@ -7,30 +7,34 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/toast';
-import { saveMyProfileAction, type ProfileSaveState } from './actions';
-import { callAction, isTransportError, type TransportError } from '@/lib/call-action';
+import { saveMyProfileAction, myProfileAction, type ProfileSaveState } from './actions';
+import {
+  callAction,
+  callActionWithRetry,
+  isTransportError,
+  type TransportError,
+} from '@/lib/call-action';
 
 type Msgs = FormsMessages['admin']['settings'];
 
 /**
- * Read a save attempt as a statement about PERSISTED state.
+ * What a save attempt proves about the STORED profile.
  *
- * The switch used to move on click and stay there, so a refused save left the
- * toggle — and the "View page" link beside it — describing a page the server
- * had declined to publish, or hiding one it had declined to take down. Only a
- * server verdict may move the screen: a success adopts the profile that came
- * back, a refusal keeps the last confirmed one, and a transport failure (no
- * verdict at all) settles nothing rather than promoting a hope to a fact.
+ * `saved` is the server's own copy. `rejected` means the server refused and
+ * stored nothing. `unknown` is the dangerous one: the call never produced a
+ * verdict, and a client-side timeout does not abort the PUT — the write may
+ * have landed. Neither the value that was sent nor the one held before it is
+ * evidence of what is stored, so this outcome carries no profile at all.
  */
-export function reconcileProfileSave(
-  confirmed: MemberProfile | null,
-  res: ProfileSaveState | TransportError,
-): { profile: MemberProfile | null; saved: boolean; message: string | null } {
-  // Never reached the server: the write may or may not have landed, so the only
-  // honest thing on screen is the last state the server did confirm.
-  if (isTransportError(res)) return { profile: confirmed, saved: false, message: null };
-  if (!res.ok) return { profile: confirmed, saved: false, message: res.message ?? null };
-  return { profile: res.profile, saved: true, message: null };
+export type SaveVerdict =
+  | { status: 'saved'; profile: MemberProfile | null }
+  | { status: 'rejected'; message: string | null }
+  | { status: 'unknown' };
+
+export function readSaveVerdict(res: ProfileSaveState | TransportError): SaveVerdict {
+  if (isTransportError(res)) return { status: 'unknown' };
+  if (!res.ok) return { status: 'rejected', message: res.message ?? null };
+  return { status: 'saved', profile: res.profile };
 }
 
 /**
@@ -54,14 +58,36 @@ export function PublicPageSettings({
 }) {
   const { success, error } = useToast();
   const [pending, start] = useTransition();
-  // The last profile the server confirmed — what the switch and the View link
-  // render. It moves only when a save comes back, never on click.
+  // The last profile the server told us it stores — what the switch and the
+  // View link render. It moves only when the server answers, never on click.
   const [saved, setSaved] = useState<MemberProfile | null>(initial);
+  // `false` while a save's outcome is unknown: the screen has no authority to
+  // show a state or to write one, so it shows neither until the reread lands.
+  const [settled, setSettled] = useState(true);
   const [headline, setHeadline] = useState(initial?.headline ?? '');
   const [bio, setBio] = useState(initial?.bio ?? '');
   const enabled = saved?.enabled ?? false;
 
+  /** Ask the server what it stores. The only way out of an unknown state. */
+  function reread() {
+    start(async () => {
+      // A read is idempotent, so a few in-place attempts are safe and spare the
+      // member a reload to escape a blocked section.
+      const res = await callActionWithRetry(() => myProfileAction());
+      if (isTransportError(res) || !res.ok) {
+        // Still nothing authoritative: stay blocked rather than guess.
+        error(m.publicPageError);
+        return;
+      }
+      setSaved(res.profile);
+      setSettled(true);
+    });
+  }
+
   function save(nextEnabled = enabled) {
+    // Blocked while the stored state is unknown: any payload built here would
+    // carry a pre-save value over whatever the server ended up storing.
+    if (!settled) return;
     start(async () => {
       const profile: MemberProfile = {
         version: 1,
@@ -74,11 +100,19 @@ export function PublicPageSettings({
         formSlugs: saved?.formSlugs,
         branding: saved?.branding,
       };
-      const res = await callAction(() => saveMyProfileAction(profile));
-      const next = reconcileProfileSave(saved, res);
-      setSaved(next.profile);
-      if (next.saved) success(m.publicPageSaved);
-      else error(next.message ?? m.publicPageError);
+      const verdict = readSaveVerdict(await callAction(() => saveMyProfileAction(profile)));
+      if (verdict.status === 'unknown') {
+        setSettled(false);
+        error(m.publicPageError);
+        reread();
+        return;
+      }
+      if (verdict.status === 'rejected') {
+        error(verdict.message ?? m.publicPageError);
+        return;
+      }
+      setSaved(verdict.profile);
+      success(m.publicPageSaved);
     });
   }
 
@@ -93,13 +127,23 @@ export function PublicPageSettings({
           <p className="mt-0.5 text-sm text-muted-foreground">{m.publicPageSubtitle}</p>
         </div>
         <label className="flex shrink-0 items-center gap-2 text-sm">
-          <Switch
-            checked={enabled}
-            onCheckedChange={(v) => save(v)}
-            disabled={pending || !publicPath}
-            aria-label={m.publicPageEnable}
-          />
-          {m.publicPageEnable}
+          {settled ? (
+            <>
+              <Switch
+                checked={enabled}
+                onCheckedChange={(v) => save(v)}
+                disabled={pending || !publicPath}
+                aria-label={m.publicPageEnable}
+              />
+              {m.publicPageEnable}
+            </>
+          ) : (
+            // Nothing is known about the stored page: no toggle to click, and
+            // no on/off claim to read, until the reread answers.
+            <span aria-live="polite" className="text-muted-foreground">
+              {m.publicPageSaving}
+            </span>
+          )}
         </label>
       </div>
 
@@ -133,10 +177,10 @@ export function PublicPageSettings({
               />
             </label>
             <div className="flex items-center gap-3">
-              <Button onClick={() => save()} disabled={pending} size="sm">
+              <Button onClick={() => save()} disabled={pending || !settled} size="sm">
                 {pending ? m.publicPageSaving : m.publicPageSave}
               </Button>
-              {enabled ? (
+              {settled && enabled ? (
                 <a
                   href={publicPath}
                   target="_blank"

--- a/apps/web/app/api/settings/public-page/reconcile/route.spec.ts
+++ b/apps/web/app/api/settings/public-page/reconcile/route.spec.ts
@@ -19,6 +19,14 @@ vi.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => revalidatePa
 
 import * as route from './route';
 
+/** A request as it arrives behind a proxy: public Origin, internal Host. */
+const proxied = (headers: Record<string, string>): Request =>
+  new Request('https://forms.example.com/api/settings/public-page/reconcile', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify({ expectedRevision: 4 }),
+  });
+
 const post = (body: unknown, headers: Record<string, string> = {}): Request =>
   new Request('https://forms.example.com/api/settings/public-page/reconcile', {
     method: 'POST',
@@ -92,6 +100,64 @@ describe('POST /api/settings/public-page/reconcile', () => {
 
     expect(fenceMyProfileV2).toHaveBeenCalledWith(1);
     expect(fenceMyProfileV2).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a proxied call whose forwarded host matches the public origin', async () => {
+    // The internal Host is a service name; the browser only ever sees the public
+    // origin. Comparing the raw Host would reject every real call behind a
+    // proxy, and "Check again" could never leave the unresolved state.
+    fenceMyProfileV2.mockResolvedValue({ status: 'ok', profile: null, revision: 5 });
+
+    const res = await route.POST(
+      proxied({
+        origin: 'https://forms.example.com',
+        host: 'web.internal.svc:3000',
+        'x-forwarded-host': 'forms.example.com',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(fenceMyProfileV2).toHaveBeenCalledWith(4);
+  });
+
+  it('takes the first hop of a chained forwarded host', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'ok', profile: null, revision: 5 });
+
+    const res = await route.POST(
+      proxied({
+        origin: 'https://forms.example.com',
+        host: 'web.internal.svc:3000',
+        'x-forwarded-host': 'forms.example.com, inner.mesh',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it('still rejects a foreign origin behind that same proxy shape', async () => {
+    const res = await route.POST(
+      proxied({
+        origin: 'https://evil.example',
+        host: 'web.internal.svc:3000',
+        'x-forwarded-host': 'forms.example.com',
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(fenceMyProfileV2).not.toHaveBeenCalled();
+  });
+
+  it('rejects a forwarded host that does not match the claimed origin', async () => {
+    const res = await route.POST(
+      proxied({
+        origin: 'https://forms.example.com',
+        host: 'forms.example.com',
+        'x-forwarded-host': 'attacker.example',
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(fenceMyProfileV2).not.toHaveBeenCalled();
   });
 
   it('answers an expired session with JSON 401, never login HTML at 200', async () => {

--- a/apps/web/app/api/settings/public-page/reconcile/route.spec.ts
+++ b/apps/web/app/api/settings/public-page/reconcile/route.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * The reconciliation Route Handler — the only thing that can settle a public
+ * page save whose answer never arrived.
+ *
+ * It exists off the Server Action queue, so its guarantees are its own: POST
+ * only, same-origin only, revision required, and every refusal is JSON with a
+ * matching status code. A background caller must never receive login HTML with
+ * a 200, and a GET must never be able to advance a revision.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fenceMyProfileV2 = vi.fn();
+const revalidatePath = vi.fn();
+
+vi.mock('@/lib/admin-api', () => ({
+  fenceMyProfileV2: (...a: unknown[]) => fenceMyProfileV2(...a),
+}));
+vi.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => revalidatePath(...a) }));
+
+import * as route from './route';
+
+const post = (body: unknown, headers: Record<string, string> = {}): Request =>
+  new Request('https://forms.example.com/api/settings/public-page/reconcile', {
+    method: 'POST',
+    headers: { origin: 'https://forms.example.com', host: 'forms.example.com', ...headers },
+    body: JSON.stringify(body),
+  });
+
+describe('POST /api/settings/public-page/reconcile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is the only verb: nothing else can mutate a revision', () => {
+    expect(typeof route.POST).toBe('function');
+    for (const verb of ['GET', 'HEAD', 'PUT', 'PATCH', 'DELETE'] as const) {
+      expect(route[verb as keyof typeof route]).toBeUndefined();
+    }
+  });
+
+  it('fences with the revision it was given and returns the settled state', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'ok', profile: null, revision: 7 });
+
+    const res = await route.POST(post({ expectedRevision: 6 }));
+
+    expect(fenceMyProfileV2).toHaveBeenCalledWith(6);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok', profile: null, revision: 7 });
+    expect(revalidatePath).toHaveBeenCalledWith('/admin/settings');
+  });
+
+  it('passes a conflict back with the authoritative state', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'conflict', profile: null, revision: 9 });
+
+    const res = await route.POST(post({ expectedRevision: 6 }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: 'conflict', revision: 9 });
+  });
+
+  it('refuses a cross-site POST', async () => {
+    const res = await route.POST(post({ expectedRevision: 6 }, { origin: 'https://evil.example' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ status: 'forbidden' });
+    expect(fenceMyProfileV2).not.toHaveBeenCalled();
+  });
+
+  it('refuses a POST with no Origin at all', async () => {
+    const req = new Request('https://forms.example.com/api/settings/public-page/reconcile', {
+      method: 'POST',
+      headers: { host: 'forms.example.com' },
+      body: JSON.stringify({ expectedRevision: 1 }),
+    });
+
+    expect((await route.POST(req)).status).toBe(403);
+    expect(fenceMyProfileV2).not.toHaveBeenCalled();
+  });
+
+  it('accepts only a non-negative integer revision on the wire', async () => {
+    for (const bad of [undefined, null, '6', 6.5, -1, Number.MAX_SAFE_INTEGER + 1]) {
+      const res = await route.POST(post({ expectedRevision: bad }));
+      expect(res.status, `expectedRevision=${String(bad)}`).toBe(400);
+    }
+    expect(fenceMyProfileV2).not.toHaveBeenCalled();
+  });
+
+  it('ignores anything else on the wire — no profile, no member id', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'ok', profile: null, revision: 2 });
+
+    await route.POST(post({ expectedRevision: 1, memberId: 'someone-else', profile: { enabled: true } }));
+
+    expect(fenceMyProfileV2).toHaveBeenCalledWith(1);
+    expect(fenceMyProfileV2).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers an expired session with JSON 401, never login HTML at 200', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'unauthorized' });
+
+    const res = await route.POST(post({ expectedRevision: 3 }));
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(await res.json()).toEqual({ status: 'unauthorized' });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('keeps an undecided fence undecided (503), so the screen stays blocked', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'unknown' });
+
+    const res = await route.POST(post({ expectedRevision: 3 }));
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ status: 'unknown' });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('reports an API that cannot fence rather than pretending it settled', async () => {
+    fenceMyProfileV2.mockResolvedValue({ status: 'unsupported' });
+
+    expect((await route.POST(post({ expectedRevision: 3 }))).status).toBe(409);
+  });
+});

--- a/apps/web/app/api/settings/public-page/reconcile/route.ts
+++ b/apps/web/app/api/settings/public-page/reconcile/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import { fenceMyProfileV2 } from '@/lib/admin-api';
+
+/**
+ * Settle ONE public page save whose answer never arrived.
+ *
+ * Why a Route Handler and not another Server Action: actions from one tab run
+ * serially, so the call that would ask "did that save land?" queues behind the
+ * very request that is stuck. This runs off that queue, on the same origin,
+ * with the same session cookie.
+ *
+ * What it does is a FENCE, not a read: it advances the member's profile
+ * revision without touching content, using the revision the ambiguous save
+ * expected. Winning proves that save never landed and never can — its expected
+ * revision is now spent. Losing proves something else got there first and
+ * returns the authoritative state. A plain reread could not decide either way,
+ * because it can overtake the in-flight write and answer with pre-write state.
+ *
+ * POST only. A GET or HEAD must never mutate.
+ *
+ * CSRF: the session cookie is httpOnly and SameSite=Lax, so a cross-site form
+ * POST does not carry it; this route additionally requires a same-origin
+ * `Origin` header. It does not change cookie policy, and it inherits whatever
+ * SameSite guarantee the session cookie already provides — a browser that
+ * ignored SameSite would still be stopped by the Origin check below.
+ */
+
+interface FenceBody {
+  expectedRevision?: unknown;
+}
+
+const json = (body: unknown, status: number): NextResponse =>
+  NextResponse.json(body, { status, headers: { 'cache-control': 'no-store' } });
+
+/** Same-origin only: compare the Origin's host to the host we were reached on. */
+function sameOrigin(request: Request): boolean {
+  const origin = request.headers.get('origin');
+  const host = request.headers.get('host');
+  if (!origin || !host) return false;
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request) {
+  if (!sameOrigin(request)) return json({ status: 'forbidden' }, 403);
+
+  const body = (await request.json().catch(() => ({}))) as FenceBody;
+  const expectedRevision = body.expectedRevision;
+  // Only the expectation travels on the wire. No profile, no member id: the
+  // principal and account are re-derived per request from the session by the
+  // API, through the same `resolveHost` path every other admin call uses.
+  if (
+    typeof expectedRevision !== 'number' ||
+    !Number.isSafeInteger(expectedRevision) ||
+    expectedRevision < 0
+  ) {
+    return json(
+      { status: 'failed', message: 'expectedRevision must be a non-negative integer.' },
+      400,
+    );
+  }
+
+  const result = await fenceMyProfileV2(expectedRevision);
+
+  // An expired or missing session answers with a JSON status and the matching
+  // HTTP code — never login HTML at 200, which a background caller would parse
+  // as success.
+  if (result.status === 'unauthorized') return json({ status: 'unauthorized' }, 401);
+  if (result.status === 'not_found') return json({ status: 'not_found' }, 404);
+  if (result.status === 'unsupported') return json({ status: 'unsupported' }, 409);
+  if (result.status === 'failed') return json({ status: 'unknown', message: result.message }, 503);
+  if (result.status === 'unknown') return json({ status: 'unknown' }, 503);
+
+  // Settled either way: the stored state moved, so the rendered page is stale.
+  revalidatePath('/admin/settings');
+  return json(result, 200);
+}

--- a/apps/web/app/api/settings/public-page/reconcile/route.ts
+++ b/apps/web/app/api/settings/public-page/reconcile/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
 import { fenceMyProfileV2 } from '@/lib/admin-api';
+import { selfHost } from '@/lib/request-origin';
 
 /**
  * Settle ONE public page save whose answer never arrived.
@@ -33,10 +34,20 @@ interface FenceBody {
 const json = (body: unknown, status: number): NextResponse =>
   NextResponse.json(body, { status, headers: { 'cache-control': 'no-store' } });
 
-/** Same-origin only: compare the Origin's host to the host we were reached on. */
+/**
+ * Same-origin only, measured against the host this deployment actually answers
+ * onrather than the raw `Host` header.
+ *
+ * Behind a proxy the internal `Host` is a service name while the browser sends
+ * the public origin, so a raw comparison rejects every legitimate call and the
+ * screen can never leave its unresolved state. `selfHost` is the one resolver
+ * for that question — `PUBLIC_APP_URL` when configured, `X-Forwarded-Host` (first
+ * hop) then `Host` for a self-host clone that has not set it. Sharing it is the
+ * point: a second copy is how a chained proxy header quietly inverts a check.
+ */
 function sameOrigin(request: Request): boolean {
   const origin = request.headers.get('origin');
-  const host = request.headers.get('host');
+  const host = selfHost((name) => request.headers.get(name));
   if (!origin || !host) return false;
   try {
     return new URL(origin).host === host;

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -30,17 +30,34 @@ export class ApiError extends Error {
   }
 }
 
-async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+/**
+ * The identity headers one API call carries. Factored out of `req` so the
+ * revision-guarded profile calls can send exactly the same identity WITHOUT
+ * `req`'s redirect-to-login behaviour, which only makes sense while rendering a
+ * page — a Route Handler answering a background reconciliation must return
+ * JSON, not login HTML with a 200.
+ *
+ * Always returns headers, even when there is no session: the `local` provider
+ * serves developers who have none, and the API — not this function — is the
+ * authority on whether a caller is authenticated. An unauthenticated call comes
+ * back 401 from the API and is reported as such.
+ */
+export async function apiIdentityHeaders(): Promise<Record<string, string>> {
   const session = await getSession();
   // Which workspace, asked separately from who — and read from its own cookie,
   // because the local provider serves developers who have no session at all.
   // The API re-checks membership against the database; this authorizes nothing.
   const workspace = await getWorkspace();
   const headers: Record<string, string> = {};
-  if (body) headers['content-type'] = 'application/json';
   if (session?.provider === 'workos') headers['authorization'] = `Bearer ${session.accessToken}`;
   else if (session?.provider === 'local') headers['x-quill-email'] = session.email;
   if (workspace) headers['x-quill-workspace'] = workspace;
+  return headers;
+}
+
+async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = { ...(await apiIdentityHeaders()) };
+  if (body) headers['content-type'] = 'application/json';
 
   const res = await fetch(`${API_URL}${path}`, {
     method,
@@ -70,7 +87,7 @@ async function req<T>(method: string, path: string, body?: unknown): Promise<T> 
   // a Server Component render, where `cookies().set()` throws. Clearing it here
   // and redirecting anyway produced an infinite loop — the dead workspace was
   // re-sent on every hop. The handler owns its response, so the delete lands.
-  if (res.status === 403 && workspace) {
+  if (res.status === 403 && headers['x-quill-workspace']) {
     const j = (await res.clone().json().catch(() => ({}))) as { error?: string };
     if (j.error === 'WORKSPACE_FORBIDDEN') redirect('/api/workspace/reset');
   }
@@ -554,12 +571,16 @@ export const adminApi = {
   listIntegrations: () => req<IntegrationsResponse>('GET', '/v1/integrations'),
   /** Every webhook across this account's forms, read-only (secrets never selected). */
   listAccountWebhooks: () => req<AccountWebhooksResponse>('GET', '/v1/integrations/webhooks'),
-  /** The caller's own public page config (raw blob or null). */
-  myProfile: () => req<{ handle: string | null; profile: MemberProfile | null }>('GET', '/v1/me/profile'),
-  /** Replace the caller's own public page; null removes it. Echoes what is now
-   *  stored, so a caller reconciles against the server's copy, never its own. */
-  saveMyProfile: (profile: MemberProfile | null) =>
-    req<{ ok: boolean; profile: MemberProfile | null }>('PUT', '/v1/me/profile', { profile }),
+  /**
+   * The caller's own public page, with the revision to write against. `revision`
+   * is absent when the API predates the compare-and-set contract — that is the
+   * capability signal, and a client without it must not write.
+   */
+  myProfile: () =>
+    req<{ handle: string | null; profile: MemberProfile | null; revision?: number }>(
+      'GET',
+      '/v1/me/profile',
+    ),
   /** Every workspace the caller can enter, for the switcher. */
   listWorkspaces: () => req<Workspace[]>('GET', '/v1/workspaces'),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */
@@ -598,3 +619,122 @@ export const adminApi = {
   resetFormNotification: (id: string, emailKey: NotificationEmailKey) =>
     req<FormNotificationView>('POST', `/v1/forms/${id}/notifications/${emailKey}/reset`),
 };
+
+
+// --- Public page writes (v2: compare-and-set + fence) ------------------------
+
+/**
+ * How long a server-side profile call may run before we abort it.
+ *
+ * Strictly shorter than the 15s ceiling `callAction` puts on a Server Action, so
+ * the ambiguity is decided HERE, in one place we control, instead of the action
+ * being killed from outside while this fetch is still open.
+ *
+ * Aborting proves nothing about the API: the request may already have been
+ * received and committed. That is exactly why an aborted write is reported as
+ * `unknown` and settled by the fence, never reported as a failure.
+ */
+export const PROFILE_CALL_TIMEOUT_MS = 8_000;
+
+/** The stored public page and the revision behind it. */
+export interface ProfileState {
+  profile: MemberProfile | null;
+  revision: number;
+}
+
+/**
+ * Outcome of a revision-guarded profile call, as the web sees it.
+ * `unknown` is the honest answer to an aborted or dropped call: the write may
+ * have landed. `unsupported` means this API cannot guard writes at all.
+ */
+export type ProfileCallResult =
+  | { status: 'ok'; profile: MemberProfile | null; revision: number }
+  | { status: 'conflict'; profile: MemberProfile | null; revision: number }
+  | { status: 'unsupported' }
+  | { status: 'unauthorized' }
+  | { status: 'not_found' }
+  | { status: 'unknown' }
+  | { status: 'failed'; message?: string };
+
+const numericRevision = (v: unknown): number | null =>
+  typeof v === 'number' && Number.isSafeInteger(v) && v >= 0 ? v : null;
+
+/**
+ * One revision-guarded call to the API, with no redirect behaviour: every
+ * outcome comes back as a value so both a Server Action and a Route Handler can
+ * branch on it.
+ */
+async function profileCall(
+  method: 'PUT' | 'POST',
+  path: string,
+  body: Record<string, unknown>,
+  opts?: { signal?: AbortSignal },
+): Promise<ProfileCallResult> {
+  const identity = await apiIdentityHeaders();
+  const budget = AbortSignal.timeout(PROFILE_CALL_TIMEOUT_MS);
+  const signal = opts?.signal ? AbortSignal.any([opts.signal, budget]) : budget;
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}${path}`, {
+      method,
+      headers: { ...identity, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      signal,
+    });
+  } catch {
+    // Aborted, dropped, or refused before an answer: the write may still be
+    // running server-side. Do not call this a failure.
+    return { status: 'unknown' };
+  }
+
+  if (res.status === 401) return { status: 'unauthorized' };
+  if (res.status === 403) return { status: 'unauthorized' };
+  // An API that predates this contract has no /v2 route (404) and a rolled-out
+  // one has retired the /v1 shim (410). Both mean: do not write here.
+  if (res.status === 404 || res.status === 410) {
+    const body404 = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 410 || body404.error === 'NOT_FOUND') {
+      return res.status === 410 ? { status: 'unsupported' } : { status: 'not_found' };
+    }
+    return { status: 'unsupported' };
+  }
+
+  const payload = (await res.json().catch(() => ({}))) as {
+    profile?: MemberProfile | null;
+    revision?: unknown;
+    message?: string;
+    error?: string;
+  };
+  const revision = numericRevision(payload.revision);
+
+  if (res.status === 409) {
+    // A conflict without authoritative state is unusable — treat it as failure
+    // rather than adopting an invented revision.
+    if (revision === null) return { status: 'failed', message: payload.message };
+    return { status: 'conflict', profile: payload.profile ?? null, revision };
+  }
+  if (!res.ok) return { status: 'failed', message: payload.message ?? payload.error };
+  if (revision === null) return { status: 'unsupported' };
+  return { status: 'ok', profile: payload.profile ?? null, revision };
+}
+
+/** Replace the caller's public page, but only if it is still at `expectedRevision`. */
+export const saveMyProfileV2 = (
+  profile: MemberProfile | null,
+  expectedRevision: number,
+  opts?: { signal?: AbortSignal },
+): Promise<ProfileCallResult> =>
+  profileCall('PUT', '/v2/me/profile', { profile, expectedRevision }, opts);
+
+/**
+ * Order one ambiguous save: advance the revision without touching content.
+ * Winning proves the ambiguous write never landed; losing returns the state
+ * that beat it. Always called with the revision the ambiguous save expected.
+ */
+export const fenceMyProfileV2 = (
+  expectedRevision: number,
+  opts?: { signal?: AbortSignal },
+): Promise<ProfileCallResult> =>
+  profileCall('POST', '/v2/me/profile/fence', { expectedRevision }, opts);

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -577,10 +577,13 @@ export const adminApi = {
    * capability signal, and a client without it must not write.
    */
   myProfile: () =>
-    req<{ handle: string | null; profile: MemberProfile | null; revision?: number }>(
-      'GET',
-      '/v1/me/profile',
-    ),
+    req<{
+      handle: string | null;
+      profile: MemberProfile | null;
+      revision?: number;
+      /** False, or absent on a pre-CAS build: this server must not be written to. */
+      writesEnabled?: boolean;
+    }>('GET', '/v1/me/profile'),
   /** Every workspace the caller can enter, for the switcher. */
   listWorkspaces: () => req<Workspace[]>('GET', '/v1/workspaces'),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */
@@ -691,6 +694,11 @@ async function profileCall(
 
   if (res.status === 401) return { status: 'unauthorized' };
   if (res.status === 403) return { status: 'unauthorized' };
+  // The server can guard writes but has not been switched on yet. Same answer
+  // as an API that never could: do not write here.
+  if (res.status === 501) return { status: 'unsupported' };
+  // Neither landed nor lost — the API could not resolve it. Stay blocked.
+  if (res.status === 503) return { status: 'unknown' };
   // An API that predates this contract has no /v2 route (404) and a rolled-out
   // one has retired the /v1 shim (410). Both mean: do not write here.
   if (res.status === 404 || res.status === 410) {

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -581,8 +581,15 @@ export const adminApi = {
       handle: string | null;
       profile: MemberProfile | null;
       revision?: number;
-      /** False, or absent on a pre-CAS build: this server must not be written to. */
+      /** False, or absent on a pre-CAS build: no NEW save may start here. */
       writesEnabled?: boolean;
+      /**
+       * Whether this build can settle an ambiguous save. Reported separately
+       * because recovery outlives write admission: an operator closing the
+       * write gate must not strand a browser holding an expectation. Absent on
+       * an API that predates the contract, which supports neither.
+       */
+      fenceSupported?: boolean;
     }>('GET', '/v1/me/profile'),
   /** Every workspace the caller can enter, for the switcher. */
   listWorkspaces: () => req<Workspace[]>('GET', '/v1/workspaces'),
@@ -694,11 +701,6 @@ async function profileCall(
 
   if (res.status === 401) return { status: 'unauthorized' };
   if (res.status === 403) return { status: 'unauthorized' };
-  // The server can guard writes but has not been switched on yet. Same answer
-  // as an API that never could: do not write here.
-  if (res.status === 501) return { status: 'unsupported' };
-  // Neither landed nor lost — the API could not resolve it. Stay blocked.
-  if (res.status === 503) return { status: 'unknown' };
   // An API that predates this contract has no /v2 route (404) and a rolled-out
   // one has retired the /v1 shim (410). Both mean: do not write here.
   if (res.status === 404 || res.status === 410) {
@@ -723,6 +725,18 @@ async function profileCall(
     if (revision === null) return { status: 'failed', message: payload.message };
     return { status: 'conflict', profile: payload.profile ?? null, revision };
   }
+  // The ONE 5xx that is a decision rather than an accident: this build can
+  // guard writes but has not been switched on, and it says so before touching
+  // the row. It is recognised by its code, not by the status alone, so a proxy
+  // returning a bare 501 is still treated as ambiguous below.
+  if (res.status === 501 && payload.error === 'V2_WRITES_DISABLED') {
+    return { status: 'unsupported' };
+  }
+  // Every other 5xx is ambiguous, full stop. A 500 or a 502 can be raised after
+  // the row was already written — by the app, by a proxy, by a load balancer
+  // that gave up on a response — so calling it a failure would drop an
+  // expectation that is still live and let the screen claim nothing happened.
+  if (res.status >= 500) return { status: 'unknown' };
   if (!res.ok) return { status: 'failed', message: payload.message ?? payload.error };
   if (revision === null) return { status: 'unsupported' };
   return { status: 'ok', profile: payload.profile ?? null, revision };

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -556,9 +556,10 @@ export const adminApi = {
   listAccountWebhooks: () => req<AccountWebhooksResponse>('GET', '/v1/integrations/webhooks'),
   /** The caller's own public page config (raw blob or null). */
   myProfile: () => req<{ handle: string | null; profile: MemberProfile | null }>('GET', '/v1/me/profile'),
-  /** Replace the caller's own public page; null removes it. */
+  /** Replace the caller's own public page; null removes it. Echoes what is now
+   *  stored, so a caller reconciles against the server's copy, never its own. */
   saveMyProfile: (profile: MemberProfile | null) =>
-    req<{ ok: boolean }>('PUT', '/v1/me/profile', { profile }),
+    req<{ ok: boolean; profile: MemberProfile | null }>('PUT', '/v1/me/profile', { profile }),
   /** Every workspace the caller can enter, for the switcher. */
   listWorkspaces: () => req<Workspace[]>('GET', '/v1/workspaces'),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */

--- a/apps/web/lib/profile-capability.spec.ts
+++ b/apps/web/lib/profile-capability.spec.ts
@@ -112,13 +112,21 @@ describe('new web against an API with no /v2', () => {
 
 
 describe('an API that speaks v2 but has writes switched off', () => {
-  it('reports the capability as unavailable rather than letting a write through', async () => {
+  it('reports write admission as unavailable while keeping recovery available', async () => {
     server.removeAllListeners('request');
     server.on('request', (req, res) => {
       touched.push(`${req.method} ${req.url}`);
       res.setHeader('content-type', 'application/json');
       if (req.method === 'GET') {
-        res.end(JSON.stringify({ handle: 'alex-rivera', profile: null, revision: 3, writesEnabled: false }));
+        res.end(
+          JSON.stringify({
+            handle: 'alex-rivera',
+            profile: null,
+            revision: 3,
+            writesEnabled: false,
+            fenceSupported: true,
+          }),
+        );
         return;
       }
       // The gate refuses before the row is touched.
@@ -128,11 +136,89 @@ describe('an API that speaks v2 but has writes switched off', () => {
     const { saveMyProfileV2, fenceMyProfileV2, adminApi } = await import('./admin-api');
 
     expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toEqual({ status: 'unsupported' });
-    expect(await fenceMyProfileV2(3)).toEqual({ status: 'unsupported' });
-    // The read still works and says why the screen must block.
-    expect(await adminApi.myProfile()).toMatchObject({ revision: 3, writesEnabled: false });
+    // The read still works and says why the screen must block — and says,
+    // separately, that an ambiguous save can still be settled here.
+    expect(await adminApi.myProfile()).toMatchObject({
+      revision: 3,
+      writesEnabled: false,
+      fenceSupported: true,
+    });
     // And it never reaches for the deprecated writer.
     expect(touched.some((t) => t.includes('/v1/me/profile') && !t.startsWith('GET'))).toBe(false);
+  });
+
+  it('settles a fence even though new saves are refused', async () => {
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      touched.push(`${req.method} ${req.url}`);
+      res.setHeader('content-type', 'application/json');
+      if (req.url?.endsWith('/fence')) {
+        res.end(JSON.stringify({ ok: true, profile: null, revision: 4 }));
+        return;
+      }
+      res.statusCode = 501;
+      res.end(JSON.stringify({ error: 'V2_WRITES_DISABLED', message: 'not enabled' }));
+    });
+    const { saveMyProfileV2, fenceMyProfileV2 } = await import('./admin-api');
+
+    expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toEqual({ status: 'unsupported' });
+    expect(await fenceMyProfileV2(3)).toEqual({ status: 'ok', profile: null, revision: 4 });
+  });
+});
+
+describe('a mutation that came back 5xx', () => {
+  /** Answer every mutation with `status`, and record what was asked. */
+  const answerWith = (status: number, body: unknown) => {
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      touched.push(`${req.method} ${req.url}`);
+      res.statusCode = status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(body));
+    });
+  };
+
+  it('is unknown for a 500, because the row may already have been written', async () => {
+    answerWith(500, { statusCode: 500, message: 'Internal server error' });
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toEqual({ status: 'unknown' });
+  });
+
+  it('is unknown for a proxy 502 or 504, which never saw the outcome at all', async () => {
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    for (const status of [502, 504]) {
+      answerWith(status, { message: 'bad gateway' });
+      expect(await saveMyProfileV2({ version: 1, enabled: true }, 3), String(status)).toEqual({
+        status: 'unknown',
+      });
+    }
+  });
+
+  it('is unknown for a bare 501 with no contract code — a proxy can invent one', async () => {
+    answerWith(501, { message: 'not implemented' });
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toEqual({ status: 'unknown' });
+  });
+
+  it('sends exactly one mutation — never a silent retry that could double-apply', async () => {
+    answerWith(500, { message: 'boom' });
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    await saveMyProfileV2({ version: 1, enabled: true }, 3);
+
+    expect(touched).toEqual(['PUT /v2/me/profile']);
+  });
+
+  it('still reports a deterministic 4xx as the contract outcome it is', async () => {
+    answerWith(400, { error: 'REVISION_REQUIRED', message: 'expectedRevision required' });
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toMatchObject({
+      status: 'failed',
+    });
   });
 });
 

--- a/apps/web/lib/profile-capability.spec.ts
+++ b/apps/web/lib/profile-capability.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * New web against a LITERAL old API — over real HTTP, not a mocked module.
+ *
+ * During a rolling deploy a new web pod can reach an API pod that predates the
+ * compare-and-set contract. That API has no `/v2` route at all, so it answers a
+ * framework 404, and its `/v1` writer is sitting right there, reachable and
+ * unguarded. The rule this pins: the new web treats "no v2" as a capability
+ * failure and blocks, and it NEVER quietly writes through `/v1` instead — that
+ * fallback is exactly how an unguarded write would slip past the guard.
+ *
+ * The fake below is the old build's shape: `/v1` works and records every call,
+ * `/v2` is unknown.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+vi.mock('@/lib/auth-session', () => ({
+  getSession: async () => ({ provider: 'local', email: 'alex@example.com' }),
+  getWorkspace: async () => null,
+  clearSession: async () => undefined,
+  authProvider: () => 'local',
+}));
+
+/** Every path the web touched, in order. */
+let touched: string[] = [];
+let server: Server;
+let baseUrl: string;
+
+beforeEach(async () => {
+  touched = [];
+  server = createServer((req, res) => {
+    touched.push(`${req.method} ${req.url}`);
+    res.setHeader('content-type', 'application/json');
+    if (req.url?.startsWith('/v1/me/profile')) {
+      // The old build's writer: alive, reachable, and revision-free.
+      if (req.method === 'GET') {
+        res.end(JSON.stringify({ handle: 'alex-rivera', profile: null }));
+        return;
+      }
+      res.end(JSON.stringify({ ok: true, profile: null }));
+      return;
+    }
+    // Nest's 404 for a route this build has never heard of.
+    res.statusCode = 404;
+    res.end(
+      JSON.stringify({ statusCode: 404, message: `Cannot ${req.method} ${req.url}`, error: 'Not Found' }),
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  vi.stubEnv('API_URL', baseUrl);
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('new web against an API with no /v2', () => {
+  it('reports the capability as unavailable instead of writing', async () => {
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    const res = await saveMyProfileV2({ version: 1, enabled: true }, 0);
+
+    expect(res).toEqual({ status: 'unsupported' });
+  });
+
+  it('never falls back to the /v1 writer that is sitting right there', async () => {
+    const { saveMyProfileV2, fenceMyProfileV2 } = await import('./admin-api');
+
+    await saveMyProfileV2({ version: 1, enabled: true }, 0);
+    await fenceMyProfileV2(0);
+
+    expect(touched).toEqual(['PUT /v2/me/profile', 'POST /v2/me/profile/fence']);
+    expect(touched.some((t) => t.includes('/v1/'))).toBe(false);
+  });
+
+  it('cannot fence either, so an ambiguous save stays unsettled rather than guessed', async () => {
+    const { fenceMyProfileV2 } = await import('./admin-api');
+
+    expect(await fenceMyProfileV2(3)).toEqual({ status: 'unsupported' });
+  });
+
+  it('reads no revision from the old GET, which is what makes the screen block', async () => {
+    const { adminApi } = await import('./admin-api');
+
+    const read = await adminApi.myProfile();
+
+    expect(read.revision).toBeUndefined();
+    // The settings page maps a missing revision to `unsupported`, which blocks
+    // editing — see `public-page.spec.tsx` for what that renders.
+  });
+
+  it('still recognises a genuine member 404 as different from a missing route', async () => {
+    // A current API answers `{ error: 'NOT_FOUND' }` for a member who is gone.
+    // That must not be read as "this build cannot guard writes".
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      touched.push(`${req.method} ${req.url}`);
+      res.statusCode = 404;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ error: 'NOT_FOUND', message: 'Not found.' }));
+    });
+    const { saveMyProfileV2 } = await import('./admin-api');
+
+    expect(await saveMyProfileV2(null, 0)).toEqual({ status: 'not_found' });
+  });
+});

--- a/apps/web/lib/profile-capability.spec.ts
+++ b/apps/web/lib/profile-capability.spec.ts
@@ -35,6 +35,7 @@ beforeEach(async () => {
     if (req.url?.startsWith('/v1/me/profile')) {
       // The old build's writer: alive, reachable, and revision-free.
       if (req.method === 'GET') {
+        // An old build reports no revision and no capability at all.
         res.end(JSON.stringify({ handle: 'alex-rivera', profile: null }));
         return;
       }
@@ -106,5 +107,47 @@ describe('new web against an API with no /v2', () => {
     const { saveMyProfileV2 } = await import('./admin-api');
 
     expect(await saveMyProfileV2(null, 0)).toEqual({ status: 'not_found' });
+  });
+});
+
+
+describe('an API that speaks v2 but has writes switched off', () => {
+  it('reports the capability as unavailable rather than letting a write through', async () => {
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      touched.push(`${req.method} ${req.url}`);
+      res.setHeader('content-type', 'application/json');
+      if (req.method === 'GET') {
+        res.end(JSON.stringify({ handle: 'alex-rivera', profile: null, revision: 3, writesEnabled: false }));
+        return;
+      }
+      // The gate refuses before the row is touched.
+      res.statusCode = 501;
+      res.end(JSON.stringify({ error: 'V2_WRITES_DISABLED', message: 'not enabled' }));
+    });
+    const { saveMyProfileV2, fenceMyProfileV2, adminApi } = await import('./admin-api');
+
+    expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toEqual({ status: 'unsupported' });
+    expect(await fenceMyProfileV2(3)).toEqual({ status: 'unsupported' });
+    // The read still works and says why the screen must block.
+    expect(await adminApi.myProfile()).toMatchObject({ revision: 3, writesEnabled: false });
+    // And it never reaches for the deprecated writer.
+    expect(touched.some((t) => t.includes('/v1/me/profile') && !t.startsWith('GET'))).toBe(false);
+  });
+});
+
+describe('an API that cannot resolve a write', () => {
+  it('is reported as unknown, so the screen stays blocked instead of adopting', async () => {
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      touched.push(`${req.method} ${req.url}`);
+      res.statusCode = 503;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ error: 'WRITE_UNRESOLVED', message: 'ask again' }));
+    });
+    const { saveMyProfileV2, fenceMyProfileV2 } = await import('./admin-api');
+
+    expect(await saveMyProfileV2({ version: 1, enabled: true }, 3)).toEqual({ status: 'unknown' });
+    expect(await fenceMyProfileV2(3)).toEqual({ status: 'unknown' });
   });
 });

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -174,6 +174,16 @@ export const serverEnvSchema = z.object({
   OUTBOX_POLL_MS: z.coerce.number().int().positive().default(5000),
   OUTBOX_MAX_ATTEMPTS: z.coerce.number().int().positive().default(5),
 
+  // Revision-guarded public page writes (PUT /v2/me/profile and its fence).
+  // OFF by default and enabled only once an operator has confirmed every API
+  // instance in the fleet increments `member.profile_revision` — a pre-revision
+  // writer running beside an enabled one would move the page without moving the
+  // counter, and a fence could no longer decide anything. Reads are never gated:
+  // with this false the read reports the capability as unavailable, so a new web
+  // build blocks writing instead of failing one save at a time. Turning it back
+  // off is the FIRST step of a rollback.
+  PROFILE_V2_WRITES_ENABLED: boolish.default('false'),
+
   // DEPRECATED, REMOVE AFTER THE ROLLOUT. `PUT /v1/me/profile` is the public
   // page write that cannot compare-and-set, kept only so a web build from
   // before `PUT /v2/me/profile` keeps working while the deploy rolls. Default

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -186,12 +186,14 @@ export const serverEnvSchema = z.object({
 
   // DEPRECATED, REMOVE AFTER THE ROLLOUT. `PUT /v1/me/profile` is the public
   // page write that cannot compare-and-set, kept only so a web build from
-  // before `PUT /v2/me/profile` keeps working while the deploy rolls. Default
-  // ON so the API can roll ahead of the web without breaking old pods; set it
-  // to false once every web pod is on v2, then delete the route, the shim
-  // writer, and this flag together. It never weakens v2: the shim still
-  // increments the profile revision atomically with its write.
-  PROFILE_V1_WRITE_SHIM: boolish.default('true'),
+  // before `PUT /v2/me/profile` keeps working during the transition. OFF by
+  // default: an unguarded writer must be something a deployment switches on for
+  // a bounded window and then switches off, never something that stays alive
+  // because nobody set a variable. Turn it on for the transition, then off once
+  // no old web pod remains, then delete the route, the shim writer, and this
+  // flag together. It never weakens v2: the shim still increments the profile
+  // revision atomically with its write.
+  PROFILE_V1_WRITE_SHIM: boolish.default('false'),
 
   // CORS: a comma-separated allowlist of origins permitted to call the API from
   // a browser. When UNSET we default to PUBLIC_APP_URL only (the app's own web

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -174,6 +174,15 @@ export const serverEnvSchema = z.object({
   OUTBOX_POLL_MS: z.coerce.number().int().positive().default(5000),
   OUTBOX_MAX_ATTEMPTS: z.coerce.number().int().positive().default(5),
 
+  // DEPRECATED, REMOVE AFTER THE ROLLOUT. `PUT /v1/me/profile` is the public
+  // page write that cannot compare-and-set, kept only so a web build from
+  // before `PUT /v2/me/profile` keeps working while the deploy rolls. Default
+  // ON so the API can roll ahead of the web without breaking old pods; set it
+  // to false once every web pod is on v2, then delete the route, the shim
+  // writer, and this flag together. It never weakens v2: the shim still
+  // increments the profile revision atomically with its write.
+  PROFILE_V1_WRITE_SHIM: boolish.default('true'),
+
   // CORS: a comma-separated allowlist of origins permitted to call the API from
   // a browser. When UNSET we default to PUBLIC_APP_URL only (the app's own web
   // origin) — NOT reflect-any. To embed the public form widget on other

--- a/packages/db/migrations/postgres/0016_member_profile_revision.sql
+++ b/packages/db/migrations/postgres/0016_member_profile_revision.sql
@@ -1,0 +1,17 @@
+-- Public page write revision — additive, nullable. Migration 0016; 0015 belongs
+-- to the cache branch.
+--
+-- The public page switch could disagree with what is stored. A save whose
+-- response never arrives does not abort the write server-side, so the browser
+-- cannot tell "not applied" from "applied, answer lost". Reading the profile
+-- back does not settle it either: a read that overtakes the in-flight write
+-- returns the old value and looks like proof that nothing landed.
+--
+-- A per-member counter makes the ambiguity decidable. Every profile write
+-- increments it by exactly one, so a client that knows the revision it started
+-- from can name the write it is asking about instead of comparing content.
+--
+-- NULL is every member that existed before this column and means logical 0:
+-- reads and writes use coalesce(profile_revision, 0), never profile_revision
+-- directly, so a legacy row compares and increments like any other.
+ALTER TABLE member ADD COLUMN IF NOT EXISTS profile_revision INTEGER;

--- a/packages/db/migrations/sqlite/0016_member_profile_revision.sql
+++ b/packages/db/migrations/sqlite/0016_member_profile_revision.sql
@@ -1,0 +1,17 @@
+-- Public page write revision — additive, nullable. Migration 0016; 0015 belongs
+-- to the cache branch. Mirrors postgres/0016_member_profile_revision.sql.
+--
+-- The public page switch could disagree with what is stored. A save whose
+-- response never arrives does not abort the write server-side, so the browser
+-- cannot tell "not applied" from "applied, answer lost". Reading the profile
+-- back does not settle it either: a read that overtakes the in-flight write
+-- returns the old value and looks like proof that nothing landed.
+--
+-- A per-member counter makes the ambiguity decidable. Every profile write
+-- increments it by exactly one, so a client that knows the revision it started
+-- from can name the write it is asking about instead of comparing content.
+--
+-- NULL is every member that existed before this column and means logical 0:
+-- reads and writes use coalesce(profile_revision, 0), never profile_revision
+-- directly, so a legacy row compares and increments like any other.
+ALTER TABLE member ADD COLUMN profile_revision INTEGER;

--- a/packages/db/src/member-profile-concurrency.spec.ts
+++ b/packages/db/src/member-profile-concurrency.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * The revision contract under REAL concurrency — two connections, one row.
+ *
+ * `member-profile-revision.spec.ts` runs on either dialect, but on SQLite it can
+ * only prove sequential semantics: better-sqlite3 is synchronous and a single
+ * process serializes everything, so nothing there is a race. These orderings
+ * need two independent connections committing against the same row, so they run
+ * on Postgres only — the dialect production uses — and skip elsewhere rather
+ * than pretending SQLite proved them.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createDb, sql, type Db } from './client';
+import { migrate } from './migrate';
+import { casSetMemberProfile, fenceMemberProfile, getMemberProfileState } from './members';
+
+const url = process.env.DATABASE_URL ?? '';
+const isPostgres = url.startsWith('postgres://') || url.startsWith('postgresql://');
+
+/** Connection A and connection B — two clients, as in production. */
+let a: Db;
+let b: Db;
+let accountId: string;
+let memberId: string;
+
+const page = (headline: string) => ({ version: 1 as const, enabled: true, headline });
+
+describe.skipIf(!isPostgres)('two connections racing one public page', () => {
+  beforeEach(async () => {
+    a = await createDb(url);
+    b = await createDb(url);
+    await migrate(a);
+    accountId = randomUUID();
+    memberId = randomUUID();
+    await a.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${accountId}, ${'t' + accountId.slice(0, 8)}, ${'Test'}, ${Date.now()})`,
+    );
+    await a.run(
+      sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, created_at)
+          VALUES (${memberId}, ${accountId}, ${memberId + '@example.com'}, ${'Alex'},
+                  ${'h' + memberId.slice(0, 8)}, ${'owner'}, ${'active'}, ${Date.now()})`,
+    );
+    // Get the row to revision 5 so the expectations below are not the 0 case.
+    for (let i = 0; i < 5; i += 1) {
+      await a.run(
+        sql`UPDATE member SET profile = ${JSON.stringify(page('seed'))},
+                              profile_revision = coalesce(profile_revision, 0) + 1
+              WHERE id = ${memberId} AND account_id = ${accountId}`,
+      );
+    }
+    expect((await getMemberProfileState(a, accountId, memberId))!.revision).toBe(5);
+  });
+
+  afterEach(async () => {
+    await a.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+    await a.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+    await a.close();
+    await b.close();
+  });
+
+  it('refuses A’s delayed write once B has committed r6', async () => {
+    // A read at r5 and its request is slow. B writes and commits meanwhile.
+    const bWrote = await casSetMemberProfile(b, accountId, memberId, page('from B'), 5);
+    expect(bWrote).toMatchObject({ status: 'ok', revision: 6 });
+
+    // A finally lands. Its expectation is spent, so it must not overwrite B.
+    const aLate = await casSetMemberProfile(a, accountId, memberId, page('from A'), 5);
+
+    expect(aLate).toMatchObject({ status: 'conflict', revision: 6 });
+    expect((await getMemberProfileState(a, accountId, memberId))!.profile).toMatchObject({
+      headline: 'from B',
+    });
+  });
+
+  it('lets exactly one of two simultaneous writers win', async () => {
+    const [first, second] = await Promise.all([
+      casSetMemberProfile(a, accountId, memberId, page('from A'), 5),
+      casSetMemberProfile(b, accountId, memberId, page('from B'), 5),
+    ]);
+
+    const outcomes = [first.status, second.status].sort();
+    expect(outcomes).toEqual(['conflict', 'ok']);
+    // One increment, not two: the loser burned nothing.
+    expect((await getMemberProfileState(a, accountId, memberId))!.revision).toBe(6);
+  });
+
+  it('ordering 1 — the fence wins first, so A’s in-flight write can never land', async () => {
+    // The browser timed out on A's write and fenced from another connection.
+    const fenced = await fenceMemberProfile(b, accountId, memberId, 5);
+    expect(fenced).toMatchObject({ status: 'ok', revision: 6 });
+    expect((fenced as { profile: { headline: string } }).profile.headline).toBe('seed');
+
+    // A's write arrives late and is refused — which is exactly what the fence
+    // told the browser: "that save was not applied".
+    const aLate = await casSetMemberProfile(a, accountId, memberId, page('from A'), 5);
+
+    expect(aLate).toMatchObject({ status: 'conflict', revision: 6 });
+    expect((await getMemberProfileState(a, accountId, memberId))!.profile).toMatchObject({
+      headline: 'seed',
+    });
+  });
+
+  it('ordering 2 — A commits first, so the fence loses and reports A’s state', async () => {
+    const aWrote = await casSetMemberProfile(a, accountId, memberId, page('from A'), 5);
+    expect(aWrote).toMatchObject({ status: 'ok', revision: 6 });
+
+    // The browser still does not know that. Its fence, with the ORIGINAL
+    // expectation, now conflicts and hands back what is really stored.
+    const fenced = await fenceMemberProfile(b, accountId, memberId, 5);
+
+    expect(fenced).toMatchObject({ status: 'conflict', revision: 6 });
+    expect((fenced as { profile: { headline: string } }).profile.headline).toBe('from A');
+    // The fence lost, so it advanced nothing.
+    expect((await getMemberProfileState(a, accountId, memberId))!.revision).toBe(6);
+  });
+
+  it('keeps repeated fences from burning revisions under contention', async () => {
+    const first = await fenceMemberProfile(b, accountId, memberId, 5);
+    expect(first).toMatchObject({ status: 'ok', revision: 6 });
+
+    const repeats = await Promise.all([
+      fenceMemberProfile(a, accountId, memberId, 5),
+      fenceMemberProfile(b, accountId, memberId, 5),
+      fenceMemberProfile(a, accountId, memberId, 5),
+    ]);
+
+    for (const r of repeats) expect(r).toMatchObject({ status: 'conflict', revision: 6 });
+    expect((await getMemberProfileState(a, accountId, memberId))!.revision).toBe(6);
+  });
+});

--- a/packages/db/src/member-profile-revision.spec.ts
+++ b/packages/db/src/member-profile-revision.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * The public page write contract, at the data layer.
+ *
+ * A save whose answer never reaches the browser is ambiguous — the timeout does
+ * not abort the write. `member.profile_revision` is what makes that decidable:
+ * every writer increments it by exactly one, so a caller that knows the revision
+ * it started from can name ITS write instead of guessing from content.
+ *
+ * Runs on whichever dialect DATABASE_URL points at, so CI re-runs the same
+ * suite against real Postgres (the parity job); locally it is in-memory SQLite.
+ * SQLite here proves SEQUENTIAL semantics only — a genuine race needs two
+ * connections and lives in `member-profile-concurrency.spec.ts`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { createDb, sql, type Db } from './client';
+import { migrate } from './migrate';
+import {
+  casSetMemberProfile,
+  fenceMemberProfile,
+  getMemberProfileState,
+  normalizeProfileRevision,
+  overwriteMemberProfileLegacy,
+} from './members';
+
+let db: Db;
+let accountId: string;
+let otherAccountId: string;
+let memberId: string;
+
+const page = (enabled: boolean, headline = 'Growth partner') => ({
+  version: 1 as const,
+  enabled,
+  headline,
+});
+
+async function addAccount(): Promise<string> {
+  const id = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${id}, ${'t' + id.slice(0, 8)}, ${'Test'}, ${Date.now()})`,
+  );
+  return id;
+}
+
+async function addMember(account: string): Promise<string> {
+  const id = randomUUID();
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, display_name, handle, role, status, created_at)
+        VALUES (${id}, ${account}, ${id + '@example.com'}, ${'Alex'}, ${'h' + id.slice(0, 8)},
+                ${'owner'}, ${'active'}, ${Date.now()})`,
+  );
+  return id;
+}
+
+/** A member row as it existed before migration 0016: revision IS NULL. */
+async function makeLegacy(id: string): Promise<void> {
+  await db.run(sql`UPDATE member SET profile_revision = NULL WHERE id = ${id}`);
+}
+
+const rawRevision = async (id: string): Promise<unknown> =>
+  (await db.get<Record<string, unknown>>(sql`SELECT profile_revision FROM member WHERE id = ${id}`))
+    ?.profile_revision;
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+  accountId = await addAccount();
+  otherAccountId = await addAccount();
+  memberId = await addMember(accountId);
+});
+
+afterEach(async () => {
+  // Leave a shared Postgres database clean (memory SQLite just evaporates).
+  await db.run(sql`DELETE FROM member WHERE account_id IN (${accountId}, ${otherAccountId})`);
+  await db.run(sql`DELETE FROM account WHERE id IN (${accountId}, ${otherAccountId})`);
+  await db.close();
+});
+
+describe('compare-and-set writes', () => {
+  it('starts at 0 and advances by exactly one per write', async () => {
+    const before = await getMemberProfileState(db, accountId, memberId);
+    expect(before).toEqual({ profile: null, revision: 0 });
+
+    const first = await casSetMemberProfile(db, accountId, memberId, page(true), 0);
+    expect(first).toMatchObject({ status: 'ok', revision: 1 });
+    expect((first as { profile: { enabled: boolean } }).profile.enabled).toBe(true);
+
+    const second = await casSetMemberProfile(db, accountId, memberId, page(false), 1);
+    expect(second).toMatchObject({ status: 'ok', revision: 2 });
+    expect(await getMemberProfileState(db, accountId, memberId)).toMatchObject({ revision: 2 });
+  });
+
+  it('treats a pre-0016 row (NULL revision) as logical 0 and writes it', async () => {
+    await makeLegacy(memberId);
+    expect(await rawRevision(memberId)).toBeNull();
+
+    // Without coalesce(), the predicate `profile_revision = 0` never matches a
+    // NULL row and `profile_revision + 1` stays NULL: this is the counterfactual
+    // that fails if either loses its coalesce.
+    const res = await casSetMemberProfile(db, accountId, memberId, page(true), 0);
+
+    expect(res).toMatchObject({ status: 'ok', revision: 1 });
+    expect(await getMemberProfileState(db, accountId, memberId)).toMatchObject({ revision: 1 });
+  });
+
+  it('hands back a NUMBER, not whatever the driver returned', async () => {
+    const res = await casSetMemberProfile(db, accountId, memberId, page(true), 0);
+
+    expect(typeof (res as { revision: unknown }).revision).toBe('number');
+    const state = await getMemberProfileState(db, accountId, memberId);
+    expect(typeof state?.revision).toBe('number');
+  });
+
+  it('orders 9 before 10 — numerically, not as text', async () => {
+    for (let i = 0; i < 9; i += 1) {
+      expect(await casSetMemberProfile(db, accountId, memberId, page(true), i)).toMatchObject({
+        status: 'ok',
+        revision: i + 1,
+      });
+    }
+    const tenth = await casSetMemberProfile(db, accountId, memberId, page(false), 9);
+
+    expect(tenth).toMatchObject({ status: 'ok', revision: 10 });
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(10);
+    // A stale 9 is refused even though "9" sorts after "10" as text.
+    expect(await casSetMemberProfile(db, accountId, memberId, page(true), 9)).toMatchObject({
+      status: 'conflict',
+      revision: 10,
+    });
+  });
+
+  it('refuses a stale expectation, and burns no revision doing it', async () => {
+    await casSetMemberProfile(db, accountId, memberId, page(true), 0); // -> 1
+    await casSetMemberProfile(db, accountId, memberId, page(false), 1); // -> 2
+
+    const stale = await casSetMemberProfile(db, accountId, memberId, page(true), 0);
+
+    expect(stale).toMatchObject({ status: 'conflict', revision: 2 });
+    // The refusal is free: retrying after adopting state must not have to race a
+    // counter that the refusal itself moved.
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(2);
+    expect((await getMemberProfileState(db, accountId, memberId))!.profile).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  it('says 404 for a member who does not exist, 409 for one who moved', async () => {
+    expect(await casSetMemberProfile(db, accountId, randomUUID(), page(true), 0)).toEqual({
+      status: 'not_found',
+    });
+
+    await casSetMemberProfile(db, accountId, memberId, page(true), 0);
+    expect(await casSetMemberProfile(db, accountId, memberId, page(false), 0)).toMatchObject({
+      status: 'conflict',
+    });
+  });
+
+  it('never writes or reveals a member through the wrong account', async () => {
+    await casSetMemberProfile(db, accountId, memberId, page(true), 0);
+
+    // Same member id, different account: not a conflict — invisible.
+    expect(await casSetMemberProfile(db, otherAccountId, memberId, page(false), 1)).toEqual({
+      status: 'not_found',
+    });
+    expect(await fenceMemberProfile(db, otherAccountId, memberId, 1)).toEqual({
+      status: 'not_found',
+    });
+    expect(await getMemberProfileState(db, otherAccountId, memberId)).toBeNull();
+    // Untouched by the attempts above.
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(1);
+  });
+});
+
+describe('the fence', () => {
+  it('advances the revision without touching the page', async () => {
+    await casSetMemberProfile(db, accountId, memberId, page(true, 'Before'), 0);
+
+    const fenced = await fenceMemberProfile(db, accountId, memberId, 1);
+
+    expect(fenced).toMatchObject({ status: 'ok', revision: 2 });
+    expect((fenced as { profile: { headline: string } }).profile.headline).toBe('Before');
+    expect((await getMemberProfileState(db, accountId, memberId))!.profile).toMatchObject({
+      enabled: true,
+      headline: 'Before',
+    });
+  });
+
+  it('fences a pre-0016 row too', async () => {
+    await makeLegacy(memberId);
+
+    expect(await fenceMemberProfile(db, accountId, memberId, 0)).toMatchObject({
+      status: 'ok',
+      revision: 1,
+      profile: null,
+    });
+  });
+
+  it('is idempotent when repeated with the SAME original expectation', async () => {
+    await casSetMemberProfile(db, accountId, memberId, page(true), 0); // -> 1
+
+    const first = await fenceMemberProfile(db, accountId, memberId, 1);
+    expect(first).toMatchObject({ status: 'ok', revision: 2 });
+
+    // "Check again" re-uses the original expectation. It must not advance the
+    // counter a second time, or every retry would look like a new writer.
+    for (let i = 0; i < 3; i += 1) {
+      expect(await fenceMemberProfile(db, accountId, memberId, 1)).toMatchObject({
+        status: 'conflict',
+        revision: 2,
+      });
+    }
+    expect((await getMemberProfileState(db, accountId, memberId))!.revision).toBe(2);
+  });
+
+  it('blocks the write it fenced: that expectation can never land again', async () => {
+    await casSetMemberProfile(db, accountId, memberId, page(true), 0); // -> 1
+    await fenceMemberProfile(db, accountId, memberId, 1); // -> 2
+
+    // This is the ambiguous save arriving late. It is refused, exactly as the
+    // fence promised the browser it would be.
+    expect(await casSetMemberProfile(db, accountId, memberId, page(false), 1)).toMatchObject({
+      status: 'conflict',
+      revision: 2,
+    });
+  });
+});
+
+describe('the deprecated v1 shim writer', () => {
+  it('cannot compare, but still increments atomically with its write', async () => {
+    await casSetMemberProfile(db, accountId, memberId, page(true), 0); // -> 1
+
+    const legacy = await overwriteMemberProfileLegacy(db, accountId, memberId, page(false));
+
+    expect(legacy).toMatchObject({ status: 'ok', revision: 2 });
+    expect((await getMemberProfileState(db, accountId, memberId))!.profile).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  it('keeps the fence decidable: a fence after a shim write conflicts', async () => {
+    await overwriteMemberProfileLegacy(db, accountId, memberId, page(true)); // -> 1
+
+    expect(await fenceMemberProfile(db, accountId, memberId, 0)).toMatchObject({
+      status: 'conflict',
+      revision: 1,
+    });
+  });
+
+  it('is account-scoped like everything else', async () => {
+    expect(await overwriteMemberProfileLegacy(db, otherAccountId, memberId, page(true))).toEqual({
+      status: 'not_found',
+    });
+  });
+});
+
+describe('revision normalization', () => {
+  it('accepts what a driver may hand back for an integer column', () => {
+    // postgres-js can return integer columns as strings depending on driver
+    // configuration; SQLite hands back a number. Both must compare as numbers.
+    expect(normalizeProfileRevision(7)).toBe(7);
+    expect(normalizeProfileRevision('7')).toBe(7);
+    expect(normalizeProfileRevision(null)).toBe(0);
+    expect(normalizeProfileRevision(undefined)).toBe(0);
+  });
+
+  it('refuses to reconcile against a value that is not a safe count', () => {
+    for (const bad of [-1, 1.5, 'abc', Number.NaN, Number.MAX_SAFE_INTEGER + 1, '9007199254740993']) {
+      expect(() => normalizeProfileRevision(bad), String(bad)).toThrow();
+    }
+  });
+});
+
+describe('the writer set is closed', () => {
+  it('has no profile writer that skips the revision', () => {
+    // The guarantee the fence rests on: nothing moves `profile` without moving
+    // `profile_revision` in the same statement.
+    const source = readFileSync(fileURLToPath(new URL('./members.ts', import.meta.url)), 'utf8');
+    const writes = source.split('UPDATE member').slice(1);
+    const profileWrites = writes.filter((stmt) => /SET[\s\S]{0,120}?profile\s*=/.test(stmt));
+
+    expect(profileWrites).toHaveLength(2); // CAS + the deprecated shim
+    for (const stmt of profileWrites) {
+      expect(stmt).toContain('profile_revision = coalesce(profile_revision, 0) + 1');
+    }
+    // And every revision increment goes through coalesce, never a bare +1.
+    expect(source).not.toMatch(/profile_revision\s*\+\s*1/);
+  });
+});

--- a/packages/db/src/member-profile-serialization.spec.ts
+++ b/packages/db/src/member-profile-serialization.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * What a serialization failure is allowed to mean.
+ *
+ * Postgres can abort a statement with `40001` under contention. That rollback
+ * proves the write did not commit — and nothing else. Reading it as "somebody
+ * else won" would be a lie the UI acts on: it would adopt state, drop the
+ * blocked flag, and tell the member their save was resolved while the very same
+ * expectation is still live and retryable.
+ *
+ * The rule pinned here: after `40001`, the outcome is decided by re-reading the
+ * account-scoped row. Conflict only when the stored revision has actually moved
+ * past the expectation; absent member is not-found; a revision still sitting at
+ * the expectation is `unresolved`, which keeps the caller blocked.
+ *
+ * The failure is injected through a stub `Db`, so both dialects and both call
+ * sites are covered deterministically without racing a real database.
+ */
+import { describe, it, expect } from 'vitest';
+import { casSetMemberProfile, fenceMemberProfile } from './members';
+import type { Db } from './client';
+
+const serializationFailure = Object.assign(new Error('could not serialize access'), {
+  code: '40001',
+});
+
+/** Convenience: build the stub and expose the read counter. */
+function stub(row: Record<string, unknown> | undefined) {
+  let reads = 0;
+  const db = {
+    dialect: 'postgres' as const,
+    all: async () => {
+      throw serializationFailure;
+    },
+    get: async () => {
+      reads += 1;
+      return row;
+    },
+    run: async () => undefined,
+    execRaw: async () => undefined,
+    close: async () => undefined,
+  } as unknown as Db;
+  return { db, reads: () => reads };
+}
+
+const storedRow = (revision: number, profile: unknown = null) => ({
+  profile: profile == null ? null : JSON.stringify(profile),
+  profile_revision: revision,
+});
+
+describe('a 40001 that rolled back with the revision untouched', () => {
+  it('leaves a CAS unresolved — never a conflict', async () => {
+    // The row is still exactly where the caller expected it, so nothing consumed
+    // the expectation. Reporting a conflict here would let the UI adopt state
+    // and stop blocking while this write can still be retried.
+    const { db } = stub(storedRow(5));
+
+    expect(await casSetMemberProfile(db, 'acct', 'member', { version: 1 }, 5)).toEqual({
+      status: 'unresolved',
+    });
+  });
+
+  it('leaves a fence unresolved — never a conflict', async () => {
+    const { db } = stub(storedRow(5));
+
+    expect(await fenceMemberProfile(db, 'acct', 'member', 5)).toEqual({ status: 'unresolved' });
+  });
+
+  it('releases no revision: the expectation is still the one to retry with', async () => {
+    const { db } = stub(storedRow(0));
+
+    expect(await fenceMemberProfile(db, 'acct', 'member', 0)).toEqual({ status: 'unresolved' });
+    expect(await casSetMemberProfile(db, 'acct', 'member', null, 0)).toEqual({
+      status: 'unresolved',
+    });
+  });
+
+  it('decides by asking the database, not by assuming', async () => {
+    const s = stub(storedRow(5));
+
+    await casSetMemberProfile(s.db, 'acct', 'member', { version: 1 }, 5);
+
+    expect(s.reads()).toBe(1);
+  });
+});
+
+describe('a 40001 where the row really did move on', () => {
+  it('is a conflict, carrying the state that beat it', async () => {
+    const { db } = stub(storedRow(6, { version: 1, enabled: true }));
+
+    expect(await casSetMemberProfile(db, 'acct', 'member', { version: 1 }, 5)).toEqual({
+      status: 'conflict',
+      revision: 6,
+      profile: { version: 1, enabled: true },
+    });
+  });
+
+  it('is a conflict for a fence too', async () => {
+    const { db } = stub(storedRow(9));
+
+    expect(await fenceMemberProfile(db, 'acct', 'member', 5)).toMatchObject({
+      status: 'conflict',
+      revision: 9,
+    });
+  });
+});
+
+describe('a 40001 for a member who is not there', () => {
+  it('is not-found, for both writers', async () => {
+    const { db } = stub(undefined);
+
+    expect(await casSetMemberProfile(db, 'acct', 'member', null, 5)).toEqual({
+      status: 'not_found',
+    });
+    expect(await fenceMemberProfile(db, 'acct', 'member', 5)).toEqual({ status: 'not_found' });
+  });
+});
+
+describe('other database errors', () => {
+  it('propagate instead of being dressed up as a conflict', async () => {
+    const db = {
+      dialect: 'postgres',
+      all: async () => {
+        throw Object.assign(new Error('syntax error'), { code: '42601' });
+      },
+      get: async () => storedRow(5),
+      run: async () => undefined,
+      execRaw: async () => undefined,
+      close: async () => undefined,
+    } as unknown as Db;
+
+    await expect(casSetMemberProfile(db, 'acct', 'member', null, 5)).rejects.toThrow('syntax error');
+    await expect(fenceMemberProfile(db, 'acct', 'member', 5)).rejects.toThrow('syntax error');
+  });
+});

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -443,28 +443,199 @@ export async function listPublishedFormsForAccount(
   });
 }
 
-/** Replace a member's public page (account-scoped). NULL removes it entirely. */
-export async function setMemberProfile(
+/**
+ * The public page write path — compare-and-set over a per-member revision.
+ *
+ * A save whose answer never reaches the browser is ambiguous: the client-side
+ * timeout does not abort the write. Content cannot settle it (the stored value
+ * may equal what was sent, by coincidence or by an ABA sequence) and neither
+ * can a plain reread (it can overtake the in-flight write and return the old
+ * value). A counter can: every writer below increments it by exactly one, so a
+ * caller that knows the revision it started from can ask about ITS write.
+ *
+ * These three functions are the ONLY writers of `member.profile`, and each one
+ * increments the revision in the same statement that touches the blob — there
+ * is no path that moves the profile without moving the counter.
+ * `member-profile-revision.spec.ts` pins that closed set against the source.
+ *
+ * NULL revision is a pre-0016 row and means logical 0, so every predicate and
+ * increment goes through coalesce(profile_revision, 0).
+ */
+
+/** Authoritative profile state: the stored blob and the revision behind it. */
+export interface MemberProfileState {
+  /** The raw JSON blob, or null when this member has no page. */
+  profile: unknown;
+  revision: number;
+}
+
+/**
+ * Outcome of a revision-guarded write.
+ * - `ok`: this caller's write landed; state is what it produced.
+ * - `conflict`: the row moved on — the expected revision can never land now.
+ *   Carries authoritative state and burns NO revision.
+ * - `not_found`: no such member in this account.
+ */
+export type ProfileWriteResult =
+  | { status: 'ok'; profile: unknown; revision: number }
+  | { status: 'conflict'; profile: unknown; revision: number }
+  | { status: 'not_found' };
+
+/** Postgres serialization failure — retryable, and here it means "re-decide". */
+const PG_SERIALIZATION_FAILURE = '40001';
+
+const isSerializationFailure = (e: unknown): boolean =>
+  typeof e === 'object' && e !== null && (e as { code?: unknown }).code === PG_SERIALIZATION_FAILURE;
+
+/**
+ * A revision read off a row, as a number we can compare and hand out.
+ *
+ * Postgres drivers may return an integer column as a string (bigint coercion
+ * rules bite even on int4 once a driver is configured for it) and SQLite hands
+ * back whatever the column holds, so every read normalizes here rather than at
+ * a dozen call sites. A value that is not a safe non-negative integer is
+ * corruption, not a state to reconcile from — it fails loudly instead of
+ * silently reconciling against a wrong number.
+ */
+export function normalizeProfileRevision(raw: unknown): number {
+  const n = Number(raw ?? 0);
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new Error(`member.profile_revision is not a safe non-negative integer: ${String(raw)}`);
+  }
+  return n;
+}
+
+/** Read the authoritative profile + revision for one member (account-scoped). */
+export async function getMemberProfileState(
+  db: Db,
+  accountId: string,
+  memberId: string,
+): Promise<MemberProfileState | null> {
+  const r = await db.get<Record<string, unknown>>(
+    sql`SELECT profile, coalesce(profile_revision, 0) AS profile_revision
+          FROM member WHERE id = ${memberId} AND account_id = ${accountId} LIMIT 1`,
+  );
+  if (!r) return null;
+  return {
+    profile: r.profile == null ? null : parseJsonColumn<unknown>(r.profile, null),
+    revision: normalizeProfileRevision(r.profile_revision),
+  };
+}
+
+/** Shape one RETURNING row into an `ok` result. */
+function writtenState(r: Record<string, unknown>): ProfileWriteResult {
+  return {
+    status: 'ok',
+    profile: r.profile == null ? null : parseJsonColumn<unknown>(r.profile, null),
+    revision: normalizeProfileRevision(r.profile_revision),
+  };
+}
+
+/**
+ * Why zero rows changed: the member is gone (or belongs to another account), or
+ * the revision moved. Re-read account-scoped so a wrong account can never be
+ * answered with someone else's state.
+ */
+async function explainNoRows(
+  db: Db,
+  accountId: string,
+  memberId: string,
+): Promise<ProfileWriteResult> {
+  const current = await getMemberProfileState(db, accountId, memberId);
+  if (!current) return { status: 'not_found' };
+  return { status: 'conflict', profile: current.profile, revision: current.revision };
+}
+
+/**
+ * Replace a member's public page if — and only if — the row is still at
+ * `expectedRevision`. One atomic statement: the guard, the write and the
+ * increment cannot be separated by another writer.
+ */
+export async function casSetMemberProfile(
   db: Db,
   accountId: string,
   memberId: string,
   profile: unknown | null,
-): Promise<void> {
-  await db.run(
-    sql`UPDATE member SET profile = ${profile == null ? null : JSON.stringify(profile)}
-        WHERE id = ${memberId} AND account_id = ${accountId}`,
-  );
+  expectedRevision: number,
+): Promise<ProfileWriteResult> {
+  const expected = normalizeProfileRevision(expectedRevision);
+  try {
+    const rows = await db.all<Record<string, unknown>>(
+      sql`UPDATE member
+             SET profile = ${profile == null ? null : JSON.stringify(profile)},
+                 profile_revision = coalesce(profile_revision, 0) + 1
+           WHERE id = ${memberId} AND account_id = ${accountId}
+             AND coalesce(profile_revision, 0) = ${expected}
+       RETURNING profile, profile_revision`,
+    );
+    const row = rows[0];
+    if (row) return writtenState(row);
+  } catch (e) {
+    // A serialization failure means this write definitely did not commit, so
+    // the caller's expected revision is simply no longer decidable here — that
+    // is the conflict path, not a permanent unknown. Anything else propagates.
+    if (!isSerializationFailure(e)) throw e;
+  }
+  return explainNoRows(db, accountId, memberId);
 }
 
-/** The stored public-page blob for one member (account-scoped), or null. */
-export async function getMemberProfileRaw(
+/**
+ * Order one ambiguous write without touching content.
+ *
+ * Same predicate as the CAS, same single increment, but the profile is left
+ * exactly as it is. Winning proves the ambiguous CAS never landed and can never
+ * land (its expected revision is now spent). Losing proves something else got
+ * there first, and the authoritative state comes back so the caller can adopt
+ * it instead of guessing.
+ *
+ * A same-value profile write would not do: the blob passes through schema
+ * normalization, so "write what is already there" can still change bytes.
+ */
+export async function fenceMemberProfile(
   db: Db,
   accountId: string,
   memberId: string,
-): Promise<unknown> {
-  const r = await db.get<Record<string, unknown>>(
-    sql`SELECT profile FROM member WHERE id = ${memberId} AND account_id = ${accountId} LIMIT 1`,
+  expectedRevision: number,
+): Promise<ProfileWriteResult> {
+  const expected = normalizeProfileRevision(expectedRevision);
+  try {
+    const rows = await db.all<Record<string, unknown>>(
+      sql`UPDATE member
+             SET profile_revision = coalesce(profile_revision, 0) + 1
+           WHERE id = ${memberId} AND account_id = ${accountId}
+             AND coalesce(profile_revision, 0) = ${expected}
+       RETURNING profile, profile_revision`,
+    );
+    const row = rows[0];
+    if (row) return writtenState(row);
+  } catch (e) {
+    if (!isSerializationFailure(e)) throw e;
+  }
+  return explainNoRows(db, accountId, memberId);
+}
+
+/**
+ * DEPRECATED — the last-write-wins writer, for the `/v1` compatibility shim
+ * only (see `PROFILE_V1_WRITE_SHIM`). Remove with the shim.
+ *
+ * It cannot check a revision, because the web build that calls it does not know
+ * revisions exist. It still increments in the same statement as the write, so a
+ * fence stays monotonic and decidable even while an old tab is saving.
+ */
+export async function overwriteMemberProfileLegacy(
+  db: Db,
+  accountId: string,
+  memberId: string,
+  profile: unknown | null,
+): Promise<ProfileWriteResult> {
+  const rows = await db.all<Record<string, unknown>>(
+    sql`UPDATE member
+           SET profile = ${profile == null ? null : JSON.stringify(profile)},
+               profile_revision = coalesce(profile_revision, 0) + 1
+         WHERE id = ${memberId} AND account_id = ${accountId}
+     RETURNING profile, profile_revision`,
   );
-  if (!r || r.profile == null) return null;
-  return parseJsonColumn<unknown>(r.profile, null);
+  const row = rows[0];
+  if (row) return writtenState(row);
+  return { status: 'not_found' };
 }

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -479,7 +479,14 @@ export interface MemberProfileState {
 export type ProfileWriteResult =
   | { status: 'ok'; profile: unknown; revision: number }
   | { status: 'conflict'; profile: unknown; revision: number }
-  | { status: 'not_found' };
+  | { status: 'not_found' }
+  /**
+   * The statement did not commit AND nothing proves the expectation was
+   * consumed — a serialization failure that rolled back with the revision still
+   * where it started. It is not a conflict (nothing else won) and not a success
+   * (nothing was written), so the caller must stay blocked and ask again.
+   */
+  | { status: 'unresolved' };
 
 /** Postgres serialization failure — retryable, and here it means "re-decide". */
 const PG_SERIALIZATION_FAILURE = '40001';
@@ -535,14 +542,24 @@ function writtenState(r: Record<string, unknown>): ProfileWriteResult {
  * Why zero rows changed: the member is gone (or belongs to another account), or
  * the revision moved. Re-read account-scoped so a wrong account can never be
  * answered with someone else's state.
+ *
+ * `expectedRevision` is what makes this safe to reuse for a serialization
+ * failure. Zero rows from a COMMITTED statement already proves the expectation
+ * was consumed, but a 40001 rollback proves nothing — so the conflict is only
+ * reported when the stored revision has actually moved past what the caller
+ * expected. A revision still sitting at the expectation is unresolved, never a
+ * conflict, or a client would adopt state and publish a claim about a write
+ * that may still be retried.
  */
 async function explainNoRows(
   db: Db,
   accountId: string,
   memberId: string,
+  expectedRevision: number,
 ): Promise<ProfileWriteResult> {
   const current = await getMemberProfileState(db, accountId, memberId);
   if (!current) return { status: 'not_found' };
+  if (current.revision === expectedRevision) return { status: 'unresolved' };
   return { status: 'conflict', profile: current.profile, revision: current.revision };
 }
 
@@ -571,12 +588,12 @@ export async function casSetMemberProfile(
     const row = rows[0];
     if (row) return writtenState(row);
   } catch (e) {
-    // A serialization failure means this write definitely did not commit, so
-    // the caller's expected revision is simply no longer decidable here — that
-    // is the conflict path, not a permanent unknown. Anything else propagates.
+    // A serialization failure rolled this write back. Whether the expectation
+    // survived is decided by re-reading, not assumed: `explainNoRows` reports a
+    // conflict only when the revision actually moved. Anything else propagates.
     if (!isSerializationFailure(e)) throw e;
   }
-  return explainNoRows(db, accountId, memberId);
+  return explainNoRows(db, accountId, memberId, expected);
 }
 
 /**
@@ -611,7 +628,7 @@ export async function fenceMemberProfile(
   } catch (e) {
     if (!isSerializationFailure(e)) throw e;
   }
-  return explainNoRows(db, accountId, memberId);
+  return explainNoRows(db, accountId, memberId, expected);
 }
 
 /**
@@ -627,7 +644,7 @@ export async function overwriteMemberProfileLegacy(
   accountId: string,
   memberId: string,
   profile: unknown | null,
-): Promise<ProfileWriteResult> {
+): Promise<Extract<ProfileWriteResult, { status: 'ok' } | { status: 'not_found' }>> {
   const rows = await db.all<Record<string, unknown>>(
     sql`UPDATE member
            SET profile = ${profile == null ? null : JSON.stringify(profile)},
@@ -636,6 +653,8 @@ export async function overwriteMemberProfileLegacy(
      RETURNING profile, profile_revision`,
   );
   const row = rows[0];
-  if (row) return writtenState(row);
+  // No predicate beyond identity, so there is no conflict and nothing to
+  // resolve: it either wrote, or there was no such member in this account.
+  if (row) return writtenState(row) as Extract<ProfileWriteResult, { status: 'ok' }>;
   return { status: 'not_found' };
 }

--- a/packages/db/src/migration-order.spec.ts
+++ b/packages/db/src/migration-order.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * How the migrator decides what has run — the contract behind numbered files.
+ *
+ * Migrations arrive from parallel branches, so numbers are claimed before they
+ * merge and they do not merge in order. That is safe here, and these pin why:
+ * application is tracked by FILENAME, not by a high-water mark, so a gap in the
+ * numbering is not a hole to be filled and a lower-numbered file that lands
+ * later still applies on its own.
+ *
+ * Concretely: `0016_member_profile_revision.sql` adds a member column and has no
+ * dependency on the `0015` slot, which belongs to a separate account-integration
+ * change on another branch. Either can be applied first, or alone.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDb, sql, type Db } from './client';
+import { migrate } from './migrate';
+
+let db: Db;
+let root: string;
+let dir: string;
+
+const write = (name: string, body: string): void => writeFileSync(join(dir, name), body, 'utf8');
+
+/** Only the scratch files — the real ones are already recorded. */
+const appliedNames = async (): Promise<string[]> => {
+  const rows = await db.all<{ name: string }>(
+    sql`SELECT name FROM _migrations WHERE name LIKE '%scratch%' ORDER BY name`,
+  );
+  return rows.map((r) => r.name);
+};
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  // Start from the real schema, applied by the real migrator, so these tests
+  // measure ORDERING against the code that actually ships. The scratch set
+  // below then exercises arrival order on top of it.
+  await migrate(db);
+  root = mkdtempSync(join(tmpdir(), 'quill-migrations-'));
+  dir = join(root, db.dialect);
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(async () => {
+  await db.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('migration application is tracked by name', () => {
+  it('records each file by filename, not by a highest-number watermark', async () => {
+    write('0001_scratch_first.sql', 'CREATE TABLE scratch_a (id TEXT);');
+    write('0003_scratch_third.sql', 'CREATE TABLE scratch_c (id TEXT);');
+
+    expect(await migrate(db, root)).toEqual(['0001_scratch_first.sql', '0003_scratch_third.sql']);
+    expect(await appliedNames()).toEqual(['0001_scratch_first.sql', '0003_scratch_third.sql']);
+  });
+
+  it('allows numeric gaps: a missing number is not a missing migration', async () => {
+    write('0001_scratch_first.sql', 'CREATE TABLE scratch_a (id TEXT);');
+    write('0003_scratch_third.sql', 'CREATE TABLE scratch_c (id TEXT);');
+    await migrate(db, root);
+
+    // Nothing is waiting for 0002 to show up.
+    expect(await migrate(db, root)).toEqual([]);
+  });
+
+  it('applies a lower-numbered file that arrives later, on its own', async () => {
+    // This is the merge order these branches actually produce: the higher number
+    // lands first, and the other branch's file appears afterwards.
+    await db.execRaw('CREATE TABLE scratch_high (id TEXT); CREATE TABLE scratch_low (id TEXT);');
+    write('0016_scratch_higher.sql', 'ALTER TABLE scratch_high ADD COLUMN x TEXT;');
+    expect(await migrate(db, root)).toEqual(['0016_scratch_higher.sql']);
+
+    write('0015_scratch_lower.sql', 'ALTER TABLE scratch_low ADD COLUMN y TEXT;');
+
+    // It applies independently, and does not re-run the one already recorded.
+    expect(await migrate(db, root)).toEqual(['0015_scratch_lower.sql']);
+    expect(await appliedNames()).toEqual(['0015_scratch_lower.sql', '0016_scratch_higher.sql']);
+  });
+
+  it('never applies the same file twice', async () => {
+    write('0001_scratch_first.sql', 'CREATE TABLE scratch_a (id TEXT);');
+    await migrate(db, root);
+
+    // A second run would fail outright on the CREATE if the name check did not
+    // hold, so a clean empty list is the assertion.
+    expect(await migrate(db, root)).toEqual([]);
+  });
+});
+
+describe('the shipped 0016 stands alone', () => {
+  it('only touches member.profile_revision, so no other numbered change gates it', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const sqlText = readFileSync(
+      fileURLToPath(new URL('../migrations/sqlite/0016_member_profile_revision.sql', import.meta.url)),
+      'utf8',
+    );
+    const pg = readFileSync(
+      fileURLToPath(
+        new URL('../migrations/postgres/0016_member_profile_revision.sql', import.meta.url),
+      ),
+      'utf8',
+    );
+
+    for (const text of [sqlText, pg]) {
+      const statements = text
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('--') && line.trim() !== '');
+      expect(statements).toHaveLength(1);
+      expect(statements[0]).toMatch(/ALTER TABLE member ADD COLUMN/);
+      expect(statements[0]).toContain('profile_revision');
+      // No dependency on the account-integration work that owns the 0015 slot.
+      expect(text).not.toMatch(/account_integration/);
+    }
+  });
+});

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -58,6 +58,12 @@ export const member = pgTable(
     locale: text('locale'),
     /** The public member page, or NULL when there is none (see 0008). */
     profile: jsonb('profile'),
+    /**
+     * Write counter for `profile` (see 0016). NULL is a row that predates the
+     * column and means logical 0 — always read/compare through
+     * coalesce(profile_revision, 0), never the raw column.
+     */
+    profileRevision: integer('profile_revision'),
     /** Epoch-ms of the member's last authenticated request; NULL = never seen (see 0010). */
     lastSeenAt: bigint('last_seen_at', { mode: 'number' }),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -68,6 +68,12 @@ export const member = sqliteTable(
     locale: text('locale'),
     /** The public member page, or NULL when there is none (see 0008). */
     profile: text('profile'),
+    /**
+     * Write counter for `profile` (see 0016). NULL is a row that predates the
+     * column and means logical 0 — always read/compare through
+     * coalesce(profile_revision, 0), never the raw column.
+     */
+    profileRevision: integer('profile_revision'),
     /** Epoch-ms of the member's last authenticated request; NULL = never seen (see 0010). */
     lastSeenAt: integer('last_seen_at'),
     createdAt: integer('created_at').notNull(),

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -280,6 +280,29 @@ export interface FormsMessages {
       publicPageSaved: string;
       publicPageError: string;
       publicPageView: string;
+      /**
+       * The nine states this section can be in. Ambiguity gets its OWN copy:
+       * reusing "Saving…" or "Could not save" for a save whose outcome is
+       * unknown is exactly the false certainty that made the switch lie.
+       */
+      /** 1 — the page could not be read at all; nothing here may be edited. */
+      publicPageLoadFailed: string;
+      /** 2 — this server cannot guard writes (older API); writing is blocked. */
+      publicPageUnsupported: string;
+      /** 3 — a save's outcome is unknown and is being settled right now. */
+      publicPageReconciling: string;
+      /** 4 — settled: the save timed out and was NOT applied. */
+      publicPageTimedOutNotApplied: string;
+      /** 5 — settled after uncertainty: a newer stored version is now shown. */
+      publicPageLatestLoaded: string;
+      /** 6 — an ordinary save lost to a change made somewhere else. */
+      publicPageChangedElsewhere: string;
+      /** 7 — still unsettled: editing stays blocked, with a way to retry. */
+      publicPageUnresolved: string;
+      publicPageCheckAgain: string;
+      publicPageReload: string;
+      /** 8 — settled: the stored page is unchanged, but a write went first. */
+      publicPageNoOpAdvance: string;
       membersEmpty: string;
       you: string;
       addMember: string;
@@ -1753,6 +1776,22 @@ export const en: FormsMessages = {
       publicPageSaved: 'Public page saved.',
       publicPageError: 'Could not save your public page.',
       publicPageView: 'View page',
+      publicPageLoadFailed:
+        'We could not load your public page, so it cannot be edited right now. Reload to try again.',
+      publicPageUnsupported:
+        'This server cannot save public page changes safely yet. Reload after the update finishes.',
+      publicPageReconciling: 'Checking whether your last save was applied…',
+      publicPageTimedOutNotApplied: 'That save timed out and was not applied. Nothing changed.',
+      publicPageLatestLoaded:
+        'Your last save did not complete. Your page changed in the meantime, so the current version is shown.',
+      publicPageChangedElsewhere:
+        'Your public page changed somewhere else. The current version is shown — review it, then save again.',
+      publicPageUnresolved:
+        'We still cannot tell whether your last save was applied. Editing stays off until we know.',
+      publicPageCheckAgain: 'Check again',
+      publicPageReload: 'Reload',
+      publicPageNoOpAdvance:
+        'Your last save did not complete. Your page is unchanged, but another save finished first.',
       membersEmpty: 'No members yet.',
       you: 'You',
       addMember: 'Add member',
@@ -3137,6 +3176,23 @@ export const es: FormsMessages = {
       publicPageSaved: 'Página pública guardada.',
       publicPageError: 'No se pudo guardar tu página pública.',
       publicPageView: 'Ver página',
+      publicPageLoadFailed:
+        'No pudimos cargar tu página pública, así que no se puede editar ahora. Vuelve a cargar para intentarlo otra vez.',
+      publicPageUnsupported:
+        'Este servidor todavía no puede guardar cambios de la página pública de forma segura. Vuelve a cargar cuando termine la actualización.',
+      publicPageReconciling: 'Comprobando si se aplicó tu último guardado…',
+      publicPageTimedOutNotApplied:
+        'Ese guardado agotó el tiempo de espera y no se aplicó. Nada cambió.',
+      publicPageLatestLoaded:
+        'Tu último guardado no se completó. Tu página cambió mientras tanto, así que se muestra la versión actual.',
+      publicPageChangedElsewhere:
+        'Tu página pública cambió en otro lugar. Se muestra la versión actual: revísala y vuelve a guardar.',
+      publicPageUnresolved:
+        'Todavía no podemos saber si se aplicó tu último guardado. La edición queda desactivada hasta saberlo.',
+      publicPageCheckAgain: 'Comprobar de nuevo',
+      publicPageReload: 'Volver a cargar',
+      publicPageNoOpAdvance:
+        'Tu último guardado no se completó. Tu página no cambió, pero otro guardado terminó primero.',
       membersEmpty: 'Aún no hay miembros.',
       you: 'Tú',
       addMember: 'Añadir miembro',

--- a/qa/e2e/public-page-transport.spec.ts
+++ b/qa/e2e/public-page-transport.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * The public page switch under a TRANSPORT failure — the one state a unit test
+ * in node cannot reach, because it needs a real click, a real server action and
+ * a request that is still in flight when the client stops waiting.
+ *
+ * `callAction` gives up after 15s, but the timeout does NOT abort the PUT: the
+ * write lands, and the browser never hears about it. Anything the screen shows
+ * from that moment is a guess. The screen used to keep showing the value it had
+ * before the save and let you save again from it, so the switch (and the "View
+ * page" link) could disagree with the stored profile until a reload, and the
+ * next save would resubmit the stale value over the newer stored one.
+ *
+ * The run below holds the action response past that 15s deadline while letting
+ * the write reach the API, then checks what the screen does with the gap:
+ * writes stay blocked while nothing is known, the profile is reread, and the
+ * switch and the link settle on what the server actually stores.
+ */
+
+const API = 'http://localhost:4400';
+
+/** Longer than `callAction`'s 15s ceiling, so the client gives up first. */
+const HOLD_MS = 22_000;
+
+/** The stored profile, straight from the API — the truth the UI must match. */
+async function storedProfile(request: APIRequestContext): Promise<{ enabled?: boolean } | null> {
+  const res = await request.get(`${API}/v1/me/profile`);
+  expect(res.ok(), `profile read failed: ${res.status()}`).toBeTruthy();
+  return ((await res.json()) as { profile: { enabled?: boolean } | null }).profile;
+}
+
+test.describe('public page: a save the client never hears back about', () => {
+  test.beforeEach(async ({ request }) => {
+    // Start from "no public page" so the run is idempotent and the click below
+    // is an ENABLE: prior value off, requested value on.
+    const res = await request.put(`${API}/v1/me/profile`, { data: { profile: null } });
+    expect(res.ok(), `profile reset failed: ${res.status()}`).toBeTruthy();
+  });
+
+  test('blocks writes, rereads, and settles on the stored profile', async ({ page, request }) => {
+    test.setTimeout(180_000);
+
+    // Every server action this tab sends, counted: the save, and then whatever
+    // the screen does to find out what actually happened.
+    let actionPosts = 0;
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.headers()['next-action']) actionPosts += 1;
+    });
+
+    // Hold the FIRST action response past the client's deadline. The request is
+    // forwarded first, so the write really does land server-side — this is a
+    // client that stopped listening, not a write that never happened.
+    let held = false;
+    await page.route('**/admin/settings**', async (route) => {
+      const req = route.request();
+      if (held || req.method() !== 'POST' || !req.headers()['next-action']) return route.fallback();
+      held = true;
+      const response = await route.fetch();
+      await new Promise((resolve) => setTimeout(resolve, HOLD_MS));
+      await route.fulfill({ response });
+    });
+
+    await page.goto('/admin/settings');
+    const section = page.getByTestId('public-page-settings');
+    const toggle = section.getByRole('switch', { name: 'Published' });
+    const viewLink = section.getByRole('link', { name: 'View page' });
+    // The section's only plain button is the save control. Located by role, not
+    // by label, because its label changes while a save is unresolved.
+    const saveButton = section.getByRole('button');
+
+    // Nothing published yet: switch off, no link to a page that would 404.
+    await expect(toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+    await expect(viewLink).toHaveCount(0);
+
+    await toggle.click();
+
+    // Past the 15s ceiling: the client has given up, the write is landing (or
+    // has landed) anyway, and the screen knows nothing about the stored state.
+    await page.waitForTimeout(17_000);
+
+    // While nothing is known, no profile write may leave this screen — neither
+    // from the toggle nor from the Save button — because any payload built here
+    // would carry the pre-save value over whatever the server now stores.
+    const toggleIsWritable = (await toggle.count()) > 0 && (await toggle.isEnabled());
+    expect(toggleIsWritable, 'the toggle stayed writable while the stored state was unknown').toBe(
+      false,
+    );
+    await expect(saveButton).toBeDisabled();
+
+    // A click attempted in that window must not reach the server. Bounded, so
+    // it fails while the write is blocked instead of queueing until the screen
+    // settles and then landing a save of its own.
+    await toggle.click({ force: true, timeout: 1_500 }).catch(() => undefined);
+
+    // The screen has to go and ask, and then show the answer: the save landed,
+    // so the page is published and the link to it is offered.
+    await expect(toggle).toHaveAttribute('aria-checked', 'true', { timeout: 60_000 });
+    await expect(viewLink).toBeVisible();
+    await expect(saveButton).toBeEnabled();
+
+    // It asked: the save plus at least one reread. The value alone would not
+    // prove that — only a reread can tell this tab what the server stores.
+    expect(actionPosts, 'no reread followed the transport failure').toBeGreaterThanOrEqual(2);
+
+    // And nothing stale was written back on top of it.
+    expect(await storedProfile(request)).toMatchObject({ enabled: true });
+  });
+});

--- a/qa/e2e/public-page-transport.spec.ts
+++ b/qa/e2e/public-page-transport.spec.ts
@@ -460,44 +460,50 @@ test.describe('public page: settling without claiming authorship', () => {
   });
 });
 
-test.describe('public page: reconciling behind a proxy', () => {
+/**
+ * The reconciliation route's same-origin check is NOT driven from here.
+ *
+ * It compares the caller's `Origin` against the host this deployment answers on
+ * (`selfHost`: `PUBLIC_APP_URL` when configured, else `X-Forwarded-Host` then
+ * `Host`). A browser will not let a test forge either header — Playwright's
+ * route interception cannot override `Host`, and Chromium rewrites `Origin` for
+ * a same-origin fetch — so a run staged here proves nothing about that check and
+ * would pass against an implementation that ignored it. The accepting and
+ * refusing cases are asserted directly against the route, with the environment
+ * under test control, in
+ * `apps/web/app/api/settings/public-page/reconcile/route.spec.ts`.
+ */
+
+test.describe('public page: a mutation that came back 5xx', () => {
   test.beforeEach(async ({ request }) => {
     await resetProfile(request);
   });
 
-  /**
-   * The route decides same-origin against the host this deployment ANSWERS on,
-   * which behind a proxy is `X-Forwarded-Host`, not the internal `Host`. That
-   * cuts both ways, and the browser can only prove the strict half: a forwarded
-   * host that disagrees with the caller's Origin must be refused, which leaves
-   * the screen unresolved with its way out still on offer.
-   *
-   * A raw-`Host` implementation ignores the forwarded header, accepts this call
-   * and settles — so this run fails against it. The accepting direction (public
-   * Origin, internal Host, matching X-Forwarded-Host) cannot be staged from a
-   * browser, because Chromium will not let a test forge `Host`; it is asserted
-   * directly against the route in
-   * `apps/web/app/api/settings/public-page/reconcile/route.spec.ts`.
-   */
-  test('refuses a reconciliation whose forwarded host is not ours, and stays unresolved', async ({
+  test('stays pinned and recoverable when the write applied but the answer was a 500', async ({
     page,
     request,
   }) => {
     test.setTimeout(120_000);
     const start = (await stored(request)).revision;
 
-    let dropped = false;
+    // Forward the save so it really lands, then answer 500. A server error can
+    // be raised after the row is written — by the app, a proxy, or a balancer
+    // that gave up — so nothing about the outcome may be concluded from it.
+    let broke = false;
+    let actionPosts = 0;
     await page.route('**/admin/settings**', async (route) => {
       const r = route.request();
-      if (dropped || !isAction(r.method(), r.headers())) return route.fallback();
-      dropped = true;
-      return route.abort('connectionfailed');
+      if (!isAction(r.method(), r.headers())) return route.fallback();
+      actionPosts += 1;
+      if (broke) return route.fallback();
+      broke = true;
+      await route.fetch();
+      return route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Internal server error' }),
+      });
     });
-    await page.route('**/api/settings/public-page/reconcile', async (route) =>
-      route.continue({
-        headers: { ...route.request().headers(), 'x-forwarded-host': 'proxy.invalid' },
-      }),
-    );
 
     await page.goto('/admin/settings');
     const s = section(page);
@@ -505,14 +511,18 @@ test.describe('public page: reconciling behind a proxy', () => {
 
     await s.toggle.click();
 
-    // Refused, so nothing was decided: still blocked, still offering a way out.
-    await expect(s.status).toHaveText(COPY.unresolved, { timeout: 60_000 });
-    await expect(s.checkAgain).toBeVisible();
-    await expect(s.reload).toBeVisible();
-    expect(await writesAreBlocked(page)).toBe(true);
+    // The write landed, so the fence loses and the current page is adopted —
+    // reported as a changed state, never as a save this screen completed.
+    await expect(s.notice).toHaveText(COPY.latestLoaded, { timeout: 60_000 });
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(s.viewLink).toBeVisible();
     await expect(page.getByText(COPY.saved)).toHaveCount(0);
-    await expect(page.getByText(COPY.notApplied)).toHaveCount(0);
-    // A refused reconciliation fences nothing.
-    expect((await stored(request)).revision).toBe(start);
+
+    const after = await stored(request);
+    expect(after.profile).toMatchObject({ enabled: true });
+    // Exactly one write: the 500 must not have triggered a retry, and the
+    // losing fence burns nothing.
+    expect(after.revision).toBe(start + 1);
+    expect(actionPosts).toBe(1);
   });
 });

--- a/qa/e2e/public-page-transport.spec.ts
+++ b/qa/e2e/public-page-transport.spec.ts
@@ -26,6 +26,9 @@ const API = 'http://localhost:4400';
 /** Copy families this screen must keep distinct (en). */
 const COPY = {
   notApplied: 'That save timed out and was not applied. Nothing changed.',
+  noOp: 'Your last save did not complete. Your page is unchanged, but another save finished first.',
+  changedElsewhere:
+    'Your public page changed somewhere else. The current version is shown — review it, then save again.',
   latestLoaded:
     'Your last save did not complete. Your page changed in the meantime, so the current version is shown.',
   unresolved:
@@ -35,10 +38,27 @@ const COPY = {
   saved: 'Public page saved.',
 };
 
+interface StoredProfile {
+  enabled?: boolean;
+  headline?: string | null;
+  links?: { label: string; url: string }[];
+}
+
 interface Stored {
-  profile: { enabled?: boolean } | null;
+  profile: StoredProfile | null;
   revision: number;
 }
+
+/** Copy families in Spanish — the same nine states, in the other locale. */
+const COPY_ES = {
+  noOp: 'Tu último guardado no se completó. Tu página no cambió, pero otro guardado terminó primero.',
+  unresolved:
+    'Todavía no podemos saber si se aplicó tu último guardado. La edición queda desactivada hasta saberlo.',
+  changedElsewhere:
+    'Tu página pública cambió en otro lugar. Se muestra la versión actual: revísala y vuelve a guardar.',
+  saved: 'Página pública guardada.',
+  checkAgain: 'Comprobar de nuevo',
+};
 
 const stored = async (request: APIRequestContext): Promise<Stored> => {
   const res = await request.get(`${API}/v2/me/profile`);
@@ -57,6 +77,22 @@ async function resetProfile(request: APIRequestContext): Promise<number> {
   return ((await res.json()) as Stored).revision;
 }
 
+/** Write a page straight through the API, at whatever revision it is at now. */
+async function writeProfile(request: APIRequestContext, profile: StoredProfile): Promise<number> {
+  const before = await stored(request);
+  const res = await request.put(`${API}/v2/me/profile`, {
+    data: { profile: { version: 1, ...profile }, expectedRevision: before.revision },
+  });
+  expect(res.ok(), `profile write failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+  return ((await res.json()) as Stored).revision;
+}
+
+/** Advance the revision from outside the browser WITHOUT changing content. */
+async function fenceFromOutside(request: APIRequestContext, expectedRevision: number): Promise<void> {
+  const res = await request.post(`${API}/v2/me/profile/fence`, { data: { expectedRevision } });
+  expect(res.ok(), `outside fence failed: ${res.status()}`).toBeTruthy();
+}
+
 const isAction = (method: string, headers: Record<string, string>): boolean =>
   method === 'POST' && Boolean(headers['next-action']);
 
@@ -66,6 +102,8 @@ function section(page: Page) {
     root,
     toggle: root.getByRole('switch', { name: 'Published' }),
     viewLink: root.getByRole('link', { name: 'View page' }),
+    headline: root.getByRole('textbox').first(),
+    saveButton: root.getByRole('button').last(),
     notice: page.getByTestId('public-page-notice'),
     status: page.getByTestId('public-page-status'),
     checkAgain: page.getByTestId('public-page-check-again'),
@@ -259,5 +297,165 @@ test.describe('public page: a save whose answer never arrives', () => {
     expect(afterConflict.profile).toMatchObject({ enabled: true });
     // The refused save burned nothing: only the outside write advanced it.
     expect(afterConflict.revision).toBe(afterDisable.revision + 1);
+  });
+});
+
+test.describe('public page: settling without claiming authorship', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetProfile(request);
+  });
+
+  for (const locale of ['en', 'es'] as const) {
+    test(`a revision that advanced without changing the page gets its own copy (${locale})`, async ({
+      page,
+      request,
+      context,
+    }) => {
+      test.setTimeout(120_000);
+      const copy = locale === 'en' ? COPY : COPY_ES;
+      const label = locale === 'en' ? 'Published' : 'Publicada';
+      const baseline = { enabled: false, headline: 'Baseline' };
+      const start = await writeProfile(request, baseline);
+      if (locale === 'es') {
+        await context.addCookies([
+          { name: 'quill_locale', value: 'es', url: 'http://localhost:3400' },
+        ]);
+      }
+
+      // The save never reaches the server, and the first reconciliation cannot
+      // reach it either — which parks the screen where we can stage the no-op.
+      let dropped = false;
+      let fenceAttempts = 0;
+      await page.route('**/admin/settings**', async (route) => {
+        const r = route.request();
+        if (dropped || !isAction(r.method(), r.headers())) return route.fallback();
+        dropped = true;
+        return route.abort('connectionfailed');
+      });
+      await page.route('**/api/settings/public-page/reconcile', async (route) => {
+        fenceAttempts += 1;
+        return fenceAttempts === 1 ? route.abort('connectionfailed') : route.fallback();
+      });
+
+      await page.goto('/admin/settings');
+      const s = section(page);
+      const toggle = page.getByTestId('public-page-settings').getByRole('switch', { name: label });
+      await expect(toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+      await toggle.click();
+      await expect(s.status).toHaveText(copy.unresolved, { timeout: 60_000 });
+
+      // Something advances the revision without touching content — another tab
+      // fencing its own ambiguous save, for instance.
+      await fenceFromOutside(request, start);
+
+      // The retry uses the ORIGINAL expectation, so it now conflicts against a
+      // page that is byte-for-byte the one it started from.
+      await s.checkAgain.click();
+
+      await expect(s.notice).toHaveText(copy.noOp, { timeout: 60_000 });
+      // Not "changed elsewhere" (nothing changed) and certainly not "Saved".
+      await expect(page.getByText(copy.changedElsewhere)).toHaveCount(0);
+      await expect(page.getByText(copy.saved)).toHaveCount(0);
+
+      const after = await stored(request);
+      expect(after.profile).toMatchObject(baseline);
+      expect(after.revision).toBe(start + 1);
+    });
+  }
+
+  test('a conflict adopts the stored page but never eats the draft being typed', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const start = await writeProfile(request, {
+      enabled: false,
+      headline: 'Stored headline',
+      links: [{ label: 'Kept', url: 'https://kept.example' }],
+    });
+
+    await page.goto('/admin/settings');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+    // Unsaved work in progress.
+    await s.headline.fill('Draft in progress');
+
+    // Meanwhile, somewhere else, the page is published and its links change.
+    await request.put(`${API}/v2/me/profile`, {
+      data: {
+        profile: {
+          version: 1,
+          enabled: true,
+          headline: 'Outside headline',
+          links: [{ label: 'Outside', url: 'https://outside.example' }],
+        },
+        expectedRevision: start,
+      },
+    });
+
+    await s.saveButton.click();
+
+    // Authoritative state is adopted: published, live link, and the fields this
+    // screen only carries.
+    await expect(s.notice).toHaveText(COPY.changedElsewhere, { timeout: 30_000 });
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(s.viewLink).toBeVisible();
+    // The draft is still exactly where the member left it.
+    await expect(s.headline).toHaveValue('Draft in progress');
+
+    // Saving again keeps the adopted links and finally stores the draft.
+    await s.saveButton.click();
+    await expect(page.getByText(COPY.saved)).toBeVisible({ timeout: 30_000 });
+
+    const after = await stored(request);
+    expect(after.profile).toMatchObject({ enabled: true, headline: 'Draft in progress' });
+    expect(after.profile?.links).toEqual([{ label: 'Outside', url: 'https://outside.example' }]);
+    expect(after.revision).toBe(start + 2);
+  });
+
+  test('after reconciling, the next save uses the reconciled revision, not the stale one', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const start = (await stored(request)).revision;
+
+    let dropped = false;
+    await page.route('**/admin/settings**', async (route) => {
+      const r = route.request();
+      if (dropped || !isAction(r.method(), r.headers())) return route.fallback();
+      dropped = true;
+      return route.abort('connectionfailed');
+    });
+
+    await page.goto('/admin/settings');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+    await s.toggle.click();
+    await expect(s.notice).toHaveText(COPY.notApplied, { timeout: 60_000 });
+    const fenced = await stored(request);
+    expect(fenced.revision).toBe(start + 1);
+
+    // The reconciliation revalidated on the server and refreshed the client. If
+    // any of that had put the stale initial revision back, this save would come
+    // back 409 "changed somewhere else" and store nothing.
+    await s.toggle.click();
+    await expect(page.getByText(COPY.saved)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(COPY.changedElsewhere)).toHaveCount(0);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true');
+
+    const saved = await stored(request);
+    expect(saved.profile).toMatchObject({ enabled: true });
+    expect(saved.revision).toBe(fenced.revision + 1);
+
+    // A real remount agrees with the server, and can still write.
+    await page.reload();
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true', { timeout: 20_000 });
+    await s.toggle.click();
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 30_000 });
+    expect((await stored(request)).revision).toBe(saved.revision + 1);
   });
 });

--- a/qa/e2e/public-page-transport.spec.ts
+++ b/qa/e2e/public-page-transport.spec.ts
@@ -1,109 +1,263 @@
-import { test, expect, type APIRequestContext } from '@playwright/test';
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
 
 /**
- * The public page switch under a TRANSPORT failure — the one state a unit test
- * in node cannot reach, because it needs a real click, a real server action and
- * a request that is still in flight when the client stops waiting.
+ * The public page save under a TRANSPORT failure — a real click, a real Server
+ * Action, and a request whose answer never comes back.
  *
- * `callAction` gives up after 15s, but the timeout does NOT abort the PUT: the
- * write lands, and the browser never hears about it. Anything the screen shows
- * from that moment is a guess. The screen used to keep showing the value it had
- * before the save and let you save again from it, so the switch (and the "View
- * page" link) could disagree with the stored profile until a reload, and the
- * next save would resubmit the stale value over the newer stored one.
+ * A client-side timeout does not abort the write, so "not applied" and
+ * "applied, answer lost" look identical from the browser. Rereading cannot tell
+ * them apart either: a read can overtake the in-flight write and return
+ * pre-write state. The screen therefore fences — it advances the member's
+ * profile revision from the revision the ambiguous save expected — through a
+ * POST Route Handler that runs OFF the Server Action queue (actions from one
+ * tab are serialized, so the question would otherwise queue behind the very
+ * request that is stuck).
  *
- * The run below holds the action response past that 15s deadline while letting
- * the write reach the API, then checks what the screen does with the gap:
- * writes stay blocked while nothing is known, the profile is reread, and the
- * switch and the link settle on what the server actually stores.
+ * Fence wins  -> that save can never land: nothing was applied.
+ * Fence loses -> something else got there first: adopt what is stored, and say
+ *                so without ever claiming we saved it.
+ *
+ * Every ordering below also asserts the revision ledger: exactly one increment
+ * per real write, and none at all for a refusal or a repeated check.
  */
 
 const API = 'http://localhost:4400';
 
-/** Longer than `callAction`'s 15s ceiling, so the client gives up first. */
-const HOLD_MS = 22_000;
+/** Copy families this screen must keep distinct (en). */
+const COPY = {
+  notApplied: 'That save timed out and was not applied. Nothing changed.',
+  latestLoaded:
+    'Your last save did not complete. Your page changed in the meantime, so the current version is shown.',
+  unresolved:
+    'We still cannot tell whether your last save was applied. Editing stays off until we know.',
+  checkAgain: 'Check again',
+  reload: 'Reload',
+  saved: 'Public page saved.',
+};
 
-/** The stored profile, straight from the API — the truth the UI must match. */
-async function storedProfile(request: APIRequestContext): Promise<{ enabled?: boolean } | null> {
-  const res = await request.get(`${API}/v1/me/profile`);
-  expect(res.ok(), `profile read failed: ${res.status()}`).toBeTruthy();
-  return ((await res.json()) as { profile: { enabled?: boolean } | null }).profile;
+interface Stored {
+  profile: { enabled?: boolean } | null;
+  revision: number;
 }
 
-test.describe('public page: a save the client never hears back about', () => {
+const stored = async (request: APIRequestContext): Promise<Stored> => {
+  const res = await request.get(`${API}/v2/me/profile`);
+  expect(res.ok(), `profile read failed: ${res.status()}`).toBeTruthy();
+  return (await res.json()) as Stored;
+};
+
+/** Put the page back to "not published", whatever revision it is at now. */
+async function resetProfile(request: APIRequestContext): Promise<number> {
+  const before = await stored(request);
+  if (before.profile === null) return before.revision;
+  const res = await request.put(`${API}/v2/me/profile`, {
+    data: { profile: null, expectedRevision: before.revision },
+  });
+  expect(res.ok(), `profile reset failed: ${res.status()}`).toBeTruthy();
+  return ((await res.json()) as Stored).revision;
+}
+
+const isAction = (method: string, headers: Record<string, string>): boolean =>
+  method === 'POST' && Boolean(headers['next-action']);
+
+function section(page: Page) {
+  const root = page.getByTestId('public-page-settings');
+  return {
+    root,
+    toggle: root.getByRole('switch', { name: 'Published' }),
+    viewLink: root.getByRole('link', { name: 'View page' }),
+    notice: page.getByTestId('public-page-notice'),
+    status: page.getByTestId('public-page-status'),
+    checkAgain: page.getByTestId('public-page-check-again'),
+    reload: page.getByTestId('public-page-reload'),
+  };
+}
+
+/** No toggle to click, and no on/off claim to read. */
+async function writesAreBlocked(page: Page): Promise<boolean> {
+  const { toggle } = section(page);
+  return (await toggle.count()) === 0 || !(await toggle.isEnabled());
+}
+
+test.describe('public page: a save whose answer never arrives', () => {
   test.beforeEach(async ({ request }) => {
-    // Start from "no public page" so the run is idempotent and the click below
-    // is an ENABLE: prior value off, requested value on.
-    const res = await request.put(`${API}/v1/me/profile`, { data: { profile: null } });
-    expect(res.ok(), `profile reset failed: ${res.status()}`).toBeTruthy();
+    await resetProfile(request);
   });
 
-  test('blocks writes, rereads, and settles on the stored profile', async ({ page, request }) => {
-    test.setTimeout(180_000);
+  test('fence wins: the save never landed, and the screen says exactly that', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const start = await stored(request);
 
-    // Every server action this tab sends, counted: the save, and then whatever
-    // the screen does to find out what actually happened.
-    let actionPosts = 0;
-    page.on('request', (req) => {
-      if (req.method() === 'POST' && req.headers()['next-action']) actionPosts += 1;
-    });
-
-    // Hold the FIRST action response past the client's deadline. The request is
-    // forwarded first, so the write really does land server-side — this is a
-    // client that stopped listening, not a write that never happened.
-    let held = false;
+    // The action never reaches the server: a dropped request, which is the
+    // ambiguity this whole mechanism exists for.
+    let dropped = false;
     await page.route('**/admin/settings**', async (route) => {
-      const req = route.request();
-      if (held || req.method() !== 'POST' || !req.headers()['next-action']) return route.fallback();
-      held = true;
-      const response = await route.fetch();
-      await new Promise((resolve) => setTimeout(resolve, HOLD_MS));
-      await route.fulfill({ response });
+      const r = route.request();
+      if (dropped || !isAction(r.method(), r.headers())) return route.fallback();
+      dropped = true;
+      return route.abort('connectionfailed');
     });
 
     await page.goto('/admin/settings');
-    const section = page.getByTestId('public-page-settings');
-    const toggle = section.getByRole('switch', { name: 'Published' });
-    const viewLink = section.getByRole('link', { name: 'View page' });
-    // The section's only plain button is the save control. Located by role, not
-    // by label, because its label changes while a save is unresolved.
-    const saveButton = section.getByRole('button');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
 
-    // Nothing published yet: switch off, no link to a page that would 404.
-    await expect(toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
-    await expect(viewLink).toHaveCount(0);
+    await s.toggle.click();
 
-    await toggle.click();
+    // Settled by the fence, not by a guess.
+    await expect(s.notice).toHaveText(COPY.notApplied, { timeout: 60_000 });
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(s.viewLink).toHaveCount(0);
+    // Never a success claim for something that was never applied.
+    await expect(page.getByText(COPY.saved)).toHaveCount(0);
 
-    // Past the 15s ceiling: the client has given up, the write is landing (or
-    // has landed) anyway, and the screen knows nothing about the stored state.
+    const after = await stored(request);
+    expect(after.profile).toBeNull();
+    // Exactly one increment: the fence. The refused save burned nothing.
+    expect(after.revision).toBe(start.revision + 1);
+  });
+
+  test('fence loses: the write did land, so the current page is adopted — not "Saved"', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const start = await stored(request);
+
+    // The action runs and the write lands; only the ANSWER is held, past the
+    // 15s ceiling the client puts on a Server Action.
+    let held = false;
+    await page.route('**/admin/settings**', async (route) => {
+      const r = route.request();
+      if (held || !isAction(r.method(), r.headers())) return route.fallback();
+      held = true;
+      // Forward it, capture the answer, then sit on it. Buffer the body first:
+      // a fetched response is disposed while we wait, and this test is about
+      // the ANSWER being late, not the write.
+      const response = await route.fetch();
+      const status = response.status();
+      const body = await response.body();
+      const headers = { ...response.headers() };
+      delete headers['content-encoding'];
+      delete headers['content-length'];
+      await new Promise((resolve) => setTimeout(resolve, 17_000));
+      await route.fulfill({ status, headers, body });
+    });
+
+    await page.goto('/admin/settings');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+    await s.toggle.click();
+
+    // While nothing is known, nothing may be written from here.
     await page.waitForTimeout(17_000);
+    expect(await writesAreBlocked(page), 'writes stayed open while the state was unknown').toBe(true);
 
-    // While nothing is known, no profile write may leave this screen — neither
-    // from the toggle nor from the Save button — because any payload built here
-    // would carry the pre-save value over whatever the server now stores.
-    const toggleIsWritable = (await toggle.count()) > 0 && (await toggle.isEnabled());
-    expect(toggleIsWritable, 'the toggle stayed writable while the stored state was unknown').toBe(
-      false,
-    );
-    await expect(saveButton).toBeDisabled();
+    // The fence lost to the write that landed, so the stored page is adopted and
+    // the copy says the state changed — it never claims we saved it.
+    await expect(s.notice).toHaveText(COPY.latestLoaded, { timeout: 60_000 });
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(s.viewLink).toBeVisible();
+    await expect(page.getByText(COPY.saved)).toHaveCount(0);
 
-    // A click attempted in that window must not reach the server. Bounded, so
-    // it fails while the write is blocked instead of queueing until the screen
-    // settles and then landing a save of its own.
-    await toggle.click({ force: true, timeout: 1_500 }).catch(() => undefined);
+    const after = await stored(request);
+    expect(after.profile).toMatchObject({ enabled: true });
+    // One increment for the write that landed; the losing fence burned nothing.
+    expect(after.revision).toBe(start.revision + 1);
+  });
 
-    // The screen has to go and ask, and then show the answer: the save landed,
-    // so the page is published and the link to it is offered.
-    await expect(toggle).toHaveAttribute('aria-checked', 'true', { timeout: 60_000 });
-    await expect(viewLink).toBeVisible();
-    await expect(saveButton).toBeEnabled();
+  test('fence unreachable: editing stays blocked, and Check again settles it without burning more', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const start = await stored(request);
 
-    // It asked: the save plus at least one reread. The value alone would not
-    // prove that — only a reread can tell this tab what the server stores.
-    expect(actionPosts, 'no reread followed the transport failure').toBeGreaterThanOrEqual(2);
+    let dropped = false;
+    let fenceAttempts = 0;
+    await page.route('**/admin/settings**', async (route) => {
+      const r = route.request();
+      if (dropped || !isAction(r.method(), r.headers())) return route.fallback();
+      dropped = true;
+      return route.abort('connectionfailed');
+    });
+    // The first reconciliation attempt fails too, so the screen has to sit in
+    // the unresolved state and offer a way out.
+    await page.route('**/api/settings/public-page/reconcile', async (route) => {
+      fenceAttempts += 1;
+      if (fenceAttempts === 1) return route.abort('connectionfailed');
+      return route.fallback();
+    });
 
-    // And nothing stale was written back on top of it.
-    expect(await storedProfile(request)).toMatchObject({ enabled: true });
+    await page.goto('/admin/settings');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+    await s.toggle.click();
+
+    await expect(s.status).toHaveText(COPY.unresolved, { timeout: 60_000 });
+    expect(await writesAreBlocked(page)).toBe(true);
+    await expect(s.checkAgain).toBeVisible();
+    await expect(s.reload).toBeVisible();
+    await expect(page.getByText(COPY.saved)).toHaveCount(0);
+
+    // "Check again" re-uses the ORIGINAL expected revision.
+    await s.checkAgain.click();
+
+    await expect(s.notice).toHaveText(COPY.notApplied, { timeout: 60_000 });
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false');
+
+    const after = await stored(request);
+    expect(after.profile).toBeNull();
+    // Still exactly one increment across the whole episode: the fence that won.
+    expect(after.revision).toBe(start.revision + 1);
+  });
+
+  test('an ordinary save still saves, and an ordinary conflict is not ambiguity', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const start = await stored(request);
+
+    await page.goto('/admin/settings');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+    // Enable: normal path, normal copy, live link.
+    await s.toggle.click();
+    await expect(page.getByText(COPY.saved)).toBeVisible({ timeout: 20_000 });
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(s.viewLink).toBeVisible();
+    expect((await stored(request)).revision).toBe(start.revision + 1);
+
+    // Disable: the mirror direction, same guarantees.
+    await s.toggle.click();
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+    await expect(s.viewLink).toHaveCount(0);
+    const afterDisable = await stored(request);
+    expect(afterDisable.profile).toMatchObject({ enabled: false });
+    expect(afterDisable.revision).toBe(start.revision + 2);
+
+    // Someone else writes behind this tab's back: the next save must lose and
+    // adopt, not overwrite.
+    const outside = await request.put(`${API}/v2/me/profile`, {
+      data: {
+        profile: { version: 1, enabled: true, headline: 'from another tab' },
+        expectedRevision: afterDisable.revision,
+      },
+    });
+    expect(outside.ok()).toBeTruthy();
+
+    await s.toggle.click();
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'true', { timeout: 20_000 });
+    const afterConflict = await stored(request);
+    expect(afterConflict.profile).toMatchObject({ enabled: true });
+    // The refused save burned nothing: only the outside write advanced it.
+    expect(afterConflict.revision).toBe(afterDisable.revision + 1);
   });
 });

--- a/qa/e2e/public-page-transport.spec.ts
+++ b/qa/e2e/public-page-transport.spec.ts
@@ -459,3 +459,60 @@ test.describe('public page: settling without claiming authorship', () => {
     expect((await stored(request)).revision).toBe(saved.revision + 1);
   });
 });
+
+test.describe('public page: reconciling behind a proxy', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetProfile(request);
+  });
+
+  /**
+   * The route decides same-origin against the host this deployment ANSWERS on,
+   * which behind a proxy is `X-Forwarded-Host`, not the internal `Host`. That
+   * cuts both ways, and the browser can only prove the strict half: a forwarded
+   * host that disagrees with the caller's Origin must be refused, which leaves
+   * the screen unresolved with its way out still on offer.
+   *
+   * A raw-`Host` implementation ignores the forwarded header, accepts this call
+   * and settles — so this run fails against it. The accepting direction (public
+   * Origin, internal Host, matching X-Forwarded-Host) cannot be staged from a
+   * browser, because Chromium will not let a test forge `Host`; it is asserted
+   * directly against the route in
+   * `apps/web/app/api/settings/public-page/reconcile/route.spec.ts`.
+   */
+  test('refuses a reconciliation whose forwarded host is not ours, and stays unresolved', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const start = (await stored(request)).revision;
+
+    let dropped = false;
+    await page.route('**/admin/settings**', async (route) => {
+      const r = route.request();
+      if (dropped || !isAction(r.method(), r.headers())) return route.fallback();
+      dropped = true;
+      return route.abort('connectionfailed');
+    });
+    await page.route('**/api/settings/public-page/reconcile', async (route) =>
+      route.continue({
+        headers: { ...route.request().headers(), 'x-forwarded-host': 'proxy.invalid' },
+      }),
+    );
+
+    await page.goto('/admin/settings');
+    const s = section(page);
+    await expect(s.toggle).toHaveAttribute('aria-checked', 'false', { timeout: 20_000 });
+
+    await s.toggle.click();
+
+    // Refused, so nothing was decided: still blocked, still offering a way out.
+    await expect(s.status).toHaveText(COPY.unresolved, { timeout: 60_000 });
+    await expect(s.checkAgain).toBeVisible();
+    await expect(s.reload).toBeVisible();
+    expect(await writesAreBlocked(page)).toBe(true);
+    await expect(page.getByText(COPY.saved)).toHaveCount(0);
+    await expect(page.getByText(COPY.notApplied)).toHaveCount(0);
+    // A refused reconciliation fences nothing.
+    expect((await stored(request)).revision).toBe(start);
+  });
+});


### PR DESCRIPTION
**Problem**

A public-page save can reach the API after the browser stops waiting for its response. The page could then show an old value or send another save without knowing which value was stored.

**Fix**

- Add a profile revision and use compare-and-set updates for public-page saves.
- Add a revision fence that resolves saves with unknown outcomes without writing a guessed value.
- Keep new writes disabled by default during deployment while leaving fence recovery available.
- Require authentication before either write endpoint reports its deployment-gate state.
- Keep the draft, saved state, switch, and public-page link aligned with the authoritative profile.

**Tests**

Regression tests cover delayed responses, applied 5xx responses, fence wins and conflicts, disabled writes, cross-account access, private gate posture, ordinary saves, and browser remount ordering. API, database, web, Playwright, type-check, and lint checks pass.

**Deployment**

Deploy the migration, API, and web in that order. Enable revision-guarded writes only after every API instance is revision-aware. After v2 writes are enabled, rolling back to a pre-revision API is unsupported; disable new writes and retain the revision-aware API for recovery.
