### PR TITLE
feat(api): send lead_source and use_case to the HubSpot sync flow

### DIFF
--- a/apps/api/src/dapta-sync.spec.ts
+++ b/apps/api/src/dapta-sync.spec.ts
@@ -236,6 +236,51 @@ describe('buildFlowPayload — pure mapping', () => {
 
     expect(body).toEqual({ email: 'a@b.com', user_id: 'user-ext-1' });
   });
+
+  it('carries lead_source and use_case at the TOP level, never inside params', () => {
+    // The flow overwrites `params` with the IAM's stored UTMs for anyone who
+    // has them (the whole Dapta cohort), so anything nested there would be
+    // lost for exactly the people whose only answers these two are.
+    const body = buildFlowPayload({
+      email: 'a@b.com',
+      userId: 'user-ext-1',
+      accountExternalId: null,
+      displayName: null,
+      blob: {
+        version: 1,
+        cohort: 'dapta',
+        leadSource: 'google_ads',
+        useCase: 'leads',
+      } as AccountOnboarding,
+      attribution: { utmSource: 'landing' },
+    });
+
+    expect(body).toEqual({
+      email: 'a@b.com',
+      user_id: 'user-ext-1',
+      lead_source: 'google_ads',
+      use_case: 'leads',
+      params: { utm_source: 'landing' },
+    });
+    expect(body.params).not.toHaveProperty('lead_source');
+  });
+
+  it('omits lead_source and use_case while unanswered (the early call is phone-only)', () => {
+    // The flow keeps a contact's existing values when the keys are absent;
+    // sending empty strings would clear what the Typeform quiz already wrote.
+    const body = buildFlowPayload({
+      email: 'a@b.com',
+      userId: 'user-ext-1',
+      accountExternalId: null,
+      displayName: null,
+      blob: { version: 1, phone: '3001234567', lastStep: 'phone' } as AccountOnboarding,
+      attribution: null,
+    });
+
+    expect(body).toEqual({ email: 'a@b.com', user_id: 'user-ext-1', phone: '3001234567' });
+    expect(body).not.toHaveProperty('lead_source');
+    expect(body).not.toHaveProperty('use_case');
+  });
 });
 
 describe('DaptaSyncEffects — enqueue', () => {
@@ -358,6 +403,14 @@ describe('DaptaSyncDelivery — worker-side', () => {
     await newWorker(newDelivery(envWith(), calls)).drainOnce();
 
     expect(calls.map((c) => c.url)).toEqual([FLOW_URL]);
+    // ...and those two answers are the ONLY thing this cohort contributes to
+    // HubSpot, so they must ride the webhook body itself.
+    expect(calls[0]!.body).toMatchObject({
+      email: 'a@b.com',
+      user_id: 'user-ext-1',
+      lead_source: 'outbound',
+      use_case: 'leads',
+    });
   });
 
   it('skips a member with no external identity — the flow dies silently on unknown ids', async () => {

--- a/apps/api/src/dapta-sync.ts
+++ b/apps/api/src/dapta-sync.ts
@@ -268,6 +268,16 @@ export interface FlowPayload {
   phone?: string;
   name?: string;
   params?: Record<string, string>;
+  /**
+   * The two Forms answers the IAM bank has no home for, so they cannot ride
+   * the IAM path like industry/crm/volume do. The flow reads them straight from
+   * its trigger body, maps `lead_source` onto HubSpot's `como_obtienes_leads`
+   * options and writes `use_case` to `dapta_forms_use_case`, and treats an
+   * absent or unknown value as "keep whatever the contact already has". Sent
+   * as our raw enum keys; the flow owns the HubSpot-side labels.
+   */
+  lead_source?: string;
+  use_case?: string;
 }
 
 /**
@@ -283,6 +293,13 @@ const MIN_PHONE_LENGTH = 7;
  * actually reads (`utm_source`, `utm_medium`, `utm_campaign`) — verified
  * against the flow's own JSON. gclid/fbclid have no vehicle and are dropped.
  * Empty values are omitted entirely; an empty `params` omits the field.
+ *
+ * `lead_source` / `use_case` sit at the TOP level, not inside `params`: the
+ * flow replaces `params` wholesale with the IAM's stored UTMs whenever the
+ * user has any, which is exactly the Dapta-cohort case, and those two answers
+ * are the only ones that cohort gives us. They are omitted when unanswered,
+ * so the `early` call (phone only) never carries them and the flow keeps the
+ * contact's existing values.
  */
 export function buildFlowPayload(input: {
   email: string;
@@ -298,6 +315,9 @@ export function buildFlowPayload(input: {
 
   const phone = input.blob?.phone?.trim();
   if (phone && phone.length >= MIN_PHONE_LENGTH) body.phone = phone;
+
+  if (input.blob?.leadSource) body.lead_source = input.blob.leadSource;
+  if (input.blob?.useCase) body.use_case = input.blob.useCase;
 
   const params: Record<string, string> = {};
   const a = input.attribution;


### PR DESCRIPTION
## What

`buildFlowPayload` now sends the two onboarding answers the IAM bank has no home for, `lead_source` and `use_case`, on the body of the `sync_hubspot_contact` webhook. Top level, not inside `params`; omitted while unanswered.

## Why

The wizard stores six answers. Industry, CRM and lead volume reach HubSpot through the IAM (Forms posts them to `/onboarding/responses`, the flow reads them back). `lead_source` and `use_case` were only ever stored in `account.onboarding` and never left Forms. For the Dapta cohort those two are the only answers Forms collects, so that cohort contributed nothing to the HubSpot contact.

## Flow side (already live, verified 2026-08-18)

Flow `sync_hubspot_contact` (XlAul, workspace Dapta Devops) was updated first:

- `find_contact` also returns `como_obtienes_leads` and `dapta_forms_use_case`.
- `set_hubspot_contact` maps `lead_source` onto the existing `como_obtienes_leads` options and passes `use_case` through to the new `dapta_forms_use_case` enum. Absent or unknown value = re-send the contact's current value (never `''`, never `undefined`), so a Dapta AI signup produces the same request as before.
- Both HubSpot nodes (create and update) carry the two new properties.

Verified against a prod test contact, 5 cases: body without fields leaves the contact untouched; Forms body writes `Google Ads` / `leads`; a second call without fields keeps them; junk values are ignored; `none` maps to `I don’t have leads` (curly apostrophe matches).

## Why top level and why omit

- The flow overwrites `params` with the IAM's stored UTMs whenever the user has any (the whole Dapta cohort). Anything nested there would be lost for exactly the people whose only answers these are.
- Sending `''` would clear what the Typeform quiz already wrote in `como_obtienes_leads`. Absent keys are the "keep" signal.

## Tests

- `buildFlowPayload` carries both keys at the top level with `params` intact.
- `buildFlowPayload` omits them on the phone-only (early) blob.
- Worker test for the dapta cohort asserts the webhook body carries them.

All three fail without the change (checked by stashing the source edit). `pnpm --filter @quill/api test`, typecheck, lint and `scripts/dash-check.sh origin/develop` clean.

No changeset: only `apps/api` changes, no published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
