### PR TITLE
fix(db): stabilize submission ordering ties

### DIFF
--- a/packages/db/src/analytics.spec.ts
+++ b/packages/db/src/analytics.spec.ts
@@ -27,6 +27,8 @@ import {
   dailyViewSessions,
   dailyStartSessions,
   DAY_MS,
+  querySubmissions,
+  allSubmissionsForExport,
 } from './analytics';
 
 let db: Db;
@@ -69,11 +71,11 @@ async function booking(sessionId: string, createdAt: number): Promise<void> {
 /** Insert one submission (partial or complete) for a session. */
 async function sub(
   sessionId: string,
-  opts: { startedAt: number; completedAt?: number | null; partialAt?: number | null },
+  opts: { id?: string; startedAt: number; completedAt?: number | null; partialAt?: number | null },
 ): Promise<void> {
   await db.run(
     sql`INSERT INTO submission (id, form_id, session_id, data, score, started_at, completed_at, partial_at)
-        VALUES (${randomUUID()}, ${formId}, ${sessionId}, ${'{}'}, ${0},
+        VALUES (${opts.id ?? randomUUID()}, ${formId}, ${sessionId}, ${'{}'}, ${0},
                 ${opts.startedAt}, ${opts.completedAt ?? null}, ${opts.partialAt ?? null})`,
   );
 }
@@ -238,6 +240,36 @@ describe('partial submissions windowed by cohort anchor', () => {
     expect(await partialCount(db, formId, WINDOW)).toBe(1);
     expect(await partialCount(db, formId, { from: D0, to: D1 - 1 })).toBe(0);
     expect(await partialCount(db, formId)).toBe(1);
+  });
+});
+
+describe('submission-table ordering', () => {
+  it('keeps tied timestamps stable across adjacent pages and exports', async () => {
+    const tiedAt = D1 + 1_000;
+    await sub('newest', { id: 'submission-newest', startedAt: tiedAt + 1 });
+    await sub('tie-a', { id: 'submission-tie-a', startedAt: tiedAt });
+    await sub('tie-b', { id: 'submission-tie-b', startedAt: tiedAt });
+    await sub('tie-c', { id: 'submission-tie-c', startedAt: tiedAt });
+    await sub('tie-d', { id: 'submission-tie-d', startedAt: tiedAt });
+    await sub('oldest', { id: 'submission-oldest', startedAt: tiedAt - 1 });
+
+    const expected = [
+      'submission-newest',
+      'submission-tie-d',
+      'submission-tie-c',
+      'submission-tie-b',
+      'submission-tie-a',
+      'submission-oldest',
+    ];
+    const first = await querySubmissions(db, formId, { limit: 2, offset: 0 });
+    const second = await querySubmissions(db, formId, { limit: 2, offset: 2 });
+    const third = await querySubmissions(db, formId, { limit: 2, offset: 4 });
+    const pageIds = [...first.items, ...second.items, ...third.items].map((row) => row.id);
+
+    expect(first.total).toBe(expected.length);
+    expect(pageIds).toEqual(expected);
+    expect(new Set(pageIds)).toHaveLength(expected.length);
+    expect((await allSubmissionsForExport(db, formId)).map((row) => row.id)).toEqual(expected);
   });
 });
 

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -390,7 +390,7 @@ export async function querySubmissions(
   );
   const rows = await db.all<Record<string, unknown>>(
     sql`SELECT * FROM submission ${where}
-        ORDER BY started_at DESC
+        ORDER BY started_at DESC, id DESC
         LIMIT ${limit} OFFSET ${offset}`,
   );
   return { items: rows.map(mapSubmission), total: Number(totalRow?.n ?? 0), limit, offset };
@@ -408,7 +408,7 @@ export async function allSubmissionsForExport(
 ): Promise<SubmissionRow[]> {
   const where = sql`WHERE form_id = ${formId} ${statusClause(q.status)} ${andRange(sql`started_at`, q)}`;
   const rows = await db.all<Record<string, unknown>>(
-    sql`SELECT * FROM submission ${where} ORDER BY started_at DESC`,
+    sql`SELECT * FROM submission ${where} ORDER BY started_at DESC, id DESC`,
   );
   return rows.map(mapSubmission);
 }

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -681,7 +681,7 @@ export async function listSubmissions(
 ): Promise<SubmissionRow[]> {
   const rows = await db.all<Record<string, unknown>>(
     sql`SELECT * FROM submission WHERE form_id = ${formId}
-        ORDER BY started_at DESC LIMIT ${limit}`,
+        ORDER BY started_at DESC, id DESC LIMIT ${limit}`,
   );
   return rows.map(mapSubmission);
 }
@@ -705,4 +705,3 @@ export async function recordFormEvent(
           ${input.stepIndex ?? null}, ${input.stepKey ?? null}, ${input.now ?? Date.now()})`,
   );
 }
-

--- a/packages/db/src/submission.spec.ts
+++ b/packages/db/src/submission.spec.ts
@@ -104,6 +104,22 @@ describe('submission upsert', () => {
     expect(await listSubmissions(db, formId)).toHaveLength(2);
   });
 
+  it('orders tied started timestamps by id descending', async () => {
+    const startedAt = 1_700_000_000_000;
+    for (const id of ['submission-tie-a', 'submission-tie-b', 'submission-tie-c']) {
+      await db.run(
+        sql`INSERT INTO submission (id, form_id, session_id, data, score, started_at)
+            VALUES (${id}, ${formId}, ${'session-' + id}, ${'{}'}, ${0}, ${startedAt})`,
+      );
+    }
+
+    expect((await listSubmissions(db, formId)).map((row) => row.id)).toEqual([
+      'submission-tie-c',
+      'submission-tie-b',
+      'submission-tie-a',
+    ]);
+  });
+
   it('enforces the (form_id, session_id) unique index', async () => {
     await upsertSubmission(db, { formId, sessionId: 'dup', data: {}, score: 0 });
     // A raw duplicate insert must violate the unique index (the parity guarantee).


### PR DESCRIPTION
## Summary

- Add the submission ID as a deterministic tie-breaker after the start time.
- Use the same order for submission lists, paginated queries, and exports.
- Add regression tests for tied timestamps and adjacent pages.

## Why

Database row order is not stable when submissions have the same start time. Offset pagination can then repeat or skip submissions, and exports can use a different order.

## Validation

- Focused database tests pass.
- Tie-breaker counterfactual tests fail as expected.
- Type checking and linting pass.