### PR TITLE
feat: workspaces are the identity service's workspaces

### DIFF
--- a/.changeset/iam-workspaces.md
+++ b/.changeset/iam-workspaces.md
@@ -20,8 +20,8 @@ every write, which goes upstream first.
   `account.synced_at`, `member.iam_workspace_user_id`.
 - Home is the workspace the person opened LAST, in either app: the upstream
   `feature_flags.last_workspace`, which this product now also writes on every
-  switch. Pre-0015 rows are rebound lazily on the owner's next login, keeping their
-  id, public code and forms.
+  switch. Pre-0015 rows are rebound lazily on the next login of anyone whose token
+  names that upstream account, keeping their id, public code and forms.
 - New: create a workspace (upstream first, under the caller's own account, then
   projected), rename it, refresh the list; the switcher is always visible and is
   where "New workspace" lives.
@@ -33,5 +33,9 @@ every write, which goes upstream first.
   changes exactly one place.
 - Onboarding is per person, not per workspace: someone who finished the wizard is
   not sent through it again for a workspace projected from upstream.
+- Upstream is the authority on status: a membership disabled locally BEFORE
+  `IAM_BASE_URL` was set is revived on that person's next login if upstream
+  still lists them active. Disable them upstream (or via Settings, which now
+  writes upstream) instead.
 - Without `IAM_BASE_URL` (every fork, plain local dev) nothing changes: the same
   operations act on local rows only.

--- a/.changeset/iam-workspaces.md
+++ b/.changeset/iam-workspaces.md
@@ -1,0 +1,37 @@
+---
+'@quill/db': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+The identity service's workspaces ARE the workspaces.
+
+Until now one local `account` was born per identity-service ACCOUNT (the billing
+layer above workspaces): a person with three workspaces upstream had exactly one
+here, and a workspace created here was invisible upstream. From migration 0015 on,
+`account.external_id` means the upstream WORKSPACE id and the local
+`account`/`member` rows are a projection of what the identity service says: read
+on login (at most once per TTL), on demand when the switcher opens, and after
+every write, which goes upstream first.
+
+- `packages/db/src/workspaces.ts` — `projectMemberships`, `projectRoster`,
+  `rebindLegacyAccount`, `pickHomeAccount`, `createLocalWorkspace`,
+  `humanHasCompletedOnboarding`. Three additive columns: `account.iam_account_id`,
+  `account.synced_at`, `member.iam_workspace_user_id`.
+- Home is the workspace the person opened LAST, in either app: the upstream
+  `feature_flags.last_workspace`, which this product now also writes on every
+  switch. Pre-0015 rows are rebound lazily on the owner's next login, keeping their
+  id, public code and forms.
+- New: create a workspace (upstream first, under the caller's own account, then
+  projected), rename it, refresh the list; the switcher is always visible and is
+  where "New workspace" lives.
+- Members: the roster is re-projected from the upstream `users[]`; invitations,
+  their email and their acceptance live upstream; removals and role changes go
+  upstream first. Pending invitations are listed and can be resent.
+- Roles: `OWNER` → owner, `MEMBER` holding `workspace_admin` → admin, any other →
+  member — one function (`roleFromIam`) so a future `forms` permission component
+  changes exactly one place.
+- Onboarding is per person, not per workspace: someone who finished the wizard is
+  not sent through it again for a workspace projected from upstream.
+- Without `IAM_BASE_URL` (every fork, plain local dev) nothing changes: the same
+  operations act on local rows only.

--- a/.env.example
+++ b/.env.example
@@ -221,6 +221,12 @@ MAIL_FROM_NAME=Forms
 # enqueued, no third-party request is made. IAM_API_KEY is read by BOTH apps:
 # the API (sync) and the web (the cohort probe's x-api-key). IAM_BASE_URL was
 # already a web var (login/logout hand-off); the API now reads it too.
+#
+# IAM_BASE_URL on the API, together with AUTH_PROVIDER=workos, ALSO turns on
+# identity-service-backed WORKSPACES (migration 0015): the person's workspaces,
+# their memberships and roles, invitations, and "last opened" are read from and
+# written to the IAM with the caller's own bearer, and the local account/member
+# rows become a projection of it. Unset = workspaces stay local-only.
 # IAM_BASE_URL=https://iam.example.com/iam
 # IAM_API_KEY=
 # DAPTA_SYNC_FLOW_URL=https://flows.example.com/api/WORKSPACE/sync_contact

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -66,12 +66,15 @@ import {
   memberProfileSchema,
   onboardingCompleteSchema,
   onboardingProgressSchema,
+  workspaceCreateSchema,
+  workspaceRenameSchema,
 } from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
 import { SubmissionService } from './submission.service';
 import { AnalyticsService } from './analytics.service';
 import { AuthService, type ReqLike } from './auth.service';
+import { WorkspaceService } from './workspace.service';
 import { EmailEffects } from './email-effects';
 import { AnalyticsEffects } from './analytics-effects';
 import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
@@ -128,7 +131,14 @@ export class AdminCrudController {
     // service (per-question drop-off shown to a form owner). This one is our own
     // telemetry about the people using the builder. Different audience entirely.
     @Optional() @Inject(AnalyticsEffects) private readonly productAnalytics?: AnalyticsEffects,
+    // Last on purpose: existing tests construct this controller positionally.
+    @Optional() @Inject(WorkspaceService) private readonly workspacesSvc?: WorkspaceService,
   ) {}
+
+  private ws(): WorkspaceService {
+    if (!this.workspacesSvc) throw new Error('WorkspaceService not wired');
+    return this.workspacesSvc;
+  }
 
   // --- Identity ----------------------------------------------------------
   @Get('me')
@@ -294,6 +304,38 @@ export class AdminCrudController {
   @Get('workspaces')
   async workspaces(@Req() req: ReqLike) {
     return this.auth.listWorkspaces(req);
+  }
+
+  /** Same list, after forcing a re-read from the identity service (when there is one). */
+  @Post('workspaces/refresh')
+  @HttpCode(200)
+  async refreshWorkspaces(@Req() req: ReqLike) {
+    return this.ws().refresh(req);
+  }
+
+  /** Create a workspace with the caller as owner (upstream first when configured). */
+  @Post('workspaces')
+  @HttpCode(201)
+  async createWorkspace(@Req() req: ReqLike, @Body() body: unknown) {
+    const input = parse(workspaceCreateSchema, body);
+    return this.ws().create(req, input);
+  }
+
+  /** Rename the workspace the caller is acting in (admin/owner). */
+  @Patch('workspaces/current')
+  async renameWorkspace(@Req() req: ReqLike, @Body() body: unknown) {
+    const input = parse(workspaceRenameSchema, body);
+    return this.ws().rename(req, input);
+  }
+
+  /**
+   * The caller is about to open this workspace. Membership is re-checked, and
+   * the choice is remembered upstream so the Dapta app opens the same one.
+   */
+  @Post('workspaces/:id/enter')
+  @HttpCode(200)
+  async enterWorkspace(@Req() req: ReqLike, @Param('id') id: string) {
+    return this.ws().enter(req, id);
   }
 
   /** This member's public page config (the raw blob, or null). */
@@ -531,19 +573,47 @@ export class AdminCrudController {
   }
 
   // --- Members (workspace roster; admin/owner-only) ----------------------
+  //
+  // With the identity service configured (0015) the roster IS the upstream
+  // workspace's `users[]`, invitations live upstream (their email included),
+  // and every change goes upstream first. Without it (forks, dev stub) the
+  // local model below is the whole story. `hasUpstream` is what decides.
   @Get('members')
   async members(@Req() req: ReqLike) {
+    if (this.workspacesSvc && (await this.workspacesSvc.hasUpstream(req))) {
+      return this.workspacesSvc.roster(req);
+    }
     const p = await this.auth.resolveHost(req);
     assertAdmin(p);
     return listMembers(this.db, p.accountId);
   }
 
+  /** Pending invitations (upstream-only; empty without an identity service). */
+  @Get('invitations')
+  async invitations(@Req() req: ReqLike) {
+    if (this.workspacesSvc && (await this.workspacesSvc.hasUpstream(req))) {
+      return this.workspacesSvc.listInvitations(req);
+    }
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    return [];
+  }
+
+  @Post('invitations/:id/resend')
+  @HttpCode(200)
+  async resendInvitation(@Req() req: ReqLike, @Param('id') id: string) {
+    return this.ws().resendInvitation(req, id);
+  }
+
   @Post('members')
   @HttpCode(201)
   async inviteMember(@Req() req: ReqLike, @Body() body: unknown) {
+    const input = parse(memberInviteSchema, body);
+    if (this.workspacesSvc && (await this.workspacesSvc.hasUpstream(req))) {
+      return this.workspacesSvc.inviteUpstream(req, input);
+    }
     const p = await this.auth.resolveHost(req);
     assertAdmin(p);
-    const input = parse(memberInviteSchema, body);
     const member = unwrapCrud(await inviteMember(this.db, p.accountId, input));
     // Tell them. Until now the row was created and nobody was ever notified.
     // Enqueued (never sent inline) and fire-and-forget: a mail provider being
@@ -561,10 +631,13 @@ export class AdminCrudController {
 
   @Patch('members/:id')
   async updateMember(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const input = parse(memberPatchSchema, body);
+    if (this.workspacesSvc && (await this.workspacesSvc.hasUpstream(req))) {
+      return this.workspacesSvc.updateMemberUpstream(req, id, input);
+    }
     const p = await this.auth.resolveHost(req);
     assertAdmin(p);
     assertNotSelf(p, id);
-    const input = parse(memberPatchSchema, body);
     const target = await getAccountMember(this.db, p.accountId, id);
     if (!target) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
     assertCanManageTarget(p, target, { toRole: input.role });
@@ -577,6 +650,9 @@ export class AdminCrudController {
   @Delete('members/:id')
   @HttpCode(200)
   async removeMember(@Req() req: ReqLike, @Param('id') id: string) {
+    if (this.workspacesSvc && (await this.workspacesSvc.hasUpstream(req))) {
+      return this.workspacesSvc.removeMemberUpstream(req, id);
+    }
     const p = await this.auth.resolveHost(req);
     assertAdmin(p);
     assertNotSelf(p, id);

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import {
   ONBOARDING_ENABLED,
   PREMIUM_MODE,
   RATE_LIMITER,
+  WORKSPACE_PROJECTION,
 } from './tokens';
 import { SubmissionService } from './submission.service';
 import { AdminService } from './admin.service';
@@ -27,7 +28,10 @@ import { DaptaSyncDelivery } from './dapta-sync';
 import { OutboxWorker } from './outbox.worker';
 import { RateLimitGuard, createRateLimiter } from './rate-limit';
 import { resolveEntitlementsProvider } from './entitlements.provider';
-import { createAuthProvider } from './auth.provider';
+import { createAuthProvider, type SignupObserver } from './auth.provider';
+import { WorkspaceProjection } from './workspace-projection';
+import { IamWorkspacesClient } from './iam-workspaces';
+import { WorkspaceService } from './workspace.service';
 import type { Db } from '@quill/db';
 import { HealthController, DocsController } from './controllers';
 import { PublicController } from './public.controller';
@@ -41,6 +45,23 @@ import {
   HubspotPropertiesService,
   IntegrationsController,
 } from './integrations.controller';
+
+/** Product telemetry for "a person joined" — shared by the auth provider and the projection. */
+function signupObserver(productAnalytics: AnalyticsEffects): SignupObserver {
+  return (signup) => {
+    if (!signup.email) return;
+    void productAnalytics.capture('signup_completed', {
+      distinctId: signup.email,
+      accountId: signup.accountId,
+      properties: {
+        member_id: signup.memberId,
+        role: signup.role,
+        is_first_member: signup.isFirstMember,
+        from_invite: signup.fromInvite,
+      },
+    });
+  };
+}
 
 @Module({
   controllers: [
@@ -101,6 +122,20 @@ import {
       useFactory: (env: ServerEnv) => env.ONBOARDING_WIZARD,
       inject: [ENV],
     },
+    // The identity service's workspaces ARE the workspaces (0015). Present only
+    // when IAM_BASE_URL is configured AND the workos provider is selected; a
+    // fork / plain local dev gets null and every workspace path stays local.
+    {
+      provide: WORKSPACE_PROJECTION,
+      useFactory: (env: ServerEnv, db: Db, productAnalytics: AnalyticsEffects) =>
+        env.AUTH_PROVIDER === 'workos' && env.IAM_BASE_URL
+          ? new WorkspaceProjection(db, new IamWorkspacesClient({ baseUrl: env.IAM_BASE_URL }), {
+              seedEnv: env,
+              onSignup: signupObserver(productAnalytics),
+            })
+          : null,
+      inject: [ENV, DB, AnalyticsEffects],
+    },
     // Host auth backend selected by AUTH_PROVIDER (local stub / WorkOS overlay).
     {
       provide: AUTH_PROVIDER,
@@ -108,21 +143,13 @@ import {
       // members are materialized just-in-time inside the provider, so there is
       // no signup endpoint to instrument. Passed as a plain callback so the auth
       // adapters stay ignorant of analytics (invariant 6).
-      useFactory: (env: ServerEnv, db: Db, productAnalytics: AnalyticsEffects) =>
-        createAuthProvider(env, db, (signup) => {
-          if (!signup.email) return;
-          void productAnalytics.capture('signup_completed', {
-            distinctId: signup.email,
-            accountId: signup.accountId,
-            properties: {
-              member_id: signup.memberId,
-              role: signup.role,
-              is_first_member: signup.isFirstMember,
-              from_invite: signup.fromInvite,
-            },
-          });
-        }),
-      inject: [ENV, DB, AnalyticsEffects],
+      useFactory: (
+        env: ServerEnv,
+        db: Db,
+        productAnalytics: AnalyticsEffects,
+        projection: WorkspaceProjection | null,
+      ) => createAuthProvider(env, db, signupObserver(productAnalytics), projection ?? undefined),
+      inject: [ENV, DB, AnalyticsEffects, WORKSPACE_PROJECTION],
     },
     // Rate limiter for the public surface (P1-5): token bucket by default, noop
     // when RATE_LIMIT_ENABLED=false; swappable for a distributed limiter.
@@ -132,6 +159,7 @@ import {
     AnalyticsService,
     AdminService,
     AuthService,
+    WorkspaceService,
     EmailEffects,
     // Fans submissions out to enabled destinations (webhook/HubSpot) via the
     // durable outbox; delivery never blocks or fails submission handling.

--- a/apps/api/src/auth.provider.ts
+++ b/apps/api/src/auth.provider.ts
@@ -27,6 +27,7 @@ import type { ServerEnv } from '@quill/config/env';
 // from here) is safe: each side references the other only inside function
 // bodies, never during module evaluation.
 import { WorkOsAuthProvider } from './auth.provider.workos';
+import type { WorkspaceProjection } from './workspace-projection';
 
 export interface ReqLike {
   headers: Record<string, string | string[] | undefined>;
@@ -114,11 +115,33 @@ export async function maybeSeedDemoForm(
   }
 }
 
+/**
+ * What a provider can say about the caller's UPSTREAM identity, for the parts
+ * of the product that must talk to the identity service on the caller's behalf
+ * (workspace create/rename, invitations, "last opened" bookkeeping). Shape is
+ * provider-agnostic on purpose: a subject, the person's own upstream account,
+ * and an opaque bearer to forward. `null` means "this provider has no
+ * upstream" (the dev stub, every fork), and callers fall back to local-only.
+ */
+export interface UpstreamIdentity {
+  sub: string;
+  iamAccountId: string;
+  email: string | null;
+  displayName: string | null;
+  bearer: string;
+}
+
 /** The port every host-auth backend implements. */
 export interface AuthProvider {
   readonly name: string;
   /** Resolve the authenticated host (dashboard). Throws 401 if unresolved. */
   resolveHost(req: ReqLike): Promise<ResolvedHost>;
+  /**
+   * The caller's upstream identity, when this provider has one. Optional so the
+   * dev stub and forks implement nothing; MUST throw 401 (not return null) when
+   * the request carries no valid credential at all.
+   */
+  resolveUpstream?(req: ReqLike): Promise<UpstreamIdentity | null>;
 }
 
 /**
@@ -288,6 +311,13 @@ export function createAuthProvider(
   env: ServerEnv,
   db: Db,
   onSignup?: SignupObserver,
+  /**
+   * The workspace projection (identity-service-backed workspaces). Present only
+   * when `IAM_BASE_URL` is configured; the workos adapter then resolves the
+   * HOME workspace from what the identity service says instead of the token's
+   * `account_id`. Absent = pre-0015 behavior, one local account per token account.
+   */
+  projection?: WorkspaceProjection,
 ): AuthProvider {
   switch (env.AUTH_PROVIDER) {
     case 'local':
@@ -300,7 +330,7 @@ export function createAuthProvider(
             'AUTH_PROVIDER=local for development only.',
         );
       }
-      return new WorkOsAuthProvider(db, env, onSignup);
+      return new WorkOsAuthProvider(db, env, onSignup, projection);
     default:
       throw new Error(`Unknown AUTH_PROVIDER: ${String((env as ServerEnv).AUTH_PROVIDER)}`);
   }

--- a/apps/api/src/auth.provider.workos.ts
+++ b/apps/api/src/auth.provider.workos.ts
@@ -31,8 +31,10 @@ import {
   type ResolvedHost,
   type ReqLike,
   type SignupObserver,
+  type UpstreamIdentity,
 } from './auth.provider';
 import { verifyJwtHs256, JwtError, type JwtClaims } from './jwt';
+import type { WorkspaceProjection } from './workspace-projection';
 
 type WorkOsEnv = Pick<
   ServerEnv,
@@ -58,6 +60,14 @@ export class WorkOsAuthProvider implements AuthProvider {
     private readonly env: WorkOsEnv,
     /** Optional; omitted means nothing observes signups (the fork default). */
     private readonly onSignup?: SignupObserver,
+    /**
+     * Optional; present when the identity service's workspaces are the
+     * workspaces (`IAM_BASE_URL` set). Then HOME is whatever the identity
+     * service says the person opened last, and the local rows are a projection
+     * of their upstream memberships. Absent = the token's `account_id` IS the
+     * one local account (pre-0015 shape; still what tests and forks get).
+     */
+    private readonly projection?: WorkspaceProjection,
   ) {
     if (!env.JWT_SECRET) {
       // Defensive: the factory already guards this, but never run without a key.
@@ -66,7 +76,8 @@ export class WorkOsAuthProvider implements AuthProvider {
     this.secret = env.JWT_SECRET;
   }
 
-  async resolveHost(req: ReqLike): Promise<ResolvedHost> {
+  /** Verify the bearer and read the claims this provider relies on. */
+  private verify(req: ReqLike): { token: string; claims: JwtClaims; sub: string; accountExtId: string } {
     const authHeader = header(req, 'authorization');
     const token =
       authHeader && authHeader.startsWith('Bearer ')
@@ -90,6 +101,41 @@ export class WorkOsAuthProvider implements AuthProvider {
     const sub = typeof claims.sub === 'string' ? claims.sub : undefined;
     if (!accountExtId) throw unauthenticated('Token missing account_id.');
     if (!sub) throw unauthenticated('Token missing sub.');
+    return { token, claims, sub, accountExtId };
+  }
+
+  async resolveUpstream(req: ReqLike): Promise<UpstreamIdentity | null> {
+    if (!this.projection) return null;
+    const { token, claims, sub, accountExtId } = this.verify(req);
+    return {
+      sub,
+      iamAccountId: accountExtId,
+      email: typeof claims.email === 'string' ? claims.email : null,
+      displayName: typeof claims.name === 'string' ? claims.name : null,
+      bearer: token,
+    };
+  }
+
+  async resolveHost(req: ReqLike): Promise<ResolvedHost> {
+    const { token, claims, sub, accountExtId } = this.verify(req);
+
+    if (this.projection) {
+      const upstream: UpstreamIdentity = {
+        sub,
+        iamAccountId: accountExtId,
+        email: typeof claims.email === 'string' ? claims.email : null,
+        displayName: typeof claims.name === 'string' ? claims.name : null,
+        bearer: token,
+      };
+      const state = await this.projection.ensure(upstream);
+      const home = await this.projection.home(upstream, state);
+      if (home) return home;
+      // Nothing upstream and nothing local for this person. The identity
+      // service creates a workspace at signup, so this is not expected — fall
+      // through to the token-account path rather than refuse a valid token,
+      // and the next projection pass rebinds that row once a workspace exists.
+      this.log.warn(`no upstream workspace for ${sub}; falling back to token account ${accountExtId}`);
+    }
 
     const accountId = await this.resolveAccount(accountExtId, claims);
     const memberId = await this.resolveMember(accountId, sub, claims);

--- a/apps/api/src/auth.provider.workos.ts
+++ b/apps/api/src/auth.provider.workos.ts
@@ -18,7 +18,7 @@
  * `createAuthProvider` still fails loud without it. No vendor host/secret name
  * appears here — issuer/audience/secret all arrive via env.
  */
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, Logger, UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import type { Db, AccountRole } from '@quill/db';
 import { deriveUniqueHandle, insertAccountWithShortCode, sql } from '@quill/db';
@@ -127,14 +127,24 @@ export class WorkOsAuthProvider implements AuthProvider {
         displayName: typeof claims.name === 'string' ? claims.name : null,
         bearer: token,
       };
-      const state = await this.projection.ensure(upstream);
-      const home = await this.projection.home(upstream, state);
+      let state = await this.projection.ensure(upstream);
+      let home = await this.projection.home(upstream, state);
+      if (!home && !state.degraded) {
+        // A warm cache can hide a membership that was just restored upstream;
+        // one forced re-read is cheap and honest.
+        state = await this.projection.ensure(upstream, { force: true });
+        home = await this.projection.home(upstream, state);
+      }
       if (home) return home;
-      // Nothing upstream and nothing local for this person. The identity
-      // service creates a workspace at signup, so this is not expected — fall
-      // through to the token-account path rather than refuse a valid token,
-      // and the next projection pass rebinds that row once a workspace exists.
-      this.log.warn(`no upstream workspace for ${sub}; falling back to token account ${accountExtId}`);
+      // Nothing upstream and nothing local. The identity service creates a
+      // workspace at signup, so this is a real fault, not a first login — and
+      // minting a token-account row here would recreate exactly the pre-0015
+      // shape 0015 retires. Refuse, loudly.
+      this.log.warn(`no workspace for ${sub} (upstream account ${accountExtId}); refusing`);
+      throw new ForbiddenException({
+        error: 'NO_WORKSPACE',
+        message: 'Your account has no workspace yet. Open the Dapta app once, then try again.',
+      });
     }
 
     const accountId = await this.resolveAccount(accountExtId, claims);

--- a/apps/api/src/dapta-sync.ts
+++ b/apps/api/src/dapta-sync.ts
@@ -67,8 +67,11 @@ export class DaptaSyncDelivery {
     const me = await getMe(this.db, payload.accountId, payload.memberId);
     const state = await getAccountOnboarding(this.db, payload.accountId);
     const blob = state?.onboarding ?? null;
+    // `iam_account_id` is the upstream ACCOUNT (billing) id since 0015;
+    // `external_id` was that same value before and is the upstream WORKSPACE
+    // id after, so the coalesce keeps rows the projection has not touched yet.
     const account = await this.db.get<{ external_id: string | null }>(
-      sql`SELECT external_id FROM account WHERE id = ${payload.accountId} LIMIT 1`,
+      sql`SELECT COALESCE(iam_account_id, external_id) AS external_id FROM account WHERE id = ${payload.accountId} LIMIT 1`,
     );
 
     if (action === 'complete' && blob) {

--- a/apps/api/src/iam-workspaces.ts
+++ b/apps/api/src/iam-workspaces.ts
@@ -1,0 +1,321 @@
+/**
+ * The identity service's workspace API, as this product consumes it.
+ *
+ * Every call forwards the CALLER's bearer token — the same platform JWT the
+ * auth provider validated — so the identity service applies its own
+ * authorization and this client never holds a privileged credential. Nothing
+ * here is cached or persisted; `workspace-projection.ts` decides what to keep.
+ *
+ * Only the shapes this product reads are typed. Upstream returns far more per
+ * row (phone numbers, plans, stripe ids); it is dropped at the boundary.
+ *
+ * Kept behind `IAM_BASE_URL`: unset (every fork, plain local dev) means this
+ * client is never constructed and the auth provider keeps its pre-0015 shape.
+ */
+
+import type { AccountRole } from '@quill/db';
+
+/** How the upstream classifies a membership row. */
+export type IamMembershipType = 'OWNER' | 'MEMBER';
+
+/**
+ * One membership row. The upstream ships TWO shapes of it — the search list
+ * nests the role under `role` and the person under `user`; the workspace
+ * detail flattens both — so every field that differs is optional here and read
+ * through the accessors below, never directly.
+ */
+export interface IamWorkspaceUser {
+  /** `workspace_users.id` — what removal / re-roling is keyed on. */
+  id: string;
+  user_id: string;
+  type: IamMembershipType;
+  is_active: boolean;
+  /** Roles assigned to this membership. Empty for an OWNER (implicit admin). */
+  roles?: Array<{ role_id?: string; id?: string; name?: string; role?: { name?: string } | null }> | null;
+  user?: { email?: string | null; name?: string | null } | null;
+  email?: string | null;
+  name?: string | null;
+}
+
+/** The person's email on a membership row, whichever shape it arrived in. */
+export function userEmailOf(u: IamWorkspaceUser): string | null {
+  return u.email ?? u.user?.email ?? null;
+}
+
+/** The person's display name on a membership row, whichever shape it arrived in. */
+export function userNameOf(u: IamWorkspaceUser): string | null {
+  return u.name ?? u.user?.name ?? null;
+}
+
+export interface IamWorkspace {
+  id: string;
+  name: string;
+  description?: string | null;
+  account_id: string;
+  is_active: boolean;
+  isOwner?: boolean;
+  users?: IamWorkspaceUser[];
+}
+
+export interface IamAccount {
+  id: string;
+  name?: string | null;
+  feature_flags?: Record<string, unknown> | null;
+}
+
+export interface IamRole {
+  id: string;
+  name: string;
+  is_system?: boolean;
+  workspace_id?: string | null;
+}
+
+export interface IamInvitation {
+  id: string;
+  workspace_id: string;
+  invited_email: string;
+  role?: string | null;
+  status: string;
+  created_at?: string;
+  expires_at?: string | null;
+}
+
+/** The upstream system role that maps to this product's `admin`. */
+export const IAM_ADMIN_ROLE_NAME = 'workspace_admin';
+
+/**
+ * Upstream membership → local account role.
+ *
+ *   OWNER                              → owner
+ *   MEMBER holding `workspace_admin`   → admin   (can manage members, branding, integrations)
+ *   MEMBER with any other / no role    → member  (creates and edits forms, reads results)
+ *
+ * One function on purpose: when the identity service grows a `forms` component
+ * in its permission catalog, this is the only place that changes.
+ */
+export function roleFromIam(wu: Pick<IamWorkspaceUser, 'type' | 'roles'>): AccountRole {
+  if (wu.type === 'OWNER') return 'owner';
+  const admin = (wu.roles ?? []).some((r) => (r.name ?? r.role?.name) === IAM_ADMIN_ROLE_NAME);
+  return admin ? 'admin' : 'member';
+}
+
+/** A membership of `sub` in one workspace, or null when they hold none. */
+export function membershipOf(ws: IamWorkspace, sub: string): IamWorkspaceUser | null {
+  return (ws.users ?? []).find((u) => u.user_id === sub) ?? null;
+}
+
+export class IamHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly method: string,
+    public readonly path: string,
+    public readonly body: string,
+  ) {
+    super(`IAM ${method} ${path} → HTTP ${status}`);
+    this.name = 'IamHttpError';
+  }
+}
+
+export class IamUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IamUnavailableError';
+  }
+}
+
+const IAM_TIMEOUT_MS = 10_000;
+const PAGE_SIZE = 100;
+/** Guard against an upstream that pages forever; a person is in far fewer than this. */
+const MAX_PAGES = 20;
+
+export interface IamWorkspacesClientOptions {
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export class IamWorkspacesClient {
+  private readonly base: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(opts: IamWorkspacesClientOptions) {
+    this.base = opts.baseUrl.replace(/\/$/, '');
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.timeoutMs = opts.timeoutMs ?? IAM_TIMEOUT_MS;
+  }
+
+  // --- Accounts ------------------------------------------------------------
+
+  getAccount(bearer: string, accountId: string): Promise<IamAccount> {
+    return this.call<IamAccount>(bearer, 'GET', `/account/${encodeURIComponent(accountId)}`);
+  }
+
+  /**
+   * Remember the workspace this person opened last. Written on the person's OWN
+   * account (the token's `account_id`) even when the workspace belongs to
+   * someone else's — that is where the Dapta app reads it from at bootstrap, so
+   * the "last opened" answer is shared in both directions.
+   */
+  async setLastWorkspace(
+    bearer: string,
+    accountId: string,
+    workspaceId: string,
+    currentFlags: Record<string, unknown> | null | undefined,
+  ): Promise<void> {
+    await this.call(bearer, 'PUT', `/account/${encodeURIComponent(accountId)}`, {
+      feature_flags: { ...(currentFlags ?? {}), last_workspace: workspaceId },
+    });
+  }
+
+  // --- Workspaces ----------------------------------------------------------
+
+  /**
+   * Every workspace `sub` is a member of. The upstream search is NOT "mine" —
+   * for some callers it returns every workspace in the estate — so membership is
+   * decided here, from `users[]`, never from presence in the list.
+   */
+  async listMyWorkspaces(bearer: string, sub: string): Promise<IamWorkspace[]> {
+    const out: IamWorkspace[] = [];
+    const seen = new Set<string>();
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      const res = await this.call<{ data?: IamWorkspace[]; totalPages?: number; total?: number }>(
+        bearer,
+        'GET',
+        `/workspace/search?page=${page}&limit=${PAGE_SIZE}`,
+      );
+      const rows = Array.isArray(res?.data) ? res.data : [];
+      for (const ws of rows) {
+        if (!ws || typeof ws.id !== 'string' || seen.has(ws.id)) continue;
+        seen.add(ws.id);
+        if (ws.is_active === false) continue;
+        const me = membershipOf(ws, sub);
+        if (me || ws.isOwner === true) out.push(ws);
+      }
+      const totalPages = typeof res?.totalPages === 'number' ? res.totalPages : 1;
+      if (rows.length < PAGE_SIZE || page >= totalPages) break;
+    }
+    return out;
+  }
+
+  getWorkspace(bearer: string, workspaceId: string): Promise<IamWorkspace> {
+    return this.call<IamWorkspace>(bearer, 'GET', `/workspace/${encodeURIComponent(workspaceId)}`);
+  }
+
+  createWorkspace(
+    bearer: string,
+    input: { name: string; description?: string; timezone?: string; account_id: string },
+  ): Promise<IamWorkspace> {
+    return this.call<IamWorkspace>(bearer, 'POST', '/workspace', {
+      name: input.name,
+      description: input.description ?? '',
+      timezone: input.timezone ?? 'UTC',
+      account_id: input.account_id,
+    });
+  }
+
+  updateWorkspace(
+    bearer: string,
+    workspaceId: string,
+    input: { name: string; description?: string },
+  ): Promise<IamWorkspace> {
+    return this.call<IamWorkspace>(bearer, 'PUT', `/workspace/${encodeURIComponent(workspaceId)}`, {
+      name: input.name,
+      ...(input.description !== undefined ? { description: input.description } : {}),
+    });
+  }
+
+  // --- Roles + members -----------------------------------------------------
+
+  async listRoles(bearer: string, workspaceId: string): Promise<IamRole[]> {
+    const res = await this.call<IamRole[] | { data?: IamRole[] }>(
+      bearer,
+      'GET',
+      `/role/roles-workspace/${encodeURIComponent(workspaceId)}`,
+    );
+    return Array.isArray(res) ? res : Array.isArray(res?.data) ? res.data : [];
+  }
+
+  removeWorkspaceUser(bearer: string, workspaceUserId: string): Promise<unknown> {
+    return this.call(bearer, 'DELETE', `/workspaceUser/member/${encodeURIComponent(workspaceUserId)}`);
+  }
+
+  setWorkspaceUserActive(bearer: string, workspaceUserId: string, active: boolean): Promise<unknown> {
+    return this.call(bearer, 'PUT', '/workspaceUser', { id: workspaceUserId, is_active: active });
+  }
+
+  assignRole(bearer: string, workspaceUserId: string, roleId: string): Promise<unknown> {
+    return this.call(bearer, 'POST', '/workspaceUser/assign-role', {
+      workspace_user_id: workspaceUserId,
+      role_id: roleId,
+    });
+  }
+
+  // --- Invitations ---------------------------------------------------------
+
+  createInvitation(
+    bearer: string,
+    input: { invited_email: string; workspace_id: string; role_id?: string; message?: string },
+  ): Promise<IamInvitation> {
+    return this.call<IamInvitation>(bearer, 'POST', '/workspace-invitations', {
+      invited_email: input.invited_email,
+      workspace_id: input.workspace_id,
+      role: 'MEMBER',
+      ...(input.role_id ? { role_id: input.role_id } : {}),
+      message: input.message ?? '',
+    });
+  }
+
+  resendInvitation(bearer: string, invitationId: string): Promise<unknown> {
+    return this.call(bearer, 'POST', '/workspace-invitations/resend', { invitation_id: invitationId });
+  }
+
+  /** `status` is upstream's enum, UPPERCASE: PENDING | ACCEPTED | REJECTED | EXPIRED | CANCELLED. */
+  async listInvitations(
+    bearer: string,
+    workspaceId: string,
+    status = 'PENDING',
+  ): Promise<IamInvitation[]> {
+    const res = await this.call<{ data?: IamInvitation[] }>(
+      bearer,
+      'GET',
+      `/workspace-invitations/${encodeURIComponent(workspaceId)}/paginated?page=1&limit=${PAGE_SIZE}&status=${encodeURIComponent(status.toUpperCase())}`,
+    );
+    return Array.isArray(res?.data) ? res.data : [];
+  }
+
+  // --- Transport -----------------------------------------------------------
+
+  private async call<T = unknown>(bearer: string, method: string, path: string, body?: unknown): Promise<T> {
+    let res: Response;
+    try {
+      res = await this.fetchImpl(`${this.base}${path}`, {
+        method,
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          accept: 'application/json',
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (err) {
+      throw new IamUnavailableError(`IAM ${method} ${path} unreachable: ${String(err)}`);
+    }
+    if (res.status === 429 || res.status >= 500) {
+      throw new IamUnavailableError(`IAM ${method} ${path} → HTTP ${res.status}`);
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new IamHttpError(res.status, method, path, text.slice(0, 500));
+    }
+    if (res.status === 204) return undefined as T;
+    const text = await res.text();
+    if (!text) return undefined as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return undefined as T;
+    }
+  }
+}

--- a/apps/api/src/tokens.ts
+++ b/apps/api/src/tokens.ts
@@ -8,3 +8,4 @@ export const RATE_LIMITER = Symbol('RATE_LIMITER');
 export const ENTITLEMENTS = Symbol('ENTITLEMENTS');
 export const PREMIUM_MODE = Symbol('PREMIUM_MODE');
 export const ONBOARDING_ENABLED = Symbol('ONBOARDING_ENABLED');
+export const WORKSPACE_PROJECTION = Symbol('WORKSPACE_PROJECTION');

--- a/apps/api/src/workspace-projection.spec.ts
+++ b/apps/api/src/workspace-projection.spec.ts
@@ -292,6 +292,57 @@ describe('workspace projection (IAM-backed workspaces)', () => {
   });
 });
 
+describe('workspace projection: edge cases', () => {
+  let db: Db;
+  let iam: FakeIam;
+  let projection: WorkspaceProjection;
+  let auth: AuthService;
+  const now = 1_700_000_000_000;
+
+  beforeEach(async () => {
+    db = await createDb('file::memory:');
+    await migrate(db);
+    iam = new FakeIam();
+    iam.workspaces = [ws(WS_OWN, 'dapta', IAM_ACCOUNT, [{ id: 'wu-own', user_id: SUB, type: 'OWNER', is_active: true, roles: [] }])];
+    projection = new WorkspaceProjection(
+      db,
+      new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl: iam.fetch }),
+      { ttlMs: 60_000, now: () => now },
+    );
+    auth = new AuthService(
+      db,
+      new WorkOsAuthProvider(
+        db,
+        { JWT_SECRET: SECRET, JWT_ISSUER: undefined, JWT_AUDIENCE: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false },
+        undefined,
+        projection,
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('coalesces concurrent cold requests into ONE upstream read', async () => {
+    await Promise.all([auth.resolveHost(asReq(tokenFor(SUB))), auth.resolveHost(asReq(tokenFor(SUB))), auth.resolveHost(asReq(tokenFor(SUB)))]);
+    expect(iam.calls.filter((c) => c.path.startsWith('/iam/workspace/search')).length).toBe(1);
+  });
+
+  it('a person with no workspace anywhere is refused (403), never given a token-account row', async () => {
+    iam.workspaces = [];
+    await expect(auth.resolveHost(asReq(tokenFor(OTHER_SUB, 'acct-x')))).rejects.toBeInstanceOf(ForbiddenException);
+    const rows = await db.all<{ id: string }>(sql`SELECT id FROM account WHERE external_id = 'acct-x'`);
+    expect(rows.length).toBe(0);
+  });
+
+  it('a workspace whose users[] omits the owner still projects with the owner role', async () => {
+    iam.workspaces = [{ id: WS_OWN, name: 'dapta', account_id: IAM_ACCOUNT, is_active: true, isOwner: true, users: [] }];
+    const p = await auth.resolveHost(asReq(tokenFor(SUB)));
+    expect(p.role).toBe('owner');
+  });
+});
+
 describe('roleFromIam', () => {
   it('maps OWNER → owner, workspace_admin → admin, anything else → member', () => {
     expect(roleFromIam({ type: 'OWNER', roles: [] })).toBe('owner');

--- a/apps/api/src/workspace-projection.spec.ts
+++ b/apps/api/src/workspace-projection.spec.ts
@@ -1,0 +1,305 @@
+/**
+ * The identity service's workspaces ARE the workspaces (0015).
+ *
+ * Runs the real `WorkOsAuthProvider` + `WorkspaceProjection` + `AuthService`
+ * against in-memory SQLite and a fake identity service (a fetch stub that
+ * records every call). What each test protects, worst first:
+ *
+ *   1. membership is decided by `users[]`, never by presence in the search
+ *      list — the upstream search can return workspaces the caller is NOT in.
+ *   2. HOME is the workspace the person opened last (upstream `last_workspace`),
+ *      when they still belong to it; the header switch still works on top.
+ *   3. a pre-0015 row (`external_id` = upstream ACCOUNT id) is rebound onto
+ *      the upstream workspace, keeping its id, code, and forms.
+ *   4. the identity service being down serves what is already local instead of
+ *      locking the person out; a first-ever login with nothing local is a 503.
+ *   5. a person who finished the wizard is not sent through it again for a
+ *      workspace projected from upstream.
+ *   6. one upstream read per TTL, not one per request.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
+import { createDb, migrate, sql, type Db } from '@quill/db';
+import { AuthService, WORKSPACE_HEADER } from './auth.service';
+import { WorkOsAuthProvider } from './auth.provider.workos';
+import { WorkspaceProjection } from './workspace-projection';
+import { IamWorkspacesClient, roleFromIam, type IamWorkspace } from './iam-workspaces';
+import { signJwtHs256 } from './jwt';
+import type { ReqLike } from './auth.provider';
+
+const SECRET = 'test-secret';
+const SUB = '4bd0984c-0000-4000-8000-000000000001';
+const OTHER_SUB = '4bd0984c-0000-4000-8000-000000000002';
+const IAM_ACCOUNT = 'a49b1229-0000-4000-8000-0000000000aa';
+const WS_OWN = '38bafc53-0000-4000-8000-0000000000b1';
+const WS_INVITED = '21e7f594-0000-4000-8000-0000000000b2';
+const WS_STRANGER = 'deadbeef-0000-4000-8000-0000000000b3';
+
+function ws(id: string, name: string, accountId: string, users: IamWorkspace['users']): IamWorkspace {
+  return { id, name, account_id: accountId, is_active: true, users };
+}
+
+/** A fake identity service: routes + a call log. Mutable so tests can change what it says. */
+class FakeIam {
+  calls: Array<{ method: string; path: string; body?: unknown }> = [];
+  down = false;
+  lastWorkspace: string | null = null;
+  workspaces: IamWorkspace[] = [];
+
+  fetch: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? 'GET';
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    this.calls.push({ method, path: url.pathname + url.search, body });
+    if (this.down) return new Response('boom', { status: 503 });
+    if (!(init?.headers as Record<string, string>)?.authorization?.startsWith('Bearer '))
+      return new Response('{}', { status: 401 });
+
+    if (method === 'GET' && url.pathname === `/iam/account/${IAM_ACCOUNT}`) {
+      return json({ id: IAM_ACCOUNT, feature_flags: this.lastWorkspace ? { last_workspace: this.lastWorkspace } : {} });
+    }
+    if (method === 'PUT' && url.pathname === `/iam/account/${IAM_ACCOUNT}`) {
+      this.lastWorkspace = body?.feature_flags?.last_workspace ?? null;
+      return json({ ok: true });
+    }
+    if (method === 'GET' && url.pathname === '/iam/workspace/search') {
+      return json({ data: this.workspaces, total: this.workspaces.length, totalPages: 1 });
+    }
+    if (method === 'POST' && url.pathname === '/iam/workspace') {
+      const created = ws(`new-${this.workspaces.length}`, body.name, body.account_id, [
+        { id: `wu-new-${this.workspaces.length}`, user_id: SUB, type: 'OWNER', is_active: true, roles: [] },
+      ]);
+      this.workspaces.push(created);
+      return json(created);
+    }
+    if (method === 'PUT' && url.pathname.startsWith('/iam/workspace/')) {
+      const id = url.pathname.split('/').pop()!;
+      const w = this.workspaces.find((x) => x.id === id);
+      if (w) w.name = body.name;
+      return json(w ?? {});
+    }
+    return new Response('not found', { status: 404 });
+  };
+}
+
+function json(v: unknown, status = 200): Response {
+  return new Response(JSON.stringify(v), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function tokenFor(sub: string, accountId = IAM_ACCOUNT): string {
+  return signJwtHs256(
+    { sub, account_id: accountId, email: `${sub.slice(-1)}@example.com`, name: 'Alex', iat: 1, exp: 4102444800 },
+    SECRET,
+  );
+}
+
+const asReq = (token: string, workspace?: string): ReqLike => ({
+  headers: {
+    authorization: `Bearer ${token}`,
+    ...(workspace ? { [WORKSPACE_HEADER]: workspace } : {}),
+  },
+});
+
+describe('workspace projection (IAM-backed workspaces)', () => {
+  let db: Db;
+  let iam: FakeIam;
+  let projection: WorkspaceProjection;
+  let auth: AuthService;
+  let now = 1_700_000_000_000;
+
+  beforeEach(async () => {
+    db = await createDb('file::memory:');
+    await migrate(db);
+    iam = new FakeIam();
+    iam.workspaces = [
+      ws(WS_OWN, 'dapta', IAM_ACCOUNT, [
+        { id: 'wu-own', user_id: SUB, type: 'OWNER', is_active: true, roles: [] },
+      ]),
+      ws(WS_INVITED, 'Test', 'someone-elses-account', [
+        { id: 'wu-them', user_id: OTHER_SUB, type: 'OWNER', is_active: true, roles: [] },
+        {
+          id: 'wu-me',
+          user_id: SUB,
+          type: 'MEMBER',
+          is_active: true,
+          roles: [{ role_id: 'r1', role: { name: 'workspace_admin' } }],
+        },
+      ]),
+      // Visible in the search, but the caller is NOT in it.
+      ws(WS_STRANGER, 'Siigo', 'stranger-account', [
+        { id: 'wu-x', user_id: OTHER_SUB, type: 'OWNER', is_active: true, roles: [] },
+      ]),
+    ];
+    projection = new WorkspaceProjection(
+      db,
+      new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl: iam.fetch }),
+      { ttlMs: 60_000, now: () => now },
+    );
+    const provider = new WorkOsAuthProvider(
+      db,
+      { JWT_SECRET: SECRET, JWT_ISSUER: undefined, JWT_AUDIENCE: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false },
+      undefined,
+      projection,
+    );
+    auth = new AuthService(db, provider);
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('projects only the workspaces the caller is a member of, with the upstream role', async () => {
+    const p = await auth.resolveHost(asReq(tokenFor(SUB)));
+    const list = await auth.listWorkspaces(asReq(tokenFor(SUB)));
+    expect(list.map((w) => w.accountName).sort()).toEqual(['Test', 'dapta']);
+    expect(list.find((w) => w.accountName === 'dapta')!.role).toBe('owner');
+    expect(list.find((w) => w.accountName === 'Test')!.role).toBe('admin');
+    // The stranger's workspace never became a local row.
+    const stranger = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${WS_STRANGER}`);
+    expect(stranger).toBeUndefined();
+    // With no last_workspace upstream, home is the oldest membership: the first projected.
+    expect(list.some((w) => w.accountId === p.accountId)).toBe(true);
+    // The account rows carry the upstream ids.
+    const own = await db.get<{ iam_account_id: string; external_id: string }>(
+      sql`SELECT iam_account_id, external_id FROM account WHERE name = 'dapta'`,
+    );
+    expect(own!.external_id).toBe(WS_OWN);
+    expect(own!.iam_account_id).toBe(IAM_ACCOUNT);
+  });
+
+  it('home is the workspace opened last upstream, and the header still switches on top', async () => {
+    iam.lastWorkspace = WS_INVITED;
+    const p = await auth.resolveHost(asReq(tokenFor(SUB)));
+    const home = await db.get<{ external_id: string }>(sql`SELECT external_id FROM account WHERE id = ${p.accountId}`);
+    expect(home!.external_id).toBe(WS_INVITED);
+    expect(p.role).toBe('admin');
+
+    const own = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${WS_OWN}`);
+    const switched = await auth.resolveHost(asReq(tokenFor(SUB), own!.id));
+    expect(switched.accountId).toBe(own!.id);
+    expect(switched.role).toBe('owner');
+  });
+
+  it('a header naming a workspace the caller is not in is a 403, even if upstream lists it', async () => {
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    // Project the stranger's workspace as someone else so a local row exists.
+    iam.workspaces[2]!.users!.push({ id: 'wu-o', user_id: OTHER_SUB, type: 'MEMBER', is_active: true, roles: [] });
+    await auth.resolveHost(asReq(tokenFor(OTHER_SUB, 'stranger-account')));
+    const stranger = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${WS_STRANGER}`);
+    expect(stranger).toBeDefined();
+    await expect(auth.resolveHost(asReq(tokenFor(SUB), stranger!.id))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rebinds a pre-0015 account (external_id = upstream account id) onto the upstream workspace, keeping its forms', async () => {
+    // A legacy row as the pre-0015 provider would have made it, with a form in it.
+    await db.run(
+      sql`INSERT INTO account (id, code, name, external_id, iam_account_id, created_at)
+          VALUES ('legacy-1', 'lgcy01', 'Old name', ${IAM_ACCOUNT}, ${IAM_ACCOUNT}, 1)`,
+    );
+    await db.run(
+      sql`INSERT INTO member (id, account_id, external_id, email, handle, role, status, created_at)
+          VALUES ('legacy-m', 'legacy-1', ${SUB}, 'a@example.com', 'alex', 'owner', 'active', 1)`,
+    );
+    await db.run(
+      sql`INSERT INTO form (id, account_id, slug, name, config, created_at, updated_at)
+          VALUES ('f1', 'legacy-1', 'f1', 'F1', '{}', 1, 1)`,
+    );
+
+    const p = await auth.resolveHost(asReq(tokenFor(SUB)));
+    // Home is the SAME local account the forms live in...
+    expect(p.accountId).toBe('legacy-1');
+    // ...now bound to the upstream workspace and renamed after it.
+    const row = await db.get<{ external_id: string; name: string; iam_account_id: string }>(
+      sql`SELECT external_id, name, iam_account_id FROM account WHERE id = 'legacy-1'`,
+    );
+    expect(row!.external_id).toBe(WS_OWN);
+    expect(row!.name).toBe('dapta');
+    expect(row!.iam_account_id).toBe(IAM_ACCOUNT);
+    // And no second local account was minted for that workspace.
+    const n = await db.get<{ n: number }>(sql`SELECT COUNT(*) AS n FROM account WHERE external_id = ${WS_OWN}`);
+    expect(Number(n!.n)).toBe(1);
+  });
+
+  it('reads upstream once per TTL, not once per request', async () => {
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    const after1 = iam.calls.length;
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    expect(iam.calls.length).toBe(after1);
+    now += 61_000;
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    expect(iam.calls.length).toBeGreaterThan(after1);
+  });
+
+  it('serves what is local when upstream is down; refuses a first-ever login with 503', async () => {
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    now += 61_000;
+    iam.down = true;
+    const p = await auth.resolveHost(asReq(tokenFor(SUB)));
+    expect(p.accountId).toBeTruthy();
+    await expect(auth.resolveHost(asReq(tokenFor(OTHER_SUB, 'x')))).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it('a membership upstream no longer names is disabled locally, never deleted', async () => {
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    // Removed from "Test" upstream.
+    iam.workspaces[1]!.users = iam.workspaces[1]!.users!.filter((u) => u.user_id !== SUB);
+    now += 61_000;
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    const list = await auth.listWorkspaces(asReq(tokenFor(SUB)));
+    expect(list.map((w) => w.accountName)).toEqual(['dapta']);
+    const row = await db.get<{ status: string }>(
+      sql`SELECT m.status FROM member m JOIN account a ON a.id = m.account_id
+          WHERE a.external_id = ${WS_INVITED} AND m.external_id = ${SUB}`,
+    );
+    expect(row!.status).toBe('disabled');
+  });
+
+  it('a person who finished the wizard is not sent through it again for a projected workspace', async () => {
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    await db.run(sql`UPDATE account SET onboarding_completed_at = 5 WHERE external_id = ${WS_OWN}`);
+    // A third workspace appears upstream.
+    iam.workspaces.push(
+      ws('ws-3', 'Third', IAM_ACCOUNT, [{ id: 'wu-3', user_id: SUB, type: 'OWNER', is_active: true, roles: [] }]),
+    );
+    now += 61_000;
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    const third = await db.get<{ onboarding_completed_at: number | null }>(
+      sql`SELECT onboarding_completed_at FROM account WHERE external_id = 'ws-3'`,
+    );
+    expect(third!.onboarding_completed_at).not.toBeNull();
+    // Whereas the very first projection for a fresh human leaves the wizard on.
+    const fresh = await db.get<{ onboarding_completed_at: number | null }>(
+      sql`SELECT onboarding_completed_at FROM account WHERE external_id = ${WS_INVITED}`,
+    );
+    expect(fresh!.onboarding_completed_at).toBeNull();
+  });
+
+  it('rememberLastWorkspace writes the person’s own account upstream, even for a workspace someone else owns', async () => {
+    const provider = new WorkOsAuthProvider(
+      db,
+      { JWT_SECRET: SECRET, JWT_ISSUER: undefined, JWT_AUDIENCE: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false },
+      undefined,
+      projection,
+    );
+    const up = (await provider.resolveUpstream!(asReq(tokenFor(SUB))))!;
+    await auth.resolveHost(asReq(tokenFor(SUB)));
+    const invited = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${WS_INVITED}`);
+    await projection.rememberLastWorkspace(up, invited!.id);
+    const put = iam.calls.find((c) => c.method === 'PUT' && c.path === `/iam/account/${IAM_ACCOUNT}`);
+    expect(put).toBeDefined();
+    expect((put!.body as { feature_flags: { last_workspace: string } }).feature_flags.last_workspace).toBe(WS_INVITED);
+  });
+});
+
+describe('roleFromIam', () => {
+  it('maps OWNER → owner, workspace_admin → admin, anything else → member', () => {
+    expect(roleFromIam({ type: 'OWNER', roles: [] })).toBe('owner');
+    expect(roleFromIam({ type: 'MEMBER', roles: [{ role_id: 'x', role: { name: 'workspace_admin' } }] })).toBe('admin');
+    expect(roleFromIam({ type: 'MEMBER', roles: [{ role_id: 'x', role: { name: 'custom_role' } }] })).toBe('member');
+    expect(roleFromIam({ type: 'MEMBER', roles: [] })).toBe('member');
+    // The workspace DETAIL flattens the role: `{ id, name }` rather than `{ role_id, role: { name } }`.
+    expect(roleFromIam({ type: 'MEMBER', roles: [{ id: 'x', name: 'workspace_admin' }] })).toBe('admin');
+    expect(roleFromIam({ type: 'MEMBER', roles: null })).toBe('member');
+  });
+});

--- a/apps/api/src/workspace-projection.ts
+++ b/apps/api/src/workspace-projection.ts
@@ -60,6 +60,8 @@ const DEFAULT_TTL_MS = 60_000;
 export class WorkspaceProjection {
   private readonly log = new Logger('WorkspaceProjection');
   private readonly cache = new Map<string, ProjectionState>();
+  /** One upstream read per person at a time: a cold session fires several API calls at once. */
+  private readonly inflight = new Map<string, Promise<ProjectionState>>();
   private readonly ttlMs: number;
 
   constructor(
@@ -94,7 +96,20 @@ export class WorkspaceProjection {
     const cached = this.cache.get(id.sub);
     const now = this.now();
     if (cached && !opts.force && now - cached.syncedAt < this.ttlMs) return cached;
+    const pending = this.inflight.get(id.sub);
+    if (pending && !opts.force) return pending;
+    const run = this.refresh(id, cached, now).finally(() => {
+      if (this.inflight.get(id.sub) === run) this.inflight.delete(id.sub);
+    });
+    this.inflight.set(id.sub, run);
+    return run;
+  }
 
+  private async refresh(
+    id: UpstreamIdentity,
+    cached: ProjectionState | undefined,
+    now: number,
+  ): Promise<ProjectionState> {
     let workspaces: IamWorkspace[];
     let featureFlags: Record<string, unknown> | null = null;
     try {
@@ -157,7 +172,16 @@ export class WorkspaceProjection {
 
     for (const c of result.created) {
       if (c.role === 'owner' && result.createdAccounts.includes(c.accountId) && this.opts.seedEnv) {
-        await maybeSeedDemoForm(this.db, c.accountId, this.opts.seedEnv, this.log);
+        // No demo form in a workspace whose upstream ACCOUNT still has a
+        // pre-0015 local row: that row holds the owner's real forms and must be
+        // able to absorb this account on the owner's next login (see
+        // rebindLegacyAccount) — a seeded form here would block the absorb.
+        const row = await this.db.get<{ external_id: string | null }>(
+          sql`SELECT external_id FROM account WHERE id = ${c.accountId} LIMIT 1`,
+        );
+        const ws = workspaces.find((w) => w.id === row?.external_id);
+        const legacyBlocked = ws?.account_id ? !!(await getAccountByExternalId(this.db, ws.account_id)) : false;
+        if (!legacyBlocked) await maybeSeedDemoForm(this.db, c.accountId, this.opts.seedEnv, this.log);
       }
       notifySignup(this.opts.onSignup, this.log, {
         accountId: c.accountId,

--- a/apps/api/src/workspace-projection.ts
+++ b/apps/api/src/workspace-projection.ts
@@ -1,0 +1,239 @@
+/**
+ * Keeps the local workspace rows in step with the identity service, per person.
+ *
+ * `ensure()` is the whole contract: given a validated identity and its bearer,
+ * make the local `account`/`member` rows agree with what the identity service
+ * says about that person, at most once per TTL. Everything downstream — the
+ * switcher, the header check, the role a route sees — keeps reading local
+ * rows, so a request costs zero upstream calls once a session is warm.
+ *
+ * Failure policy: the identity service being down must not lock anyone out
+ * who has been here before. A stale projection is served (with a warning);
+ * only a first-ever login with nothing local behind it is refused, and it is
+ * refused as 503, not 401 — the token was fine, we could not learn what it is
+ * allowed to see.
+ */
+import { Logger, ServiceUnavailableException } from '@nestjs/common';
+import type { Db } from '@quill/db';
+import {
+  getAccountByExternalId,
+  humanHasCompletedOnboarding,
+  pickHomeAccount,
+  projectMemberships,
+  rebindLegacyAccount,
+  sql,
+  type ProjectedMembership,
+} from '@quill/db';
+import {
+  IamUnavailableError,
+  IamWorkspacesClient,
+  membershipOf,
+  roleFromIam,
+  type IamWorkspace,
+} from './iam-workspaces';
+import { maybeSeedDemoForm, notifySignup, type SeedDemoEnv, type SignupObserver } from './auth.provider';
+
+/** What the auth provider proved about the caller — never read from the request body. */
+export interface UpstreamIdentity {
+  /** The token `sub` = the identity service's user id = `member.external_id`. */
+  sub: string;
+  /** The person's OWN upstream account (billing layer), from the token. */
+  iamAccountId: string;
+  email: string | null;
+  displayName: string | null;
+  /** The raw bearer, forwarded upstream as-is. */
+  bearer: string;
+}
+
+export interface ProjectionState {
+  /** Upstream workspace id the person opened last (anywhere), or null. */
+  lastWorkspace: string | null;
+  /** The person's own account `feature_flags`, as last read (for read-modify-write). */
+  featureFlags: Record<string, unknown> | null;
+  /** True when this state was served from cache past its TTL because upstream failed. */
+  degraded: boolean;
+  syncedAt: number;
+}
+
+const DEFAULT_TTL_MS = 60_000;
+
+export class WorkspaceProjection {
+  private readonly log = new Logger('WorkspaceProjection');
+  private readonly cache = new Map<string, ProjectionState>();
+  private readonly ttlMs: number;
+
+  constructor(
+    private readonly db: Db,
+    /** Public so the workspace service can write upstream with the same client. */
+    readonly iam: IamWorkspacesClient,
+    private readonly opts: {
+      ttlMs?: number;
+      seedEnv?: SeedDemoEnv;
+      onSignup?: SignupObserver;
+      now?: () => number;
+    } = {},
+  ) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  private now(): number {
+    return this.opts.now ? this.opts.now() : Date.now();
+  }
+
+  /** Forget the cached state for one person (after a write that changed it). */
+  invalidate(sub: string): void {
+    this.cache.delete(sub);
+  }
+
+  /**
+   * Refresh the projection for this person unless it was refreshed within the
+   * TTL. `force` bypasses the TTL (after a create/invite/switch, and when the
+   * switcher opens).
+   */
+  async ensure(id: UpstreamIdentity, opts: { force?: boolean } = {}): Promise<ProjectionState> {
+    const cached = this.cache.get(id.sub);
+    const now = this.now();
+    if (cached && !opts.force && now - cached.syncedAt < this.ttlMs) return cached;
+
+    let workspaces: IamWorkspace[];
+    let featureFlags: Record<string, unknown> | null = null;
+    try {
+      const [account, wss] = await Promise.all([
+        this.iam.getAccount(id.bearer, id.iamAccountId).catch((err) => {
+          // The person's account row is nice-to-have (last_workspace); a
+          // failure there must not fail the workspace list.
+          if (err instanceof IamUnavailableError) throw err;
+          this.log.warn(`IAM account read failed for ${id.iamAccountId}: ${String(err)}`);
+          return null;
+        }),
+        this.iam.listMyWorkspaces(id.bearer, id.sub),
+      ]);
+      workspaces = wss;
+      featureFlags =
+        account?.feature_flags && typeof account.feature_flags === 'object' ? account.feature_flags : null;
+    } catch (err) {
+      if (!(err instanceof IamUnavailableError)) throw err;
+      if (cached) {
+        this.log.warn(`IAM unavailable; serving stale projection for ${id.sub}: ${err.message}`);
+        return { ...cached, degraded: true };
+      }
+      const local = await pickHomeAccount(this.db, id.sub, null);
+      if (local) {
+        this.log.warn(`IAM unavailable; serving local rows for ${id.sub}: ${err.message}`);
+        const state: ProjectionState = { lastWorkspace: null, featureFlags: null, degraded: true, syncedAt: now };
+        // Do NOT cache a degraded state past this call: retry upstream next time.
+        return state;
+      }
+      throw new ServiceUnavailableException({
+        error: 'IDENTITY_UNAVAILABLE',
+        message: 'The identity service is unavailable. Try again in a moment.',
+      });
+    }
+
+    const lastWorkspace =
+      typeof featureFlags?.last_workspace === 'string' ? (featureFlags.last_workspace as string) : null;
+
+    await this.rebindLegacy(id, workspaces, lastWorkspace);
+
+    const memberships: ProjectedMembership[] = workspaces.map((ws) => {
+      const me = membershipOf(ws, id.sub);
+      return {
+        workspaceId: ws.id,
+        workspaceName: ws.name,
+        iamAccountId: ws.account_id ?? null,
+        workspaceUserId: me?.id ?? null,
+        role: me ? roleFromIam(me) : 'owner',
+        active: me ? me.is_active !== false : true,
+      };
+    });
+
+    const inheritOnboarding = await humanHasCompletedOnboarding(this.db, id.sub);
+    const result = await projectMemberships(
+      this.db,
+      { externalId: id.sub, email: id.email, displayName: id.displayName },
+      memberships,
+      { inheritOnboarding, now },
+    );
+
+    for (const c of result.created) {
+      if (c.role === 'owner' && result.createdAccounts.includes(c.accountId) && this.opts.seedEnv) {
+        await maybeSeedDemoForm(this.db, c.accountId, this.opts.seedEnv, this.log);
+      }
+      notifySignup(this.opts.onSignup, this.log, {
+        accountId: c.accountId,
+        memberId: c.memberId,
+        email: id.email,
+        role: c.role,
+        isFirstMember: c.isFirstMember,
+        fromInvite: false,
+      });
+    }
+
+    const state: ProjectionState = { lastWorkspace, featureFlags, degraded: false, syncedAt: now };
+    this.cache.set(id.sub, state);
+    return state;
+  }
+
+  /**
+   * Where this person lands: the workspace they opened last (in either app),
+   * if they are still a member of it; else their most recently seen local
+   * membership; else null (nothing upstream, nothing local).
+   */
+  async home(id: UpstreamIdentity, state: ProjectionState): Promise<{ accountId: string; memberId: string } | null> {
+    return pickHomeAccount(this.db, id.sub, state.lastWorkspace);
+  }
+
+  /**
+   * Record that this person opened a workspace — upstream, so the Dapta app
+   * opens the same one next. Best-effort: a failure here is logged and costs
+   * the switch nothing.
+   */
+  async rememberLastWorkspace(id: UpstreamIdentity, accountId: string): Promise<void> {
+    const row = await this.db.get<{ external_id: string | null }>(
+      sql`SELECT external_id FROM account WHERE id = ${accountId} LIMIT 1`,
+    );
+    const workspaceId = row?.external_id ?? null;
+    if (!workspaceId || workspaceId.startsWith('local:') || workspaceId.startsWith('dev:')) return;
+    const cached = this.cache.get(id.sub);
+    if (cached?.lastWorkspace === workspaceId) return;
+    try {
+      await this.iam.setLastWorkspace(id.bearer, id.iamAccountId, workspaceId, cached?.featureFlags ?? null);
+      if (cached) {
+        cached.lastWorkspace = workspaceId;
+        cached.featureFlags = { ...(cached.featureFlags ?? {}), last_workspace: workspaceId };
+      }
+    } catch (err) {
+      this.log.warn(`last_workspace write failed for ${id.sub}: ${String(err)}`);
+    }
+  }
+
+  /**
+   * Pre-0015 rows: `account.external_id` held the person's upstream ACCOUNT id.
+   * Bind that row to the upstream workspace it should mean — the last one they
+   * opened if it belongs to that account, else the first of that account's.
+   */
+  private async rebindLegacy(id: UpstreamIdentity, workspaces: IamWorkspace[], lastWorkspace: string | null) {
+    const legacy = await getAccountByExternalId(this.db, id.iamAccountId);
+    if (!legacy) return;
+    // Only workspaces that hang from the person's own account can absorb their
+    // legacy row; a workspace someone else owns is not where their forms live.
+    const own = workspaces.filter((w) => w.account_id === id.iamAccountId);
+    if (own.length === 0) {
+      this.log.warn(`legacy account ${legacy.id} for ${id.iamAccountId}: no upstream workspace of that account is visible; left as is`);
+      return;
+    }
+    const target = own.find((w) => w.id === lastWorkspace) ?? own[0]!;
+    const res = await rebindLegacyAccount(this.db, {
+      iamAccountId: id.iamAccountId,
+      workspaceId: target.id,
+      workspaceName: target.name,
+    });
+    if (res?.parkedLegacyId) {
+      this.log.error(
+        `legacy account ${res.parkedLegacyId} could not absorb workspace ${target.id} (projected account ${res.accountId} already has forms); parked`,
+      );
+    } else if (res) {
+      this.log.log(`legacy account ${res.accountId} rebound to upstream workspace ${target.id}`);
+    }
+  }
+}

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Create / rename / enter, on both shapes of the WorkspaceService:
+ *
+ *   - IAM-backed: the write goes upstream FIRST (under the caller's OWN
+ *     account), then the local rows are re-projected; `enter` remembers the
+ *     choice upstream.
+ *   - local-only (dev stub, forks): the same operations act on local rows.
+ *
+ * Plus the guards that must hold on both: a plain member cannot rename, and
+ * `enter` refuses an account the caller is not in.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import { createDb, migrate, seed, getAccountByCode, sql, type Db } from '@quill/db';
+import { AuthService, WORKSPACE_HEADER } from './auth.service';
+import { LocalAuthProvider, type ReqLike } from './auth.provider';
+import { WorkOsAuthProvider } from './auth.provider.workos';
+import { WorkspaceProjection } from './workspace-projection';
+import { IamWorkspacesClient, type IamWorkspace } from './iam-workspaces';
+import { WorkspaceService } from './workspace.service';
+import { signJwtHs256 } from './jwt';
+
+const SECRET = 's';
+const SUB = 'sub-1';
+const IAM_ACCOUNT = 'acct-1';
+const WS_OWN = 'ws-own';
+
+function json(v: unknown, status = 200): Response {
+  return new Response(JSON.stringify(v), { status, headers: { 'content-type': 'application/json' } });
+}
+
+describe('WorkspaceService (IAM-backed)', () => {
+  let db: Db;
+  let svc: WorkspaceService;
+  let calls: Array<{ method: string; path: string; body?: unknown }>;
+  let workspaces: IamWorkspace[];
+  let lastWorkspace: string | null;
+  let invitations: Array<{ id: string; workspace_id: string; invited_email: string; status: string; role_id?: string }>;
+
+  const token = signJwtHs256({ sub: SUB, account_id: IAM_ACCOUNT, email: 'a@x.com', name: 'A', exp: 4102444800 }, SECRET);
+  const req = (workspace?: string): ReqLike => ({
+    headers: { authorization: `Bearer ${token}`, ...(workspace ? { [WORKSPACE_HEADER]: workspace } : {}) },
+  });
+
+  beforeEach(async () => {
+    db = await createDb('file::memory:');
+    await migrate(db);
+    calls = [];
+    lastWorkspace = null;
+    invitations = [];
+    workspaces = [
+      { id: WS_OWN, name: 'Mine', account_id: IAM_ACCOUNT, is_active: true, users: [{ id: 'wu1', user_id: SUB, type: 'OWNER', is_active: true, roles: [] }] },
+    ];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? 'GET';
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ method, path: url.pathname, body });
+      if (method === 'GET' && url.pathname === `/iam/account/${IAM_ACCOUNT}`)
+        return json({ id: IAM_ACCOUNT, feature_flags: lastWorkspace ? { last_workspace: lastWorkspace } : {} });
+      if (method === 'PUT' && url.pathname === `/iam/account/${IAM_ACCOUNT}`) {
+        lastWorkspace = body.feature_flags.last_workspace;
+        return json({});
+      }
+      if (method === 'GET' && url.pathname === '/iam/workspace/search') return json({ data: workspaces, totalPages: 1 });
+      if (method === 'POST' && url.pathname === '/iam/workspace') {
+        const created: IamWorkspace = {
+          id: `ws-new-${workspaces.length}`, name: body.name, account_id: body.account_id, is_active: true,
+          users: [{ id: `wu-new`, user_id: SUB, type: 'OWNER', is_active: true, roles: [] }],
+        };
+        workspaces.push(created);
+        return json(created, 201);
+      }
+      if (method === 'PUT' && url.pathname.startsWith('/iam/workspace/')) {
+        const w = workspaces.find((x) => x.id === url.pathname.split('/').pop());
+        if (w) w.name = body.name;
+        return json(w ?? {});
+      }
+      if (method === 'GET' && url.pathname.startsWith('/iam/workspace/')) {
+        const w = workspaces.find((x) => x.id === url.pathname.split('/').pop());
+        return w ? json(w) : new Response('nf', { status: 404 });
+      }
+      if (method === 'GET' && url.pathname.startsWith('/iam/role/roles-workspace/'))
+        return json([{ id: 'role-admin', name: 'workspace_admin', is_system: true }]);
+      if (method === 'POST' && url.pathname === '/iam/workspace-invitations') {
+        invitations.push({ id: `inv-${invitations.length + 1}`, workspace_id: body.workspace_id, invited_email: body.invited_email, status: 'pending', role_id: body.role_id });
+        return json(invitations[invitations.length - 1], 201);
+      }
+      if (method === 'GET' && url.pathname.startsWith('/iam/workspace-invitations/'))
+        return json({ data: invitations.filter((i) => i.status.toLowerCase() === 'pending') });
+      if (method === 'POST' && url.pathname === '/iam/workspace-invitations/resend') return json({ ok: true });
+      if (method === 'DELETE' && url.pathname.startsWith('/iam/workspaceUser/member/')) {
+        const wuId = url.pathname.split('/').pop();
+        for (const w of workspaces) w.users = (w.users ?? []).filter((u) => u.id !== wuId);
+        return json({ ok: true });
+      }
+      return new Response('nope', { status: 404 });
+    };
+    const projection = new WorkspaceProjection(db, new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl }));
+    const provider = new WorkOsAuthProvider(
+      db,
+      { JWT_SECRET: SECRET, JWT_ISSUER: undefined, JWT_AUDIENCE: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false },
+      undefined,
+      projection,
+    );
+    const auth = new AuthService(db, provider);
+    svc = new WorkspaceService(db, provider, auth, projection);
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('creates upstream under the caller’s own account, projects it, and remembers it as last opened', async () => {
+    const res = await svc.create(req(), { name: 'Sales' });
+    const post = calls.find((c) => c.method === 'POST' && c.path === '/iam/workspace');
+    expect(post).toBeDefined();
+    expect((post!.body as { account_id: string }).account_id).toBe(IAM_ACCOUNT);
+    const row = await db.get<{ name: string; external_id: string }>(sql`SELECT name, external_id FROM account WHERE id = ${res.accountId}`);
+    expect(row!.name).toBe('Sales');
+    expect(row!.external_id).toBe('ws-new-1');
+    const me = await db.get<{ role: string }>(sql`SELECT role FROM member WHERE account_id = ${res.accountId} AND external_id = ${SUB}`);
+    expect(me!.role).toBe('owner');
+    expect(lastWorkspace).toBe('ws-new-1');
+    // And it is in the switcher list.
+    const list = await svc.list(req());
+    expect(list.map((w) => w.accountName).sort()).toEqual(['Mine', 'Sales']);
+  });
+
+  it('a new workspace does not re-trigger the wizard for someone who already finished it', async () => {
+    await svc.list(req()); // project
+    await db.run(sql`UPDATE account SET onboarding_completed_at = 1 WHERE external_id = ${WS_OWN}`);
+    const res = await svc.create(req(), { name: 'Second' });
+    const row = await db.get<{ onboarding_completed_at: number | null }>(sql`SELECT onboarding_completed_at FROM account WHERE id = ${res.accountId}`);
+    expect(row!.onboarding_completed_at).not.toBeNull();
+  });
+
+  it('renames upstream then locally; a plain member cannot', async () => {
+    await svc.list(req());
+    const out = await svc.rename(req(), { name: 'Renamed' });
+    expect(calls.some((c) => c.method === 'PUT' && c.path === `/iam/workspace/${WS_OWN}`)).toBe(true);
+    const row = await db.get<{ name: string }>(sql`SELECT name FROM account WHERE id = ${out.accountId}`);
+    expect(row!.name).toBe('Renamed');
+
+    // Demoted UPSTREAM (the authority): the rename invalidated the cache, so the
+    // next request re-projects and the guard sees `member`.
+    workspaces[0]!.users![0]!.type = 'MEMBER';
+    await expect(svc.rename(req(), { name: 'Nope' })).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('enter re-checks membership and writes last_workspace upstream; a stranger account is a 403', async () => {
+    const list = await svc.list(req());
+    await svc.enter(req(), list[0]!.accountId);
+    expect(lastWorkspace).toBe(WS_OWN);
+    await expect(svc.enter(req(), 'not-mine')).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('roster is re-projected from the upstream users[]: joiners appear, leavers are disabled', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    let roster = await svc.roster(req());
+    expect(roster.map((m) => m.email).sort()).toEqual(['a@x.com', 'b@x.com']);
+    expect(roster.find((m) => m.email === 'b@x.com')!.role).toBe('member');
+    workspaces[0]!.users = workspaces[0]!.users!.filter((u) => u.id !== 'wu2');
+    roster = await svc.roster(req());
+    expect(roster.find((m) => m.email === 'b@x.com')!.status).toBe('disabled');
+  });
+
+  it('invites through the identity service (admin → workspace_admin role_id) and lists it as pending; no local member row', async () => {
+    await svc.list(req());
+    const out = await svc.inviteUpstream(req(), { email: 'New@X.com', role: 'admin' });
+    expect(out.status).toBe('invited');
+    const post = calls.find((c) => c.method === 'POST' && c.path === '/iam/workspace-invitations');
+    expect((post!.body as { invited_email: string; role_id: string; workspace_id: string })).toMatchObject({
+      invited_email: 'new@x.com', role_id: 'role-admin', workspace_id: WS_OWN,
+    });
+    const local = await db.get<{ id: string }>(sql`SELECT id FROM member WHERE lower(email) = 'new@x.com'`);
+    expect(local).toBeUndefined();
+    const pending = await svc.listInvitations(req());
+    expect(pending.map((i) => i.email)).toEqual(['new@x.com']);
+    await svc.resendInvitation(req(), pending[0]!.id);
+    expect(calls.some((c) => c.path === '/iam/workspace-invitations/resend')).toBe(true);
+  });
+
+  it('removes a member upstream first, then locally', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    const roster = await svc.roster(req());
+    const b = roster.find((m) => m.email === 'b@x.com')!;
+    await svc.removeMemberUpstream(req(), b.id);
+    expect(calls.some((c) => c.method === 'DELETE' && c.path === '/iam/workspaceUser/member/wu2')).toBe(true);
+    const gone = await db.get<{ id: string }>(sql`SELECT id FROM member WHERE id = ${b.id}`);
+    expect(gone).toBeUndefined();
+  });
+
+  it('refresh forces an upstream re-read within the TTL', async () => {
+    await svc.list(req());
+    const before = calls.filter((c) => c.path === '/iam/workspace/search').length;
+    workspaces.push({ id: 'ws-late', name: 'Late', account_id: 'other', is_active: true, users: [{ id: 'wu-l', user_id: SUB, type: 'MEMBER', is_active: true, roles: [] }] });
+    const list = await svc.refresh(req());
+    expect(calls.filter((c) => c.path === '/iam/workspace/search').length).toBe(before + 1);
+    expect(list.map((w) => w.accountName).sort()).toEqual(['Late', 'Mine']);
+  });
+});
+
+describe('WorkspaceService (local-only)', () => {
+  let db: Db;
+  let svc: WorkspaceService;
+  const req = (email = 'alex@example.com', workspace?: string): ReqLike => ({
+    headers: { 'x-quill-email': email, ...(workspace ? { [WORKSPACE_HEADER]: workspace } : {}) },
+  });
+
+  beforeEach(async () => {
+    db = await createDb('file::memory:');
+    await migrate(db);
+    await seed(db);
+    const provider = new LocalAuthProvider(db, {
+      NODE_ENV: 'test', DEV_LOGIN_EMAIL: undefined, AUTH_LOCAL_STRICT: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false,
+    });
+    const auth = new AuthService(db, provider);
+    svc = new WorkspaceService(db, provider, auth, null);
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('creates a local workspace with the caller as owner and lists it', async () => {
+    const home = (await getAccountByCode(db, 'acme'))!.id;
+    const res = await svc.create(req(), { name: 'Side project' });
+    expect(res.accountId).not.toBe(home);
+    const me = await db.get<{ role: string; email: string }>(sql`SELECT role, email FROM member WHERE account_id = ${res.accountId}`);
+    expect(me!.role).toBe('owner');
+    expect(me!.email).toBe('alex@example.com');
+    const list = await svc.list(req());
+    expect(list.some((w) => w.accountId === res.accountId)).toBe(true);
+    // And it can be entered via the header.
+    const p = await new AuthService(db, new LocalAuthProvider(db, {
+      NODE_ENV: 'test', DEV_LOGIN_EMAIL: undefined, AUTH_LOCAL_STRICT: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false,
+    })).resolveHost(req('alex@example.com', res.accountId));
+    expect(p.role).toBe('owner');
+  });
+
+  it('renames locally', async () => {
+    const out = await svc.rename(req(), { name: 'Acme Renamed' });
+    const row = await db.get<{ name: string }>(sql`SELECT name FROM account WHERE id = ${out.accountId}`);
+    expect(row!.name).toBe('Acme Renamed');
+  });
+});

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -1,0 +1,406 @@
+/**
+ * Workspace lifecycle: create, rename, refresh the list, remember the last one
+ * opened.
+ *
+ * Two shapes behind one service. With the identity service configured
+ * (`WORKSPACE_PROJECTION` present) every write goes UPSTREAM FIRST — the
+ * workspace is created or renamed there, where the rest of the Dapta estate
+ * reads it — and the local rows are then re-projected. Without it (forks, the
+ * dev stub, tests) the same operations act on local rows only, so the product
+ * behaves identically from the outside.
+ *
+ * Nothing here trusts a client-supplied account id: the principal comes from
+ * `AuthService.resolveHost`, and the only id a client may name (`enter`) is
+ * re-checked against membership before it is remembered.
+ */
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+  Optional,
+} from '@nestjs/common';
+import type { Db } from '@quill/db';
+import {
+  createLocalWorkspace,
+  findMembership,
+  getAccountByExternalId,
+  getAccountMember,
+  getMemberIdentity,
+  getMemberUpstreamRef,
+  humanHasCompletedOnboarding,
+  listMembers,
+  listWorkspacesForIdentity,
+  projectRoster,
+  removeMember,
+  renameAccount,
+  sql,
+  type MemberView,
+  type WorkspaceRow,
+} from '@quill/db';
+import { AUTH_PROVIDER, DB, WORKSPACE_PROJECTION } from './tokens';
+import type { AuthProvider, HostPrincipal, ReqLike, UpstreamIdentity } from './auth.provider';
+import { AuthService } from './auth.service';
+import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
+import { IAM_ADMIN_ROLE_NAME, IamHttpError, roleFromIam, userEmailOf, userNameOf } from './iam-workspaces';
+import type { WorkspaceProjection } from './workspace-projection';
+
+@Injectable()
+export class WorkspaceService {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AUTH_PROVIDER) private readonly provider: AuthProvider,
+    @Inject(AuthService) private readonly auth: AuthService,
+    @Optional() @Inject(WORKSPACE_PROJECTION) private readonly projection: WorkspaceProjection | null = null,
+  ) {}
+
+  /** The caller's upstream identity when this deployment has one, else null. */
+  private async upstream(req: ReqLike): Promise<UpstreamIdentity | null> {
+    if (!this.projection || !this.provider.resolveUpstream) return null;
+    return this.provider.resolveUpstream(req);
+  }
+
+  /** Force a re-read from the identity service (when there is one), then list. */
+  async refresh(req: ReqLike): Promise<WorkspaceRow[]> {
+    const up = await this.upstream(req);
+    if (up && this.projection) await this.projection.ensure(up, { force: true });
+    return this.auth.listWorkspaces(req);
+  }
+
+  /**
+   * Create a workspace with the caller as its owner. Upstream first when there
+   * is an upstream: it is created under the caller's OWN account (the billing
+   * layer the token names), never under whichever workspace they happen to be
+   * viewing — that would put it on someone else's plan.
+   */
+  async create(req: ReqLike, input: { name: string }): Promise<{ accountId: string }> {
+    const name = input.name.trim();
+    if (!name) throw new BadRequestException({ error: 'BAD_REQUEST', message: 'A name is required.' });
+
+    const p = await this.auth.resolveHost(req);
+    const up = await this.upstream(req);
+
+    if (up && this.projection) {
+      let created: { id?: string } | { data?: { id?: string } } | undefined;
+      try {
+        created = (await this.projection.iam.createWorkspace(up.bearer, {
+          name,
+          account_id: up.iamAccountId,
+        })) as typeof created;
+      } catch (err) {
+        if (err instanceof IamHttpError && err.status === 403) {
+          throw new ForbiddenException({
+            error: 'WORKSPACE_CREATE_FORBIDDEN',
+            message: 'Your account cannot create workspaces.',
+          });
+        }
+        throw err;
+      }
+      const wsId =
+        (created && 'id' in created && typeof created.id === 'string' && created.id) ||
+        (created && 'data' in created && created.data && typeof created.data.id === 'string' && created.data.id) ||
+        null;
+      // Re-project so the new workspace (and the caller's owner row in it) exists locally.
+      await this.projection.ensure(up, { force: true });
+      const local = wsId ? await getAccountByExternalId(this.db, wsId) : null;
+      if (!local) {
+        // Created upstream but not visible in the caller's memberships yet — a
+        // consistency lag upstream. Surface it rather than pretend.
+        throw new BadRequestException({
+          error: 'WORKSPACE_NOT_VISIBLE',
+          message: 'The workspace was created but is not visible yet. Try refreshing.',
+        });
+      }
+      await this.projection.rememberLastWorkspace(up, local.id);
+      return { accountId: local.id };
+    }
+
+    // Local-only path.
+    const identity = await getMemberIdentity(this.db, p.accountId, p.memberId);
+    const inherit = identity?.externalId
+      ? await humanHasCompletedOnboarding(this.db, identity.externalId)
+      : await this.accountCompletedOnboarding(p.accountId);
+    const res = await createLocalWorkspace(
+      this.db,
+      {
+        externalId: identity?.externalId ?? null,
+        email: identity?.email ?? null,
+        displayName: await this.displayNameOf(p),
+      },
+      { name, inheritOnboarding: inherit },
+    );
+    return { accountId: res.accountId };
+  }
+
+  /** Rename the workspace the caller is acting in (admin/owner). */
+  async rename(req: ReqLike, input: { name: string }): Promise<{ accountId: string; name: string }> {
+    const name = input.name.trim();
+    if (!name) throw new BadRequestException({ error: 'BAD_REQUEST', message: 'A name is required.' });
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+
+    const up = await this.upstream(req);
+    if (up && this.projection) {
+      const row = await this.db.get<{ external_id: string | null }>(
+        sql`SELECT external_id FROM account WHERE id = ${p.accountId} LIMIT 1`,
+      );
+      const wsId = row?.external_id ?? null;
+      if (wsId && !wsId.startsWith('local:') && !wsId.startsWith('dev:') && !wsId.startsWith('legacy:')) {
+        await this.projection.iam.updateWorkspace(up.bearer, wsId, { name });
+        this.projection.invalidate(up.sub);
+      }
+    }
+    await renameAccount(this.db, p.accountId, name);
+    return { accountId: p.accountId, name };
+  }
+
+  /**
+   * The caller is about to open `accountId`. Verifies membership (from the
+   * home identity, exactly like the header check) and remembers the choice
+   * upstream so the Dapta app opens the same workspace next time.
+   */
+  async enter(req: ReqLike, accountId: string): Promise<{ ok: true }> {
+    const home = await this.provider.resolveHost(req);
+    const identity = await getMemberIdentity(this.db, home.accountId, home.memberId);
+    const membership = identity ? await findMembership(this.db, identity, accountId) : null;
+    if (!membership) {
+      throw new ForbiddenException({
+        error: 'WORKSPACE_FORBIDDEN',
+        message: 'You are not a member of that workspace.',
+      });
+    }
+    const up = await this.upstream(req);
+    if (up && this.projection) await this.projection.rememberLastWorkspace(up, accountId);
+    return { ok: true };
+  }
+
+  /** Every workspace the caller can enter — the projection, never upstream directly. */
+  async list(req: ReqLike): Promise<WorkspaceRow[]> {
+    const home = await this.provider.resolveHost(req);
+    const identity = await getMemberIdentity(this.db, home.accountId, home.memberId);
+    return identity ? listWorkspacesForIdentity(this.db, identity) : [];
+  }
+
+  // --- Members via the identity service ------------------------------------
+
+  /** True when this deployment routes member management upstream. */
+  async hasUpstream(req: ReqLike): Promise<boolean> {
+    return (await this.upstream(req)) !== null;
+  }
+
+  /** The upstream workspace id behind a local account, or null when it has none. */
+  private async upstreamWorkspaceId(accountId: string): Promise<string | null> {
+    const row = await this.db.get<{ external_id: string | null }>(
+      sql`SELECT external_id FROM account WHERE id = ${accountId} LIMIT 1`,
+    );
+    const id = row?.external_id ?? null;
+    if (!id || id.startsWith('local:') || id.startsWith('dev:') || id.startsWith('legacy:')) return null;
+    return id;
+  }
+
+  /**
+   * The roster, re-projected from the upstream workspace's `users[]` first so an
+   * admin sees who is REALLY in (someone added or removed from the Dapta app
+   * shows up here without a login of their own).
+   */
+  async roster(req: ReqLike): Promise<MemberView[]> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    const up = await this.upstream(req);
+    const wsId = up ? await this.upstreamWorkspaceId(p.accountId) : null;
+    if (up && this.projection && wsId) {
+      try {
+        const ws = await this.projection.iam.getWorkspace(up.bearer, wsId);
+        await projectRoster(
+          this.db,
+          p.accountId,
+          (ws.users ?? []).map((u) => ({
+            externalId: u.user_id,
+            email: userEmailOf(u),
+            displayName: userNameOf(u),
+            role: roleFromIam(u),
+            active: u.is_active !== false,
+            workspaceUserId: u.id,
+          })),
+        );
+      } catch (err) {
+        // A roster read that fails upstream still shows what is local.
+        this.logWarn(`roster sync failed for ${p.accountId}: ${String(err)}`);
+      }
+    }
+    return listMembers(this.db, p.accountId);
+  }
+
+  /**
+   * Invite by email through the identity service. The invitation, its email,
+   * and its acceptance all live upstream; the person appears in the roster
+   * once they accept (next roster read). Admin → the upstream `workspace_admin`
+   * role; member → the workspace's default.
+   */
+  async inviteUpstream(
+    req: ReqLike,
+    input: { email: string; role?: 'admin' | 'member' },
+  ): Promise<MemberView> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    const up = await this.upstream(req);
+    const wsId = await this.upstreamWorkspaceId(p.accountId);
+    if (!up || !this.projection || !wsId) {
+      throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This workspace has no identity service behind it.' });
+    }
+    const email = input.email.trim().toLowerCase();
+    let roleId: string | undefined;
+    if (input.role === 'admin') {
+      const roles = await this.projection.iam.listRoles(up.bearer, wsId);
+      roleId = roles.find((r) => r.name === IAM_ADMIN_ROLE_NAME)?.id;
+    }
+    try {
+      const inv = await this.projection.iam.createInvitation(up.bearer, {
+        invited_email: email,
+        workspace_id: wsId,
+        ...(roleId ? { role_id: roleId } : {}),
+      });
+      // Shaped like a roster row so the caller's contract does not fork: the
+      // invitation is `invited` until upstream turns it into a membership.
+      return {
+        id: inv?.id ? `invitation:${inv.id}` : `invitation:${email}`,
+        email,
+        displayName: null,
+        handle: null,
+        avatarUrl: null,
+        role: input.role === 'admin' ? 'admin' : 'member',
+        status: 'invited',
+        createdAt: Date.now(),
+      };
+    } catch (err) {
+      if (err instanceof IamHttpError && (err.status === 409 || err.status === 400)) {
+        throw new ConflictException({ error: 'EMAIL_TAKEN', message: 'That address is already invited or a member.' });
+      }
+      throw err;
+    }
+  }
+
+  /** Pending invitations, from upstream. Empty when there is no upstream. */
+  async listInvitations(req: ReqLike): Promise<Array<{ id: string; email: string; status: string; createdAt: string | null; expiresAt: string | null }>> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    const up = await this.upstream(req);
+    const wsId = up ? await this.upstreamWorkspaceId(p.accountId) : null;
+    if (!up || !this.projection || !wsId) return [];
+    const rows = await this.projection.iam.listInvitations(up.bearer, wsId, 'PENDING');
+    return rows.map((r) => ({
+      id: r.id,
+      email: r.invited_email,
+      status: r.status,
+      createdAt: r.created_at ?? null,
+      expiresAt: r.expires_at ?? null,
+    }));
+  }
+
+  async resendInvitation(req: ReqLike, invitationId: string): Promise<{ ok: true }> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    const up = await this.upstream(req);
+    const wsId = up ? await this.upstreamWorkspaceId(p.accountId) : null;
+    if (!up || !this.projection || !wsId) {
+      throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This workspace has no identity service behind it.' });
+    }
+    // Scope: only an invitation of THIS workspace may be resent from here.
+    const mine = await this.projection.iam.listInvitations(up.bearer, wsId, 'PENDING');
+    if (!mine.some((i) => i.id === invitationId)) {
+      throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    }
+    await this.projection.iam.resendInvitation(up.bearer, invitationId);
+    return { ok: true };
+  }
+
+  /**
+   * Change a member upstream: promote to admin (assign `workspace_admin`),
+   * enable/disable. Demoting to member is not expressible upstream (roles are
+   * assigned, never removed, through the API this product has) → 409.
+   */
+  async updateMemberUpstream(
+    req: ReqLike,
+    memberId: string,
+    input: { role?: 'owner' | 'admin' | 'member'; status?: 'active' | 'invited' | 'disabled' },
+  ): Promise<MemberView> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    assertNotSelf(p, memberId);
+    const target = await getAccountMember(this.db, p.accountId, memberId);
+    if (!target) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
+    assertCanManageTarget(p, target, { toRole: input.role });
+    const up = await this.upstream(req);
+    const wsId = up ? await this.upstreamWorkspaceId(p.accountId) : null;
+    const ref = await getMemberUpstreamRef(this.db, p.accountId, memberId);
+    if (!up || !this.projection || !wsId || !ref?.workspaceUserId) {
+      throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This member is not managed by the identity service.' });
+    }
+    if (input.role !== undefined && input.role !== target.role) {
+      if (input.role === 'admin') {
+        const roles = await this.projection.iam.listRoles(up.bearer, wsId);
+        const roleId = roles.find((r) => r.name === IAM_ADMIN_ROLE_NAME)?.id;
+        if (!roleId) throw new ConflictException({ error: 'ROLE_UNAVAILABLE', message: 'The admin role is not available upstream.' });
+        await this.projection.iam.assignRole(up.bearer, ref.workspaceUserId, roleId);
+      } else {
+        throw new ConflictException({
+          error: 'NOT_SUPPORTED_UPSTREAM',
+          message: 'Change this role from the Dapta app.',
+        });
+      }
+    }
+    if (input.status !== undefined && input.status !== target.status) {
+      if (input.status === 'invited') {
+        throw new BadRequestException({ error: 'BAD_REQUEST', message: 'Cannot set a member back to invited.' });
+      }
+      await this.projection.iam.setWorkspaceUserActive(up.bearer, ref.workspaceUserId, input.status === 'active');
+    }
+    if (ref.externalId) this.projection.invalidate(ref.externalId);
+    await this.roster(req);
+    return (await getAccountMember(this.db, p.accountId, memberId)) ?? target;
+  }
+
+  /** Remove a member upstream, then locally. Idempotent. */
+  async removeMemberUpstream(req: ReqLike, memberId: string): Promise<{ ok: true }> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    assertNotSelf(p, memberId);
+    const target = await getAccountMember(this.db, p.accountId, memberId);
+    if (!target) return { ok: true };
+    assertCanManageTarget(p, target);
+    const up = await this.upstream(req);
+    const ref = await getMemberUpstreamRef(this.db, p.accountId, memberId);
+    if (up && this.projection && ref?.workspaceUserId) {
+      try {
+        await this.projection.iam.removeWorkspaceUser(up.bearer, ref.workspaceUserId);
+      } catch (err) {
+        if (!(err instanceof IamHttpError && err.status === 404)) throw err;
+      }
+      if (ref.externalId) this.projection.invalidate(ref.externalId);
+    }
+    const res = await removeMember(this.db, p.accountId, memberId);
+    if (!res.ok) throw new ConflictException({ error: res.reason, message: res.message ?? 'Conflict.' });
+    return { ok: true };
+  }
+
+  private logWarn(message: string): void {
+    // Kept tiny on purpose; the projection carries the real logger.
+    console.warn(`[WorkspaceService] ${message}`);
+  }
+
+  private async accountCompletedOnboarding(accountId: string): Promise<boolean> {
+    const r = await this.db.get<{ id: string }>(
+      sql`SELECT id FROM account WHERE id = ${accountId} AND onboarding_completed_at IS NOT NULL LIMIT 1`,
+    );
+    return !!r;
+  }
+
+  private async displayNameOf(p: HostPrincipal): Promise<string | null> {
+    const r = await this.db.get<{ display_name: string | null }>(
+      sql`SELECT display_name FROM member WHERE id = ${p.memberId} AND account_id = ${p.accountId} LIMIT 1`,
+    );
+    return r?.display_name ?? null;
+  }
+}

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -19,6 +19,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   Optional,
 } from '@nestjs/common';
@@ -37,6 +38,7 @@ import {
   removeMember,
   renameAccount,
   sql,
+  wouldOrphanWorkspace,
   type MemberView,
   type WorkspaceRow,
 } from '@quill/db';
@@ -49,6 +51,8 @@ import type { WorkspaceProjection } from './workspace-projection';
 
 @Injectable()
 export class WorkspaceService {
+  private readonly log = new Logger('WorkspaceService');
+
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(AUTH_PROVIDER) private readonly provider: AuthProvider,
@@ -338,6 +342,13 @@ export class WorkspaceService {
     if (!up || !this.projection || !wsId || !ref?.workspaceUserId) {
       throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This member is not managed by the identity service.' });
     }
+    // The last-owner guard runs BEFORE anything is written upstream: an
+    // upstream write that then 409s locally would leave the two disagreeing.
+    const demoting = input.role !== undefined && input.role !== 'owner' && target.role === 'owner';
+    const disabling = input.status !== undefined && input.status !== 'active' && target.role === 'owner';
+    if ((demoting || disabling) && (await wouldOrphanWorkspace(this.db, p.accountId, memberId))) {
+      throw new ConflictException({ error: 'LAST_OWNER', message: 'A workspace must keep at least one owner.' });
+    }
     if (input.role !== undefined && input.role !== target.role) {
       if (input.role === 'admin') {
         const roles = await this.projection.iam.listRoles(up.bearer, wsId);
@@ -370,6 +381,9 @@ export class WorkspaceService {
     const target = await getAccountMember(this.db, p.accountId, memberId);
     if (!target) return { ok: true };
     assertCanManageTarget(p, target);
+    if (await wouldOrphanWorkspace(this.db, p.accountId, memberId)) {
+      throw new ConflictException({ error: 'LAST_OWNER', message: 'A workspace must keep at least one owner.' });
+    }
     const up = await this.upstream(req);
     const ref = await getMemberUpstreamRef(this.db, p.accountId, memberId);
     if (up && this.projection && ref?.workspaceUserId) {
@@ -379,6 +393,11 @@ export class WorkspaceService {
         if (!(err instanceof IamHttpError && err.status === 404)) throw err;
       }
       if (ref.externalId) this.projection.invalidate(ref.externalId);
+    } else if (up && this.projection && ref?.externalId) {
+      // Known to the identity service (has a subject) but we hold no upstream
+      // membership id to remove: a local delete would be undone by their next
+      // login. Refuse rather than pretend.
+      throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This member is not managed by the identity service.' });
     }
     const res = await removeMember(this.db, p.accountId, memberId);
     if (!res.ok) throw new ConflictException({ error: res.reason, message: res.message ?? 'Conflict.' });
@@ -386,8 +405,7 @@ export class WorkspaceService {
   }
 
   private logWarn(message: string): void {
-    // Kept tiny on purpose; the projection carries the real logger.
-    console.warn(`[WorkspaceService] ${message}`);
+    this.log.warn(message);
   }
 
   private async accountCompletedOnboarding(accountId: string): Promise<boolean> {

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -67,13 +67,16 @@ export async function inviteMemberAction(
  */
 export type ManageMemberState =
   | { ok: true }
-  | { ok: false; code: 'LAST_OWNER' | 'FORBIDDEN' | 'FAILED' };
+  | { ok: false; code: 'LAST_OWNER' | 'FORBIDDEN' | 'UPSTREAM' | 'FAILED' };
 
 /** Map an API failure to a stable, localizable code (never a raw server string). */
 function manageError(e: unknown): ManageMemberState {
   if (e instanceof ApiError) {
     if (e.code === 'LAST_OWNER') return { ok: false, code: 'LAST_OWNER' };
     if (e.status === 403 || e.code === 'FORBIDDEN') return { ok: false, code: 'FORBIDDEN' };
+    // Identity-service deployments: some changes are only expressible over there.
+    if (e.code === 'NOT_SUPPORTED_UPSTREAM' || e.code === 'NO_UPSTREAM' || e.code === 'ROLE_UNAVAILABLE')
+      return { ok: false, code: 'UPSTREAM' };
   }
   return { ok: false, code: 'FAILED' };
 }

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -189,3 +189,14 @@ export async function saveMyProfileAction(
     };
   }
 }
+
+/** Resend a pending invitation (identity-service deployments). */
+export async function resendInvitationAction(id: string): Promise<{ ok: boolean }> {
+  try {
+    await adminApi.resendInvitation(id);
+    return { ok: true };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}

--- a/apps/web/app/admin/settings/member-row-actions.tsx
+++ b/apps/web/app/admin/settings/member-row-actions.tsx
@@ -24,6 +24,7 @@ export interface MemberRowActionsLabels {
   manageErrorLastOwner: string;
   manageErrorForbidden: string;
   manageErrorFailed: string;
+  manageErrorUpstream: string;
 }
 
 /**
@@ -85,7 +86,9 @@ export function MemberRowActions({
         ? labels.manageErrorLastOwner
         : result.code === 'FORBIDDEN'
           ? labels.manageErrorForbidden
-          : labels.manageErrorFailed;
+          : result.code === 'UPSTREAM'
+            ? labels.manageErrorUpstream
+            : labels.manageErrorFailed;
     toast.error(message);
   };
 

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -10,6 +10,8 @@ import { MemberRowActions } from './member-row-actions';
 import { NotificationSettings } from './notification-settings';
 import { PublicPageSettings } from './public-page';
 import { ThemeSettings } from './theme-settings';
+import { WorkspaceName } from './workspace-name';
+import { PendingInvitations } from './pending-invitations';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,6 +23,8 @@ export default async function SettingsPage() {
   const members: AccountMember[] = isAdminRole(me.role)
     ? await adminApi.listMembers().catch(() => [])
     : [];
+  // Invitations not yet accepted — only identity-service deployments have any.
+  const invitations = isAdminRole(me.role) ? await adminApi.listInvitations().catch(() => []) : [];
   // The two submission emails (owner notice + respondent confirmation), admin-only.
   const notifications = isAdminRole(me.role)
     ? await adminApi.getNotifications().catch(() => null)
@@ -52,6 +56,16 @@ export default async function SettingsPage() {
         <h2 className="text-lg font-semibold tracking-tight">{s.workspaceHeading}</h2>
         <p className="mt-0.5 text-sm text-muted-foreground">{s.workspaceSubtitle}</p>
         <dl className="mt-5 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
+          <WorkspaceName
+            initial={me.accountName}
+            canEdit={isAdminRole(me.role)}
+            labels={{
+              workspaceName: s.workspaceName,
+              workspaceNameSave: s.workspaceNameSave,
+              workspaceNameSaved: s.workspaceNameSaved,
+              workspaceNameError: s.workspaceNameError,
+            }}
+          />
           <Field label={s.displayName} value={me.displayName ?? '—'} />
           <Field label={s.email} value={me.email ?? '—'} />
           <Field label={s.handle} value={me.handle ?? '—'} mono />
@@ -162,6 +176,16 @@ export default async function SettingsPage() {
               })}
             </ul>
           )}
+          <PendingInvitations
+            invitations={invitations}
+            labels={{
+              pendingHeading: s.pendingHeading,
+              pendingBadge: s.pendingBadge,
+              resendInvite: s.resendInvite,
+              resendSuccess: s.resendSuccess,
+              resendError: s.resendError,
+            }}
+          />
         </section>
       ) : null}
 

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -166,6 +166,7 @@ export default async function SettingsPage() {
                           manageErrorLastOwner: s.manageErrorLastOwner,
                           manageErrorForbidden: s.manageErrorForbidden,
                           manageErrorFailed: s.manageErrorFailed,
+                          manageErrorUpstream: s.manageErrorUpstream,
                         }}
                       />
                     ) : (

--- a/apps/web/app/admin/settings/pending-invitations.tsx
+++ b/apps/web/app/admin/settings/pending-invitations.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useTransition } from 'react';
+import type { PendingInvitation } from '@/lib/admin-api';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/toast';
+import { callAction, isTransportError } from '@/lib/call-action';
+import { resendInvitationAction } from './actions';
+
+export interface PendingInvitationsLabels {
+  pendingHeading: string;
+  pendingBadge: string;
+  resendInvite: string;
+  resendSuccess: string;
+  resendError: string;
+}
+
+/**
+ * Invitations that have not been accepted yet. They live in the identity
+ * service (which also sends the email), so the only thing to do here is
+ * resend. Renders nothing when there are none.
+ */
+export function PendingInvitations({
+  invitations,
+  labels,
+}: {
+  invitations: PendingInvitation[];
+  labels: PendingInvitationsLabels;
+}) {
+  const [pending, start] = useTransition();
+  const toast = useToast();
+  if (invitations.length === 0) return null;
+
+  function resend(id: string) {
+    start(async () => {
+      const res = await callAction(() => resendInvitationAction(id));
+      if (!isTransportError(res) && res.ok) toast.success(labels.resendSuccess);
+      else toast.error(labels.resendError);
+    });
+  }
+
+  return (
+    <div className="mt-6 border-t border-border pt-5" data-testid="pending-invitations">
+      <h3 className="text-sm font-semibold">{labels.pendingHeading}</h3>
+      <ul className="mt-3 flex flex-col gap-2">
+        {invitations.map((inv) => (
+          <li
+            key={inv.id}
+            className="flex items-center gap-3 rounded-md border border-dashed border-border bg-background/40 px-4 py-2.5"
+          >
+            <span className="min-w-0 flex-1 truncate text-sm">{inv.email}</span>
+            <span className="shrink-0 rounded-full bg-secondary/15 px-2 py-0.5 text-2xs font-medium text-secondary">
+              {labels.pendingBadge}
+            </span>
+            <Button size="sm" variant="ghost" disabled={pending} onClick={() => resend(inv.id)}>
+              {labels.resendInvite}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/admin/settings/workspace-name.tsx
+++ b/apps/web/app/admin/settings/workspace-name.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useActionState, useEffect, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/toast';
+import { renameWorkspaceAction, type RenameWorkspaceState } from '@/app/admin/workspace-actions';
+
+export interface WorkspaceNameLabels {
+  workspaceName: string;
+  workspaceNameSave: string;
+  workspaceNameSaved: string;
+  workspaceNameError: string;
+}
+
+/**
+ * The workspace's name, editable by admins/owners. Renames upstream first when
+ * the identity service is configured (the server action goes through the API),
+ * so the Dapta app shows the new name too.
+ */
+export function WorkspaceName({
+  initial,
+  canEdit,
+  labels,
+}: {
+  initial: string;
+  canEdit: boolean;
+  labels: WorkspaceNameLabels;
+}) {
+  const [state, action, pending] = useActionState<RenameWorkspaceState, FormData>(
+    renameWorkspaceAction,
+    null,
+  );
+  const toast = useToast();
+  const handledRef = useRef<RenameWorkspaceState>(null);
+
+  useEffect(() => {
+    if (!state || state === handledRef.current) return;
+    handledRef.current = state;
+    if (state.ok) toast.success(labels.workspaceNameSaved);
+    else toast.error(labels.workspaceNameError);
+  }, [state, toast, labels.workspaceNameSaved, labels.workspaceNameError]);
+
+  if (!canEdit) {
+    return (
+      <div>
+        <dt className="text-xs font-medium uppercase tracking-wide text-faint">{labels.workspaceName}</dt>
+        <dd className="mt-1 text-sm text-foreground" data-testid="workspace-name">
+          {initial}
+        </dd>
+      </div>
+    );
+  }
+
+  return (
+    <form action={action} className="sm:col-span-2" data-testid="workspace-name-form">
+      <label className="flex flex-col gap-1.5 text-sm">
+        <span className="text-xs font-medium uppercase tracking-wide text-faint">{labels.workspaceName}</span>
+        <div className="flex items-center gap-2">
+          <input
+            name="name"
+            type="text"
+            required
+            maxLength={80}
+            defaultValue={initial}
+            key={initial}
+            autoComplete="off"
+            data-testid="workspace-name-input"
+            className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <Button type="submit" size="sm" disabled={pending}>
+            {labels.workspaceNameSave}
+          </Button>
+        </div>
+      </label>
+    </form>
+  );
+}

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -2,8 +2,9 @@
 
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
+import { unstable_rethrow } from 'next/navigation';
 import { setWorkspace } from '@/lib/auth-session';
-import { adminApi } from '@/lib/admin-api';
+import { adminApi, ApiError } from '@/lib/admin-api';
 
 /**
  * Enter a different workspace.
@@ -16,17 +17,99 @@ import { adminApi } from '@/lib/admin-api';
  *
  * It still verifies BEFORE writing, because failing at the moment of the click
  * is far better than storing a choice that makes the next page 403 and bounce.
+ * `enterWorkspace` is that check — and it also remembers the choice upstream
+ * (when there is an upstream), so the Dapta app opens the same workspace next.
  */
 export async function switchWorkspaceAction(accountId: string): Promise<{ error?: string }> {
   const id = accountId.trim();
   if (!id) return { error: 'unknown' };
 
-  const workspaces = await adminApi.listWorkspaces();
-  const target = workspaces.find((w) => w.accountId === id);
-  if (!target) return { error: 'forbidden' };
+  try {
+    await adminApi.enterWorkspace(id);
+  } catch (e) {
+    unstable_rethrow(e);
+    return { error: 'forbidden' };
+  }
 
   await setWorkspace(id);
   // Every admin page is scoped to the account, so all of it is now stale.
   revalidatePath('/admin', 'layout');
   redirect('/admin');
+}
+
+export type CreateWorkspaceState =
+  | null
+  | { ok: true }
+  | { ok: false; code: 'INVALID' | 'FORBIDDEN' | 'FAILED' };
+
+/**
+ * Create a workspace and enter it. Owner is the caller; with the identity
+ * service configured the workspace is created THERE first (so the rest of the
+ * Dapta estate sees it) and then projected here.
+ */
+export async function createWorkspaceAction(
+  _prev: CreateWorkspaceState,
+  formData: FormData,
+): Promise<CreateWorkspaceState> {
+  const name = String(formData.get('name') ?? '').trim();
+  if (!name || name.length > 80) return { ok: false, code: 'INVALID' };
+
+  let accountId: string;
+  try {
+    const res = await adminApi.createWorkspace(name);
+    accountId = res.accountId;
+  } catch (e) {
+    unstable_rethrow(e);
+    if (e instanceof ApiError) {
+      if (e.status === 403) return { ok: false, code: 'FORBIDDEN' };
+      if (e.status === 400) return { ok: false, code: 'INVALID' };
+    }
+    return { ok: false, code: 'FAILED' };
+  }
+
+  await setWorkspace(accountId);
+  revalidatePath('/admin', 'layout');
+  redirect('/admin');
+}
+
+/**
+ * Re-read the workspace list from the identity service (when there is one) —
+ * fired when the switcher opens, so a workspace created or joined in the Dapta
+ * app shows up without waiting for the TTL.
+ */
+export async function refreshWorkspacesAction(): Promise<{ ok: boolean }> {
+  try {
+    await adminApi.refreshWorkspaces();
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+  revalidatePath('/admin', 'layout');
+  return { ok: true };
+}
+
+export type RenameWorkspaceState =
+  | null
+  | { ok: true }
+  | { ok: false; code: 'INVALID' | 'FORBIDDEN' | 'FAILED' };
+
+/** Rename the current workspace (admin/owner; the API is the real gate). */
+export async function renameWorkspaceAction(
+  _prev: RenameWorkspaceState,
+  formData: FormData,
+): Promise<RenameWorkspaceState> {
+  const name = String(formData.get('name') ?? '').trim();
+  if (!name || name.length > 80) return { ok: false, code: 'INVALID' };
+  try {
+    await adminApi.renameWorkspace(name);
+  } catch (e) {
+    unstable_rethrow(e);
+    if (e instanceof ApiError) {
+      if (e.status === 403) return { ok: false, code: 'FORBIDDEN' };
+      if (e.status === 400) return { ok: false, code: 'INVALID' };
+    }
+    return { ok: false, code: 'FAILED' };
+  }
+  revalidatePath('/admin', 'layout');
+  return { ok: true };
 }

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -328,8 +328,9 @@ export function AdminShell({
       >
         {brand}
         {/* Directly under the wordmark and above the nav: which tenant every
-            link below belongs to. It renders nothing at all for the single-
-            workspace majority. */}
+            link below belongs to, and where a new one is made. Always
+            rendered: "New workspace" has to exist before there is a second
+            workspace to switch to. */}
         {currentAccountId ? (
           <WorkspaceSwitcher
             workspaces={workspaces}

--- a/apps/web/components/create-workspace-dialog.tsx
+++ b/apps/web/components/create-workspace-dialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useActionState, useEffect, useRef } from 'react';
+import type { FormsMessages } from '@quill/shared';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { createWorkspaceAction, type CreateWorkspaceState } from '@/app/admin/workspace-actions';
+
+type Messages = FormsMessages['admin']['chrome']['workspaces'];
+
+/**
+ * "New workspace": one field, then you are in it. Success is a redirect from
+ * the server action (the cookie now names the new workspace), so this dialog
+ * only ever handles the failure branch itself.
+ */
+export function CreateWorkspaceDialog({
+  open,
+  onClose,
+  m,
+}: {
+  open: boolean;
+  onClose: () => void;
+  m: Messages;
+}) {
+  const [state, action, pending] = useActionState<CreateWorkspaceState, FormData>(
+    createWorkspaceAction,
+    null,
+  );
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (!open) formRef.current?.reset();
+  }, [open]);
+
+  const errorMessage =
+    state && !state.ok
+      ? state.code === 'FORBIDDEN'
+        ? m.createErrorForbidden
+        : state.code === 'INVALID'
+          ? m.createErrorInvalid
+          : m.createErrorFailed
+      : null;
+
+  return (
+    <Modal open={open} onClose={onClose} title={m.createTitle} labelId="create-workspace-title">
+      <p className="-mt-2 mb-4 text-sm text-muted-foreground">{m.createSubtitle}</p>
+      <form ref={formRef} action={action} className="flex flex-col gap-4" data-testid="create-workspace-form">
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium">{m.createNameLabel}</span>
+          <input
+            name="name"
+            type="text"
+            required
+            maxLength={80}
+            autoComplete="off"
+            placeholder={m.createNamePlaceholder}
+            aria-invalid={errorMessage ? true : undefined}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </label>
+        {errorMessage ? (
+          <p role="alert" className="text-sm text-destructive">
+            {errorMessage}
+          </p>
+        ) : null}
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            {m.createCancel}
+          </Button>
+          <Button type="submit" disabled={pending} className="min-w-[120px]" data-testid="create-workspace-submit">
+            {pending ? m.creating : m.createSubmit}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/components/workspace-switcher.tsx
+++ b/apps/web/components/workspace-switcher.tsx
@@ -1,21 +1,23 @@
 'use client';
 
-import { useCallback, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
 import type { FormsMessages } from '@quill/shared';
 import type { Workspace } from '@/lib/admin-api';
-import { switchWorkspaceAction } from '@/app/admin/workspace-actions';
+import { refreshWorkspacesAction, switchWorkspaceAction } from '@/app/admin/workspace-actions';
 import { AnchoredMenu } from '@/components/ui/anchored-menu';
+import { CreateWorkspaceDialog } from '@/components/create-workspace-dialog';
 import { callAction } from '@/lib/call-action';
 
 type Messages = FormsMessages['admin']['chrome']['workspaces'];
 
 /**
- * Which workspace you are in, and how to change it.
+ * Which workspace you are in, how to change it, and how to make a new one.
  *
- * Renders NOTHING for someone who belongs to a single account — the overwhelming
- * majority — because a picker with one entry is a control that teaches you it
- * does nothing. It appears the moment a second membership exists, which in
- * practice is the moment an invitation is accepted.
+ * Always rendered — even with a single membership — because the menu is also
+ * where "New workspace" lives, and that entry point must exist BEFORE there is
+ * a second workspace to switch to. Opening the menu re-reads the list from the
+ * identity service (when there is one), so a workspace created or joined in the
+ * Dapta app appears without waiting for the projection's TTL.
  *
  * Switching is a server action: it rewrites the signed session cookie and
  * reloads. It grants nothing on its own — the API re-checks membership on every
@@ -41,12 +43,22 @@ export function WorkspaceSwitcher({
   m: Messages;
 }) {
   const [open, setOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
   const [pending, start] = useTransition();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const close = useCallback(() => setOpen(false), []);
-
-  // One membership is not a choice. Say nothing rather than show a dead control.
-  if (workspaces.length < 2) return null;
+  // One refresh per open, never per render: the action revalidates the layout,
+  // which re-renders this component with the fresh list.
+  const refreshedRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      refreshedRef.current = false;
+      return;
+    }
+    if (refreshedRef.current) return;
+    refreshedRef.current = true;
+    void callAction(() => refreshWorkspacesAction());
+  }, [open]);
 
   const current = workspaces.find((w) => w.accountId === currentAccountId);
   const label = current?.accountName ?? m.unknown;
@@ -139,7 +151,23 @@ export function WorkspaceSwitcher({
             </button>
           );
         })}
+        <div className="my-1 border-t border-border" />
+        <button
+          type="button"
+          role="menuitem"
+          data-testid="workspace-create"
+          onClick={() => {
+            setOpen(false);
+            setCreating(true);
+          }}
+          className="flex items-center gap-2 px-2.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
+        >
+          <i aria-hidden className="pi pi-plus text-muted-foreground" style={{ fontSize: 11 }} />
+          <span className="min-w-0 flex-1 truncate">{m.create}</span>
+        </button>
       </AnchoredMenu>
+
+      <CreateWorkspaceDialog open={creating} onClose={() => setCreating(false)} m={m} />
     </div>
   );
 }

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -121,6 +121,8 @@ export interface WebhookPingResult {
 
 export interface Me {
   accountId: string;
+  /** The workspace's display name. */
+  accountName: string;
   accountCode: string;
   accountShortCode: string;
   vanitySlug: string | null;
@@ -240,6 +242,15 @@ export interface AccountMember {
   role: AccountRole;
   status: MemberStatus;
   createdAt: number;
+}
+
+/** An invitation that has not been accepted yet (lives in the identity service). */
+export interface PendingInvitation {
+  id: string;
+  email: string;
+  status: string;
+  createdAt: string | null;
+  expiresAt: string | null;
 }
 
 export type { AnalyticsResponse, SubmissionsPage } from '@quill/types';
@@ -561,6 +572,15 @@ export const adminApi = {
     req<{ ok: boolean }>('PUT', '/v1/me/profile', { profile }),
   /** Every workspace the caller can enter, for the switcher. */
   listWorkspaces: () => req<Workspace[]>('GET', '/v1/workspaces'),
+  /** Same list after forcing a re-read from the identity service (when there is one). */
+  refreshWorkspaces: () => req<Workspace[]>('POST', '/v1/workspaces/refresh'),
+  /** Create a workspace with the caller as owner; returns the new local account id. */
+  createWorkspace: (name: string) => req<{ accountId: string }>('POST', '/v1/workspaces', { name }),
+  /** Rename the workspace the caller is acting in (admin/owner). */
+  renameWorkspace: (name: string) =>
+    req<{ accountId: string; name: string }>('PATCH', '/v1/workspaces/current', { name }),
+  /** Tell the API the caller is about to open this workspace (membership re-checked; remembered upstream). */
+  enterWorkspace: (accountId: string) => req<{ ok: true }>('POST', `/v1/workspaces/${accountId}/enter`),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */
   pingWebhook: (id: string) =>
     req<WebhookPingResult>('POST', `/v1/forms/${id}/destinations/webhook/ping`),
@@ -578,6 +598,9 @@ export const adminApi = {
   updateMember: (id: string, b: { role?: AccountRole; status?: MemberStatus }) =>
     req<AccountMember>('PATCH', `/v1/members/${id}`, b),
   removeMember: (id: string) => req<{ ok: boolean }>('DELETE', `/v1/members/${id}`),
+  /** Pending invitations (identity-service deployments only; empty otherwise). */
+  listInvitations: () => req<PendingInvitation[]>('GET', '/v1/invitations'),
+  resendInvitation: (id: string) => req<{ ok: true }>('POST', `/v1/invitations/${id}/resend`),
 
   // Notifications (submission emails — admin/owner only)
   getNotifications: () => req<NotificationsResponse>('GET', '/v1/notifications'),

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -216,6 +216,11 @@ export const serverEnvSchema = z.object({
   //
   // All four unset (the default, and every bare fork) = the feature does not
   // exist: nothing is enqueued, no third-party request is ever made.
+  //
+  // IAM_BASE_URL + AUTH_PROVIDER=workos ALSO selects identity-service-backed
+  // workspaces (0015): memberships, roles, invitations and "last opened" are
+  // read from / written to the IAM with the caller's bearer, and the local
+  // account/member rows are a projection. Unset = local-only workspaces.
   IAM_BASE_URL: z.string().url().optional(),
   IAM_API_KEY: z.string().optional(),
   DAPTA_SYNC_FLOW_URL: z.string().url().optional(),

--- a/packages/db/migrations/postgres/0015_iam_workspaces.sql
+++ b/packages/db/migrations/postgres/0015_iam_workspaces.sql
@@ -1,0 +1,42 @@
+-- Workspaces ARE the identity service's workspaces — additive.
+--
+-- Until now one local `account` was born per identity-service ACCOUNT (the
+-- billing/company layer above workspaces): `account.external_id` carried the
+-- token's `account_id`, so a person with three workspaces upstream had exactly
+-- one workspace here, and a workspace created here was invisible upstream.
+--
+-- From this migration on, `account.external_id` means the upstream WORKSPACE
+-- id, and the local `account`/`member` rows are a PROJECTION of what the
+-- identity service says: refreshed on login, on demand, and after every write
+-- that goes upstream first. Three nullable columns carry what the projection
+-- needs and nothing else:
+--
+--   account.iam_account_id          — the upstream ACCOUNT the workspace hangs
+--                                     from (billing; also what a create must
+--                                     name). Backfilled from `external_id`,
+--                                     because before this migration that column
+--                                     held exactly this value.
+--   account.synced_at               — epoch-ms of the last successful
+--                                     projection refresh for this workspace.
+--                                     NULL = never projected (a purely local
+--                                     account: seed, dev stub, or a legacy row
+--                                     awaiting its first post-migration login).
+--   member.iam_workspace_user_id    — the upstream `workspace_users.id` for
+--                                     this membership, which is what removing
+--                                     or re-roling a member upstream is keyed
+--                                     on. NULL for rows the identity service
+--                                     does not know (invited-by-email locally,
+--                                     dev stub, seed).
+--
+-- The legacy `external_id = <account_id>` rows are NOT rewritten here: which
+-- upstream workspace they map to depends on that person's memberships, which
+-- only their next login can read (with their own token). The auth provider does
+-- that rebind lazily; this migration only makes it possible.
+ALTER TABLE account ADD COLUMN IF NOT EXISTS iam_account_id TEXT;
+ALTER TABLE account ADD COLUMN IF NOT EXISTS synced_at BIGINT;
+ALTER TABLE member ADD COLUMN IF NOT EXISTS iam_workspace_user_id TEXT;
+
+UPDATE account SET iam_account_id = external_id
+  WHERE iam_account_id IS NULL AND external_id IS NOT NULL AND external_id NOT LIKE 'dev:%';
+
+CREATE INDEX IF NOT EXISTS account_iam_account_idx ON account (iam_account_id);

--- a/packages/db/migrations/sqlite/0015_iam_workspaces.sql
+++ b/packages/db/migrations/sqlite/0015_iam_workspaces.sql
@@ -1,0 +1,45 @@
+-- Workspaces ARE the identity service's workspaces — additive.
+--
+-- Until now one local `account` was born per identity-service ACCOUNT (the
+-- billing/company layer above workspaces): `account.external_id` carried the
+-- token's `account_id`, so a person with three workspaces upstream had exactly
+-- one workspace here, and a workspace created here was invisible upstream.
+--
+-- From this migration on, `account.external_id` means the upstream WORKSPACE
+-- id, and the local `account`/`member` rows are a PROJECTION of what the
+-- identity service says: refreshed on login, on demand, and after every write
+-- that goes upstream first. Three nullable columns carry what the projection
+-- needs and nothing else:
+--
+--   account.iam_account_id          — the upstream ACCOUNT the workspace hangs
+--                                     from (billing; also what a create must
+--                                     name). Backfilled from `external_id`,
+--                                     because before this migration that column
+--                                     held exactly this value.
+--   account.synced_at               — epoch-ms of the last successful
+--                                     projection refresh for this workspace.
+--                                     NULL = never projected (a purely local
+--                                     account: seed, dev stub, or a legacy row
+--                                     awaiting its first post-migration login).
+--   member.iam_workspace_user_id    — the upstream `workspace_users.id` for
+--                                     this membership, which is what removing
+--                                     or re-roling a member upstream is keyed
+--                                     on. NULL for rows the identity service
+--                                     does not know (invited-by-email locally,
+--                                     dev stub, seed).
+--
+-- The legacy `external_id = <account_id>` rows are NOT rewritten here: which
+-- upstream workspace they map to depends on that person's memberships, which
+-- only their next login can read (with their own token). The auth provider does
+-- that rebind lazily; this migration only makes it possible.
+--
+-- SQLite has no ADD COLUMN IF NOT EXISTS and does not need one: migrate.ts runs
+-- each numbered file exactly once, gated on the _migrations table.
+ALTER TABLE account ADD COLUMN iam_account_id TEXT;
+ALTER TABLE account ADD COLUMN synced_at INTEGER;
+ALTER TABLE member ADD COLUMN iam_workspace_user_id TEXT;
+
+UPDATE account SET iam_account_id = external_id
+  WHERE iam_account_id IS NULL AND external_id IS NOT NULL AND external_id NOT LIKE 'dev:%';
+
+CREATE INDEX IF NOT EXISTS account_iam_account_idx ON account (iam_account_id);

--- a/packages/db/src/forms-webhooks.spec.ts
+++ b/packages/db/src/forms-webhooks.spec.ts
@@ -46,18 +46,27 @@ const hook = (settings: Record<string, unknown>, extra: Record<string, unknown> 
   ...extra,
 });
 
+// Every query under test is account-scoped, so this file only ever needs its
+// OWN two accounts gone — never `DELETE FROM account` outright. On the shared
+// Postgres of the parity job the specs run in parallel, and a table-wide
+// delete here silently emptied the rows other files had just inserted.
+async function cleanOwn() {
+  for (const id of [accountId, otherAccountId].filter(Boolean)) {
+    await db.run(sql`DELETE FROM form WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM member WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${id}`);
+  }
+}
+
 beforeEach(async () => {
   db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
   await migrate(db);
-  await db.run(sql`DELETE FROM form`);
-  await db.run(sql`DELETE FROM account`);
   accountId = await insertAccount();
   otherAccountId = await insertAccount();
 });
 
 afterEach(async () => {
-  await db.run(sql`DELETE FROM form`);
-  await db.run(sql`DELETE FROM account`);
+  await cleanOwn();
   await db.close();
 });
 

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -76,6 +76,8 @@ export async function getAccountByCode(db: Db, code: string): Promise<AccountRow
 
 export interface MeView {
   accountId: string;
+  /** The workspace's display name (renameable in Settings). */
+  accountName: string;
   accountCode: string;
   accountShortCode: string;
   vanitySlug: string | null;
@@ -104,6 +106,7 @@ export interface MeView {
 export async function getMe(db: Db, accountId: string, memberId: string): Promise<MeView | null> {
   const row = await db.get<{
     code: string;
+    name: string;
     vanity_slug: string | null;
     handle: string | null;
     display_name: string | null;
@@ -113,7 +116,7 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     onboarding_completed_at: number | null;
     attribution: unknown;
   }>(
-    sql`SELECT a.code, a.vanity_slug, a.onboarding_completed_at, a.attribution,
+    sql`SELECT a.code, a.name, a.vanity_slug, a.onboarding_completed_at, a.attribution,
                m.handle, m.display_name, m.email, m.role, m.status
         FROM account a JOIN member m ON m.account_id = a.id
         WHERE a.id = ${accountId} AND m.id = ${memberId} LIMIT 1`,
@@ -121,6 +124,7 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
   if (!row) return null;
   return {
     accountId,
+    accountName: row.name,
     accountCode: canonicalPublicCode({ code: row.code, vanity_slug: row.vanity_slug }),
     accountShortCode: row.code,
     vanitySlug: row.vanity_slug,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13,6 +13,7 @@ export * from './crypto';
 export * from './analytics';
 export * from './milestones';
 export * from './members';
+export * from './workspaces';
 export * from './demo-form';
 export * from './onboarding';
 export * from './templates';

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -10,6 +10,7 @@
  */
 import { randomUUID } from 'node:crypto';
 import { sql, type Db } from './client';
+import type { SQL } from 'drizzle-orm';
 import type { CrudResult } from './crud';
 import { deriveUniqueHandle } from './short-links';
 import { getAccountByCode, parseJsonColumn } from './forms';
@@ -106,6 +107,17 @@ async function otherActiveOwners(
           AND id <> ${excludeMemberId}`,
   );
   return Number(row?.n ?? 0);
+}
+
+/**
+ * Whether removing/disabling/demoting `memberId` would leave the workspace with
+ * no active owner. Exported so callers that write UPSTREAM FIRST can refuse
+ * before the upstream write, not after.
+ */
+export async function wouldOrphanWorkspace(db: Db, accountId: string, memberId: string): Promise<boolean> {
+  const current = await getAccountMember(db, accountId, memberId);
+  if (!current || current.role !== 'owner' || current.status !== 'active') return false;
+  return (await otherActiveOwners(db, accountId, memberId)) === 0;
 }
 
 const EMAIL_LOCAL = (email: string) => email.split('@')[0] ?? email;
@@ -303,6 +315,14 @@ export async function listWorkspacesForIdentity(
   // Match on EITHER key. A person can hold rows created by two different paths
   // — an IAM-provisioned one carrying `external_id`, and an invite that only
   // ever knew their address — and both are the same human.
+  //
+  // The branches are assembled here, not as `(${x} IS NOT NULL AND …)` in SQL:
+  // Postgres cannot infer a type for a bare parameter compared to NULL
+  // ("could not determine data type of parameter $1"), and that query ran
+  // only on SQLite until the switcher became always-on.
+  const conds: SQL[] = [];
+  if (externalId) conds.push(sql`m.external_id = ${externalId}`);
+  if (email) conds.push(sql`lower(m.email) = ${email}`);
   const rows = await db.all<{
     account_id: string;
     code: string;
@@ -314,10 +334,7 @@ export async function listWorkspacesForIdentity(
     sql`SELECT a.id AS account_id, a.code, a.name, m.id AS member_id, m.role, m.status
         FROM member m JOIN account a ON a.id = m.account_id
         WHERE m.status IN ('active', 'invited')
-          AND (
-            (${externalId} IS NOT NULL AND m.external_id = ${externalId})
-            OR (${email} IS NOT NULL AND lower(m.email) = ${email})
-          )
+          AND (${sql.join(conds, sql` OR `)})
         ORDER BY a.name ASC, a.created_at ASC`,
   );
 

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -34,8 +34,18 @@ export const account = pgTable('account', {
    * NULL means "send them to the wizard".
    */
   onboardingCompletedAt: bigint('onboarding_completed_at', { mode: 'number' }),
+  /**
+   * The identity service's ACCOUNT this workspace hangs from (see 0015).
+   * `external_id` is the upstream WORKSPACE id; this is the billing layer above
+   * it. NULL for purely local accounts (seed, dev stub).
+   */
+  iamAccountId: text('iam_account_id'),
+  /** Epoch-ms of the last successful projection refresh from the identity service; NULL = never. */
+  syncedAt: bigint('synced_at', { mode: 'number' }),
   createdAt: bigint('created_at', { mode: 'number' }).notNull(),
-});
+}, (t) => ({
+  accountIamAccountIdx: index('account_iam_account_idx').on(t.iamAccountId),
+}));
 
 export const accountAlias = pgTable('account_alias', {
   alias: text('alias').primaryKey(),
@@ -60,6 +70,8 @@ export const member = pgTable(
     profile: jsonb('profile'),
     /** Epoch-ms of the member's last authenticated request; NULL = never seen (see 0010). */
     lastSeenAt: bigint('last_seen_at', { mode: 'number' }),
+    /** The upstream `workspace_users.id` for this membership (see 0015); NULL when the identity service does not know it. */
+    iamWorkspaceUserId: text('iam_workspace_user_id'),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
   },
   (t) => ({

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -43,8 +43,18 @@ export const account = sqliteTable('account', {
    * NULL means "send them to the wizard".
    */
   onboardingCompletedAt: integer('onboarding_completed_at'),
+  /**
+   * The identity service's ACCOUNT this workspace hangs from (see 0015).
+   * `external_id` is the upstream WORKSPACE id; this is the billing layer above
+   * it. NULL for purely local accounts (seed, dev stub).
+   */
+  iamAccountId: text('iam_account_id'),
+  /** Epoch-ms of the last successful projection refresh from the identity service; NULL = never. */
+  syncedAt: integer('synced_at'),
   createdAt: integer('created_at').notNull(),
-});
+}, (t) => ({
+  accountIamAccountIdx: index('account_iam_account_idx').on(t.iamAccountId),
+}));
 
 /** Retired public codes — each alias permanently resolves to its account. */
 export const accountAlias = sqliteTable('account_alias', {
@@ -70,6 +80,8 @@ export const member = sqliteTable(
     profile: text('profile'),
     /** Epoch-ms of the member's last authenticated request; NULL = never seen (see 0010). */
     lastSeenAt: integer('last_seen_at'),
+    /** The upstream `workspace_users.id` for this membership (see 0015); NULL when the identity service does not know it. */
+    iamWorkspaceUserId: text('iam_workspace_user_id'),
     createdAt: integer('created_at').notNull(),
   },
   (t) => ({

--- a/packages/db/src/workspaces.spec.ts
+++ b/packages/db/src/workspaces.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * The workspace projection at the data layer, on BOTH dialects: honors
+ * DATABASE_URL so the CI parity job re-runs this against real Postgres.
+ *
+ * What is locked here, worst first:
+ *   1. `listWorkspacesForIdentity` runs on Postgres with either key alone (it
+ *      used to fail there — "could not determine data type of parameter" — and
+ *      only SQLite ever ran it, which the always-on switcher would have found
+ *      in production).
+ *   2. `projectMemberships` is idempotent and disables only what upstream no
+ *      longer names.
+ *   3. `projectRoster` never disables a row the identity service does not know
+ *      (no upstream membership id) — the owner survives a roster read.
+ *   4. `rebindLegacyAccount` keeps the legacy row's id when it can, absorbs an
+ *      EMPTY projected row, and parks a legacy row (disabled, renamed) when the
+ *      projected one already has forms.
+ *   5. `pickHomeAccount` prefers the requested workspace, else most recent.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createDb, sql, type Db } from './client';
+import { migrate } from './migrate';
+import { listWorkspacesForIdentity } from './members';
+import {
+  createLocalWorkspace,
+  humanHasCompletedOnboarding,
+  pickHomeAccount,
+  projectMemberships,
+  projectRoster,
+  rebindLegacyAccount,
+} from './workspaces';
+
+let db: Db;
+const SUB = `sub-${randomUUID()}`;
+const EMAIL = `${randomUUID().slice(0, 8)}@example.com`;
+const created: string[] = [];
+
+async function cleanup() {
+  for (const id of created) {
+    await db.run(sql`DELETE FROM form WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM member WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM account_alias WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${id}`);
+  }
+  await db.run(sql`DELETE FROM member WHERE external_id = ${SUB} OR lower(email) = ${EMAIL}`);
+  created.length = 0;
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? 'file::memory:');
+  await migrate(db);
+});
+
+afterEach(async () => {
+  await cleanup();
+  await db.close?.();
+});
+
+async function ids(externalIds: string[]) {
+  for (const ext of externalIds) {
+    const r = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${ext}`);
+    if (r) created.push(r.id);
+  }
+}
+
+describe('listWorkspacesForIdentity (both dialects)', () => {
+  it('matches on external_id alone, on email alone, and on both', async () => {
+    const ws = `ws-${randomUUID()}`;
+    await projectMemberships(
+      db,
+      { externalId: SUB, email: EMAIL, displayName: 'A' },
+      [{ workspaceId: ws, workspaceName: 'W', iamAccountId: 'acct', workspaceUserId: 'wu', role: 'owner', active: true }],
+    );
+    await ids([ws]);
+    expect((await listWorkspacesForIdentity(db, { externalId: SUB, email: null })).length).toBe(1);
+    expect((await listWorkspacesForIdentity(db, { externalId: null, email: EMAIL })).length).toBe(1);
+    expect((await listWorkspacesForIdentity(db, { externalId: SUB, email: EMAIL })).length).toBe(1);
+    expect((await listWorkspacesForIdentity(db, { externalId: null, email: null })).length).toBe(0);
+  });
+});
+
+describe('projectMemberships', () => {
+  it('is idempotent and disables only what upstream stopped naming', async () => {
+    const a = `ws-${randomUUID()}`, b = `ws-${randomUUID()}`;
+    const identity = { externalId: SUB, email: EMAIL, displayName: 'A' };
+    const two = [
+      { workspaceId: a, workspaceName: 'A', iamAccountId: 'acct', workspaceUserId: 'wu-a', role: 'owner' as const, active: true },
+      { workspaceId: b, workspaceName: 'B', iamAccountId: 'other', workspaceUserId: 'wu-b', role: 'member' as const, active: true },
+    ];
+    const first = await projectMemberships(db, identity, two);
+    await ids([a, b]);
+    expect(first.created.length).toBe(2);
+    expect(first.createdAccounts.length).toBe(2);
+    const second = await projectMemberships(db, identity, two);
+    expect(second.created.length).toBe(0);
+    expect(second.createdAccounts.length).toBe(0);
+    // Upstream drops B.
+    await projectMemberships(db, identity, [two[0]!]);
+    const list = await listWorkspacesForIdentity(db, identity);
+    expect(list.map((w) => w.accountName)).toEqual(['A']);
+    const bRow = await db.get<{ status: string }>(
+      sql`SELECT m.status FROM member m JOIN account acc ON acc.id = m.account_id WHERE acc.external_id = ${b} AND m.external_id = ${SUB}`,
+    );
+    expect(bRow!.status).toBe('disabled');
+  });
+
+  it('inherits onboarding completion for accounts it creates when asked', async () => {
+    const a = `ws-${randomUUID()}`;
+    await projectMemberships(db, { externalId: SUB, email: EMAIL, displayName: null }, [
+      { workspaceId: a, workspaceName: 'A', iamAccountId: 'acct', workspaceUserId: 'wu', role: 'owner', active: true },
+    ]);
+    await ids([a]);
+    expect(await humanHasCompletedOnboarding(db, SUB)).toBe(false);
+    await db.run(sql`UPDATE account SET onboarding_completed_at = 1 WHERE external_id = ${a}`);
+    expect(await humanHasCompletedOnboarding(db, SUB)).toBe(true);
+    const b = `ws-${randomUUID()}`;
+    await projectMemberships(
+      db,
+      { externalId: SUB, email: EMAIL, displayName: null },
+      [
+        { workspaceId: a, workspaceName: 'A', iamAccountId: 'acct', workspaceUserId: 'wu', role: 'owner', active: true },
+        { workspaceId: b, workspaceName: 'B', iamAccountId: 'acct', workspaceUserId: 'wu2', role: 'owner', active: true },
+      ],
+      { inheritOnboarding: true },
+    );
+    await ids([b]);
+    const row = await db.get<{ onboarding_completed_at: number | null }>(sql`SELECT onboarding_completed_at FROM account WHERE external_id = ${b}`);
+    expect(row!.onboarding_completed_at).not.toBeNull();
+  });
+});
+
+describe('projectRoster', () => {
+  it('never disables a row without an upstream membership id (the owner survives)', async () => {
+    const a = `ws-${randomUUID()}`;
+    await projectMemberships(db, { externalId: SUB, email: EMAIL, displayName: null }, [
+      { workspaceId: a, workspaceName: 'A', iamAccountId: 'acct', workspaceUserId: null, role: 'owner', active: true },
+    ]);
+    await ids([a]);
+    const acc = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${a}`);
+    // Upstream lists ONLY a colleague; the owner is absent from users[].
+    await projectRoster(db, acc!.id, [
+      { externalId: `sub-${randomUUID()}`, email: 'c@example.com', displayName: 'C', role: 'member', active: true, workspaceUserId: 'wu-c' },
+    ]);
+    const owner = await db.get<{ status: string; role: string }>(sql`SELECT status, role FROM member WHERE account_id = ${acc!.id} AND external_id = ${SUB}`);
+    expect(owner!.status).toBe('active');
+    expect(owner!.role).toBe('owner');
+    // A row upstream DID know (has a membership id) and now omits IS disabled.
+    await projectRoster(db, acc!.id, []);
+    const c = await db.get<{ status: string }>(sql`SELECT status FROM member WHERE account_id = ${acc!.id} AND lower(email) = 'c@example.com'`);
+    expect(c!.status).toBe('disabled');
+  });
+});
+
+describe('rebindLegacyAccount', () => {
+  it('rebinds in place, absorbs an empty projected row, and parks when the projected row has forms', async () => {
+    const acct = `acct-${randomUUID()}`, ws = `ws-${randomUUID()}`;
+    // Legacy row: external_id = upstream ACCOUNT id.
+    const legacyId = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, created_at) VALUES (${legacyId}, ${'l' + legacyId.slice(0, 5)}, 'Old', ${acct}, 1)`);
+    created.push(legacyId);
+    const r1 = await rebindLegacyAccount(db, { iamAccountId: acct, workspaceId: ws, workspaceName: 'W' });
+    expect(r1).toEqual({ accountId: legacyId, parkedLegacyId: null });
+    const row = await db.get<{ external_id: string; iam_account_id: string }>(sql`SELECT external_id, iam_account_id FROM account WHERE id = ${legacyId}`);
+    expect(row).toEqual({ external_id: ws, iam_account_id: acct });
+
+    // Absorb: a second legacy row and an EMPTY projected row for the same workspace.
+    const acct2 = `acct-${randomUUID()}`, ws2 = `ws-${randomUUID()}`;
+    const legacy2 = randomUUID(), projected2 = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, created_at) VALUES (${legacy2}, ${'m' + legacy2.slice(0, 5)}, 'Old2', ${acct2}, 1)`);
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, created_at) VALUES (${projected2}, ${'p' + projected2.slice(0, 5)}, 'W2', ${ws2}, 2)`);
+    created.push(legacy2, projected2);
+    const r2 = await rebindLegacyAccount(db, { iamAccountId: acct2, workspaceId: ws2, workspaceName: 'W2' });
+    expect(r2).toEqual({ accountId: legacy2, parkedLegacyId: null });
+    expect(await db.get(sql`SELECT id FROM account WHERE id = ${projected2}`)).toBeUndefined();
+
+    // Park: the projected row already has a form.
+    const acct3 = `acct-${randomUUID()}`, ws3 = `ws-${randomUUID()}`;
+    const legacy3 = randomUUID(), projected3 = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, created_at) VALUES (${legacy3}, ${'n' + legacy3.slice(0, 5)}, 'Old3', ${acct3}, 1)`);
+    await db.run(sql`INSERT INTO member (id, account_id, external_id, email, handle, role, status, created_at) VALUES (${randomUUID()}, ${legacy3}, ${SUB}, ${EMAIL}, 'h', 'owner', 'active', 1)`);
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, created_at) VALUES (${projected3}, ${'q' + projected3.slice(0, 5)}, 'W3', ${ws3}, 2)`);
+    await db.run(sql`INSERT INTO form (id, account_id, slug, name, config, created_at, updated_at) VALUES (${randomUUID()}, ${projected3}, 'f', 'F', '{}', 1, 1)`);
+    created.push(legacy3, projected3);
+    const r3 = await rebindLegacyAccount(db, { iamAccountId: acct3, workspaceId: ws3, workspaceName: 'W3' });
+    expect(r3).toEqual({ accountId: projected3, parkedLegacyId: legacy3 });
+    const parked = await db.get<{ external_id: string; name: string }>(sql`SELECT external_id, name FROM account WHERE id = ${legacy3}`);
+    expect(parked!.external_id).toBe(`legacy:${acct3}`);
+    expect(parked!.name).toBe('Old3 (legacy)');
+    // Parked = unreachable from the switcher.
+    const list = await listWorkspacesForIdentity(db, { externalId: SUB, email: null });
+    expect(list.some((w) => w.accountId === legacy3)).toBe(false);
+  });
+});
+
+describe('pickHomeAccount + createLocalWorkspace', () => {
+  it('prefers the requested workspace when the person is an active member of it, else the most recent', async () => {
+    const a = `ws-${randomUUID()}`, b = `ws-${randomUUID()}`;
+    await projectMemberships(db, { externalId: SUB, email: EMAIL, displayName: null }, [
+      { workspaceId: a, workspaceName: 'A', iamAccountId: 'acct', workspaceUserId: 'wu-a', role: 'owner', active: true },
+      { workspaceId: b, workspaceName: 'B', iamAccountId: 'acct', workspaceUserId: 'wu-b', role: 'member', active: true },
+    ]);
+    await ids([a, b]);
+    const bAcc = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${b}`);
+    expect((await pickHomeAccount(db, SUB, b))!.accountId).toBe(bAcc!.id);
+    // A workspace the person is NOT in is ignored, and the fallback is a real membership.
+    const fallback = await pickHomeAccount(db, SUB, `ws-${randomUUID()}`);
+    expect([a, b]).toContain((await db.get<{ external_id: string }>(sql`SELECT external_id FROM account WHERE id = ${fallback!.accountId}`))!.external_id);
+    // Local create: owner row, listed.
+    const local = await createLocalWorkspace(db, { externalId: SUB, email: EMAIL, displayName: null }, { name: 'Local' });
+    created.push(local.accountId);
+    const list = await listWorkspacesForIdentity(db, { externalId: SUB, email: null });
+    expect(list.find((w) => w.accountId === local.accountId)!.role).toBe('owner');
+  });
+});

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -1,0 +1,412 @@
+/**
+ * Workspaces as a PROJECTION of the identity service (see migration 0015).
+ *
+ * The identity service (the Dapta IAM) owns the truth about workspaces and who
+ * belongs to them. Locally, an `account` row IS one of its workspaces
+ * (`account.external_id` = upstream workspace id) and a `member` row IS one of
+ * its `workspace_users` rows. Nothing here talks to the network: the API layer
+ * reads upstream and calls these to make the local rows agree, so every query in
+ * the product keeps scoping by `account_id` exactly as before, and the public
+ * URLs (`account.code`) never move.
+ *
+ * Everything is idempotent — a projection that runs twice must be a no-op the
+ * second time — because it runs on the login path and on demand.
+ */
+import { randomUUID } from 'node:crypto';
+import { sql, type Db } from './client';
+import { deriveUniqueHandle, insertAccountWithShortCode } from './short-links';
+import { ACCOUNT_ROLES, type AccountRole } from './members';
+
+/** One upstream membership, as the API layer hands it to the projection. */
+export interface ProjectedMembership {
+  /** Upstream workspace id → `account.external_id`. */
+  workspaceId: string;
+  workspaceName: string;
+  /** Upstream account (billing) id the workspace hangs from → `account.iam_account_id`. */
+  iamAccountId: string | null;
+  /** Upstream `workspace_users.id` → `member.iam_workspace_user_id`. */
+  workspaceUserId: string | null;
+  role: AccountRole;
+  /** Upstream `is_active` on the membership row. */
+  active: boolean;
+}
+
+/** The identity being projected — always the authenticated principal, never the request. */
+export interface ProjectedIdentity {
+  /** The token `sub` → `member.external_id`. */
+  externalId: string;
+  email: string | null;
+  displayName: string | null;
+}
+
+export interface ProjectionResult {
+  /** Local account ids for every ACTIVE upstream membership, in input order. */
+  accountIds: string[];
+  /** Local `(accountId, memberId)` pairs whose member row was CREATED by this run. */
+  created: Array<{ accountId: string; memberId: string; role: AccountRole; isFirstMember: boolean }>;
+  /** Local account ids that were CREATED by this run (a workspace never seen before). */
+  createdAccounts: string[];
+}
+
+/** Local account by the upstream workspace id, or null. */
+export async function getAccountByExternalId(
+  db: Db,
+  externalId: string,
+): Promise<{ id: string; name: string; iamAccountId: string | null } | null> {
+  const r = await db.get<{ id: string; name: string; iam_account_id: string | null }>(
+    sql`SELECT id, name, iam_account_id FROM account WHERE external_id = ${externalId} LIMIT 1`,
+  );
+  return r ? { id: r.id, name: r.name, iamAccountId: r.iam_account_id ?? null } : null;
+}
+
+/**
+ * Rebind a pre-0015 account (whose `external_id` still holds the upstream
+ * ACCOUNT id) onto the upstream WORKSPACE it should have meant all along.
+ *
+ * Returns the local account id that now carries `external_id = workspaceId`:
+ * the legacy row itself when it could be rebound; the already-projected row
+ * when one existed. Two rows can only both exist when someone else in that
+ * workspace logged in after the deploy and before this person did — and if
+ * that projected row is still empty (no forms) it is absorbed so the person's
+ * existing forms keep their account, their code, and their URLs. A projected
+ * row that already has forms is kept, and the legacy row is parked under a
+ * `legacy:` prefix so it can never be mistaken for a live workspace; that case
+ * is loud in the logs and is not expected in practice.
+ */
+export async function rebindLegacyAccount(
+  db: Db,
+  args: { iamAccountId: string; workspaceId: string; workspaceName: string },
+): Promise<{ accountId: string; parkedLegacyId: string | null } | null> {
+  const legacy = await db.get<{ id: string }>(
+    sql`SELECT id FROM account WHERE external_id = ${args.iamAccountId} LIMIT 1`,
+  );
+  if (!legacy) return null;
+
+  const projected = await db.get<{ id: string }>(
+    sql`SELECT id FROM account WHERE external_id = ${args.workspaceId} LIMIT 1`,
+  );
+  if (!projected) {
+    await db.run(
+      sql`UPDATE account SET external_id = ${args.workspaceId}, iam_account_id = ${args.iamAccountId}
+          WHERE id = ${legacy.id}`,
+    );
+    return { accountId: legacy.id, parkedLegacyId: null };
+  }
+
+  const projectedForms = await db.get<{ n: number }>(
+    sql`SELECT COUNT(*) AS n FROM form WHERE account_id = ${projected.id}`,
+  );
+  if (Number(projectedForms?.n ?? 0) === 0) {
+    // Absorb the empty projection: its member rows are re-created by the next
+    // projection pass against the legacy row, so nothing of value is lost.
+    await db.run(sql`DELETE FROM member WHERE account_id = ${projected.id}`);
+    await db.run(sql`DELETE FROM account_alias WHERE account_id = ${projected.id}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${projected.id}`);
+    await db.run(
+      sql`UPDATE account SET external_id = ${args.workspaceId}, iam_account_id = ${args.iamAccountId}
+          WHERE id = ${legacy.id}`,
+    );
+    return { accountId: legacy.id, parkedLegacyId: null };
+  }
+
+  await db.run(
+    sql`UPDATE account SET external_id = ${'legacy:' + args.iamAccountId}, iam_account_id = ${args.iamAccountId}
+        WHERE id = ${legacy.id}`,
+  );
+  return { accountId: projected.id, parkedLegacyId: legacy.id };
+}
+
+/**
+ * Whether this human has finished the first-run wizard ANYWHERE. Onboarding
+ * describes the person's first contact with the product, not each workspace
+ * they are later projected into — a workspace that came from the identity
+ * service was set up over there.
+ */
+export async function humanHasCompletedOnboarding(db: Db, externalId: string): Promise<boolean> {
+  const r = await db.get<{ id: string }>(
+    sql`SELECT a.id FROM account a JOIN member m ON m.account_id = a.id
+        WHERE m.external_id = ${externalId} AND a.onboarding_completed_at IS NOT NULL LIMIT 1`,
+  );
+  return !!r;
+}
+
+/**
+ * Make the local rows agree with the upstream memberships of one identity.
+ *
+ * For each ACTIVE membership: the account is found by `external_id` (created
+ * when unseen), its name and `iam_account_id` refreshed, and the member row for
+ * this identity upserted with the upstream role. Memberships upstream marks
+ * inactive, and local rows this identity holds in accounts the upstream list no
+ * longer names, are set `disabled` — never deleted, so `created_by` on forms
+ * keeps resolving. Rows the identity service cannot know about (an invite by
+ * email with no `external_id` yet, dev/seed rows) are left alone.
+ *
+ * `inheritOnboarding` stamps `onboarding_completed_at` on accounts CREATED by
+ * this run, so a person who already finished the wizard is not sent through it
+ * again for every workspace they belong to upstream.
+ */
+export async function projectMemberships(
+  db: Db,
+  identity: ProjectedIdentity,
+  memberships: ProjectedMembership[],
+  opts: { inheritOnboarding?: boolean; now?: number } = {},
+): Promise<ProjectionResult> {
+  const now = opts.now ?? Date.now();
+  const result: ProjectionResult = { accountIds: [], created: [], createdAccounts: [] };
+  const seenAccountIds = new Set<string>();
+
+  for (const m of memberships) {
+    if (!m.active) continue;
+    const role: AccountRole = (ACCOUNT_ROLES as readonly string[]).includes(m.role) ? m.role : 'member';
+
+    let account = await getAccountByExternalId(db, m.workspaceId);
+    let accountCreated = false;
+    if (!account) {
+      await insertAccountWithShortCode(db, {
+        name: m.workspaceName || 'Workspace',
+        externalId: m.workspaceId,
+      });
+      account = await getAccountByExternalId(db, m.workspaceId);
+      if (!account) throw new Error(`projection: could not create account for workspace ${m.workspaceId}`);
+      accountCreated = true;
+      result.createdAccounts.push(account.id);
+      if (opts.inheritOnboarding) {
+        await db.run(
+          sql`UPDATE account SET onboarding_completed_at = ${now}
+              WHERE id = ${account.id} AND onboarding_completed_at IS NULL`,
+        );
+      }
+    }
+    await db.run(
+      sql`UPDATE account SET name = ${m.workspaceName || account.name},
+            iam_account_id = COALESCE(${m.iamAccountId}, iam_account_id),
+            synced_at = ${now}
+          WHERE id = ${account.id}`,
+    );
+
+    const existing = await db.get<{ id: string; status: string }>(
+      sql`SELECT id, status FROM member WHERE account_id = ${account.id} AND external_id = ${identity.externalId} LIMIT 1`,
+    );
+    if (existing) {
+      // Upstream is the authority on role and on being active. `disabled`
+      // locally is revived here on purpose: the identity service says this
+      // membership is active NOW, and it is the only place a membership can be
+      // revoked or restored from.
+      await db.run(
+        sql`UPDATE member SET role = ${role}, status = 'active',
+              iam_workspace_user_id = COALESCE(${m.workspaceUserId}, iam_workspace_user_id),
+              email = COALESCE(email, ${identity.email}),
+              display_name = COALESCE(display_name, ${identity.displayName})
+            WHERE id = ${existing.id} AND account_id = ${account.id}`,
+      );
+    } else {
+      // Adopt an invite-by-email row before creating a second identity for the
+      // same person (mirrors the auth provider's invite adoption).
+      const email = identity.email?.trim().toLowerCase() || null;
+      const invited = email
+        ? await db.get<{ id: string }>(
+            sql`SELECT id FROM member
+                WHERE account_id = ${account.id} AND external_id IS NULL AND lower(email) = ${email}
+                ORDER BY created_at ASC LIMIT 1`,
+          )
+        : null;
+      if (invited) {
+        await db.run(
+          sql`UPDATE member SET external_id = ${identity.externalId}, status = 'active', role = ${role},
+                iam_workspace_user_id = COALESCE(${m.workspaceUserId}, iam_workspace_user_id),
+                display_name = COALESCE(display_name, ${identity.displayName})
+              WHERE id = ${invited.id} AND account_id = ${account.id}`,
+        );
+      } else {
+        const others = await db.get<{ id: string }>(
+          sql`SELECT id FROM member WHERE account_id = ${account.id} LIMIT 1`,
+        );
+        const id = randomUUID();
+        const handle = await deriveUniqueHandle(db, account.id, identity.displayName, identity.email);
+        await db.run(
+          sql`INSERT INTO member (id, account_id, external_id, email, display_name, handle, role, status,
+                iam_workspace_user_id, created_at)
+              VALUES (${id}, ${account.id}, ${identity.externalId}, ${identity.email}, ${identity.displayName},
+                ${handle}, ${role}, 'active', ${m.workspaceUserId}, ${now})
+              ON CONFLICT (account_id, external_id) DO NOTHING`,
+        );
+        const row = await db.get<{ id: string }>(
+          sql`SELECT id FROM member WHERE account_id = ${account.id} AND external_id = ${identity.externalId} LIMIT 1`,
+        );
+        if (row && row.id === id) {
+          result.created.push({ accountId: account.id, memberId: id, role, isFirstMember: !others || accountCreated });
+        }
+      }
+    }
+    seenAccountIds.add(account.id);
+    result.accountIds.push(account.id);
+  }
+
+  // Memberships upstream no longer names (or names as inactive): disable the
+  // local rows this identity holds in PROJECTED accounts only. A purely local
+  // account (never synced) is outside the identity service's authority.
+  const held = await db.all<{ id: string; account_id: string }>(
+    sql`SELECT m.id, m.account_id FROM member m JOIN account a ON a.id = m.account_id
+        WHERE m.external_id = ${identity.externalId} AND m.status = 'active' AND a.synced_at IS NOT NULL`,
+  );
+  for (const h of held) {
+    if (seenAccountIds.has(h.account_id)) continue;
+    await db.run(sql`UPDATE member SET status = 'disabled' WHERE id = ${h.id} AND account_id = ${h.account_id}`);
+  }
+
+  return result;
+}
+
+/**
+ * The account this identity should land in when nothing else says otherwise:
+ * the one it was seen in most recently, else its oldest membership. Only
+ * accounts where the membership is ACTIVE count.
+ */
+export async function pickHomeAccount(
+  db: Db,
+  externalId: string,
+  preferExternalId: string | null,
+): Promise<{ accountId: string; memberId: string } | null> {
+  if (preferExternalId) {
+    const preferred = await db.get<{ account_id: string; member_id: string }>(
+      sql`SELECT m.account_id, m.id AS member_id FROM member m JOIN account a ON a.id = m.account_id
+          WHERE m.external_id = ${externalId} AND m.status = 'active' AND a.external_id = ${preferExternalId}
+          LIMIT 1`,
+    );
+    if (preferred) return { accountId: preferred.account_id, memberId: preferred.member_id };
+  }
+  const row = await db.get<{ account_id: string; member_id: string }>(
+    sql`SELECT m.account_id, m.id AS member_id FROM member m JOIN account a ON a.id = m.account_id
+        WHERE m.external_id = ${externalId} AND m.status = 'active'
+        ORDER BY (m.last_seen_at IS NULL) ASC, m.last_seen_at DESC, m.created_at ASC LIMIT 1`,
+  );
+  return row ? { accountId: row.account_id, memberId: row.member_id } : null;
+}
+
+/**
+ * Create a purely LOCAL workspace (no identity service): a fresh account plus
+ * this identity as its owner. This is the path the dev stub and forks take;
+ * with the identity service configured the API creates upstream first and
+ * projects instead. Returns the new local account id.
+ */
+export async function createLocalWorkspace(
+  db: Db,
+  identity: Omit<ProjectedIdentity, 'externalId'> & { externalId: string | null },
+  input: { name: string; inheritOnboarding?: boolean; now?: number },
+): Promise<{ accountId: string; memberId: string }> {
+  const now = input.now ?? Date.now();
+  const externalId = `local:${randomUUID()}`;
+  await insertAccountWithShortCode(db, { name: input.name, externalId });
+  const account = await getAccountByExternalId(db, externalId);
+  if (!account) throw new Error('createLocalWorkspace: account insert did not land');
+  if (input.inheritOnboarding) {
+    await db.run(sql`UPDATE account SET onboarding_completed_at = ${now} WHERE id = ${account.id}`);
+  }
+  const memberId = randomUUID();
+  const handle = await deriveUniqueHandle(db, account.id, identity.displayName, identity.email);
+  await db.run(
+    sql`INSERT INTO member (id, account_id, external_id, email, display_name, handle, role, status, created_at)
+        VALUES (${memberId}, ${account.id}, ${identity.externalId}, ${identity.email}, ${identity.displayName},
+          ${handle}, 'owner', 'active', ${now})`,
+  );
+  return { accountId: account.id, memberId };
+}
+
+/** Rename a workspace locally (the API renames upstream first when it can). */
+export async function renameAccount(db: Db, accountId: string, name: string): Promise<void> {
+  await db.run(sql`UPDATE account SET name = ${name} WHERE id = ${accountId}`);
+}
+
+/** One upstream roster row, as the API layer hands it to `projectRoster`. */
+export interface ProjectedRosterRow {
+  externalId: string;
+  email: string | null;
+  displayName: string | null;
+  role: AccountRole;
+  active: boolean;
+  workspaceUserId: string | null;
+}
+
+/**
+ * Make one workspace's local roster agree with the upstream `users[]`.
+ *
+ * Every upstream member gets a local row (created if unseen, adopting an
+ * invite-by-email row when the address matches); role, status and the
+ * upstream membership id are refreshed. Local rows carrying an `external_id`
+ * that upstream no longer lists are disabled. Rows with NO `external_id`
+ * (invited by email locally, never signed in) are left alone — upstream cannot
+ * know them.
+ */
+export async function projectRoster(
+  db: Db,
+  accountId: string,
+  rows: ProjectedRosterRow[],
+  opts: { now?: number } = {},
+): Promise<void> {
+  const now = opts.now ?? Date.now();
+  const seen = new Set<string>();
+  for (const r of rows) {
+    seen.add(r.externalId);
+    const role: AccountRole = (ACCOUNT_ROLES as readonly string[]).includes(r.role) ? r.role : 'member';
+    const status = r.active ? 'active' : 'disabled';
+    const existing = await db.get<{ id: string }>(
+      sql`SELECT id FROM member WHERE account_id = ${accountId} AND external_id = ${r.externalId} LIMIT 1`,
+    );
+    if (existing) {
+      await db.run(
+        sql`UPDATE member SET role = ${role}, status = ${status},
+              iam_workspace_user_id = COALESCE(${r.workspaceUserId}, iam_workspace_user_id),
+              email = COALESCE(email, ${r.email}),
+              display_name = COALESCE(display_name, ${r.displayName})
+            WHERE id = ${existing.id} AND account_id = ${accountId}`,
+      );
+      continue;
+    }
+    const email = r.email?.trim().toLowerCase() || null;
+    const invited = email
+      ? await db.get<{ id: string }>(
+          sql`SELECT id FROM member WHERE account_id = ${accountId} AND external_id IS NULL AND lower(email) = ${email}
+              ORDER BY created_at ASC LIMIT 1`,
+        )
+      : null;
+    if (invited) {
+      await db.run(
+        sql`UPDATE member SET external_id = ${r.externalId}, role = ${role}, status = ${status},
+              iam_workspace_user_id = COALESCE(${r.workspaceUserId}, iam_workspace_user_id),
+              display_name = COALESCE(display_name, ${r.displayName})
+            WHERE id = ${invited.id} AND account_id = ${accountId}`,
+      );
+      continue;
+    }
+    const handle = await deriveUniqueHandle(db, accountId, r.displayName, r.email);
+    await db.run(
+      sql`INSERT INTO member (id, account_id, external_id, email, display_name, handle, role, status,
+            iam_workspace_user_id, created_at)
+          VALUES (${randomUUID()}, ${accountId}, ${r.externalId}, ${r.email}, ${r.displayName}, ${handle},
+            ${role}, ${status}, ${r.workspaceUserId}, ${now})
+          ON CONFLICT (account_id, external_id) DO NOTHING`,
+    );
+  }
+  const held = await db.all<{ id: string; external_id: string }>(
+    sql`SELECT id, external_id FROM member
+        WHERE account_id = ${accountId} AND external_id IS NOT NULL AND status = 'active'`,
+  );
+  for (const h of held) {
+    if (seen.has(h.external_id)) continue;
+    await db.run(sql`UPDATE member SET status = 'disabled' WHERE id = ${h.id} AND account_id = ${accountId}`);
+  }
+  await db.run(sql`UPDATE account SET synced_at = ${now} WHERE id = ${accountId}`);
+}
+
+/** The upstream ids the members service needs to act on one local member. */
+export async function getMemberUpstreamRef(
+  db: Db,
+  accountId: string,
+  memberId: string,
+): Promise<{ externalId: string | null; workspaceUserId: string | null; email: string | null } | null> {
+  const r = await db.get<{ external_id: string | null; iam_workspace_user_id: string | null; email: string | null }>(
+    sql`SELECT external_id, iam_workspace_user_id, email FROM member WHERE id = ${memberId} AND account_id = ${accountId} LIMIT 1`,
+  );
+  if (!r) return null;
+  return { externalId: r.external_id ?? null, workspaceUserId: r.iam_workspace_user_id ?? null, email: r.email ?? null };
+}

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -110,9 +110,12 @@ export async function rebindLegacyAccount(
   }
 
   await db.run(
-    sql`UPDATE account SET external_id = ${'legacy:' + args.iamAccountId}, iam_account_id = ${args.iamAccountId}
+    sql`UPDATE account SET external_id = ${'legacy:' + args.iamAccountId}, iam_account_id = ${args.iamAccountId},
+          name = name || ' (legacy)'
         WHERE id = ${legacy.id}`,
   );
+  // Parked means unreachable: its rows must not keep it alive in the switcher.
+  await db.run(sql`UPDATE member SET status = 'disabled' WHERE account_id = ${legacy.id}`);
   return { accountId: projected.id, parkedLegacyId: legacy.id };
 }
 
@@ -387,9 +390,14 @@ export async function projectRoster(
           ON CONFLICT (account_id, external_id) DO NOTHING`,
     );
   }
+  // Only rows the identity service KNOWS (they carry an upstream membership id)
+  // can be disabled by its silence. A row without one — the workspace owner
+  // when upstream omits them from `users[]`, an invite by email, a dev/seed
+  // row — is outside its authority and must survive a roster read.
   const held = await db.all<{ id: string; external_id: string }>(
     sql`SELECT id, external_id FROM member
-        WHERE account_id = ${accountId} AND external_id IS NOT NULL AND status = 'active'`,
+        WHERE account_id = ${accountId} AND external_id IS NOT NULL
+          AND iam_workspace_user_id IS NOT NULL AND status = 'active'`,
   );
   for (const h of held) {
     if (seen.has(h.external_id)) continue;

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -153,6 +153,18 @@ export interface FormsMessages {
         invited: string;
         /** The account is not among the caller's memberships (a stale choice). */
         unknown: string;
+        /** "New workspace" menu entry + the create dialog. */
+        create: string;
+        createTitle: string;
+        createSubtitle: string;
+        createNameLabel: string;
+        createNamePlaceholder: string;
+        createSubmit: string;
+        creating: string;
+        createCancel: string;
+        createErrorInvalid: string;
+        createErrorForbidden: string;
+        createErrorFailed: string;
       };
     };
     /** The dashboard home (/admin) — greeting, public link, stats, quick actions. */
@@ -250,6 +262,11 @@ export interface FormsMessages {
       appearanceSubtitle: string;
       workspaceHeading: string;
       workspaceSubtitle: string;
+      /** The renameable workspace name (admin/owner). */
+      workspaceName: string;
+      workspaceNameSave: string;
+      workspaceNameSaved: string;
+      workspaceNameError: string;
       displayName: string;
       email: string;
       handle: string;
@@ -260,6 +277,12 @@ export interface FormsMessages {
       viewPublic: string;
       membersHeading: string;
       membersSubtitle: string;
+      /** Pending invitations (identity-service deployments). */
+      pendingHeading: string;
+      pendingBadge: string;
+      resendInvite: string;
+      resendSuccess: string;
+      resendError: string;
       roleOwner: string;
       roleAdmin: string;
       roleMember: string;
@@ -1632,6 +1655,17 @@ export const en: FormsMessages = {
         eyebrow: 'Workspace',
         invited: 'Invited',
         unknown: 'Unknown workspace',
+        create: 'New workspace',
+        createTitle: 'New workspace',
+        createSubtitle: 'A separate space with its own forms, members, branding and integrations. You will be its owner.',
+        createNameLabel: 'Name',
+        createNamePlaceholder: 'e.g. Sales team',
+        createSubmit: 'Create',
+        creating: 'Creating…',
+        createCancel: 'Cancel',
+        createErrorInvalid: 'Give the workspace a name (up to 80 characters).',
+        createErrorForbidden: 'Your account cannot create workspaces.',
+        createErrorFailed: 'Could not create the workspace. Try again.',
       },
     },
     home: {
@@ -1723,6 +1757,10 @@ export const en: FormsMessages = {
       appearanceSubtitle: 'Choose how Dapta Forms looks on this device.',
       workspaceHeading: 'Workspace',
       workspaceSubtitle: 'Your identity and public link.',
+      workspaceName: 'Workspace name',
+      workspaceNameSave: 'Save',
+      workspaceNameSaved: 'Workspace renamed.',
+      workspaceNameError: 'Could not rename the workspace.',
       displayName: 'Name',
       email: 'Email',
       handle: 'Handle',
@@ -1733,6 +1771,11 @@ export const en: FormsMessages = {
       viewPublic: 'View public page',
       membersHeading: 'Members',
       membersSubtitle: 'People with access to this workspace.',
+      pendingHeading: 'Pending invitations',
+      pendingBadge: 'Pending',
+      resendInvite: 'Resend',
+      resendSuccess: 'Invitation sent again.',
+      resendError: 'Could not resend the invitation.',
       roleOwner: 'Owner',
       roleAdmin: 'Admin',
       roleMember: 'Member',
@@ -3015,6 +3058,17 @@ export const es: FormsMessages = {
         eyebrow: 'Workspace',
         invited: 'Invitado',
         unknown: 'Workspace desconocido',
+        create: 'Nuevo workspace',
+        createTitle: 'Nuevo workspace',
+        createSubtitle: 'Un espacio aparte con sus propios formularios, miembros, marca e integraciones. Vas a ser su owner.',
+        createNameLabel: 'Nombre',
+        createNamePlaceholder: 'p. ej. Equipo de ventas',
+        createSubmit: 'Crear',
+        creating: 'Creando…',
+        createCancel: 'Cancelar',
+        createErrorInvalid: 'Ponle un nombre al workspace (hasta 80 caracteres).',
+        createErrorForbidden: 'Tu cuenta no puede crear workspaces.',
+        createErrorFailed: 'No se pudo crear el workspace. Intenta de nuevo.',
       },
     },
     home: {
@@ -3107,6 +3161,10 @@ export const es: FormsMessages = {
       appearanceSubtitle: 'Elige cómo se ve Dapta Forms en este dispositivo.',
       workspaceHeading: 'Espacio de trabajo',
       workspaceSubtitle: 'Tu identidad y tu enlace público.',
+      workspaceName: 'Nombre del workspace',
+      workspaceNameSave: 'Guardar',
+      workspaceNameSaved: 'Workspace renombrado.',
+      workspaceNameError: 'No se pudo renombrar el workspace.',
       displayName: 'Nombre',
       email: 'Correo',
       handle: 'Alias',
@@ -3117,6 +3175,11 @@ export const es: FormsMessages = {
       viewPublic: 'Ver página pública',
       membersHeading: 'Miembros',
       membersSubtitle: 'Personas con acceso a este espacio de trabajo.',
+      pendingHeading: 'Invitaciones pendientes',
+      pendingBadge: 'Pendiente',
+      resendInvite: 'Reenviar',
+      resendSuccess: 'Invitación enviada de nuevo.',
+      resendError: 'No se pudo reenviar la invitación.',
       roleOwner: 'Propietario',
       roleAdmin: 'Administrador',
       roleMember: 'Miembro',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -327,6 +327,8 @@ export interface FormsMessages {
       manageErrorLastOwner: string;
       manageErrorForbidden: string;
       manageErrorFailed: string;
+      /** The change is only expressible in the identity service (Dapta app). */
+      manageErrorUpstream: string;
     };
     /** Settings → Notifications: edit the two submission emails the platform sends. */
     notifications: {
@@ -1820,6 +1822,7 @@ export const en: FormsMessages = {
       manageErrorLastOwner: 'A workspace must keep at least one owner.',
       manageErrorForbidden: 'You do not have permission to do that.',
       manageErrorFailed: 'Something went wrong. Please try again.',
+      manageErrorUpstream: 'Change this from the Dapta app: it manages this workspace’s members.',
     },
     notifications: {
       heading: 'Notifications',
@@ -3224,6 +3227,7 @@ export const es: FormsMessages = {
       manageErrorLastOwner: 'Un espacio de trabajo debe conservar al menos un propietario.',
       manageErrorForbidden: 'No tienes permiso para hacer eso.',
       manageErrorFailed: 'Algo salió mal. Inténtalo de nuevo.',
+      manageErrorUpstream: 'Hazlo desde la app de Dapta: ahí se administran los miembros de este workspace.',
     },
     notifications: {
       heading: 'Notificaciones',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1340,6 +1340,18 @@ export type SubmissionsPage = z.infer<typeof submissionsPageSchema>;
 
 // --- Member management (workspace roster) ------------------------------------
 
+/** Create a workspace: a name is the only thing a person types. */
+export const workspaceCreateSchema = z.object({
+  name: z.string().trim().min(1, 'A name is required.').max(80),
+});
+export type WorkspaceCreateInput = z.infer<typeof workspaceCreateSchema>;
+
+/** Rename the current workspace. */
+export const workspaceRenameSchema = z.object({
+  name: z.string().trim().min(1, 'A name is required.').max(80),
+});
+export type WorkspaceRenameInput = z.infer<typeof workspaceRenameSchema>;
+
 export const memberInviteSchema = z.object({
   email: z.string().email().max(320),
   role: z.enum(['admin', 'member']).optional(),


### PR DESCRIPTION
## What

The Dapta IAM's workspaces become **the** workspaces of Dapta Forms, in both directions: a person with three workspaces in Dapta AI sees and switches between the three here; a workspace created here appears in Dapta AI. Same table (the IAM's), one projection locally.

Until now one local `account` was born per IAM **account** (the billing layer above workspaces) — one workspace per person, and nothing created here was visible upstream. From migration **0015** on, `account.external_id` means the upstream **workspace** id, and `account`/`member` rows are a projection of the IAM: refreshed on login (once per 60 s TTL, coalesced), on demand when the switcher opens, and after every write, which goes upstream first.

## How it works

- **`WorkspaceProjection`** (`apps/api/src/workspace-projection.ts`): with the caller's own bearer, reads `GET /account/{id}` (`feature_flags.last_workspace`) + `GET /workspace/search`, decides membership from `users[]` (never from presence in the list — the search returns the whole estate to some callers), and upserts local rows (`packages/db/src/workspaces.ts`). Pre-0015 rows are rebound onto the upstream workspace on the next login, keeping id, public code and forms.
- **Home** = the workspace opened last in either app (`last_workspace`), which Forms now also writes on every switch/create (`POST /v1/workspaces/:id/enter`).
- **Create / rename** (`POST /v1/workspaces`, `PATCH /v1/workspaces/current`): upstream first, under the caller's own IAM account, then re-projected. Switcher always visible; "New workspace" lives there; refresh on open.
- **Members**: roster re-projected from the workspace's `users[]`; invitations (email + acceptance) live upstream; removals/role changes upstream first; pending invitations listed + resend.
- **Roles**: `OWNER` → owner, `MEMBER` with `workspace_admin` → admin, else member (`roleFromIam`, one place to change when the IAM grows a `forms` component).
- **Onboarding** per person, not per workspace.
- **Without `IAM_BASE_URL`** (forks, local dev, tests) everything acts on local rows only — same endpoints, same UI.

## Verified

- Unit: 383 API / 194 db / 472 web; new specs `workspace-projection.spec.ts`, `workspace.service.spec.ts`, `packages/db/src/workspaces.spec.ts` (DATABASE_URL-aware, ran 3/3 green on local Postgres 16).
- **Against the dev IAM with a real token**: projection of 4 workspaces with correct roles, home from `last_workspace`, cached second call 0 ms, roster with emails, **create** (`POST /workspace` under the caller's account) → projected as owner → `last_workspace` written, **rename** reflected upstream, `last_workspace` restored. (Left a workspace `Forms e2e (renamed)` in Josue's **dev** Dapta account; the IAM has no delete.)
- `forms-reviewer` run; all BLOCKER/SHOULD-FIX items addressed in the second commit (Postgres-typed OR in `listWorkspacesForIdentity`, roster never disables rows the IAM does not know, coalesced `ensure`, no JIT token-account fallback, last-owner guard before upstream writes, parked legacy rows unreachable).
- Side fix: `forms-webhooks.spec.ts` did `DELETE FROM account` table-wide, emptying other specs' rows on the shared parity DB (the old branding/milestones flakes). Now scoped.

## Notes / follow-ups

- Rate: 2 IAM calls per login per person, 0 per render.
- Demote-to-member and owner changes are not expressible through the IAM API we have → 409 with a clear message ("change this from the Dapta app").
- Ask to IAM: a `forms` component in `/component` so Dapta AI roles can gate Forms access; a "my workspaces" endpoint (search currently returns 51 workspaces to a @daptatech.com token); prd IAM accepts dev-minted JWTs (same secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
