### PR TITLE
fix(db): retry concurrent form slug conflicts

### DIFF
--- a/packages/db/src/forms.spec.ts
+++ b/packages/db/src/forms.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Form creation must keep account-scoped slugs deterministic even when two
+ * independent writers choose the same candidate before either can insert it.
+ * The suite defaults to a shared SQLite file so the writers are real separate
+ * connections; CI can set DATABASE_URL to run the same assertions on Postgres.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sql, type SQL } from 'drizzle-orm';
+import { createDb, type Db } from './client';
+import { migrate } from './migrate';
+import { createForm } from './forms';
+
+let writerOne: Db;
+let writerTwo: Db;
+let accountId: string;
+let otherAccountId: string;
+let sqliteDir: string | undefined;
+
+type Barrier = { wait: () => Promise<void> };
+type DbError = Error & { code?: string; constraint?: string; constraint_name?: string };
+
+function twoWriterBarrier(): Barrier {
+  let arrivals = 0;
+  let release!: () => void;
+  const bothArrived = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    async wait(): Promise<void> {
+      arrivals += 1;
+      if (arrivals === 2) release();
+      await bothArrived;
+    },
+  };
+}
+
+/**
+ * `createForm` starts with uniqueFormSlug's lookup. Holding that one lookup on
+ * each independently connected writer proves both chose the same candidate
+ * before either reaches the unique index; a sequential duplicate test cannot.
+ */
+function pauseAfterFirstLookup(db: Db, barrier: Barrier): Db {
+  let firstLookup = true;
+  return {
+    ...db,
+    get: async <T = Record<string, unknown>>(query: SQL): Promise<T | undefined> => {
+      const row = await db.get<T>(query);
+      if (firstLookup) {
+        firstLookup = false;
+        await barrier.wait();
+      }
+      return row;
+    },
+  };
+}
+
+function formSlugConflict(dialect: Db['dialect']): DbError {
+  return dialect === 'postgres'
+    ? Object.assign(new Error('duplicate key value violates unique constraint "form_account_slug_uq"'), {
+        code: '23505',
+        constraint_name: 'form_account_slug_uq',
+      })
+    : Object.assign(new Error('UNIQUE constraint failed: form.account_id, form.slug'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE',
+      });
+}
+
+function rejectEveryFormInsert(db: Db, attempts: { count: number; error: DbError }): Db {
+  return {
+    ...db,
+    run: async (_query: SQL): Promise<void> => {
+      attempts.count += 1;
+      throw attempts.error;
+    },
+  };
+}
+
+function countFormInserts(db: Db, attempts: { count: number }): Db {
+  return {
+    ...db,
+    run: async (query: SQL): Promise<void> => {
+      attempts.count += 1;
+      await db.run(query);
+    },
+  };
+}
+
+beforeEach(async () => {
+  const databaseUrl = process.env.DATABASE_URL ?? `file:${join(await mkdtemp(join(tmpdir(), 'quill-form-slug-')), 'forms.db')}`;
+  if (!process.env.DATABASE_URL) sqliteDir = join(databaseUrl.slice('file:'.length), '..');
+
+  writerOne = await createDb(databaseUrl);
+  writerTwo = await createDb(databaseUrl);
+  await migrate(writerOne);
+
+  accountId = randomUUID();
+  otherAccountId = randomUUID();
+  const now = Date.now();
+  await writerOne.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${`a${accountId.slice(0, 8)}`}, ${'Primary'}, ${now})`,
+  );
+  await writerOne.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${otherAccountId}, ${`b${otherAccountId.slice(0, 8)}`}, ${'Other'}, ${now})`,
+  );
+});
+
+afterEach(async () => {
+  if (writerOne) {
+    await writerOne.run(sql`DELETE FROM form WHERE account_id = ${accountId} OR account_id = ${otherAccountId}`);
+    await writerOne.run(sql`DELETE FROM account WHERE id = ${accountId} OR id = ${otherAccountId}`);
+  }
+  await writerTwo?.close();
+  await writerOne?.close();
+  if (sqliteDir) await rm(sqliteDir, { recursive: true, force: true });
+  sqliteDir = undefined;
+});
+
+describe('createForm slug allocation', () => {
+  it('retries the loser after two writers select the same slug', async () => {
+    const barrier = twoWriterBarrier();
+    const results = await Promise.all([
+      createForm(pauseAfterFirstLookup(writerOne, barrier), accountId, { name: 'Launch Plan' }),
+      createForm(pauseAfterFirstLookup(writerTwo, barrier), accountId, { name: 'Launch Plan' }),
+    ]);
+
+    const slugs = results.map((result) => {
+      if (!result.ok) throw new Error('expected both concurrent creates to succeed');
+      return result.value.slug;
+    });
+    expect(new Set(slugs)).toEqual(new Set(['launch-plan', 'launch-plan-2']));
+  });
+
+  it('keeps ordinary suffixing and cross-account reuse unchanged', async () => {
+    const first = await createForm(writerOne, accountId, { name: 'Weekly Check-in' });
+    const second = await createForm(writerOne, accountId, { name: 'Weekly Check-in' });
+    const otherAccount = await createForm(writerOne, otherAccountId, { name: 'Weekly Check-in' });
+
+    expect(first).toMatchObject({ ok: true, value: { slug: 'weekly-check-in' } });
+    expect(second).toMatchObject({ ok: true, value: { slug: 'weekly-check-in-2' } });
+    expect(otherAccount).toMatchObject({ ok: true, value: { slug: 'weekly-check-in' } });
+  });
+
+  it('preserves non-slug database errors', async () => {
+    const attempts = { count: 0 };
+    await expect(
+      createForm(countFormInserts(writerOne, attempts), accountId, {
+        name: null as unknown as string,
+        slug: 'not-null-control',
+      }),
+    ).rejects.toThrow();
+    expect(attempts.count).toBe(1);
+  });
+
+  it('stops after three matching slug conflicts and rethrows the original error', async () => {
+    const attempts = { count: 0, error: formSlugConflict(writerOne.dialect) };
+
+    await expect(
+      createForm(rejectEveryFormInsert(writerOne, attempts), accountId, { name: 'Bounded Retry' }),
+    ).rejects.toBe(attempts.error);
+    expect(attempts.count).toBe(3);
+  });
+});

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -224,6 +224,51 @@ export async function uniqueFormSlug(db: Db, accountId: string, base: string): P
   return `${root}-${randomUUID().slice(0, 6)}`;
 }
 
+const FORM_SLUG_INSERT_ATTEMPTS = 3;
+const SQLITE_FORM_SLUG_UNIQUE_MESSAGE = 'UNIQUE constraint failed: form.account_id, form.slug';
+
+type DatabaseError = {
+  code?: unknown;
+  constraint?: unknown;
+  constraint_name?: unknown;
+  message?: unknown;
+  cause?: unknown;
+  driverError?: unknown;
+};
+
+function asDatabaseError(error: unknown): DatabaseError | undefined {
+  return error && typeof error === 'object' ? (error as DatabaseError) : undefined;
+}
+
+/** True only for the account-scoped `form(account_id, slug)` unique index. */
+function isFormAccountSlugUniqueViolation(error: unknown): boolean {
+  const candidate = asDatabaseError(error);
+  if (!candidate) return false;
+
+  if (
+    candidate.code === '23505' &&
+    (candidate.constraint === 'form_account_slug_uq' || candidate.constraint_name === 'form_account_slug_uq')
+  ) {
+    return true;
+  }
+
+  return (
+    candidate.code === 'SQLITE_CONSTRAINT_UNIQUE' &&
+    typeof candidate.message === 'string' &&
+    candidate.message.includes(SQLITE_FORM_SLUG_UNIQUE_MESSAGE)
+  );
+}
+
+/** Drizzle wraps driver errors; inspect the immediate driver shape without widening retries. */
+function isFormAccountSlugConflict(error: unknown): boolean {
+  const wrapped = asDatabaseError(error);
+  return (
+    isFormAccountSlugUniqueViolation(error) ||
+    isFormAccountSlugUniqueViolation(wrapped?.cause) ||
+    isFormAccountSlugUniqueViolation(wrapped?.driverError)
+  );
+}
+
 export async function listForms(db: Db, accountId: string): Promise<FormSummary[]> {
   const rows = await db.all<Record<string, unknown>>(
     sql`SELECT id, name, slug, brand_applied_at, created_at, updated_at FROM form
@@ -337,17 +382,28 @@ export async function createForm(
    */
   createdBy?: string | null,
 ): Promise<CrudResult<FormRow>> {
-  const slug = await uniqueFormSlug(db, accountId, input.slug ?? input.name);
-  const id = randomUUID();
-  const now = Date.now();
-  const config = input.config ?? { version: 1, steps: [] };
-  await db.run(
-    sql`INSERT INTO form (id, account_id, name, slug, config, created_by, created_at, updated_at)
-        VALUES (${id}, ${accountId}, ${input.name}, ${slug}, ${jsonParam(config)},
-                ${createdBy ?? null}, ${now}, ${now})`,
-  );
-  const created = await getFormById(db, accountId, id);
-  return created ? { ok: true, value: created } : { ok: false, reason: 'CONFLICT' };
+   const config = input.config ?? { version: 1, steps: [] };
+
+   for (let attempt = 0; attempt < FORM_SLUG_INSERT_ATTEMPTS; attempt++) {
+     const slug = await uniqueFormSlug(db, accountId, input.slug ?? input.name);
+     const id = randomUUID();
+     const now = Date.now();
+     try {
+       await db.run(
+         sql`INSERT INTO form (id, account_id, name, slug, config, created_by, created_at, updated_at)
+             VALUES (${id}, ${accountId}, ${input.name}, ${slug}, ${jsonParam(config)},
+                     ${createdBy ?? null}, ${now}, ${now})`,
+       );
+     } catch (error) {
+       if (attempt + 1 < FORM_SLUG_INSERT_ATTEMPTS && isFormAccountSlugConflict(error)) continue;
+       throw error;
+     }
+
+     const created = await getFormById(db, accountId, id);
+     return created ? { ok: true, value: created } : { ok: false, reason: 'CONFLICT' };
+   }
+
+   throw new Error('unreachable: form slug insert retries must return or rethrow');
 }
 
 export async function updateForm(
@@ -705,4 +761,3 @@ export async function recordFormEvent(
           ${input.stepIndex ?? null}, ${input.stepKey ?? null}, ${input.now ?? Date.now()})`,
   );
 }
-


### PR DESCRIPTION
## Summary

- Retry form creation when concurrent requests collide on the account slug constraint.
- Keep retries finite and classify only the form slug constraint.
- Add regression tests for concurrent creation, suffixing, cross-account reuse, and unrelated database errors.

## Why

Two requests can select the same available slug before either insert completes. One request then fails with a unique constraint error instead of using the next slug.

## Validation

- Focused database tests pass.
- Constraint-classification and retry-bound counterfactual tests fail as expected.
- Type checking and linting pass.