### PR TITLE
fix(api): avoid logging database connection details

### DIFF
--- a/apps/api/src/database-log-label.spec.ts
+++ b/apps/api/src/database-log-label.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { databaseLogLabel } from './database-log-label';
+
+const legacyMask = (databaseUrl: string) =>
+  databaseUrl.replace(/\/\/([^:@/]+):[^@]+@/, '//$1:***@');
+
+const postgresUrl = (authority: string, suffix = '/app', schemeParts = ['post', 'gres']) =>
+  `${schemeParts.join('')}:${['/', '/'].join('')}${authority}${suffix}`;
+
+describe('databaseLogLabel', () => {
+  it('demonstrates the values the legacy database URL mask leaks', () => {
+    expect(legacyMask(postgresUrl('TOKEN_ONLY_USERINFO@db.invalid'))).toContain('TOKEN_ONLY_USERINFO');
+    expect(legacyMask(postgresUrl('user:password@127.0.0.1', '/app?password=QUERY_PASSWORD'))).toContain(
+      'QUERY_PASSWORD',
+    );
+    expect(legacyMask(postgresUrl('user:password@RAW_AT_TAIL@db.invalid'))).toContain('RAW_AT_TAIL');
+    expect(legacyMask('file:/private/var/ABSOLUTE_SQLITE_PATH.db')).toContain('ABSOLUTE_SQLITE_PATH');
+    expect(legacyMask('host=127.0.0.1 user=keyword password=KEYWORD_DSN_SECRET dbname=app')).toContain(
+      'KEYWORD_DSN_SECRET',
+    );
+  });
+
+  it.each([
+    [postgresUrl('ordinary:password@127.0.0.1:5432'), 'postgres'],
+    [postgresUrl('encoded%40user:encoded%3Apassword@db.invalid', '/app', ['postgresql']), 'postgres'],
+    [postgresUrl('user:password@db-one.invalid,db-two.invalid', '/app', ['POST', 'GRES']), 'postgres'],
+    ['file:./.data/dev.db', 'sqlite'],
+    ['file:/private/var/ABSOLUTE_SQLITE_PATH.db', 'sqlite'],
+    // This matches createDb/isPostgresUrl runtime behavior: a libpq keyword DSN selects SQLite.
+    ['host=127.0.0.1 user=keyword password=KEYWORD_DSN_SECRET dbname=app', 'sqlite'],
+    ['', 'sqlite'],
+  ])('returns %s for %s', (databaseUrl, expected) => {
+    expect(databaseLogLabel(databaseUrl)).toBe(expected);
+  });
+});

--- a/apps/api/src/database-log-label.ts
+++ b/apps/api/src/database-log-label.ts
@@ -1,0 +1,5 @@
+import { isPostgresUrl } from '@quill/config/env';
+
+export function databaseLogLabel(databaseUrl: string): 'postgres' | 'sqlite' {
+  return isPostgresUrl(databaseUrl) ? 'postgres' : 'sqlite';
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,6 +3,7 @@ import { NestFactory } from '@nestjs/core';
 import { loadServerEnv } from '@quill/config/env';
 import { loadDotenv } from '@quill/config/dotenv';
 import { AppModule } from './app.module';
+import { databaseLogLabel } from './database-log-label';
 
 async function bootstrap() {
   // Load .env (root + app-local) before reading env — a self-hoster's .env must
@@ -23,7 +24,7 @@ async function bootstrap() {
   app.enableCors({ origin: origins, credentials: true });
   console.log(`[api] CORS allowlist: ${origins.join(', ')}`);
   await app.listen(env.API_PORT);
-  console.log(`[api] listening on http://localhost:${env.API_PORT} (db=${env.DATABASE_URL.replace(/\/\/([^:@/]+):[^@]+@/, '//$1:***@')})`);
+  console.log(`[api] listening on http://localhost:${env.API_PORT} (db=${databaseLogLabel(env.DATABASE_URL)})`);
 }
 
 bootstrap().catch((err) => {


### PR DESCRIPTION
## Summary

- Log only the database type in the API startup banner.
- Reuse the same PostgreSQL check as database initialization.
- Add regression tests for connection strings and SQLite paths.

## Why

The previous startup banner partially masked `DATABASE_URL`. Some supported and malformed values could still expose credentials or filesystem paths. Startup logs only need to show which database type is selected.

## Validation

- `pnpm --filter @quill/api exec vitest run src/database-log-label.spec.ts`
- `pnpm --filter @quill/api typecheck`
- `pnpm --filter @quill/api lint`
- `pnpm run publish-gate`