### PR TITLE
fix(engine): reject invalid single-choice arrays

### DIFF
--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -1151,6 +1151,39 @@ describe('isMultiSelect + multiple_choice scoring', () => {
     expect(validateAnswer(multi, ['a', 'b']).ok).toBe(true);
     expect(validateAnswer(multi, ['a', 'zzz']).ok).toBe(false);
   });
+
+  it('rejects arrays for single-select choice steps and does not score them', () => {
+    const singleChoice = step({
+      key: 'single',
+      type: 'multiple_choice',
+      selectionMode: 'single',
+      flowGroup: 'qualification',
+      options: [
+        { label: 'A', value: 'a', points: 2 },
+        { label: 'B', value: 'b', points: 3 },
+      ],
+    });
+    const dropdown = step({
+      ...singleChoice,
+      type: 'dropdown',
+    });
+
+    for (const single of [singleChoice, dropdown]) {
+      const cfg: FormConfig = { version: 1, steps: [single] };
+      expect(validateAnswer(single, ['a', 'b']).ok).toBe(false);
+      expect(computeScore(cfg, { single: ['a', 'b'] })).toBe(0);
+      expect(validateAnswer(single, 'a').ok).toBe(true);
+      expect(computeScore(cfg, { single: 'a' })).toBe(2);
+    }
+  });
+
+  it('rejects duplicate multi-select tokens and scores each option once', () => {
+    const cfg: FormConfig = { version: 1, steps: [multi] };
+    expect(validateAnswer(multi, ['a', 'a', 'b']).ok).toBe(false);
+    expect(computeScore(cfg, { features: ['a', 'a', 'b'] })).toBe(5);
+    expect(validateAnswer(multi, ['a', 'b']).ok).toBe(true);
+    expect(computeScore(cfg, { features: ['a', 'b'] })).toBe(5);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -1323,6 +1323,8 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
     case 'multiple_choice': {
       const allowed = new Set((step.options ?? []).map((o) => o.value));
       const picked = tokens(value);
+      if ((Array.isArray(value) && !isMultiSelect(step)) || new Set(picked).size !== picked.length)
+        return { ok: false, error: 'Choose one of the available options.' };
       if (picked.some((p) => !allowed.has(p)))
         return { ok: false, error: 'Choose one of the available options.' };
       return { ok: true };
@@ -1334,8 +1336,9 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
 
 /** Points for a single choice/dropdown answer (sum across multi-select). */
 function optionPoints(step: FormStep, value: AnswerValue): number {
+  if (Array.isArray(value) && !isMultiSelect(step)) return 0;
   const byValue = new Map((step.options ?? []).map((o) => [o.value, o.points ?? 0]));
-  return tokens(value).reduce((sum, t) => sum + (byValue.get(t) ?? 0), 0);
+  return [...new Set(tokens(value))].reduce((sum, t) => sum + (byValue.get(t) ?? 0), 0);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Reject array answers for single-choice and dropdown steps.
- Deduplicate choice tokens before calculating scores.
- Add regression tests for invalid arrays, duplicate tokens, and valid multi-select scoring.

## Why

Single-choice steps could accept multiple answers, and repeated tokens could increase a score more than once.

## Validation

- Focused engine tests pass.
- Validation and scoring counterfactual tests fail as expected.
- Type checking and linting pass.