### PR TITLE
feat(web): "Dapta Agents" in the admin rail, badge reads "Made with Dapta Forms"

### DIFF
--- a/.changeset/agents-nav-and-made-with-badge.md
+++ b/.changeset/agents-nav-and-made-with-badge.md
@@ -1,0 +1,27 @@
+---
+'@quill/shared': minor
+'@quill/web': patch
+---
+
+A "Dapta Agents" door in the admin rail, and the public badge signs itself as
+Forms again.
+
+**The attribution pill reads "Made with Dapta Forms" and draws the Forms `F`.**
+Copy and mark move together (`growth.madeWith` in both locales, `BrandMark` in
+`made-with-badge.tsx`), and so does the destination: the published image now
+defaults `NEXT_PUBLIC_LANDING_URL` to the Forms landing on the platform's site,
+with the trailing slash the host requires to keep the query string. The pill's
+`utm_medium` is `form-button` (was `badge`); the thank-you CTA keeps
+`confirmation`. Reports filtering on the medium have to accept both spellings
+across the release date. Nothing changes for a fork: the loop is still gated on
+`NEXT_PUBLIC_SIGNUP_URL` and hidden by `NEXT_PUBLIC_HIDE_BADGE`.
+
+**"Dapta Agents" in the admin nav.** Last item of the rail, on every viewport
+(expanded, 64px collapsed, mobile drawer), rendered only when the deployment
+sets `NEXT_PUBLIC_PLATFORM_URL`, so a fork's rail carries no dead item. It is a
+plain anchor to a new tab with the same trailing arrow as the app-switcher rows,
+never `aria-current`, tagged `utm_source=forms&utm_medium=sidebar` through the
+new `lib/suite.ts` helper that the app-switcher now shares. The switcher's
+first row is renamed to "Dapta Agents" too, so one destination has one name.
+
+The confirmation CTA drops its em dash ("Get Dapta Forms, free").

--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,15 @@
 # and redirects through its logout. Server-only; never a secret itself.
 # IAM_BASE_URL=https://iam.example.internal
 
+# --- Suite doors (admin UI) ------------------------------------------------
+# The wider platform and the sibling product, as seen from inside the admin:
+# the app-switcher rows and the "Dapta Agents" nav item. Both are inlined at
+# build (NEXT_PUBLIC_*). Unset (the bare-fork default) renders neither door,
+# so a self-hosted rail never carries a dead item. Links carry
+# utm_source=forms&utm_medium=app_switcher|sidebar.
+# NEXT_PUBLIC_PLATFORM_URL=https://app.your-cloud.example
+# NEXT_PUBLIC_CALENDARS_URL=https://calendars.your-cloud.example
+
 # --- Growth loop / branding (public pages) ---------------------------------
 # When a signup destination is configured, public form pages carry a discreet
 # "Made with Dapta Forms" footer badge. Open-core: unset (the bare-fork
@@ -92,7 +101,7 @@
 #
 # Every badge/CTA link carries the UTM scheme
 #   utm_source=dapta-forms
-#   utm_medium=badge | confirmation        (which surface was clicked)
+#   utm_medium=form-button | confirmation  (which surface was clicked)
 #   utm_campaign=made-with-dapta
 #   utm_content=<accountCode>              (attribution only — already public in the page URL)
 #

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -236,9 +236,9 @@ are runtime server env for the web container.
 |---|---|---|---|
 | `NEXT_PUBLIC_API_URL` | `http://localhost:4000` | any real deploy (build arg) | no |
 | `NEXT_PUBLIC_PRODUCT_NAME` | `Forms` | branding (build arg) | no |
-| `NEXT_PUBLIC_PLATFORM_URL` | _(empty)_ | app-switcher link (build arg) | no |
+| `NEXT_PUBLIC_PLATFORM_URL` | _(empty)_ | the platform: app-switcher row + the "Dapta Agents" nav item; unset renders neither (build arg) | no |
 | `NEXT_PUBLIC_SIGNUP_URL` | _(empty)_ | growth-loop opt-in — unset renders no badge/CTA (build arg) | no |
-| `NEXT_PUBLIC_LANDING_URL` | product landing | where the badge/CTA point; falls back to the signup URL (build arg) | no |
+| `NEXT_PUBLIC_LANDING_URL` | product landing | where the badge/CTA point; falls back to the signup URL. Keep any trailing slash the host expects, the UTMs ride in the query (build arg) | no |
 | `NEXT_PUBLIC_HIDE_BADGE` | _(empty)_ | set truthy to hide the badge (build arg) | no |
 | `NEXT_PUBLIC_CALENDARS_URL` | _(empty)_ | app-switcher link (build arg) | no |
 | `AUTH_PROVIDER` | `local` | mirror the API value so the web picks the right login UX | no |

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -40,26 +40,27 @@ ENV NEXT_PUBLIC_SIGNUP_URL=$NEXT_PUBLIC_SIGNUP_URL
 # about a deployment. Nothing changes for a fork — the loop stays gated on
 # NEXT_PUBLIC_SIGNUP_URL, so with that unset neither surface renders at all.
 #
-# It follows the badge's COPY, and the copy now reads "Powered by Dapta". This
-# default was written when it read "Made with Dapta Forms" and pointed at the
-# product's own site; the sentence changed and this did not, so a respondent
-# clicking a badge that says Dapta was landing on daptaforms.ai.
+# It follows the badge's COPY. The copy reads "Made with Dapta Forms", so the
+# destination is the Forms landing on the platform's site — the page written
+# for a stranger who just answered someone's form. Every time the sentence
+# changed and this did not, a respondent was sent somewhere the pill did not
+# name; keep the two together.
 #
-# The APEX, with no `www.` prefix, and that is not a style choice — the two
-# spellings behave in opposite ways and the wrong one silently destroys the loop:
-#   apex, as written below   → 200, no redirect, query INTACT
-#   the `www.` prefix        → 301 to the apex, and the query is DROPPED
-# daptaforms.ai is the mirror image of that, which is where the old prefix came
-# from; carrying the habit over is exactly the mistake to avoid. Everything the
-# loop carries — utm_source=dapta-forms, utm_medium=badge | confirmation,
-# utm_campaign, utm_content=<accountCode> — rides in that query, so a redirect
-# that drops it makes every attributed signup look like direct traffic. Re-test
-# with `curl -sLo /dev/null -w '%{url_effective}' -L` before changing this host.
+# THREE spellings of this URL exist and only one keeps the query string:
+#   apex + `/forms/` with the trailing slash, as written below
+#                              → 200, no redirect, query INTACT
+#   apex + `/forms` (no slash) → 301 to the slashed path, query DROPPED
+#   the `www.` prefix          → 301 to the apex, query DROPPED
+# Everything the loop carries — utm_source=dapta-forms,
+# utm_medium=form-button | confirmation, utm_campaign, utm_content=<accountCode>
+# — rides in that query, so a redirect that drops it makes every attributed
+# signup look like direct traffic. Re-test with
+# `curl -sSo /dev/null -w '%{http_code} %{redirect_url}'` before changing this.
 #
-# (Spelled out rather than shown as two example URLs on purpose: publish-gate's
+# (Spelled out rather than shown as example URLs on purpose: publish-gate's
 # denylist bans every `*.dapta.ai` subdomain outside a short file allowlist that
 # this Dockerfile is not on, so writing the bad host even in a comment fails CI.)
-ARG NEXT_PUBLIC_LANDING_URL=https://dapta.ai
+ARG NEXT_PUBLIC_LANDING_URL=https://dapta.ai/forms/
 ENV NEXT_PUBLIC_LANDING_URL=$NEXT_PUBLIC_LANDING_URL
 ARG NEXT_PUBLIC_HIDE_BADGE=
 ENV NEXT_PUBLIC_HIDE_BADGE=$NEXT_PUBLIC_HIDE_BADGE
@@ -90,11 +91,11 @@ ARG NEXT_PUBLIC_PLATFORM_URL=
 ENV NEXT_PUBLIC_PLATFORM_URL=$NEXT_PUBLIC_PLATFORM_URL
 ARG NEXT_PUBLIC_SIGNUP_URL=
 ENV NEXT_PUBLIC_SIGNUP_URL=$NEXT_PUBLIC_SIGNUP_URL
-# Apex, no `www.` — see the note on the build stage's copy of this ARG. The two
-# stages must not drift: the client bundle takes the BUILD stage's value and SSR
-# takes this one, so a mismatch means the badge in the HTML and the badge after
-# hydration point at different hosts.
-ARG NEXT_PUBLIC_LANDING_URL=https://dapta.ai
+# Apex, no `www.`, trailing slash kept — see the note on the build stage's copy
+# of this ARG. The two stages must not drift: the client bundle takes the BUILD
+# stage's value and SSR takes this one, so a mismatch means the badge in the
+# HTML and the badge after hydration point at different places.
+ARG NEXT_PUBLIC_LANDING_URL=https://dapta.ai/forms/
 ENV NEXT_PUBLIC_LANDING_URL=$NEXT_PUBLIC_LANDING_URL
 ARG NEXT_PUBLIC_HIDE_BADGE=
 ENV NEXT_PUBLIC_HIDE_BADGE=$NEXT_PUBLIC_HIDE_BADGE

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -11,6 +11,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { WorkspaceSwitcher } from '@/components/workspace-switcher';
 import type { Workspace } from '@/lib/admin-api';
 import { resetAnalytics } from '@/lib/product-analytics';
+import { PLATFORM_URL, suiteHref } from '@/lib/suite';
 import type { ThemePref } from '@/lib/theme';
 
 type ChromeMessages = FormsMessages['admin']['chrome'];
@@ -21,7 +22,15 @@ type ChromeMessages = FormsMessages['admin']['chrome'];
  *  a desktop collapse rail (cookie-persisted, no FOUC), and a <768px off-canvas
  *  drawer with a hamburger top bar. Tokens only; R22 press/hover; R27/R28. */
 
-type IconName = 'home' | 'forms' | 'submissions' | 'analytics' | 'integrations' | 'branding' | 'cog';
+type IconName =
+  | 'home'
+  | 'forms'
+  | 'submissions'
+  | 'analytics'
+  | 'integrations'
+  | 'branding'
+  | 'cog'
+  | 'agents';
 
 interface NavItem {
   key: keyof ChromeMessages['nav'];
@@ -29,11 +38,21 @@ interface NavItem {
   icon: IconName;
   /** Active when the path matches any of these (prefix) in addition to href. */
   match?: string[];
+  /** Leaves the app: plain anchor in a new tab, never `aria-current`. */
+  external?: true;
 }
 
 // Forms information architecture: Home, Forms, Submissions, Analytics,
 // Integrations, Settings. Submissions/Analytics/Integrations are per-form
 // surfaces reached through a form picker at their global route.
+//
+// Last, and only on a deployment that has a platform: "Dapta Agents", the door
+// to the wider platform. It sits IN the nav rather than in a separate block so
+// the rail reads as one list, and it takes the external-link affordance so it
+// is never mistaken for a page of this app. Same open-core gate as the
+// app-switcher's first row: with NEXT_PUBLIC_PLATFORM_URL unset a fork's rail
+// carries no dead item. Same helper too, so both doors tag themselves alike
+// (`utm_source=forms`, medium = the piece of chrome clicked).
 const NAV: NavItem[] = [
   { key: 'home', href: '/admin', icon: 'home' },
   { key: 'forms', href: '/admin/forms', icon: 'forms' },
@@ -42,6 +61,9 @@ const NAV: NavItem[] = [
   { key: 'integrations', href: '/admin/integrations', icon: 'integrations' },
   { key: 'branding', href: '/admin/branding', icon: 'branding' },
   { key: 'settings', href: '/admin/settings', icon: 'cog' },
+  ...(PLATFORM_URL
+    ? [{ key: 'agents', href: suiteHref(PLATFORM_URL, 'sidebar'), icon: 'agents', external: true } as const]
+    : []),
 ];
 
 const NAV_COLLAPSED_KEY = 'forms.nav.collapsed';
@@ -56,6 +78,7 @@ const PI_BY_NAME: Record<IconName, string> = {
   integrations: 'pi-link',
   branding: 'pi-palette',
   cog: 'pi-cog',
+  agents: 'pi-microchip-ai',
 };
 
 function Icon({ name, className }: { name: IconName; className?: string }) {
@@ -71,48 +94,85 @@ function Icon({ name, className }: { name: IconName; className?: string }) {
 function NavLinks({
   collapsed,
   nav,
+  newTab,
   onNavigate,
 }: {
   collapsed: boolean;
   nav: ChromeMessages['nav'];
+  /** "(opens in a new tab)" — read out after an external item's label. */
+  newTab: string;
   onNavigate?: () => void;
 }) {
   const pathname = usePathname();
   return (
     <ul className="flex flex-col gap-1">
       {NAV.map((item) => {
-        const active = isNavItemActive(pathname, item.href, item.match);
+        // An external item is never "here": its href is another origin, so the
+        // prefix rule could not match anyway, but the intent should not depend
+        // on that accident.
+        const active = !item.external && isNavItemActive(pathname, item.href, item.match);
         const label = nav[item.key];
+        const className = [
+          'relative flex items-center gap-3 rounded-md text-sm transition-colors active:scale-[0.99]',
+          collapsed ? 'mx-auto h-11 w-11 justify-center gap-0 px-0' : 'min-h-[44px] px-3 py-2.5',
+          active
+            ? 'bg-muted font-medium text-foreground'
+            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+          // The `bg-muted` wash alone cannot mark "you are here": on paper it
+          // is 1.18:1 against the card behind it, well under the 3:1 WCAG
+          // 1.4.11 asks of a state indicator, and a grey chip on white can
+          // never reach it. The wash still does the scanning work; this 2px
+          // accent bar does the identifying, at 3.3:1 on light and 14:1 on
+          // dark. Two signals, so neither has to carry the whole job.
+          active &&
+            'before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary-edge before:content-[""]',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        // Label stays in the a11y tree when collapsed (sr-only) so the
+        // icon-only link keeps a discernible name (WCAG 4.1.2).
+        const body = (
+          <>
+            <Icon name={item.icon} />
+            <span className={collapsed ? 'sr-only' : ''}>{label}</span>
+          </>
+        );
         return (
           <li key={item.href}>
-            <Link
-              href={item.href}
-              onClick={onNavigate}
-              title={collapsed ? label : undefined}
-              aria-current={active ? 'page' : undefined}
-              className={[
-                'relative flex items-center gap-3 rounded-md text-sm transition-colors active:scale-[0.99]',
-                collapsed ? 'mx-auto h-11 w-11 justify-center gap-0 px-0' : 'min-h-[44px] px-3 py-2.5',
-                active
-                  ? 'bg-muted font-medium text-foreground'
-                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                // The `bg-muted` wash alone cannot mark "you are here": on paper it
-                // is 1.18:1 against the card behind it, well under the 3:1 WCAG
-                // 1.4.11 asks of a state indicator, and a grey chip on white can
-                // never reach it. The wash still does the scanning work; this 2px
-                // accent bar does the identifying, at 3.3:1 on light and 14:1 on
-                // dark. Two signals, so neither has to carry the whole job.
-                active &&
-                  'before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary-edge before:content-[""]',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-            >
-              <Icon name={item.icon} />
-              {/* Label stays in the a11y tree when collapsed (sr-only) so the
-                  icon-only link keeps a discernible name (WCAG 4.1.2). */}
-              <span className={collapsed ? 'sr-only' : ''}>{label}</span>
-            </Link>
+            {item.external ? (
+              <a
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={onNavigate}
+                title={collapsed ? label : undefined}
+                data-testid={`nav-${item.key}`}
+                className={className}
+              >
+                {body}
+                {/* The same trailing arrow the app-switcher rows carry, so
+                    "leaves the app" reads the same wherever it appears. Hidden
+                    on the 64px rail, where the 44px tile is the icon alone. */}
+                {!collapsed ? (
+                  <i
+                    aria-hidden
+                    className="pi pi-external-link ml-auto text-muted-foreground"
+                    style={{ fontSize: 13 }}
+                  />
+                ) : null}
+                <span className="sr-only"> {newTab}</span>
+              </a>
+            ) : (
+              <Link
+                href={item.href}
+                onClick={onNavigate}
+                title={collapsed ? label : undefined}
+                aria-current={active ? 'page' : undefined}
+                className={className}
+              >
+                {body}
+              </Link>
+            )}
           </li>
         );
       })}
@@ -228,7 +288,7 @@ export function AdminShell({
       target="_blank"
       rel="noopener noreferrer"
       title={messages.viewPublic}
-      aria-label={`${messages.viewPublic} (opens in a new tab)`}
+      aria-label={`${messages.viewPublic} ${messages.switcher.opensNewTab}`}
       className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.98]"
     >
       <i aria-hidden className="pi pi-external-link" style={{ fontSize: 16 }} />
@@ -339,7 +399,7 @@ export function AdminShell({
           />
         ) : null}
         <nav aria-label="Primary">
-          <NavLinks collapsed={railCollapsed} nav={messages.nav} />
+          <NavLinks collapsed={railCollapsed} nav={messages.nav} newTab={messages.switcher.opensNewTab} />
         </nav>
         {renderFooter(railCollapsed)}
       </aside>
@@ -385,7 +445,12 @@ export function AdminShell({
           />
         ) : null}
         <nav>
-          <NavLinks collapsed={false} nav={messages.nav} onNavigate={() => setDrawerOpen(false)} />
+          <NavLinks
+            collapsed={false}
+            nav={messages.nav}
+            newTab={messages.switcher.opensNewTab}
+            onNavigate={() => setDrawerOpen(false)}
+          />
         </nav>
         {renderFooter(false)}
       </aside>

--- a/apps/web/components/app-switcher.tsx
+++ b/apps/web/components/app-switcher.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useRef, useState } from 'react';
 import { BrandMark } from '@/components/brand/brand';
 import { AnchoredMenu } from '@/components/ui/anchored-menu';
+import { CALENDARS_URL, PLATFORM_URL, suiteHref } from '@/lib/suite';
 
 /**
  * App-switcher — the discreet door to the wider Dapta suite (design-parity with
  * Dapta Calendars). An Atlassian-style grid affordance next to the product
  * wordmark that opens a small menu:
- *   • Dapta AI (→ platform, new tab)  • Dapta Calendars (new tab)  • Forms (current)
+ *   • Dapta Agents (→ platform, new tab)  • Dapta Calendars (new tab)  • Forms (current)
  *
  * Growth-loop only — hidden entirely when NEITHER suite URL is configured
  * (white-label / self-host builds), so the switcher never dead-ends on a lone
@@ -26,20 +27,6 @@ interface SwitcherMessages {
 }
 
 const PRODUCT_NAME = process.env.NEXT_PUBLIC_PRODUCT_NAME || 'Forms';
-const PLATFORM_URL = process.env.NEXT_PUBLIC_PLATFORM_URL || '';
-const CALENDARS_URL = process.env.NEXT_PUBLIC_CALENDARS_URL || '';
-
-/** A suite URL carrying app-switcher UTM tags (best-effort). */
-function suiteHref(base: string): string {
-  try {
-    const url = new URL(base);
-    url.searchParams.set('utm_source', 'forms');
-    url.searchParams.set('utm_medium', 'app_switcher');
-    return url.toString();
-  } catch {
-    return base;
-  }
-}
 
 export function AppSwitcher({ messages: m }: { messages: SwitcherMessages }) {
   const [open, setOpen] = useState(false);
@@ -83,12 +70,14 @@ export function AppSwitcher({ messages: m }: { messages: SwitcherMessages }) {
           {m.eyebrow}
         </p>
 
-        {/* Dapta AI — the platform (external, new tab). First, per Felipe. */}
+        {/* Dapta Agents — the platform (external, new tab). First, per Felipe.
+            Same name and destination as the rail's own "Dapta Agents" item: one
+            door, two handles, so it never reads as two different products. */}
         {PLATFORM_URL ? (
           <a
             role="menuitem"
             tabIndex={-1}
-            href={suiteHref(PLATFORM_URL)}
+            href={suiteHref(PLATFORM_URL, 'app_switcher')}
             target="_blank"
             rel="noopener noreferrer"
             onClick={close}
@@ -123,7 +112,7 @@ export function AppSwitcher({ messages: m }: { messages: SwitcherMessages }) {
           <a
             role="menuitem"
             tabIndex={-1}
-            href={suiteHref(CALENDARS_URL)}
+            href={suiteHref(CALENDARS_URL, 'app_switcher')}
             target="_blank"
             rel="noopener noreferrer"
             onClick={close}

--- a/apps/web/components/brand/brand.tsx
+++ b/apps/web/components/brand/brand.tsx
@@ -79,9 +79,12 @@ export function BrandMark({ className, labelled }: { className?: string; labelle
  *
  * Distinct from `BrandMark` on purpose, and the two are not interchangeable: a
  * surface signs itself with the mark that matches the name written next to it.
- * In-product chrome says "Forms" and takes `BrandMark`; the attribution badge on
- * a public form says "Powered by Dapta" and takes this one. Pairing either mark
- * with the other name is the bug this split exists to prevent.
+ * Anything that says "Forms" — in-product chrome AND the "Made with Dapta Forms"
+ * attribution badge — takes `BrandMark`; only a surface that names the company
+ * takes this one. Pairing either mark with the other name is the bug this split
+ * exists to prevent. No surface takes it today (the badge did while its copy
+ * read "Powered by Dapta"); it stays because the split is the rule, and the
+ * next surface that names Dapta should not have to rediscover it.
  *
  * Same open-core gate as every other surface here — a fork gets its own initial,
  * never Dapta's `d`.

--- a/apps/web/components/brand/dapta-logo.spec.tsx
+++ b/apps/web/components/brand/dapta-logo.spec.tsx
@@ -105,8 +105,9 @@ describe('DaptaMark', () => {
   });
 
   it('is decorative by default and only announces itself when labelled', () => {
-    // The badge sets no title: the visible "Powered by Dapta" beside it already
-    // names the link, and a title would have a screen reader say it twice.
+    // A mark beside visible text sets no title (the badge did, while it carried
+    // this one): the text already names the link, and a title would have a
+    // screen reader say it twice.
     expect(markup()).toContain('aria-hidden="true"');
     expect(markup()).not.toContain('<title>');
 

--- a/apps/web/components/made-with-badge.tsx
+++ b/apps/web/components/made-with-badge.tsx
@@ -1,19 +1,19 @@
 import { getMessages } from '@quill/shared';
-import { PlatformMark } from '@/components/brand/brand';
+import { BrandMark } from '@/components/brand/brand';
 import { signupHref } from '@/lib/growth';
 
 /**
- * "Powered by Dapta" — the growth-loop attribution on every public surface (R11).
+ * "Made with Dapta Forms" — the growth-loop attribution on every public surface (R11).
  *
- * The copy names the PLATFORM, not the product: a respondent who has just filled
- * a form is a warmer lead for Dapta than for Dapta Forms, and the badge's whole
- * job is to send them somewhere. Where it sends them is `NEXT_PUBLIC_SIGNUP_URL`
- * — never a domain in this file (see `signupHref`).
- *
- * The MARK follows the copy, which is why this is the one surface taking
- * `PlatformMark` and not `BrandMark`: the badge used to set the product's `F`
- * beside a sentence naming the company, so the two halves of the pill argued
- * with each other about who the reader was being sent to.
+ * The copy names the PRODUCT, and so does the mark: this is `BrandMark`, the
+ * Forms `F`, never `PlatformMark`. A pill signs itself with the mark that
+ * matches the name written beside it; the two halves used to argue (the F next
+ * to "Powered by Dapta", then the d), and each swap was a release on its own.
+ * Where it sends the reader is a deployment fact — `NEXT_PUBLIC_LANDING_URL`
+ * with `NEXT_PUBLIC_SIGNUP_URL` as the opt-in — never a domain in this file
+ * (see `signupHref`). Dapta's image points it at the Forms landing, so a
+ * stranger who just answered someone's form lands on a page written for a
+ * stranger, tagged `utm_medium=form-button`.
  *
  * It is FORM CHROME, not a document footer. It used to render as a `<footer>`
  * AFTER the renderer in `page.tsx`, and `.pf` carries `min-height: 100dvh` —
@@ -39,7 +39,7 @@ export function MadeWithBadge({
   locale?: string;
   accountCode?: string | null;
 }) {
-  const href = signupHref('badge', accountCode);
+  const href = signupHref('form-button', accountCode);
   if (!href) return null;
   const m = getMessages(locale);
   return (
@@ -50,11 +50,11 @@ export function MadeWithBadge({
         target="_blank"
         rel="noopener noreferrer"
       >
-        {/* The bowl is currentColor, so it picks up the pill's foreground and
-            stays legible on any host background; only the lime tick is literal.
+        {/* The stem is currentColor, so it picks up the pill's foreground and
+            stays legible on any host background; only the lime arms are literal.
             Unlabelled on purpose — the visible text right beside it already
             names the destination, so a title here would read it out twice. */}
-        <PlatformMark className="pf__attribution-mark" />
+        <BrandMark className="pf__attribution-mark" />
         <span>{m.growth.madeWith}</span>
         {/* Localized, like every other string on this surface — this used to be
             a hardcoded English "(opens in a new tab)". Same catalog key the

--- a/apps/web/lib/suite.spec.ts
+++ b/apps/web/lib/suite.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { suiteHref } from './suite';
+
+describe('suiteHref — the in-app doors to the suite', () => {
+  it('tags the link with the product as source and the chrome as medium', () => {
+    const url = new URL(suiteHref('https://app.example.com', 'sidebar'));
+    expect(url.searchParams.get('utm_source')).toBe('forms');
+    expect(url.searchParams.get('utm_medium')).toBe('sidebar');
+  });
+
+  it('names the door, so the switcher and the rail item stay distinguishable', () => {
+    expect(new URL(suiteHref('https://app.example.com', 'app_switcher')).searchParams.get('utm_medium')).toBe(
+      'app_switcher',
+    );
+  });
+
+  it('keeps an existing query and path', () => {
+    const url = new URL(suiteHref('https://app.example.com/agents?ref=x', 'sidebar'));
+    expect(url.pathname).toBe('/agents');
+    expect(url.searchParams.get('ref')).toBe('x');
+    expect(url.searchParams.get('utm_source')).toBe('forms');
+  });
+
+  it('returns an unparseable base verbatim rather than hiding it', () => {
+    // A suite link that looks broken is a bug worth seeing; only the public
+    // badge hides, because a fork may legitimately have no destination.
+    expect(suiteHref('not a url', 'sidebar')).toBe('not a url');
+  });
+});

--- a/apps/web/lib/suite.ts
+++ b/apps/web/lib/suite.ts
@@ -1,0 +1,32 @@
+/**
+ * In-app doors to the rest of the Dapta suite — the app-switcher rows and the
+ * "Dapta Agents" nav item. One helper so every door tags itself the same way.
+ *
+ * A different loop from the public badge (`lib/growth.ts`): the reader here is
+ * already a Forms user, so `utm_source` is the product's own name and
+ * `utm_medium` is the piece of chrome that was clicked. Best-effort on purpose:
+ * a base that cannot be parsed comes back untouched rather than hidden — a
+ * suite link that looks broken is a bug worth seeing, whereas the public badge
+ * hides because a fork may legitimately have no destination at all.
+ *
+ * The URLs themselves come only from the deployment (`NEXT_PUBLIC_PLATFORM_URL`,
+ * `NEXT_PUBLIC_CALENDARS_URL`), read as full static property accesses so Next
+ * inlines them into the client bundle. Empty on a bare fork → the callers render
+ * nothing, so the rail never carries a dead item.
+ */
+export type SuiteMedium = 'app_switcher' | 'sidebar';
+
+export const PLATFORM_URL = process.env.NEXT_PUBLIC_PLATFORM_URL || '';
+export const CALENDARS_URL = process.env.NEXT_PUBLIC_CALENDARS_URL || '';
+
+/** A suite URL carrying the in-app UTM tags. */
+export function suiteHref(base: string, medium: SuiteMedium): string {
+  try {
+    const url = new URL(base);
+    url.searchParams.set('utm_source', 'forms');
+    url.searchParams.set('utm_medium', medium);
+    return url.toString();
+  } catch {
+    return base;
+  }
+}

--- a/packages/shared/src/growth.spec.ts
+++ b/packages/shared/src/growth.spec.ts
@@ -3,19 +3,33 @@ import { buildSignupUrl, badgeHidden, growthTarget, UTM_SOURCE, UTM_CAMPAIGN } f
 
 describe('growth attribution', () => {
   it('tags signup URLs with the forms UTM source', () => {
-    const built = buildSignupUrl({ baseUrl: 'https://app.example.com', medium: 'badge', accountCode: 'acme' });
+    const built = buildSignupUrl({ baseUrl: 'https://app.example.com', medium: 'form-button', accountCode: 'acme' });
     expect(built).not.toBeNull();
     const url = new URL(built!);
     expect(url.searchParams.get('utm_source')).toBe('dapta-forms');
     expect(url.searchParams.get('utm_source')).toBe(UTM_SOURCE);
-    expect(url.searchParams.get('utm_medium')).toBe('badge');
+    expect(url.searchParams.get('utm_medium')).toBe('form-button');
     expect(url.searchParams.get('utm_campaign')).toBe(UTM_CAMPAIGN);
     expect(url.searchParams.get('utm_content')).toBe('acme');
   });
 
+  it('names the surface in utm_medium', () => {
+    const pill = new URL(buildSignupUrl({ baseUrl: 'https://app.example.com', medium: 'form-button' })!);
+    const cta = new URL(buildSignupUrl({ baseUrl: 'https://app.example.com', medium: 'confirmation' })!);
+    expect(pill.searchParams.get('utm_medium')).toBe('form-button');
+    expect(cta.searchParams.get('utm_medium')).toBe('confirmation');
+  });
+
+  it('keeps a trailing slash on the landing path', () => {
+    // The host may 301 the slash-less spelling to the slashed one and drop the
+    // query on the way — every UTM lost. The base is appended to verbatim.
+    const built = buildSignupUrl({ baseUrl: 'https://www.example.ai/forms/', medium: 'form-button' });
+    expect(built).toMatch(/^https:\/\/www\.example\.ai\/forms\/\?utm_source=/);
+  });
+
   it('returns null for a missing/non-http base (fork carries no dead link)', () => {
-    expect(buildSignupUrl({ baseUrl: null, medium: 'badge' })).toBeNull();
-    expect(buildSignupUrl({ baseUrl: 'ftp://x', medium: 'badge' })).toBeNull();
+    expect(buildSignupUrl({ baseUrl: null, medium: 'form-button' })).toBeNull();
+    expect(buildSignupUrl({ baseUrl: 'ftp://x', medium: 'form-button' })).toBeNull();
   });
 
   it('badgeHidden only honors explicit truthy flags', () => {
@@ -55,7 +69,7 @@ describe('growthTarget — the loop is gated on signup, but points at the landin
   it('the built URL still carries every UTM tag', () => {
     const built = buildSignupUrl({
       baseUrl: growthTarget({ signupUrl: 'https://app.example.com', landingUrl: 'https://www.example.ai' }),
-      medium: 'badge',
+      medium: 'form-button',
       accountCode: 'acme',
     });
     const url = new URL(built!);

--- a/packages/shared/src/growth.ts
+++ b/packages/shared/src/growth.ts
@@ -1,5 +1,5 @@
 /**
- * Growth loop — the "Powered by Dapta" attribution on public pages.
+ * Growth loop — the "Made with Dapta Forms" attribution on public pages.
  *
  * Open-core rule: like the app-switcher's platform URL, the signup destination
  * comes ONLY from the deployment (NEXT_PUBLIC_SIGNUP_URL) — no internal host
@@ -10,8 +10,15 @@
  * identical on every surface.
  */
 
-/** UTM values are fixed product-wide; only the medium varies by surface. */
-export type SignupMedium = 'badge' | 'confirmation';
+/**
+ * UTM values are fixed product-wide; only the medium varies by surface.
+ *
+ * `form-button` is the attribution pill on the form itself; `confirmation` is
+ * the "Want your own form?" CTA on the thank-you screen. The pill's medium was
+ * `badge` until 2026-08 — any report filtering on it has to accept BOTH values
+ * across that date, or the earlier days read as zero.
+ */
+export type SignupMedium = 'form-button' | 'confirmation';
 
 export const UTM_SOURCE = 'dapta-forms';
 export const UTM_CAMPAIGN = 'made-with-dapta';
@@ -22,6 +29,8 @@ export const UTM_CAMPAIGN = 'made-with-dapta';
  * `accountCode` (already public — it's in the page URL) rides along as
  * utm_content for attribution; nothing else about the tenant is leaked.
  * String-built (no URL/URLSearchParams): this package stays lib-ES2022-only.
+ * The base is appended to verbatim — a trailing slash on its path survives,
+ * which matters when the host 301s the slash-less spelling and drops the query.
  */
 export function buildSignupUrl(opts: {
   baseUrl?: string | null;
@@ -55,10 +64,10 @@ export function buildSignupUrl(opts: {
  *    `signupUrl` otherwise.
  *
  * They were the same value once, and that was the bug: both surfaces greet a
- * STRANGER — the badge says "Powered by Dapta", the CTA asks "Want your own
- * form?" — and both were dropping that person on the app's login screen for a
- * product they had never heard of. A landing page is written for exactly that
- * reader; a login screen is written for someone who already decided.
+ * STRANGER — the badge says "Made with Dapta Forms", the CTA asks "Want your
+ * own form?" — and both were dropping that person on the app's login screen
+ * for a product they had never heard of. A landing page is written for exactly
+ * that reader; a login screen is written for someone who already decided.
  */
 export function growthTarget(opts: {
   signupUrl?: string | null;

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -135,6 +135,12 @@ export interface FormsMessages {
         integrations: string;
         branding: string;
         settings: string;
+        /**
+         * The door to the wider platform (agents), an EXTERNAL link. Rendered
+         * only when the deployment configures a platform URL, so a fork's rail
+         * never carries a dead item.
+         */
+        agents: string;
       };
       /** The Dapta suite app-switcher. */
       switcher: {
@@ -1527,9 +1533,9 @@ export interface FormsMessages {
 
 export const en: FormsMessages = {
   growth: {
-    madeWith: 'Powered by Dapta',
+    madeWith: 'Made with Dapta Forms',
     ctaQuestion: 'Want your own form?',
-    ctaAction: 'Get Dapta Forms — free',
+    ctaAction: 'Get Dapta Forms, free',
     seoForm: 'Fill out {name} online.',
     shareCardSteps: '{count} questions',
     shareCardUntitled: 'Form',
@@ -1543,7 +1549,7 @@ export const en: FormsMessages = {
     thankYouTitle: 'Thank you!',
     thankYouBody: 'Your answers were recorded.',
     ctaQuestion: 'Want your own form?',
-    ctaAction: 'Get Dapta Forms — free',
+    ctaAction: 'Get Dapta Forms, free',
     progressLabel: 'Step {current} of {total}',
     verticalProgress: '{answered} of {total} answered',
     verticalErrors: 'Check the highlighted questions above.',
@@ -1618,12 +1624,13 @@ export const en: FormsMessages = {
         integrations: 'Integrations',
         branding: 'Brand kit',
         settings: 'Settings',
+        agents: 'Dapta Agents',
       },
       switcher: {
         trigger: 'Switch product',
         menuLabel: 'Dapta products',
         eyebrow: 'Dapta',
-        dapta: 'Dapta AI',
+        dapta: 'Dapta Agents',
         calendars: 'Dapta Calendars',
         opensNewTab: '(opens in a new tab)',
       },
@@ -2910,9 +2917,9 @@ export const en: FormsMessages = {
 
 export const es: FormsMessages = {
   growth: {
-    madeWith: 'Con tecnología de Dapta',
+    madeWith: 'Hecho con Dapta Forms',
     ctaQuestion: '¿Quieres tu propio formulario?',
-    ctaAction: 'Consigue Dapta Forms — gratis',
+    ctaAction: 'Consigue Dapta Forms, gratis',
     seoForm: 'Completa {name} en línea.',
     shareCardSteps: '{count} preguntas',
     shareCardUntitled: 'Formulario',
@@ -2926,7 +2933,7 @@ export const es: FormsMessages = {
     thankYouTitle: '¡Gracias!',
     thankYouBody: 'Tus respuestas quedaron registradas.',
     ctaQuestion: '¿Quieres tu propio formulario?',
-    ctaAction: 'Consigue Dapta Forms — gratis',
+    ctaAction: 'Consigue Dapta Forms, gratis',
     progressLabel: 'Paso {current} de {total}',
     verticalProgress: '{answered} de {total} respondidas',
     verticalErrors: 'Revisa las preguntas marcadas arriba.',
@@ -3001,12 +3008,13 @@ export const es: FormsMessages = {
         integrations: 'Integraciones',
         branding: 'Kit de marca',
         settings: 'Ajustes',
+        agents: 'Dapta Agents',
       },
       switcher: {
         trigger: 'Cambiar producto',
         menuLabel: 'Productos Dapta',
         eyebrow: 'Dapta',
-        dapta: 'Dapta AI',
+        dapta: 'Dapta Agents',
         calendars: 'Dapta Calendars',
         opensNewTab: '(se abre en una pestaña nueva)',
       },


### PR DESCRIPTION
## What

Two doors, one for each direction of the loop.

**Public attribution pill → "Made with Dapta Forms", Forms `F`, Forms landing.**
- `growth.madeWith`: "Made with Dapta Forms" / "Hecho con Dapta Forms".
- `made-with-badge.tsx` takes `BrandMark` (the F) instead of `PlatformMark` (the d). `PlatformMark` stays with no call site; the mark-follows-the-name rule is kept in its docblock.
- `utm_medium` of the pill: `badge` → `form-button`. Thank-you CTA keeps `confirmation`. Source (`dapta-forms`) and campaign unchanged.
- Dockerfile default `NEXT_PUBLIC_LANDING_URL` → `https://dapta.ai/forms/` in **both** stages. Trailing slash is load-bearing: `/forms` (no slash) and `www.` both 301 and drop the query string, i.e. every UTM. Verified with curl 2026-08-17; only the apex with the slash answers 200 with the query intact.
- Resulting URL: `https://dapta.ai/forms/?utm_source=dapta-forms&utm_medium=form-button&utm_campaign=made-with-dapta&utm_content=<accountCode>`.

**"Dapta Agents" nav item.**
- Last item of the admin rail: `<a target="_blank" rel="noopener noreferrer">`, never `aria-current`, `pi-microchip-ai` icon, the same trailing external arrow the app-switcher rows carry (hidden on the 64px rail, where `title` mirrors the label). Present in the expanded rail, the collapsed rail and the mobile drawer.
- Rendered only when `NEXT_PUBLIC_PLATFORM_URL` is set: a fork's rail carries no dead item.
- New `apps/web/lib/suite.ts` (`suiteHref(base, medium)`, `utm_source=forms&utm_medium=sidebar|app_switcher`) shared with the app-switcher, which drops its private copy. The switcher's first row is renamed "Dapta AI" → "Dapta Agents": one destination, one name.
- i18n `chrome.nav.agents` (en/es); `.env.example` now documents `NEXT_PUBLIC_PLATFORM_URL` / `NEXT_PUBLIC_CALENDARS_URL`; SELF-HOSTING table updated; changeset (`@quill/shared` minor, `@quill/web` patch).
- Also: em dash out of `growth.ctaAction` ("Get Dapta Forms, free"), and the "View public page" new-tab hint uses the localized `switcher.opensNewTab` instead of hardcoded English.

## Why now

The badge went full circle in three PRs (#71 copy "Made with", #80 mark → d, #81 host → apex). This time copy, mark and destination move together in one change.

## Heads-up

- **Analytics rename trap.** Any filter on `utm_medium=badge` must accept `form-button` too from the release date, or the earlier days read as zero (same trap as `landing` → `dapta_forms` in August).
- The confirmation CTA ("Want your own form?") shares `growthTarget`, so it also points at `dapta.ai/forms/`. Intended.
- No pipeline change needed: `ci-cd.yml` does not pass `NEXT_PUBLIC_LANDING_URL`, so the image default set here is what ships (same mechanism as #81).

## Verification

- `@quill/shared` 50/50, `@quill/web` 476/476, `pnpm typecheck` + `pnpm lint` clean, publish-gate internal-token scan OK.
- `forms-reviewer` agent: PASS (its SHOULD-FIX and nits applied).
- Visual on a production build (`next build` + `next start`, pipeline env values): rail expanded / collapsed / mobile drawer, app-switcher, badge on cover + question + ES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

