### PR TITLE
feat: demote members through the identity service; removal is owner-only

### DIFF
--- a/.changeset/iam-member-roles.md
+++ b/.changeset/iam-member-roles.md
@@ -1,0 +1,26 @@
+---
+'@quill/db': minor
+'@quill/shared': patch
+---
+
+Member roles are fully editable from this product when the identity service is
+behind a workspace, and removal follows its rule.
+
+- Demoting an admin to member now works: the identity service replaces a
+  membership's role, so "make them a member" assigns its `workspace_editor`
+  system role (what the Dapta app's role dialog does when a non-admin role is
+  picked). Promotion assigns `workspace_admin` as before. Both are resolved BY
+  NAME from the upstream role catalog (`GET /role`, cached 5 min) because the
+  ids differ per environment. Inviting as member sends the editor role too, so
+  what the invitee lands with is what the inviter picked, in both apps.
+- `workspace_owner` upstream reads as `admin` here (alongside `workspace_admin`).
+- Making someone an owner (or un-owning them) is a 409: ownership is a
+  membership TYPE upstream, not a role, and nothing this product calls transfers it.
+- Removing a member is OWNER-only, the identity service's rule, on the local
+  path too so a fork and an identity-backed deployment agree. Admins still
+  invite, promote, demote and disable.
+- `listWorkspacesForIdentity` rows carry `memberCount` (active members), for
+  the workspace cards in Account settings.
+- The web API client takes a per-call `{ workspace }` override so a workspace can
+  be managed by id without switching into it; a 403 on an override never resets
+  the cookie's workspace.

--- a/.changeset/iam-member-roles.md
+++ b/.changeset/iam-member-roles.md
@@ -18,7 +18,8 @@ behind a workspace, and removal follows its rule.
   membership TYPE upstream, not a role, and nothing this product calls transfers it.
 - Removing a member is OWNER-only, the identity service's rule, on the local
   path too so a fork and an identity-backed deployment agree. Admins still
-  invite, promote, demote and disable.
+  invite, promote, demote, disable, and may retract an invitation that has not
+  been accepted (an `invited` row is not a membership yet).
 - `listWorkspacesForIdentity` rows carry `memberCount` (active members), for
   the workspace cards in Account settings.
 - The web API client takes a per-call `{ workspace }` override so a workspace can

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -650,7 +650,9 @@ export class AdminCrudController {
   /**
    * Remove a member. OWNER-only (an admin may invite, promote, demote and
    * disable, but not remove) — the identity service's rule, applied on the
-   * local path too so a fork and an identity-backed deployment agree.
+   * local path too so a fork and an identity-backed deployment agree. An
+   * `invited` row is an invitation, not a membership: retracting one is the
+   * inviter's call, so an admin may remove those.
    */
   @Delete('members/:id')
   @HttpCode(200)
@@ -659,10 +661,14 @@ export class AdminCrudController {
       return this.workspacesSvc.removeMemberUpstream(req, id);
     }
     const p = await this.auth.resolveHost(req);
-    assertOwner(p);
+    assertAdmin(p);
     assertNotSelf(p, id);
     const target = await getAccountMember(this.db, p.accountId, id);
-    if (!target) return { ok: true }; // idempotent — already gone
+    if (!target) {
+      assertOwner(p);
+      return { ok: true }; // idempotent — already gone
+    }
+    if (target.status !== 'invited') assertOwner(p);
     assertCanManageTarget(p, target);
     unwrapCrud(await removeMember(this.db, p.accountId, id));
     return { ok: true };

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -77,7 +77,7 @@ import { AuthService, type ReqLike } from './auth.service';
 import { WorkspaceService } from './workspace.service';
 import { EmailEffects } from './email-effects';
 import { AnalyticsEffects } from './analytics-effects';
-import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
+import { assertAdmin, assertCanManageTarget, assertNotSelf, assertOwner } from './permissions';
 import { parseBound, parseIntParam, parseKinds, parseOutboxStatuses, parseStatus } from './query-params';
 import { DB } from './tokens';
 
@@ -647,6 +647,11 @@ export class AdminCrudController {
     return updated;
   }
 
+  /**
+   * Remove a member. OWNER-only (an admin may invite, promote, demote and
+   * disable, but not remove) — the identity service's rule, applied on the
+   * local path too so a fork and an identity-backed deployment agree.
+   */
   @Delete('members/:id')
   @HttpCode(200)
   async removeMember(@Req() req: ReqLike, @Param('id') id: string) {
@@ -654,7 +659,7 @@ export class AdminCrudController {
       return this.workspacesSvc.removeMemberUpstream(req, id);
     }
     const p = await this.auth.resolveHost(req);
-    assertAdmin(p);
+    assertOwner(p);
     assertNotSelf(p, id);
     const target = await getAccountMember(this.db, p.accountId, id);
     if (!target) return { ok: true }; // idempotent — already gone

--- a/apps/api/src/iam-workspaces.ts
+++ b/apps/api/src/iam-workspaces.ts
@@ -80,22 +80,34 @@ export interface IamInvitation {
   expires_at?: string | null;
 }
 
-/** The upstream system role that maps to this product's `admin`. */
+/** The upstream system role this product ASSIGNS for `admin`. */
 export const IAM_ADMIN_ROLE_NAME = 'workspace_admin';
+/**
+ * The upstream system role this product ASSIGNS for `member` (demote / invite as
+ * member). Roles upstream are replaced, never removed, so "make them a member"
+ * means "give them the editor role" — the same thing the Dapta app's role dialog
+ * does when it picks a non-admin role.
+ */
+export const IAM_MEMBER_ROLE_NAME = 'workspace_editor';
+/** Every upstream role name that READS as `admin` here (assigned by us or by the Dapta app). */
+export const IAM_ADMIN_ROLE_NAMES: readonly string[] = ['workspace_admin', 'workspace_owner'];
 
 /**
  * Upstream membership → local account role.
  *
- *   OWNER                              → owner
- *   MEMBER holding `workspace_admin`   → admin   (can manage members, branding, integrations)
- *   MEMBER with any other / no role    → member  (creates and edits forms, reads results)
+ *   OWNER                                              → owner
+ *   MEMBER holding `workspace_admin` / `workspace_owner` → admin   (manages members, branding, integrations)
+ *   MEMBER with any other / no role                    → member  (creates and edits forms, reads results)
  *
  * One function on purpose: when the identity service grows a `forms` component
  * in its permission catalog, this is the only place that changes.
  */
 export function roleFromIam(wu: Pick<IamWorkspaceUser, 'type' | 'roles'>): AccountRole {
   if (wu.type === 'OWNER') return 'owner';
-  const admin = (wu.roles ?? []).some((r) => (r.name ?? r.role?.name) === IAM_ADMIN_ROLE_NAME);
+  const admin = (wu.roles ?? []).some((r) => {
+    const name = r.name ?? r.role?.name;
+    return typeof name === 'string' && IAM_ADMIN_ROLE_NAMES.includes(name);
+  });
   return admin ? 'admin' : 'member';
 }
 
@@ -127,22 +139,33 @@ const IAM_TIMEOUT_MS = 10_000;
 const PAGE_SIZE = 100;
 /** Guard against an upstream that pages forever; a person is in far fewer than this. */
 const MAX_PAGES = 20;
+/**
+ * The system role catalog changes when the identity service deploys, not per
+ * request. Cached per client instance; a name that is not in the cached copy
+ * forces one re-read before giving up (see `roleIdByName`).
+ */
+const ROLE_CATALOG_TTL_MS = 5 * 60_000;
 
 export interface IamWorkspacesClientOptions {
   baseUrl: string;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
+  /** Test seam; defaults to `Date.now`. */
+  now?: () => number;
 }
 
 export class IamWorkspacesClient {
   private readonly base: string;
   private readonly fetchImpl: typeof fetch;
   private readonly timeoutMs: number;
+  private readonly now: () => number;
+  private roleCatalog: { at: number; roles: IamRole[] } | null = null;
 
   constructor(opts: IamWorkspacesClientOptions) {
     this.base = opts.baseUrl.replace(/\/$/, '');
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.timeoutMs = opts.timeoutMs ?? IAM_TIMEOUT_MS;
+    this.now = opts.now ?? Date.now;
   }
 
   // --- Accounts ------------------------------------------------------------
@@ -227,6 +250,11 @@ export class IamWorkspacesClient {
 
   // --- Roles + members -----------------------------------------------------
 
+  /**
+   * The roles offered for ONE workspace: `workspace_admin` plus that workspace's
+   * custom roles. This is what the Dapta app's role dialog lists; note it does
+   * NOT include the other system roles (`workspace_editor`, …).
+   */
   async listRoles(bearer: string, workspaceId: string): Promise<IamRole[]> {
     const res = await this.call<IamRole[] | { data?: IamRole[] }>(
       bearer,
@@ -234,6 +262,43 @@ export class IamWorkspacesClient {
       `/role/roles-workspace/${encodeURIComponent(workspaceId)}`,
     );
     return Array.isArray(res) ? res : Array.isArray(res?.data) ? res.data : [];
+  }
+
+  /**
+   * The whole role catalog (`is_system` roles plus every custom role the caller
+   * can see). Ids differ per environment, so roles are always resolved by NAME
+   * from this list, never hardcoded. Cached for `ROLE_CATALOG_TTL_MS`.
+   */
+  async listSystemRoles(bearer: string, opts: { force?: boolean } = {}): Promise<IamRole[]> {
+    if (this.roleCatalog && this.catalogFresh() && !opts.force) return this.roleCatalog.roles;
+    const res = await this.call<IamRole[] | { data?: IamRole[] }>(bearer, 'GET', '/role');
+    const roles = Array.isArray(res) ? res : Array.isArray(res?.data) ? res.data : [];
+    this.roleCatalog = { at: this.now(), roles };
+    return roles;
+  }
+
+  private catalogFresh(): boolean {
+    return !!this.roleCatalog && this.now() - this.roleCatalog.at < ROLE_CATALOG_TTL_MS;
+  }
+
+  /**
+   * The id of the upstream role called `name`, for `workspaceId`. Looks at the
+   * workspace's own list first (custom roles shadow nothing, but this is where
+   * `workspace_admin` is guaranteed to appear), then at the system catalog. A
+   * miss re-reads the catalog once — a role added since the cache was filled —
+   * before answering null.
+   */
+  async roleIdByName(bearer: string, name: string, workspaceId?: string): Promise<string | null> {
+    if (workspaceId) {
+      const scoped = await this.listRoles(bearer, workspaceId).catch(() => [] as IamRole[]);
+      const hit = scoped.find((r) => r.name === name);
+      if (hit?.id) return hit.id;
+    }
+    const system = (r: IamRole) => r.name === name && r.is_system !== false && !r.workspace_id;
+    const servedFromCache = this.catalogFresh();
+    let hit = (await this.listSystemRoles(bearer)).find(system);
+    if (!hit && servedFromCache) hit = (await this.listSystemRoles(bearer, { force: true })).find(system);
+    return hit?.id ?? null;
   }
 
   removeWorkspaceUser(bearer: string, workspaceUserId: string): Promise<unknown> {

--- a/apps/api/src/iam-workspaces.ts
+++ b/apps/api/src/iam-workspaces.ts
@@ -4,7 +4,10 @@
  * Every call forwards the CALLER's bearer token — the same platform JWT the
  * auth provider validated — so the identity service applies its own
  * authorization and this client never holds a privileged credential. Nothing
- * here is cached or persisted; `workspace-projection.ts` decides what to keep.
+ * per tenant is cached or persisted here — `workspace-projection.ts` decides
+ * what to keep — with one deliberate exception: the SYSTEM role catalog (the
+ * same rows for every caller, filtered of anything workspace-scoped), kept for
+ * a few minutes so role writes do not re-read it every time.
  *
  * Only the shapes this product reads are typed. Upstream returns far more per
  * row (phone numbers, plans, stripe ids); it is dropped at the boundary.
@@ -141,10 +144,16 @@ const PAGE_SIZE = 100;
 const MAX_PAGES = 20;
 /**
  * The system role catalog changes when the identity service deploys, not per
- * request. Cached per client instance; a name that is not in the cached copy
- * forces one re-read before giving up (see `roleIdByName`).
+ * request. Cached per client instance (system rows only — see `isSystemRole`);
+ * a name that is not in the cached copy forces one re-read before giving up
+ * (see `roleIdByName`).
  */
 const ROLE_CATALOG_TTL_MS = 5 * 60_000;
+
+/** A role of the identity service itself, not one a workspace defined. */
+export function isSystemRole(r: IamRole): boolean {
+  return r.is_system !== false && !r.workspace_id;
+}
 
 export interface IamWorkspacesClientOptions {
   baseUrl: string;
@@ -265,14 +274,18 @@ export class IamWorkspacesClient {
   }
 
   /**
-   * The whole role catalog (`is_system` roles plus every custom role the caller
-   * can see). Ids differ per environment, so roles are always resolved by NAME
-   * from this list, never hardcoded. Cached for `ROLE_CATALOG_TTL_MS`.
+   * The SYSTEM role catalog. `GET /role` answers with the system roles plus
+   * every custom role the caller can see; only the system rows are kept (and
+   * cached, for `ROLE_CATALOG_TTL_MS`) — the client is a process singleton
+   * shared by every tenant, so nothing workspace-scoped may sit in it. Ids
+   * differ per environment, so roles are always resolved by NAME from this
+   * list, never hardcoded.
    */
   async listSystemRoles(bearer: string, opts: { force?: boolean } = {}): Promise<IamRole[]> {
     if (this.roleCatalog && this.catalogFresh() && !opts.force) return this.roleCatalog.roles;
     const res = await this.call<IamRole[] | { data?: IamRole[] }>(bearer, 'GET', '/role');
-    const roles = Array.isArray(res) ? res : Array.isArray(res?.data) ? res.data : [];
+    const all = Array.isArray(res) ? res : Array.isArray(res?.data) ? res.data : [];
+    const roles = all.filter(isSystemRole);
     this.roleCatalog = { at: this.now(), roles };
     return roles;
   }
@@ -282,22 +295,32 @@ export class IamWorkspacesClient {
   }
 
   /**
-   * The id of the upstream role called `name`, for `workspaceId`. Looks at the
-   * workspace's own list first (custom roles shadow nothing, but this is where
-   * `workspace_admin` is guaranteed to appear), then at the system catalog. A
-   * miss re-reads the catalog once — a role added since the cache was filled —
-   * before answering null.
+   * The id of the SYSTEM role called `name`. The cached catalog is consulted
+   * first (no round trip on a hit); a miss re-reads it once — a role added
+   * since the cache was filled — and, when `workspaceId` is given, falls back
+   * to that workspace's own list, the one place `workspace_admin` is
+   * guaranteed to appear even for a caller who cannot read `/role`. A custom
+   * role that happens to share the name never wins over the system one.
    */
   async roleIdByName(bearer: string, name: string, workspaceId?: string): Promise<string | null> {
-    if (workspaceId) {
-      const scoped = await this.listRoles(bearer, workspaceId).catch(() => [] as IamRole[]);
-      const hit = scoped.find((r) => r.name === name);
-      if (hit?.id) return hit.id;
-    }
-    const system = (r: IamRole) => r.name === name && r.is_system !== false && !r.workspace_id;
+    const match = (r: IamRole) => r.name === name && isSystemRole(r);
     const servedFromCache = this.catalogFresh();
-    let hit = (await this.listSystemRoles(bearer)).find(system);
-    if (!hit && servedFromCache) hit = (await this.listSystemRoles(bearer, { force: true })).find(system);
+    let hit: IamRole | undefined;
+    let catalogError: unknown = null;
+    try {
+      hit = (await this.listSystemRoles(bearer)).find(match);
+      if (!hit && servedFromCache) hit = (await this.listSystemRoles(bearer, { force: true })).find(match);
+    } catch (err) {
+      // Not fatal yet: the workspace's own list may still name it.
+      if (!workspaceId) throw err;
+      catalogError = err;
+    }
+    if (!hit && workspaceId) {
+      hit = (await this.listRoles(bearer, workspaceId)).find(match);
+    }
+    // A catalog failure that the fallback did not paper over is the caller's
+    // to map (a 403 is THEM refusing the caller, not "no such role").
+    if (!hit && catalogError) throw catalogError;
     return hit?.id ?? null;
   }
 

--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -172,12 +172,23 @@ describe('DELETE /v1/members/:id (remove member)', () => {
     expect(await controller.removeMember(asOwner(), randomUUID())).toEqual({ ok: true });
   });
 
-  it('refuses a plain member (admin/owner only) with 403', async () => {
+  it('refuses a plain member (owner only) with 403', async () => {
     await controller.inviteMember(asOwner(), { email: 'plain@acme.test', role: 'member' });
     const target = await controller.inviteMember(asOwner(), { email: 'victim@acme.test' });
     await expect(
       controller.removeMember(asEmail('plain@acme.test'), target.id),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses an ADMIN removing a plain member with 403 — removal is owner-only, like the identity service', async () => {
+    await controller.inviteMember(asOwner(), { email: 'boss@acme.test', role: 'admin' });
+    const target = await controller.inviteMember(asOwner(), { email: 'victim@acme.test' });
+    await expect(
+      controller.removeMember(asEmail('boss@acme.test'), target.id),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    // …while the same admin can still demote / disable them.
+    const demoted = await controller.updateMember(asEmail('boss@acme.test'), target.id, { status: 'disabled' });
+    expect(demoted.status).toBe('disabled');
   });
 
   it('refuses an admin removing an owner with 403', async () => {

--- a/apps/api/src/members.controller.spec.ts
+++ b/apps/api/src/members.controller.spec.ts
@@ -180,15 +180,26 @@ describe('DELETE /v1/members/:id (remove member)', () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it('refuses an ADMIN removing a plain member with 403 — removal is owner-only, like the identity service', async () => {
+  it('refuses an ADMIN removing an ACTIVE member with 403 — removal is owner-only, like the identity service', async () => {
     await controller.inviteMember(asOwner(), { email: 'boss@acme.test', role: 'admin' });
     const target = await controller.inviteMember(asOwner(), { email: 'victim@acme.test' });
+    // Accepted membership (what first login does): the owner-only rule applies.
+    await db.run(sql`UPDATE member SET status = 'active' WHERE id = ${target.id}`);
     await expect(
       controller.removeMember(asEmail('boss@acme.test'), target.id),
     ).rejects.toBeInstanceOf(ForbiddenException);
     // …while the same admin can still demote / disable them.
     const demoted = await controller.updateMember(asEmail('boss@acme.test'), target.id, { status: 'disabled' });
     expect(demoted.status).toBe('disabled');
+  });
+
+  it('an admin CAN retract an invitation (an `invited` row is not a membership yet)', async () => {
+    await controller.inviteMember(asOwner(), { email: 'boss@acme.test', role: 'admin' });
+    const pending = await controller.inviteMember(asEmail('boss@acme.test'), { email: 'maybe@acme.test' });
+    expect(pending.status).toBe('invited');
+    expect(await controller.removeMember(asEmail('boss@acme.test'), pending.id)).toEqual({ ok: true });
+    const roster = await controller.members(asOwner());
+    expect(roster.map((m) => m.email)).not.toContain('maybe@acme.test');
   });
 
   it('refuses an admin removing an owner with 403', async () => {

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -5,8 +5,11 @@
  * a 403 with a stable `FORBIDDEN` body.
  *
  * Capability model (see ROLES-PERMISSIONS-PLAN):
- *   - owner  — everything (+ transfer / delete workspace, act on other owners)
- *   - admin  — manage members (except owners) and everyone's resources; NOT owners
+ *   - owner  — everything (+ transfer / delete workspace, act on other owners,
+ *              REMOVE members — the identity service's rule, mirrored here)
+ *   - admin  — invite, promote/demote, enable/disable members (except owners),
+ *              retract invitations, and everyone's resources; NOT owners, and
+ *              NOT removal of an accepted membership
  *   - member — own resources only
  *
  * This is the ACCOUNT role, distinct from the per-team `team_membership.role`.
@@ -33,7 +36,7 @@ export function assertAdmin(p: RoledPrincipal): void {
   if (!isAdmin(p.role)) forbidden('Requires an admin or owner.');
 }
 
-/** Owner-only routes (transfer ownership, delete workspace, act on another owner). */
+/** Owner-only routes (transfer ownership, delete workspace, act on another owner, remove a member). */
 export function assertOwner(p: RoledPrincipal): void {
   if (!isOwner(p.role)) forbidden('Requires the workspace owner.');
 }

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -10,7 +10,7 @@
  * `enter` refuses an account the caller is not in.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { ForbiddenException } from '@nestjs/common';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
 import { createDb, migrate, seed, getAccountByCode, sql, type Db } from '@quill/db';
 import { AuthService, WORKSPACE_HEADER } from './auth.service';
 import { LocalAuthProvider, type ReqLike } from './auth.provider';
@@ -80,8 +80,28 @@ describe('WorkspaceService (IAM-backed)', () => {
         const w = workspaces.find((x) => x.id === url.pathname.split('/').pop());
         return w ? json(w) : new Response('nf', { status: 404 });
       }
+      // Like the real thing: the per-workspace list carries ONLY workspace_admin
+      // (+ custom roles); the other system roles live in the catalog.
       if (method === 'GET' && url.pathname.startsWith('/iam/role/roles-workspace/'))
         return json([{ id: 'role-admin', name: 'workspace_admin', is_system: true }]);
+      if (method === 'GET' && url.pathname === '/iam/role')
+        return json([
+          { id: 'role-admin', name: 'workspace_admin', is_system: true },
+          { id: 'role-editor', name: 'workspace_editor', is_system: true },
+          { id: 'role-viewer', name: 'workspace_viewer', is_system: true },
+          { id: 'role-ws-owner', name: 'workspace_owner', is_system: true },
+          { id: 'role-custom', name: 'workspace_editor', is_system: false, workspace_id: 'elsewhere' },
+        ]);
+      if (method === 'POST' && url.pathname === '/iam/workspaceUser/assign-role') {
+        const name = ({ 'role-admin': 'workspace_admin', 'role-editor': 'workspace_editor' } as Record<string, string>)[body.role_id];
+        if (!name) return new Response('bad role', { status: 400 });
+        for (const w of workspaces) for (const u of w.users ?? []) if (u.id === body.workspace_user_id) u.roles = [{ id: body.role_id, name }];
+        return json({ ok: true });
+      }
+      if (method === 'PUT' && url.pathname === '/iam/workspaceUser') {
+        for (const w of workspaces) for (const u of w.users ?? []) if (u.id === body.id) u.is_active = body.is_active;
+        return json({ ok: true });
+      }
       if (method === 'POST' && url.pathname === '/iam/workspace-invitations') {
         invitations.push({ id: `inv-${invitations.length + 1}`, workspace_id: body.workspace_id, invited_email: body.invited_email, status: 'pending', role_id: body.role_id });
         return json(invitations[invitations.length - 1], 201);
@@ -182,15 +202,96 @@ describe('WorkspaceService (IAM-backed)', () => {
     expect(calls.some((c) => c.path === '/iam/workspace-invitations/resend')).toBe(true);
   });
 
-  it('removes a member upstream first, then locally', async () => {
+  it('invites a MEMBER with the editor role_id (from the system catalog, not the per-workspace list)', async () => {
+    await svc.list(req());
+    await svc.inviteUpstream(req(), { email: 'ed@x.com', role: 'member' });
+    const post = calls.find((c) => c.method === 'POST' && c.path === '/iam/workspace-invitations');
+    expect((post!.body as { role_id: string }).role_id).toBe('role-editor');
+    expect(calls.some((c) => c.method === 'GET' && c.path === '/iam/role')).toBe(true);
+  });
+
+  it('promotes (assign workspace_admin) and DEMOTES (assign workspace_editor) through assign-role; the roster reflects it', async () => {
     await svc.list(req());
     workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    let b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
+    expect(b.role).toBe('member');
+
+    const promoted = await svc.updateMemberUpstream(req(), b.id, { role: 'admin' });
+    expect(promoted.role).toBe('admin');
+    let assign = calls.filter((c) => c.method === 'POST' && c.path === '/iam/workspaceUser/assign-role');
+    expect(assign.at(-1)!.body).toEqual({ workspace_user_id: 'wu2', role_id: 'role-admin' });
+
+    const demoted = await svc.updateMemberUpstream(req(), b.id, { role: 'member' });
+    expect(demoted.role).toBe('member');
+    assign = calls.filter((c) => c.method === 'POST' && c.path === '/iam/workspaceUser/assign-role');
+    expect(assign.at(-1)!.body).toEqual({ workspace_user_id: 'wu2', role_id: 'role-editor' });
+    // Upstream is the authority: the fake replaced the role, and the roster read it back.
+    b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
+    expect(b.role).toBe('member');
+
+    // The catalog is read once and cached — three role writes, one GET /role.
+    expect(calls.filter((c) => c.method === 'GET' && c.path === '/iam/role').length).toBe(1);
+  });
+
+  it('a workspace_owner role upstream reads as admin here', async () => {
+    workspaces[0]!.users!.push({ id: 'wu3', user_id: 'sub-3', type: 'MEMBER', is_active: true, roles: [{ id: 'role-ws-owner', name: 'workspace_owner' }], user: { email: 'c@x.com', name: 'C' } });
+    await svc.list(req());
+    const c = (await svc.roster(req())).find((m) => m.email === 'c@x.com')!;
+    expect(c.role).toBe('admin');
+  });
+
+  it('making someone owner (or un-owning them) is a 409: ownership is not a role upstream', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    const b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
+    await expect(svc.updateMemberUpstream(req(), b.id, { role: 'owner' })).rejects.toBeInstanceOf(ConflictException);
+    expect(calls.some((c) => c.path === '/iam/workspaceUser/assign-role')).toBe(false);
+  });
+
+  it('deactivates and reactivates through PUT /workspaceUser', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    const b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
+    const off = await svc.updateMemberUpstream(req(), b.id, { status: 'disabled' });
+    expect(off.status).toBe('disabled');
+    expect(calls.filter((c) => c.method === 'PUT' && c.path === '/iam/workspaceUser').at(-1)!.body).toEqual({ id: 'wu2', is_active: false });
+    const on = await svc.updateMemberUpstream(req(), b.id, { status: 'active' });
+    expect(on.status).toBe('active');
+  });
+
+  it('removes a member upstream first, then locally — OWNER only; an admin gets 403 (the identity service’s rule)', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push(
+      { id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } },
+      { id: 'wu-adm', user_id: 'sub-adm', type: 'MEMBER', is_active: true, roles: [{ id: 'role-admin', name: 'workspace_admin' }], user: { email: 'adm@x.com', name: 'Adm' } },
+    );
     const roster = await svc.roster(req());
     const b = roster.find((m) => m.email === 'b@x.com')!;
+
+    // An admin of the same workspace, acting through their own token.
+    const admToken = signJwtHs256({ sub: 'sub-adm', account_id: 'acc-adm', email: 'adm@x.com', name: 'Adm', exp: 4102444800 }, SECRET);
+    const admReq = (): ReqLike => ({ headers: { authorization: `Bearer ${admToken}` } });
+    await expect(svc.removeMemberUpstream(admReq(), b.id)).rejects.toBeInstanceOf(ForbiddenException);
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
+    // …but that same admin CAN demote / disable.
+    const off = await svc.updateMemberUpstream(admReq(), b.id, { status: 'disabled' });
+    expect(off.status).toBe('disabled');
+
     await svc.removeMemberUpstream(req(), b.id);
     expect(calls.some((c) => c.method === 'DELETE' && c.path === '/iam/workspaceUser/member/wu2')).toBe(true);
     const gone = await db.get<{ id: string }>(sql`SELECT id FROM member WHERE id = ${b.id}`);
     expect(gone).toBeUndefined();
+  });
+
+  it('memberCount on the workspace list counts ACTIVE members only', async () => {
+    workspaces[0]!.users!.push(
+      { id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } },
+      { id: 'wu4', user_id: 'sub-4', type: 'MEMBER', is_active: false, roles: [], user: { email: 'd@x.com', name: 'D' } },
+    );
+    await svc.list(req());
+    await svc.roster(req());
+    const list = await svc.list(req());
+    expect(list.find((w) => w.accountName === 'Mine')!.memberCount).toBe(2);
   });
 
   it('refresh forces an upstream re-read within the TTL', async () => {

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -36,6 +36,9 @@ describe('WorkspaceService (IAM-backed)', () => {
   let workspaces: IamWorkspace[];
   let lastWorkspace: string | null;
   let invitations: Array<{ id: string; workspace_id: string; invited_email: string; status: string; role_id?: string }>;
+  /** Test seams: the fake clock the role-catalog cache reads, and a way to make `/role` fail. */
+  let clock: number;
+  let roleCatalogStatus: number;
 
   const token = signJwtHs256({ sub: SUB, account_id: IAM_ACCOUNT, email: 'a@x.com', name: 'A', exp: 4102444800 }, SECRET);
   const req = (workspace?: string): ReqLike => ({
@@ -48,6 +51,8 @@ describe('WorkspaceService (IAM-backed)', () => {
     calls = [];
     lastWorkspace = null;
     invitations = [];
+    clock = 1_000_000;
+    roleCatalogStatus = 200;
     workspaces = [
       { id: WS_OWN, name: 'Mine', account_id: IAM_ACCOUNT, is_active: true, users: [{ id: 'wu1', user_id: SUB, type: 'OWNER', is_active: true, roles: [] }] },
     ];
@@ -84,6 +89,8 @@ describe('WorkspaceService (IAM-backed)', () => {
       // (+ custom roles); the other system roles live in the catalog.
       if (method === 'GET' && url.pathname.startsWith('/iam/role/roles-workspace/'))
         return json([{ id: 'role-admin', name: 'workspace_admin', is_system: true }]);
+      if (method === 'GET' && url.pathname === '/iam/role' && roleCatalogStatus !== 200)
+        return new Response('nope', { status: roleCatalogStatus });
       if (method === 'GET' && url.pathname === '/iam/role')
         return json([
           { id: 'role-admin', name: 'workspace_admin', is_system: true },
@@ -116,7 +123,10 @@ describe('WorkspaceService (IAM-backed)', () => {
       }
       return new Response('nope', { status: 404 });
     };
-    const projection = new WorkspaceProjection(db, new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl }));
+    const projection = new WorkspaceProjection(
+      db,
+      new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl, now: () => clock }),
+    );
     const provider = new WorkOsAuthProvider(
       db,
       { JWT_SECRET: SECRET, JWT_ISSUER: undefined, JWT_AUDIENCE: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false },
@@ -229,8 +239,50 @@ describe('WorkspaceService (IAM-backed)', () => {
     b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
     expect(b.role).toBe('member');
 
-    // The catalog is read once and cached — three role writes, one GET /role.
+    // The catalog is read once and cached: a second demote is a cache hit.
+    await svc.updateMemberUpstream(req(), b.id, { role: 'admin' });
+    await svc.updateMemberUpstream(req(), b.id, { role: 'member' });
     expect(calls.filter((c) => c.method === 'GET' && c.path === '/iam/role').length).toBe(1);
+    // …and only the catalog is consulted for a system role: the per-workspace
+    // list is a fallback, not a probe on every write.
+    expect(calls.filter((c) => c.path.startsWith('/iam/role/roles-workspace/')).length).toBe(0);
+  });
+
+  it('the role catalog expires after its TTL, and a name missing from the cache forces one re-read', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    const b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
+    const reads = () => calls.filter((c) => c.method === 'GET' && c.path === '/iam/role').length;
+    await svc.updateMemberUpstream(req(), b.id, { role: 'admin' });
+    expect(reads()).toBe(1);
+    clock += 4 * 60_000;
+    await svc.updateMemberUpstream(req(), b.id, { role: 'member' });
+    expect(reads()).toBe(1); // still fresh
+    clock += 2 * 60_000;
+    await svc.updateMemberUpstream(req(), b.id, { role: 'admin' });
+    expect(reads()).toBe(2); // expired → re-read
+  });
+
+  it('a catalog the caller may not read is a 403; a catalog that is down is a 409 ROLE_UNAVAILABLE (never a 500)', async () => {
+    await svc.list(req());
+    workspaces[0]!.users!.push({ id: 'wu2', user_id: 'sub-2', type: 'MEMBER', is_active: true, roles: [], user: { email: 'b@x.com', name: 'B' } });
+    const b = (await svc.roster(req())).find((m) => m.email === 'b@x.com')!;
+    roleCatalogStatus = 403;
+    // The admin role still resolves: it is on the per-workspace list (fallback).
+    await svc.updateMemberUpstream(req(), b.id, { role: 'admin' });
+    // The editor role is catalog-only → the upstream's refusal is the caller's 403.
+    await expect(svc.updateMemberUpstream(req(), b.id, { role: 'member' })).rejects.toBeInstanceOf(ForbiddenException);
+    roleCatalogStatus = 503;
+    await expect(svc.updateMemberUpstream(req(), b.id, { role: 'member' })).rejects.toBeInstanceOf(ConflictException);
+    // A member invite still goes out — with the workspace's default role.
+    await svc.inviteUpstream(req(), { email: 'late@x.com', role: 'member' });
+    const post = calls.filter((c) => c.method === 'POST' && c.path === '/iam/workspace-invitations').at(-1)!;
+    expect((post.body as { role_id?: string }).role_id).toBeUndefined();
+    // An admin invite still carries the admin role: it resolves from the
+    // per-workspace list, which does not depend on the catalog.
+    await svc.inviteUpstream(req(), { email: 'boss@x.com', role: 'admin' });
+    const adm = calls.filter((c) => c.method === 'POST' && c.path === '/iam/workspace-invitations').at(-1)!;
+    expect((adm.body as { role_id?: string }).role_id).toBe('role-admin');
   });
 
   it('a workspace_owner role upstream reads as admin here', async () => {

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -45,8 +45,15 @@ import {
 import { AUTH_PROVIDER, DB, WORKSPACE_PROJECTION } from './tokens';
 import type { AuthProvider, HostPrincipal, ReqLike, UpstreamIdentity } from './auth.provider';
 import { AuthService } from './auth.service';
-import { assertAdmin, assertCanManageTarget, assertNotSelf } from './permissions';
-import { IAM_ADMIN_ROLE_NAME, IamHttpError, roleFromIam, userEmailOf, userNameOf } from './iam-workspaces';
+import { assertAdmin, assertCanManageTarget, assertNotSelf, assertOwner } from './permissions';
+import {
+  IAM_ADMIN_ROLE_NAME,
+  IAM_MEMBER_ROLE_NAME,
+  IamHttpError,
+  roleFromIam,
+  userEmailOf,
+  userNameOf,
+} from './iam-workspaces';
 import type { WorkspaceProjection } from './workspace-projection';
 
 @Injectable()
@@ -238,10 +245,29 @@ export class WorkspaceService {
   }
 
   /**
+   * The upstream role id behind one of our roles, resolved by NAME (ids differ
+   * per environment): admin → `workspace_admin`, member → `workspace_editor`.
+   * `owner` is not a role upstream but a membership TYPE, and nothing this
+   * product calls can transfer it → 409.
+   */
+  private async upstreamRoleId(bearer: string, wsId: string, role: 'admin' | 'member'): Promise<string> {
+    const name = role === 'admin' ? IAM_ADMIN_ROLE_NAME : IAM_MEMBER_ROLE_NAME;
+    const id = await this.projection!.iam.roleIdByName(bearer, name, wsId);
+    if (!id) {
+      throw new ConflictException({
+        error: 'ROLE_UNAVAILABLE',
+        message: `The ${role} role is not available upstream.`,
+      });
+    }
+    return id;
+  }
+
+  /**
    * Invite by email through the identity service. The invitation, its email,
    * and its acceptance all live upstream; the person appears in the roster
    * once they accept (next roster read). Admin → the upstream `workspace_admin`
-   * role; member → the workspace's default.
+   * role; member → `workspace_editor`, so what the invitee lands with is what
+   * the inviter picked, in both apps.
    */
   async inviteUpstream(
     req: ReqLike,
@@ -255,16 +281,12 @@ export class WorkspaceService {
       throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This workspace has no identity service behind it.' });
     }
     const email = input.email.trim().toLowerCase();
-    let roleId: string | undefined;
-    if (input.role === 'admin') {
-      const roles = await this.projection.iam.listRoles(up.bearer, wsId);
-      roleId = roles.find((r) => r.name === IAM_ADMIN_ROLE_NAME)?.id;
-    }
+    const roleId = await this.upstreamRoleId(up.bearer, wsId, input.role === 'admin' ? 'admin' : 'member');
     try {
       const inv = await this.projection.iam.createInvitation(up.bearer, {
         invited_email: email,
         workspace_id: wsId,
-        ...(roleId ? { role_id: roleId } : {}),
+        role_id: roleId,
       });
       // Shaped like a roster row so the caller's contract does not fork: the
       // invitation is `invited` until upstream turns it into a membership.
@@ -321,9 +343,10 @@ export class WorkspaceService {
   }
 
   /**
-   * Change a member upstream: promote to admin (assign `workspace_admin`),
-   * enable/disable. Demoting to member is not expressible upstream (roles are
-   * assigned, never removed, through the API this product has) → 409.
+   * Change a member upstream: promote (assign `workspace_admin`), demote (assign
+   * `workspace_editor` — roles are replaced, so this is how "member" is said),
+   * enable/disable. Ownership is a membership TYPE upstream, not a role, and
+   * nothing this product calls transfers it → 409.
    */
   async updateMemberUpstream(
     req: ReqLike,
@@ -350,16 +373,27 @@ export class WorkspaceService {
       throw new ConflictException({ error: 'LAST_OWNER', message: 'A workspace must keep at least one owner.' });
     }
     if (input.role !== undefined && input.role !== target.role) {
-      if (input.role === 'admin') {
-        const roles = await this.projection.iam.listRoles(up.bearer, wsId);
-        const roleId = roles.find((r) => r.name === IAM_ADMIN_ROLE_NAME)?.id;
-        if (!roleId) throw new ConflictException({ error: 'ROLE_UNAVAILABLE', message: 'The admin role is not available upstream.' });
-        await this.projection.iam.assignRole(up.bearer, ref.workspaceUserId, roleId);
-      } else {
+      if (input.role === 'owner' || target.role === 'owner') {
+        // OWNER is the membership type upstream; there is no call that changes it.
         throw new ConflictException({
           error: 'NOT_SUPPORTED_UPSTREAM',
-          message: 'Change this role from the Dapta app.',
+          message: 'Ownership is transferred from the Dapta app.',
         });
+      }
+      const roleId = await this.upstreamRoleId(up.bearer, wsId, input.role);
+      try {
+        await this.projection.iam.assignRole(up.bearer, ref.workspaceUserId, roleId);
+      } catch (err) {
+        // The upstream applies its own authorization: a 401/403 is THEM
+        // refusing the caller; any other 4xx is them refusing THIS role for
+        // THIS membership. Surface both as such, not as a crash.
+        if (err instanceof IamHttpError && (err.status === 401 || err.status === 403)) {
+          throw new ForbiddenException({ error: 'FORBIDDEN', message: 'The identity service refused this change.' });
+        }
+        if (err instanceof IamHttpError && err.status >= 400 && err.status < 500) {
+          throw new ConflictException({ error: 'ROLE_UNAVAILABLE', message: `The ${input.role} role was refused upstream.` });
+        }
+        throw err;
       }
     }
     if (input.status !== undefined && input.status !== target.status) {
@@ -373,10 +407,15 @@ export class WorkspaceService {
     return (await getAccountMember(this.db, p.accountId, memberId)) ?? target;
   }
 
-  /** Remove a member upstream, then locally. Idempotent. */
+  /**
+   * Remove a member upstream, then locally. Idempotent. OWNER-only, the same
+   * rule the Dapta app applies (an admin may invite, promote, demote and
+   * disable, but not remove) — kept identical so a person managing a workspace
+   * from either app meets the same door.
+   */
   async removeMemberUpstream(req: ReqLike, memberId: string): Promise<{ ok: true }> {
     const p = await this.auth.resolveHost(req);
-    assertAdmin(p);
+    assertOwner(p);
     assertNotSelf(p, memberId);
     const target = await getAccountMember(this.db, p.accountId, memberId);
     if (!target) return { ok: true };

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -50,6 +50,7 @@ import {
   IAM_ADMIN_ROLE_NAME,
   IAM_MEMBER_ROLE_NAME,
   IamHttpError,
+  IamUnavailableError,
   roleFromIam,
   userEmailOf,
   userNameOf,
@@ -249,10 +250,28 @@ export class WorkspaceService {
    * per environment): admin → `workspace_admin`, member → `workspace_editor`.
    * `owner` is not a role upstream but a membership TYPE, and nothing this
    * product calls can transfer it → 409.
+   *
+   * The upstream applies its own authorization: a 401/403 while reading the
+   * catalog is THEM refusing the caller (→ 403 here); any other failure — the
+   * role missing, a 4xx, the service unreachable — is "this role cannot be
+   * resolved right now" (→ 409 `ROLE_UNAVAILABLE`), never a crash.
    */
   private async upstreamRoleId(bearer: string, wsId: string, role: 'admin' | 'member'): Promise<string> {
     const name = role === 'admin' ? IAM_ADMIN_ROLE_NAME : IAM_MEMBER_ROLE_NAME;
-    const id = await this.projection!.iam.roleIdByName(bearer, name, wsId);
+    let id: string | null;
+    try {
+      id = await this.projection!.iam.roleIdByName(bearer, name, wsId);
+    } catch (err) {
+      if (err instanceof IamHttpError && (err.status === 401 || err.status === 403)) {
+        throw new ForbiddenException({ error: 'FORBIDDEN', message: 'The identity service refused this change.' });
+      }
+      if (err instanceof IamHttpError || err instanceof IamUnavailableError) {
+        this.logWarn(`role catalog read failed for ${wsId}: ${String(err)}`);
+        id = null;
+      } else {
+        throw err;
+      }
+    }
     if (!id) {
       throw new ConflictException({
         error: 'ROLE_UNAVAILABLE',
@@ -281,12 +300,26 @@ export class WorkspaceService {
       throw new ConflictException({ error: 'NO_UPSTREAM', message: 'This workspace has no identity service behind it.' });
     }
     const email = input.email.trim().toLowerCase();
-    const roleId = await this.upstreamRoleId(up.bearer, wsId, input.role === 'admin' ? 'admin' : 'member');
+    // Admin MUST carry the admin role (an admin invite that lands as a plain
+    // member is a silent privilege mismatch). Member SHOULD carry the editor
+    // role; when the catalog cannot be read the invitation still goes out with
+    // the workspace's default, as it did before the editor role was sent.
+    let roleId: string | undefined;
+    if (input.role === 'admin') {
+      roleId = await this.upstreamRoleId(up.bearer, wsId, 'admin');
+    } else {
+      try {
+        roleId = await this.upstreamRoleId(up.bearer, wsId, 'member');
+      } catch (err) {
+        if (!(err instanceof ConflictException)) throw err;
+        this.logWarn(`member invite for ${wsId} sent without role_id: editor role unavailable`);
+      }
+    }
     try {
       const inv = await this.projection.iam.createInvitation(up.bearer, {
         invited_email: email,
         workspace_id: wsId,
-        role_id: roleId,
+        ...(roleId ? { role_id: roleId } : {}),
       });
       // Shaped like a roster row so the caller's contract does not fork: the
       // invitation is `invited` until upstream turns it into a membership.
@@ -301,8 +334,18 @@ export class WorkspaceService {
         createdAt: Date.now(),
       };
     } catch (err) {
-      if (err instanceof IamHttpError && (err.status === 409 || err.status === 400)) {
+      // 409, or a 400 whose body says "already": the address is taken. Any
+      // other 400 is the upstream refusing the payload (the role, the address
+      // shape) and is reported as such — a retry with the same input will
+      // not help, and "already a member" would be a lie.
+      if (err instanceof IamHttpError && err.status === 409) {
         throw new ConflictException({ error: 'EMAIL_TAKEN', message: 'That address is already invited or a member.' });
+      }
+      if (err instanceof IamHttpError && err.status === 400) {
+        if (/already|exist|duplicate|invited|member/i.test(err.body)) {
+          throw new ConflictException({ error: 'EMAIL_TAKEN', message: 'That address is already invited or a member.' });
+        }
+        throw new BadRequestException({ error: 'INVALID', message: 'The identity service refused that invitation.' });
       }
       throw err;
     }
@@ -411,14 +454,20 @@ export class WorkspaceService {
    * Remove a member upstream, then locally. Idempotent. OWNER-only, the same
    * rule the Dapta app applies (an admin may invite, promote, demote and
    * disable, but not remove) — kept identical so a person managing a workspace
-   * from either app meets the same door.
+   * from either app meets the same door. The one exception is a row that is
+   * still `invited` (a pre-0015 local invitation nobody accepted): retracting
+   * an invitation is the inviter's call, so an admin may.
    */
   async removeMemberUpstream(req: ReqLike, memberId: string): Promise<{ ok: true }> {
     const p = await this.auth.resolveHost(req);
-    assertOwner(p);
+    assertAdmin(p);
     assertNotSelf(p, memberId);
     const target = await getAccountMember(this.db, p.accountId, memberId);
-    if (!target) return { ok: true };
+    if (!target) {
+      assertOwner(p); // an unknown id is a "remove" in intent; hold it to the owner rule
+      return { ok: true };
+    }
+    if (target.status !== 'invited') assertOwner(p);
     assertCanManageTarget(p, target);
     if (await wouldOrphanWorkspace(this.db, p.accountId, memberId)) {
       throw new ConflictException({ error: 'LAST_OWNER', message: 'A workspace must keep at least one owner.' });

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -105,14 +105,15 @@ export async function updateMemberRoleAction(
 }
 
 /**
- * Remove a member from the workspace. Admin/owner only; an admin cannot remove an
- * owner; you cannot remove yourself; the last active owner cannot be removed
- * (LAST_OWNER). Forms are account-owned, so removing a member never deletes
- * forms or submissions — only the roster row. Success revalidates the roster.
+ * Remove a member from the workspace. OWNER only (the identity service's rule,
+ * mirrored by the API on the local path too); you cannot remove yourself; the
+ * last active owner cannot be removed (LAST_OWNER). Forms are account-owned, so
+ * removing a member never deletes forms or submissions — only the roster row.
+ * Success revalidates the roster.
  */
 export async function removeMemberAction(id: string): Promise<ManageMemberState> {
   const me = await adminApi.me();
-  if (!isAdminRole(me.role)) return { ok: false, code: 'FORBIDDEN' };
+  if (me.role !== 'owner') return { ok: false, code: 'FORBIDDEN' };
   if (id === me.memberId) return { ok: false, code: 'FORBIDDEN' };
   try {
     await adminApi.removeMember(id);

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -16,7 +16,7 @@ import {
 /** Machine-readable outcome of an invite so the client can localize the message. */
 export type InviteMemberState =
   | { ok: true }
-  | { ok: false; code: 'INVALID' | 'TAKEN' | 'FAILED' }
+  | { ok: false; code: 'INVALID' | 'TAKEN' | 'UPSTREAM' | 'FAILED' }
   | null;
 
 /**
@@ -53,6 +53,9 @@ export async function inviteMemberAction(
     unstable_rethrow(e);
     if (e instanceof ApiError) {
       if (e.code === 'EMAIL_TAKEN') return { ok: false, code: 'TAKEN' };
+      // The identity service could not take it (role missing, unmanaged
+      // workspace, refused payload): a retry with the same input will not help.
+      if (e.code === 'ROLE_UNAVAILABLE' || e.code === 'NO_UPSTREAM') return { ok: false, code: 'UPSTREAM' };
       if (e.status === 400) return { ok: false, code: 'INVALID' };
     }
     return { ok: false, code: 'FAILED' };
@@ -63,20 +66,22 @@ export async function inviteMemberAction(
  * Machine-readable outcome of a roster management op (change-role / remove) so the
  * client localizes the message. `LAST_OWNER` = the guarded 409 (would leave the
  * workspace ownerless); `FORBIDDEN` = the guarded 403 (non-admin, or an admin
- * touching an owner); `FAILED` = anything else.
+ * touching an owner); `OWNERSHIP` = ownership is only transferred in the Dapta
+ * app; `UPSTREAM` = the identity service could not apply the change; `FAILED`
+ * = anything else.
  */
 export type ManageMemberState =
   | { ok: true }
-  | { ok: false; code: 'LAST_OWNER' | 'FORBIDDEN' | 'UPSTREAM' | 'FAILED' };
+  | { ok: false; code: 'LAST_OWNER' | 'FORBIDDEN' | 'OWNERSHIP' | 'UPSTREAM' | 'FAILED' };
 
 /** Map an API failure to a stable, localizable code (never a raw server string). */
 function manageError(e: unknown): ManageMemberState {
   if (e instanceof ApiError) {
     if (e.code === 'LAST_OWNER') return { ok: false, code: 'LAST_OWNER' };
     if (e.status === 403 || e.code === 'FORBIDDEN') return { ok: false, code: 'FORBIDDEN' };
-    // Identity-service deployments: some changes are only expressible over there.
-    if (e.code === 'NOT_SUPPORTED_UPSTREAM' || e.code === 'NO_UPSTREAM' || e.code === 'ROLE_UNAVAILABLE')
-      return { ok: false, code: 'UPSTREAM' };
+    if (e.code === 'NOT_SUPPORTED_UPSTREAM') return { ok: false, code: 'OWNERSHIP' };
+    // Identity-service deployments: the change could not be applied over there.
+    if (e.code === 'NO_UPSTREAM' || e.code === 'ROLE_UNAVAILABLE') return { ok: false, code: 'UPSTREAM' };
   }
   return { ok: false, code: 'FAILED' };
 }

--- a/apps/web/app/admin/settings/invite-member.tsx
+++ b/apps/web/app/admin/settings/invite-member.tsx
@@ -22,6 +22,7 @@ export interface InviteMemberLabels {
   inviteErrorTaken: string;
   inviteErrorInvalid: string;
   inviteErrorFailed: string;
+  inviteErrorUpstream: string;
 }
 
 /**
@@ -66,7 +67,9 @@ export function InviteMember({ labels }: { labels: InviteMemberLabels }) {
         ? labels.inviteErrorTaken
         : state.code === 'INVALID'
           ? labels.inviteErrorInvalid
-          : labels.inviteErrorFailed
+          : state.code === 'UPSTREAM'
+            ? labels.inviteErrorUpstream
+            : labels.inviteErrorFailed
       : null;
 
   return (

--- a/apps/web/app/admin/settings/member-row-actions.tsx
+++ b/apps/web/app/admin/settings/member-row-actions.tsx
@@ -40,10 +40,13 @@ export interface MemberRowActionsLabels {
 export function MemberRowActions({
   memberId,
   role,
+  canRemove,
   labels,
 }: {
   memberId: string;
   role: AccountRole;
+  /** Removal is OWNER-only (the identity service's rule); admins get the role items only. */
+  canRemove: boolean;
   labels: MemberRowActionsLabels;
 }) {
   const [open, setOpen] = useState(false);
@@ -166,19 +169,22 @@ export function MemberRowActions({
             </button>
           ) : null}
 
-          <div className="my-1 border-t border-border" role="separator" />
-
-          <button
-            type="button"
-            role="menuitem"
-            tabIndex={-1}
-            disabled={pending}
-            onClick={remove}
-            className="flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:opacity-50"
-          >
-            <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
-            {labels.removeMember}
-          </button>
+          {canRemove ? (
+            <>
+              <div className="my-1 border-t border-border" role="separator" />
+              <button
+                type="button"
+                role="menuitem"
+                tabIndex={-1}
+                disabled={pending}
+                onClick={remove}
+                className="flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:opacity-50"
+              >
+                <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
+                {labels.removeMember}
+              </button>
+            </>
+          ) : null}
         </div>
       ) : null}
       {dialog}

--- a/apps/web/app/admin/settings/member-row-actions.tsx
+++ b/apps/web/app/admin/settings/member-row-actions.tsx
@@ -25,6 +25,7 @@ export interface MemberRowActionsLabels {
   manageErrorForbidden: string;
   manageErrorFailed: string;
   manageErrorUpstream: string;
+  manageErrorOwnership: string;
 }
 
 /**
@@ -89,9 +90,11 @@ export function MemberRowActions({
         ? labels.manageErrorLastOwner
         : result.code === 'FORBIDDEN'
           ? labels.manageErrorForbidden
-          : result.code === 'UPSTREAM'
-            ? labels.manageErrorUpstream
-            : labels.manageErrorFailed;
+          : result.code === 'OWNERSHIP'
+            ? labels.manageErrorOwnership
+            : result.code === 'UPSTREAM'
+              ? labels.manageErrorUpstream
+              : labels.manageErrorFailed;
     toast.error(message);
   };
 

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -111,6 +111,7 @@ export default async function SettingsPage() {
                 inviteErrorTaken: s.inviteErrorTaken,
                 inviteErrorInvalid: s.inviteErrorInvalid,
                 inviteErrorFailed: s.inviteErrorFailed,
+                inviteErrorUpstream: s.inviteErrorUpstream,
               }}
             />
           </div>
@@ -168,6 +169,7 @@ export default async function SettingsPage() {
                           manageErrorForbidden: s.manageErrorForbidden,
                           manageErrorFailed: s.manageErrorFailed,
                           manageErrorUpstream: s.manageErrorUpstream,
+                          manageErrorOwnership: s.manageErrorOwnership,
                         }}
                       />
                     ) : (

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -155,6 +155,7 @@ export default async function SettingsPage() {
                       <MemberRowActions
                         memberId={mem.id}
                         role={mem.role}
+                        canRemove={me.role === 'owner'}
                         labels={{
                           membersMenu: s.membersMenu,
                           makeAdmin: s.makeAdmin,

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -84,7 +84,7 @@ async function req<T>(method: string, path: string, body?: unknown, opts: ReqOpt
   // Only for the COOKIE's workspace. A 403 on an explicit `opts.workspace` means
   // "you cannot manage that one" and is the caller's to show; resetting the
   // cookie for it would throw the person out of the workspace they ARE in.
-  if (res.status === 403 && cookieWorkspace && !opts.workspace) {
+  if (res.status === 403 && cookieWorkspace && (opts.workspace === undefined || opts.workspace === cookieWorkspace)) {
     const j = (await res.clone().json().catch(() => ({}))) as { error?: string };
     if (j.error === 'WORKSPACE_FORBIDDEN') redirect('/api/workspace/reset');
   }

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -30,12 +30,22 @@ export class ApiError extends Error {
   }
 }
 
-async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+/**
+ * Per-call options. `workspace` names the workspace to act in INSTEAD of the
+ * one in the cookie — the account-settings pages manage a workspace by id
+ * without switching into it. The API re-checks membership either way.
+ */
+export interface ReqOptions {
+  workspace?: string;
+}
+
+async function req<T>(method: string, path: string, body?: unknown, opts: ReqOptions = {}): Promise<T> {
   const session = await getSession();
   // Which workspace, asked separately from who — and read from its own cookie,
   // because the local provider serves developers who have no session at all.
   // The API re-checks membership against the database; this authorizes nothing.
-  const workspace = await getWorkspace();
+  const cookieWorkspace = await getWorkspace();
+  const workspace = opts.workspace ?? cookieWorkspace;
   const headers: Record<string, string> = {};
   if (body) headers['content-type'] = 'application/json';
   if (session?.provider === 'workos') headers['authorization'] = `Bearer ${session.accessToken}`;
@@ -70,7 +80,11 @@ async function req<T>(method: string, path: string, body?: unknown): Promise<T> 
   // a Server Component render, where `cookies().set()` throws. Clearing it here
   // and redirecting anyway produced an infinite loop — the dead workspace was
   // re-sent on every hop. The handler owns its response, so the delete lands.
-  if (res.status === 403 && workspace) {
+  //
+  // Only for the COOKIE's workspace. A 403 on an explicit `opts.workspace` means
+  // "you cannot manage that one" and is the caller's to show; resetting the
+  // cookie for it would throw the person out of the workspace they ARE in.
+  if (res.status === 403 && cookieWorkspace && !opts.workspace) {
     const j = (await res.clone().json().catch(() => ({}))) as { error?: string };
     if (j.error === 'WORKSPACE_FORBIDDEN') redirect('/api/workspace/reset');
   }
@@ -94,6 +108,8 @@ export interface Workspace {
   role: AccountRole;
   /** `invited` until they first open it — shown as pending in the switcher. */
   status: MemberStatus;
+  /** Active members in that workspace. */
+  memberCount: number;
 }
 
 /** Why a webhook test delivery failed — mirrors `WebhookPingReason` in the API. */
@@ -487,7 +503,8 @@ export interface FormNotificationsResponse {
 }
 
 export const adminApi = {
-  me: () => req<Me>('GET', '/v1/me'),
+  /** Who am I, in the cookie's workspace — or in `opts.workspace` when managing another one. */
+  me: (opts?: ReqOptions) => req<Me>('GET', '/v1/me', undefined, opts),
 
   // Onboarding (first-run wizard)
   saveOnboarding: (b: OnboardingProgress) =>
@@ -576,9 +593,9 @@ export const adminApi = {
   refreshWorkspaces: () => req<Workspace[]>('POST', '/v1/workspaces/refresh'),
   /** Create a workspace with the caller as owner; returns the new local account id. */
   createWorkspace: (name: string) => req<{ accountId: string }>('POST', '/v1/workspaces', { name }),
-  /** Rename the workspace the caller is acting in (admin/owner). */
-  renameWorkspace: (name: string) =>
-    req<{ accountId: string; name: string }>('PATCH', '/v1/workspaces/current', { name }),
+  /** Rename the workspace the caller is acting in (admin/owner), or `opts.workspace`. */
+  renameWorkspace: (name: string, opts?: ReqOptions) =>
+    req<{ accountId: string; name: string }>('PATCH', '/v1/workspaces/current', { name }, opts),
   /** Tell the API the caller is about to open this workspace (membership re-checked; remembered upstream). */
   enterWorkspace: (accountId: string) => req<{ ok: true }>('POST', `/v1/workspaces/${accountId}/enter`),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */
@@ -591,16 +608,21 @@ export const adminApi = {
   disconnectIntegration: (provider: IntegrationProvider) =>
     req<void>('DELETE', `/v1/integrations/${provider}`),
 
-  // Members (workspace roster — admin/owner only)
-  listMembers: () => req<AccountMember[]>('GET', '/v1/members'),
-  inviteMember: (b: { email: string; role?: 'admin' | 'member' }) =>
-    req<AccountMember>('POST', '/v1/members', b),
-  updateMember: (id: string, b: { role?: AccountRole; status?: MemberStatus }) =>
-    req<AccountMember>('PATCH', `/v1/members/${id}`, b),
-  removeMember: (id: string) => req<{ ok: boolean }>('DELETE', `/v1/members/${id}`),
+  // Members (workspace roster — admin/owner only). Every call takes `opts.workspace`
+  // so Account settings can manage a workspace without switching into it.
+  listMembers: (opts?: ReqOptions) => req<AccountMember[]>('GET', '/v1/members', undefined, opts),
+  inviteMember: (b: { email: string; role?: 'admin' | 'member' }, opts?: ReqOptions) =>
+    req<AccountMember>('POST', '/v1/members', b, opts),
+  updateMember: (id: string, b: { role?: AccountRole; status?: MemberStatus }, opts?: ReqOptions) =>
+    req<AccountMember>('PATCH', `/v1/members/${id}`, b, opts),
+  /** Owner-only (the identity service's rule, mirrored on the local path). */
+  removeMember: (id: string, opts?: ReqOptions) =>
+    req<{ ok: boolean }>('DELETE', `/v1/members/${id}`, undefined, opts),
   /** Pending invitations (identity-service deployments only; empty otherwise). */
-  listInvitations: () => req<PendingInvitation[]>('GET', '/v1/invitations'),
-  resendInvitation: (id: string) => req<{ ok: true }>('POST', `/v1/invitations/${id}/resend`),
+  listInvitations: (opts?: ReqOptions) =>
+    req<PendingInvitation[]>('GET', '/v1/invitations', undefined, opts),
+  resendInvitation: (id: string, opts?: ReqOptions) =>
+    req<{ ok: true }>('POST', `/v1/invitations/${id}/resend`, undefined, opts),
 
   // Notifications (submission emails — admin/owner only)
   getNotifications: () => req<NotificationsResponse>('GET', '/v1/notifications'),

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -270,6 +270,8 @@ export interface WorkspaceRow {
   role: AccountRole;
   /** `invited` until they first enter it — the switcher marks these as pending. */
   status: MemberStatus;
+  /** How many ACTIVE members the workspace has (the account-settings cards show it). */
+  memberCount: number;
 }
 
 /**
@@ -330,8 +332,10 @@ export async function listWorkspacesForIdentity(
     member_id: string;
     role: string;
     status: string;
+    member_count: number | string;
   }>(
-    sql`SELECT a.id AS account_id, a.code, a.name, m.id AS member_id, m.role, m.status
+    sql`SELECT a.id AS account_id, a.code, a.name, m.id AS member_id, m.role, m.status,
+               (SELECT COUNT(*) FROM member mm WHERE mm.account_id = a.id AND mm.status = 'active') AS member_count
         FROM member m JOIN account a ON a.id = m.account_id
         WHERE m.status IN ('active', 'invited')
           AND (${sql.join(conds, sql` OR `)})
@@ -357,6 +361,8 @@ export async function listWorkspacesForIdentity(
       status: (MEMBER_STATUSES as readonly string[]).includes(r.status)
         ? (r.status as MemberStatus)
         : 'active',
+      // Postgres returns COUNT(*) as a bigint string; SQLite as a number.
+      memberCount: Number(r.member_count ?? 0),
     });
   }
   return out;

--- a/packages/db/src/workspaces.spec.ts
+++ b/packages/db/src/workspaces.spec.ts
@@ -98,6 +98,10 @@ describe('projectMemberships', () => {
     await projectMemberships(db, identity, [two[0]!]);
     const list = await listWorkspacesForIdentity(db, identity);
     expect(list.map((w) => w.accountName)).toEqual(['A']);
+    // memberCount is a NUMBER on both dialects (Postgres hands COUNT(*) back as
+    // a bigint string) and counts active rows only.
+    expect(list[0]!.memberCount).toBe(1);
+    expect(typeof list[0]!.memberCount).toBe('number');
     const bRow = await db.get<{ status: string }>(
       sql`SELECT m.status FROM member m JOIN account acc ON acc.id = m.account_id WHERE acc.external_id = ${b} AND m.external_id = ${SUB}`,
     );

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1822,7 +1822,7 @@ export const en: FormsMessages = {
       manageErrorLastOwner: 'A workspace must keep at least one owner.',
       manageErrorForbidden: 'You do not have permission to do that.',
       manageErrorFailed: 'Something went wrong. Please try again.',
-      manageErrorUpstream: 'Change this from the Dapta app: it manages this workspace’s members.',
+      manageErrorUpstream: 'The identity service could not apply this change. Ownership is transferred from the Dapta app.',
     },
     notifications: {
       heading: 'Notifications',
@@ -3227,7 +3227,7 @@ export const es: FormsMessages = {
       manageErrorLastOwner: 'Un espacio de trabajo debe conservar al menos un propietario.',
       manageErrorForbidden: 'No tienes permiso para hacer eso.',
       manageErrorFailed: 'Algo salió mal. Inténtalo de nuevo.',
-      manageErrorUpstream: 'Hazlo desde la app de Dapta: ahí se administran los miembros de este workspace.',
+      manageErrorUpstream: 'El servicio de identidad no pudo aplicar este cambio. La propiedad se transfiere desde la app de Dapta.',
     },
     notifications: {
       heading: 'Notificaciones',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -317,6 +317,8 @@ export interface FormsMessages {
       inviteErrorTaken: string;
       inviteErrorInvalid: string;
       inviteErrorFailed: string;
+      /** The identity service refused the invitation (role or address). */
+      inviteErrorUpstream: string;
       membersMenu: string;
       makeAdmin: string;
       makeMember: string;
@@ -327,8 +329,10 @@ export interface FormsMessages {
       manageErrorLastOwner: string;
       manageErrorForbidden: string;
       manageErrorFailed: string;
-      /** The change is only expressible in the identity service (Dapta app). */
+      /** The identity service could not apply the change (role missing, member unmanaged, refused). */
       manageErrorUpstream: string;
+      /** Ownership is a membership type upstream; only the Dapta app transfers it. */
+      manageErrorOwnership: string;
     };
     /** Settings → Notifications: edit the two submission emails the platform sends. */
     notifications: {
@@ -1812,6 +1816,7 @@ export const en: FormsMessages = {
       inviteErrorTaken: 'A member with that email already exists.',
       inviteErrorInvalid: 'Enter a valid email address.',
       inviteErrorFailed: 'Could not add the member. Please try again.',
+      inviteErrorUpstream: 'The identity service refused that invitation.',
       membersMenu: 'Member actions',
       makeAdmin: 'Change to Admin',
       makeMember: 'Change to Member',
@@ -1822,7 +1827,8 @@ export const en: FormsMessages = {
       manageErrorLastOwner: 'A workspace must keep at least one owner.',
       manageErrorForbidden: 'You do not have permission to do that.',
       manageErrorFailed: 'Something went wrong. Please try again.',
-      manageErrorUpstream: 'The identity service could not apply this change. Ownership is transferred from the Dapta app.',
+      manageErrorUpstream: 'The identity service could not apply this change.',
+      manageErrorOwnership: 'Ownership is transferred from the Dapta app.',
     },
     notifications: {
       heading: 'Notifications',
@@ -3217,6 +3223,7 @@ export const es: FormsMessages = {
       inviteErrorTaken: 'Ya existe un miembro con ese correo.',
       inviteErrorInvalid: 'Introduce un correo válido.',
       inviteErrorFailed: 'No se pudo añadir el miembro. Inténtalo de nuevo.',
+      inviteErrorUpstream: 'El servicio de identidad rechazó esa invitación.',
       membersMenu: 'Acciones de miembro',
       makeAdmin: 'Cambiar a Administrador',
       makeMember: 'Cambiar a Miembro',
@@ -3227,7 +3234,8 @@ export const es: FormsMessages = {
       manageErrorLastOwner: 'Un espacio de trabajo debe conservar al menos un propietario.',
       manageErrorForbidden: 'No tienes permiso para hacer eso.',
       manageErrorFailed: 'Algo salió mal. Inténtalo de nuevo.',
-      manageErrorUpstream: 'El servicio de identidad no pudo aplicar este cambio. La propiedad se transfiere desde la app de Dapta.',
+      manageErrorUpstream: 'El servicio de identidad no pudo aplicar este cambio.',
+      manageErrorOwnership: 'La propiedad se transfiere desde la app de Dapta.',
     },
     notifications: {
       heading: 'Notificaciones',


### PR DESCRIPTION
## What

Follow-up to #117 (workspaces are the identity service's workspaces). Two things Josue asked for after using it:

1. **Demoting an admin to member now works from Forms.** Roles upstream are replaced, never removed, so "make them a member" assigns the identity service's `workspace_editor` system role (the same thing the Dapta app's role dialog does when a non-admin role is picked). Promotion keeps assigning `workspace_admin`. Both ids are resolved BY NAME from the upstream role catalog (`GET /role`, system rows only, cached 5 min) because the ids differ per environment; the per-workspace list only carries `workspace_admin` and custom roles, so it is the fallback, not the source. Inviting as member sends the editor `role_id` too, so what the invitee lands with is what the inviter picked, in both apps. If the catalog cannot be read, a member invite still goes out with the workspace's default role; an admin invite does not degrade.
2. **Removing a member is owner-only**, the identity service's rule, on the local path too so a fork and an identity-backed deployment agree. Admins still invite, promote, demote, disable, and may retract an invitation that was never accepted. The Settings roster hides Remove for non-owners.

Also:
- `workspace_owner` upstream reads as `admin` here. Making someone owner (or un-owning them) is a 409 with its own message: ownership is a membership TYPE upstream, not a role, and nothing this product calls transfers it.
- Upstream failures while resolving a role are mapped (401/403 from the identity service is a 403 here; anything else is 409 `ROLE_UNAVAILABLE`), never a 500. A 400 from the invitation endpoint is `EMAIL_TAKEN` only when its body says so.
- `listWorkspacesForIdentity` rows carry `memberCount` (active members) for the upcoming Account settings cards.
- Web API client: per-call `{ workspace }` override (sends `x-quill-workspace` for a workspace other than the cookie's, so Account settings can manage a workspace by id without switching into it). A 403 on an override never resets the cookie's workspace.
- i18n EN/ES: `manageErrorUpstream` / `manageErrorOwnership` / `inviteErrorUpstream`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (API 393/393) green; `packages/db` workspaces spec green on SQLite **and** Postgres (`memberCount` is a number on both).
- Live against the dev identity service (`services.dapta.dev/iam`, a real dev bearer): `GET /role` returns the flat list this client expects, with `workspace_editor` (system) present.
- **Pending a live check I could not run:** `POST /workspaceUser/assign-role` with the `workspace_editor` id (a system role NOT listed in `roles-workspace/{ws}`), and `POST /workspace-invitations` with that `role_id`. The only bearer available to me belongs to an account with no owned workspace, so it cannot exercise a write. Needs a fresh session token of someone who owns a dev workspace (Josue); the code paths are unit-tested against a fake that mirrors the observed shapes, and a refusal upstream surfaces as 409 `ROLE_UNAVAILABLE`, never a crash.

## Reviewer

`forms-reviewer` ran on the first commit; its findings (catalog-read failures unmapped, per-write probe of the workspace list, tenant rows in the shared cache, one string serving three error codes, invite `FAILED` for a non-retryable 409, missing TTL tests, admin unable to retract an invitation, stale permission comments, cookie-reset condition) are addressed in the second commit.

## Changeset

`.changeset/iam-member-roles.md` (`@quill/db` minor, `@quill/shared` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
