### PR TITLE
fix: the dash gate never read the components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,15 @@ character replaced and the outer two left alone.
 
 **Hard ban, in anything a person outside the team reads:**
 
+- **Every frontend component in `apps/web`.** Text typed straight into JSX is
+  copy, exactly like a catalog entry, and it is the easiest kind to miss because
+  it belongs to no catalog and no reviewer greps for it. That includes the text
+  between tags, the attributes a person or a screen reader hears (`title`,
+  `aria-label`, `alt`, `placeholder`), and any string literal in the component.
+  This is not hypothetical: the webhook health cell shipped a bare `—` as its
+  empty state, hardcoded in JSX, and no gate saw it. Prefer a catalog key over
+  hardcoded text anyway (invariant 8), but a dash in a component is a hard ban
+  whether or not the string should have been in the catalog.
 - Both message catalogs. There are two: `packages/shared/src/i18n/index.ts` and
   `apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts`. A sweep
   that only knows about the first one misses a third of the UI copy.
@@ -262,11 +271,23 @@ there is frozen history rather than editable prose.
 bash scripts/dash-check.sh
 ```
 
-The check has two severities, because copy and docs are in different places.
+The check has three scopes, because the three live at different counts.
+
+**Components block, on the whole tree, always.** Every `.ts`/`.tsx` under
+`apps/web/app`, `apps/web/components` and `apps/web/lib` is read as a WHOLE LINE
+once comments are removed, so JSX text and `title`/`aria-label`/`alt` attributes
+are covered, not just quoted strings. Those files were uncovered until the gate
+had already let a hardcoded `—` reach the screen.
+
+Reading whole lines is what forces the block-comment state machine in the
+script: a `{/* ... */}` continuation line starts with neither `*` nor `//`, so
+no per-line filter can tell it from copy, and roughly 140 comment lines in
+`apps/web` look exactly like on-screen text without it.
 
 **Copy blocks, on the whole tree, always.** The string catalogs, email
 templates, seed and template form content, OpenAPI descriptions and CRM payload
-text are at zero occurrences and stay there. CI runs this on every PR.
+text are at zero occurrences and stay there. Only QUOTED text counts in these,
+because their comments outnumber their strings about five to one.
 
 **Docs block only on the lines a PR adds.** `.changeset/` and `docs/` carry
 roughly 320 older dashes, most of them in changesets that already shipped as
@@ -279,8 +300,18 @@ first. Run it with a base to see exactly what CI will say:
 bash scripts/dash-check.sh origin/develop
 ```
 
-Comment lines and `*.spec.ts` titles are skipped in the copy paths, matching the
-advisory rule above. Note what is deliberately NOT done there: code spans are
+**What the check does NOT read: comments and `*.spec.ts` titles.** Both are
+advisory per the rule above, in every scope, so a dashed code comment or test
+title will never fail CI. That is a deliberate ceiling, not an oversight: the
+repo holds ~1,500 dashes in comments, and a gate that blocked on them would be
+switched off in a week. It also means the check is not a substitute for reading
+your own diff.
+
+Two more things it cannot see. `apps/api` route handlers are only covered where
+a string is a known copy path, so a message you invent and return as an error
+`reason` can still reach the integrations panel unchecked. And no static gate
+reaches copy that is already PERSISTED: form configs and saved notification
+templates carry their text in stored JSON, where only a migration can fix it. Note what is deliberately NOT done there: code spans are
 stripped before matching in docs but never in code, because stripping them in
 code would erase template literals, and a dashed template literal is copy.
 

--- a/scripts/dash-check.sh
+++ b/scripts/dash-check.sh
@@ -68,6 +68,52 @@ CODE=(
   'apps/api/src/openapi.ts'
 )
 
+# UI: every frontend component, checked as a WHOLE LINE once comments are
+# removed. The CODE list above holds the string catalogs, and that left the
+# actual components uncovered: a dash typed straight into JSX text or into a
+# `title` / `aria-label` is on screen, is in no catalog, and passed every gate.
+# That is not hypothetical, it is how the webhook health cell shipped one.
+#
+# This can block on the whole tree because the components are already at zero.
+UI=(
+  'apps/web/app'
+  'apps/web/components'
+  'apps/web/lib'
+)
+
+# Strip comments with BLOCK STATE, then look at whatever text is left.
+#
+# The CODE paths get away with a line-shaped filter because only quoted text
+# counts there. Here the target is JSX text, which carries no quotes at all, so
+# the whole line has to be read; and that makes the `{/* ... */}` block the
+# problem, because its continuation lines start with neither `*` nor `//` and
+# are indistinguishable from prose by any per-line rule. Roughly 140 comment
+# lines in apps/web look exactly like copy without this.
+scan_ui() {
+  local files
+  files=$(grep -RlE "$BANNED" "${UI[@]}" --include='*.ts' --include='*.tsx' $SKIP_SPECS 2>/dev/null || true)
+  [ -z "$files" ] && return 0
+  printf '%s\n' "$files" | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    awk -v F="$f" '
+      BEGIN { block = 0 }
+      {
+        line = $0
+        # inside a block comment: nothing counts until it closes
+        if (block) { i = index(line, "*/"); if (i == 0) next; line = substr(line, i + 2); block = 0 }
+        # whole comments opened and closed on this line, `{/* x */}` included
+        while (match(line, /\{?\/\*.*\*\/\}?/)) line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
+        # an opener with no closer takes the rest of the line and the ones after
+        p = index(line, "/*"); if (p > 0) { block = 1; line = substr(line, 1, p - 1) }
+        # a trailing // comment, only when the quotes before it balance
+        c = index(line, "//")
+        if (c > 0) { b = substr(line, 1, c - 1); t = b; n = gsub(/["\047`]/, "", t); if (n % 2 == 0) line = b }
+        if (line ~ /\xe2\x80\x94|\xe2\x80\x95/) print F ":" FNR ": " line
+      }
+    ' "$f"
+  done
+}
+
 # A dash between two quotes of the same kind.
 QUOTED=$'(\'[^\']*(—|―)[^\']*\'|"[^"]*(—|―)[^"]*"|`[^`]*(—|―)[^`]*`)'
 QUOTED_EN=$'(\'[^\']*–[^\']*\'|"[^"]*–[^"]*"|`[^`]*–[^`]*`)'
@@ -132,7 +178,8 @@ echo "== dash-check: banned characters =="
 # CODE: strings that reach a screen, an inbox, or a screen reader. Always blocks.
 CODE_HITS=$(grep -RInE "$QUOTED" "${CODE[@]}" $SKIP_SPECS 2>/dev/null | grep -vE "$COMMENT_LINE" || true)
 CODE_HITS="$CODE_HITS
-$(grep -RInE "$BANNED_ESCAPED" "${CODE[@]}" $SKIP_SPECS 2>/dev/null || true)"
+$(grep -RInE "$BANNED_ESCAPED" "${CODE[@]}" $SKIP_SPECS 2>/dev/null || true)
+$(scan_ui || true)"
 CODE_HITS=$(printf '%s\n' "$CODE_HITS" | grep -vE '^[[:space:]]*$' || true)
 
 # PROSE: docs and changesets. Blocking scope is whatever this range added.


### PR DESCRIPTION
Follow-up to #118. The gate that PR added never read the components, which is
where the copy it was meant to protect actually lives.

## The hole

#118 scoped the blocking half to the string catalogs. A dash typed straight
into JSX text, or into a `title` / `aria-label`, belongs to no catalog, and so
passed every gate. Proven rather than assumed: injecting

```jsx
<h2>Probe — dash visible</h2>
<p title="tip — dashed">x</p>
```

into a real component and running the check reports nothing.

That is not hypothetical. It is exactly how the webhook health cell shipped a
bare `—` as its empty state, and #118 had to find that one by reading the code
by hand. The check would not have caught either of the two dashes that PR fixed.

## The fix

`apps/web/{app,components,lib}` now block on the whole tree. They can, because
the components are already at zero: measured before writing anything, so this
adds a gate rather than a backlog.

These paths are read as WHOLE LINES once comments are stripped, not as quoted
text like the catalogs. JSX text carries no quotes at all, so a quote-shaped
filter has nothing to match.

Reading whole lines is what forces the block-comment state machine in the
script. A `{/* ... */}` continuation line starts with neither `*` nor `//` and
no per-line rule can tell it from copy; without the state machine, about 140
comment lines in `apps/web` read exactly like on-screen text.

Verified against the seven cases that decide whether this is usable:

| Case | Expected | Result |
|---|---|---|
| JSX text | fail | fails |
| `title` attribute | fail | fails |
| `aria-label` | fail | fails |
| String literal | fail | fails |
| `//` line comment | silent | silent |
| One-line `/* */` | silent | silent |
| JSDoc continuation | silent | silent |
| Multi-line `{/* */}` | silent | silent |

## Docs

`CLAUDE.md` states the rule where someone writing a component will read it, and
now also says what the check does NOT see, which is the more useful half:

- Comments and `*.spec.ts` titles, in every scope. A deliberate ceiling: the repo
  holds ~1,500 dashes in comments and a gate blocking on those would be switched
  off within a week.
- Error strings invented in `apps/api` outside the known copy paths, which can
  still reach the integrations panel verbatim.
- Copy already PERSISTED in stored JSON (form configs, saved notification
  templates). No static gate reaches those; only a migration does.

## Blast radius

One shell script and one markdown file. No product code, no schema, no
behavior change, so no changeset. Gate green locally: typecheck 16/16, lint
16/16, tests 16/16, build 9/9, and `dash-check origin/develop` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
