### PR TITLE
feat: type-to-find in the workspace switcher; staff may enter any workspace of the estate

### DIFF
--- a/.changeset/staff-workspace-access.md
+++ b/.changeset/staff-workspace-access.md
@@ -1,0 +1,29 @@
+---
+'@quill/db': minor
+'@quill/config': minor
+'@quill/shared': minor
+---
+
+Type-to-find in the workspace switcher, and estate-wide access for the
+deployment's staff.
+
+- The switcher's menu has a search box (from six workspaces, or always for
+  staff): typing filters your own workspaces instantly. Own workspaces list
+  first; the ones you hold by access grant carry a Staff badge.
+- `IAM_STAFF_DOMAINS` (comma-separated email domains; unset = nobody, every
+  fork) names the deployment's staff. With the identity service configured,
+  a person on one of those domains ALSO searches the whole estate, the way the
+  Dapta app's sidebar does (`GET /workspace/search?query=`), and can enter any
+  workspace of it. Nothing is projected by looking: entering one re-reads the
+  workspace upstream, projects it (no onboarding stamp, no demo form, no signup
+  event) and mints an `admin` row marked `member.access_grant = 'staff'`.
+- Migration 0016: `member.access_grant` (nullable). Grant rows are excluded
+  from rosters and member counts (a customer's team list never shows staff),
+  never send the wizard to the staff member, are never pruned by the
+  membership projection, and turn into a real membership the moment upstream
+  names the person. "First member" (demo form, signup) counts real memberships
+  only, so an account a grant created ahead of its owner still welcomes the
+  owner.
+- API: `GET /v1/workspaces/search?q=&page=`, `POST
+  /v1/workspaces/estate/:workspaceId/enter`; `/v1/me` carries `staff` and
+  `accessGrant`.

--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,11 @@ MAIL_FROM_NAME=Forms
 # written to the IAM with the caller's own bearer, and the local account/member
 # rows become a projection of it. Unset = workspaces stay local-only.
 # IAM_BASE_URL=https://iam.example.com/iam
+# Staff by email domain (comma-separated). With the identity service on, people
+# on these domains can search the whole estate and enter any workspace as an
+# admin (the same rule the Dapta app applies to its team); the row minted for
+# that is an access grant, hidden from the team's roster. Unset = nobody.
+# IAM_STAFF_DOMAINS=example.com
 # IAM_API_KEY=
 # DAPTA_SYNC_FLOW_URL=https://flows.example.com/api/WORKSPACE/sync_contact
 # DAPTA_SYNC_FLOW_KEY=

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -144,7 +144,12 @@ export class AdminCrudController {
   @Get('me')
   async me(@Req() req: ReqLike) {
     const p = await this.auth.resolveHost(req);
-    return this.admin.me(p);
+    const view = await this.admin.me(p);
+    if (!view) return view;
+    // Staff of the deployment (by email domain, identity-backed only): the
+    // switcher offers them the whole estate to search.
+    const staff = this.workspacesSvc ? await this.workspacesSvc.isStaff(req) : false;
+    return { ...view, staff };
   }
 
   /**
@@ -336,6 +341,38 @@ export class AdminCrudController {
   @HttpCode(200)
   async enterWorkspace(@Req() req: ReqLike, @Param('id') id: string) {
     return this.ws().enter(req, id);
+  }
+
+  /**
+   * Type-to-find over the workspaces the caller may enter. Everyone gets their
+   * own list filtered; the deployment's staff also get the estate (see
+   * `WorkspaceService.search`).
+   */
+  @Get('workspaces/search')
+  async searchWorkspaces(
+    @Req() req: ReqLike,
+    @Query('q') q?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const pageN = page ? Number(page) : undefined;
+    const limitN = limit ? Number(limit) : undefined;
+    return this.ws().search(req, {
+      query: typeof q === 'string' ? q.slice(0, 120) : '',
+      page: pageN && Number.isFinite(pageN) ? pageN : undefined,
+      limit: limitN && Number.isFinite(limitN) ? limitN : undefined,
+    });
+  }
+
+  /**
+   * Staff only: open an estate workspace the caller holds no membership in.
+   * The workspace is re-read upstream, projected, and the caller gets an
+   * `access_grant = 'staff'` row (never on the team's roster).
+   */
+  @Post('workspaces/estate/:workspaceId/enter')
+  @HttpCode(200)
+  async enterEstateWorkspace(@Req() req: ReqLike, @Param('workspaceId') workspaceId: string) {
+    return this.ws().enterEstateWorkspace(req, workspaceId);
   }
 
   /** This member's public page config (the raw blob, or null). */

--- a/apps/api/src/admin.service.ts
+++ b/apps/api/src/admin.service.ts
@@ -92,8 +92,10 @@ export class AdminService {
     if (!view) return view;
     return {
       ...view,
+      // Never for an access grant: the wizard describes the workspace and is
+      // its owner's to answer, not the staff member's who dropped in.
       onboardingRequired:
-        this.onboardingEnabled && view.onboardingCompletedAt == null && isAdmin(p.role),
+        this.onboardingEnabled && view.onboardingCompletedAt == null && isAdmin(p.role) && !view.accessGrant,
     };
   }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -132,6 +132,7 @@ function signupObserver(productAnalytics: AnalyticsEffects): SignupObserver {
           ? new WorkspaceProjection(db, new IamWorkspacesClient({ baseUrl: env.IAM_BASE_URL }), {
               seedEnv: env,
               onSignup: signupObserver(productAnalytics),
+              staffDomains: env.IAM_STAFF_DOMAINS,
             })
           : null,
       inject: [ENV, DB, AnalyticsEffects],

--- a/apps/api/src/iam-workspaces.ts
+++ b/apps/api/src/iam-workspaces.ts
@@ -230,6 +230,36 @@ export class IamWorkspacesClient {
     return out;
   }
 
+  /**
+   * One page of the workspace search as the upstream answers it, membership NOT
+   * applied: for the deployment's staff the identity service answers with the
+   * whole estate, and that is exactly the list they get to search (the same
+   * call the Dapta app's sidebar makes, `?query=`). Callers decide who may
+   * see it; this only fetches.
+   */
+  async searchWorkspaces(
+    bearer: string,
+    opts: { query?: string; page?: number; limit?: number } = {},
+  ): Promise<{ rows: IamWorkspace[]; total: number; totalPages: number; page: number }> {
+    const page = Math.max(1, Math.floor(opts.page ?? 1));
+    const limit = Math.min(PAGE_SIZE, Math.max(1, Math.floor(opts.limit ?? 20)));
+    const q = (opts.query ?? '').trim();
+    const res = await this.call<{ data?: IamWorkspace[]; total?: number; totalPages?: number }>(
+      bearer,
+      'GET',
+      `/workspace/search?page=${page}&limit=${limit}${q ? `&query=${encodeURIComponent(q)}` : ''}`,
+    );
+    const rows = (Array.isArray(res?.data) ? res.data : []).filter(
+      (ws) => ws && typeof ws.id === 'string' && ws.is_active !== false,
+    );
+    return {
+      rows,
+      total: typeof res?.total === 'number' ? res.total : rows.length,
+      totalPages: typeof res?.totalPages === 'number' ? res.totalPages : 1,
+      page,
+    };
+  }
+
   getWorkspace(bearer: string, workspaceId: string): Promise<IamWorkspace> {
     return this.call<IamWorkspace>(bearer, 'GET', `/workspace/${encodeURIComponent(workspaceId)}`);
   }

--- a/apps/api/src/workspace-projection.ts
+++ b/apps/api/src/workspace-projection.ts
@@ -73,9 +73,25 @@ export class WorkspaceProjection {
       seedEnv?: SeedDemoEnv;
       onSignup?: SignupObserver;
       now?: () => number;
+      /**
+       * Email domains (lowercase, no `@`) whose people are STAFF of the
+       * deployment: they may search the whole estate and enter any workspace
+       * (see `WorkspaceService.enterEstateWorkspace`). Empty = nobody.
+       */
+      staffDomains?: readonly string[];
     } = {},
   ) {
     this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /** Whether this email belongs to the deployment's staff (by domain). */
+  isStaff(email: string | null | undefined): boolean {
+    const domains = this.opts.staffDomains ?? [];
+    if (!domains.length || !email) return false;
+    const at = email.lastIndexOf('@');
+    if (at < 0) return false;
+    const domain = email.slice(at + 1).trim().toLowerCase();
+    return domains.includes(domain);
   }
 
   private now(): number {
@@ -171,7 +187,11 @@ export class WorkspaceProjection {
     );
 
     for (const c of result.created) {
-      if (c.role === 'owner' && result.createdAccounts.includes(c.accountId) && this.opts.seedEnv) {
+      // An access grant is not a person joining: no demo form, no signup event.
+      if (c.accessGrant) continue;
+      // "First member" counts REAL memberships: an account a staff grant
+      // created ahead of its owner still gets the owner's demo form.
+      if (c.role === 'owner' && c.isFirstMember && this.opts.seedEnv) {
         // No demo form in a workspace whose upstream ACCOUNT still has a
         // pre-0015 local row: that row holds the owner's real forms and must be
         // able to absorb this account on the owner's next login (see

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -67,7 +67,14 @@ describe('WorkspaceService (IAM-backed)', () => {
         lastWorkspace = body.feature_flags.last_workspace;
         return json({});
       }
-      if (method === 'GET' && url.pathname === '/iam/workspace/search') return json({ data: workspaces, totalPages: 1 });
+      if (method === 'GET' && url.pathname === '/iam/workspace/search') {
+        // Like the real thing: `query` filters by name; the estate is returned
+        // to everyone here (the fake has no idea who is staff), so the SERVICE
+        // is what keeps non-staff to their memberships.
+        const q = (url.searchParams.get('query') ?? '').toLowerCase();
+        const rows = q ? workspaces.filter((w) => w.name.toLowerCase().includes(q)) : workspaces;
+        return json({ data: rows, total: rows.length, totalPages: 1 });
+      }
       if (method === 'POST' && url.pathname === '/iam/workspace') {
         const created: IamWorkspace = {
           id: `ws-new-${workspaces.length}`, name: body.name, account_id: body.account_id, is_active: true,
@@ -126,6 +133,7 @@ describe('WorkspaceService (IAM-backed)', () => {
     const projection = new WorkspaceProjection(
       db,
       new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl, now: () => clock }),
+      { staffDomains: ['staff.test'] },
     );
     const provider = new WorkOsAuthProvider(
       db,
@@ -353,6 +361,138 @@ describe('WorkspaceService (IAM-backed)', () => {
     const list = await svc.refresh(req());
     expect(calls.filter((c) => c.path === '/iam/workspace/search').length).toBe(before + 1);
     expect(list.map((w) => w.accountName).sort()).toEqual(['Late', 'Mine']);
+  });
+});
+
+describe('WorkspaceService (IAM-backed) — staff of the deployment', () => {
+  // Same fake as above, plus a staff person with their own workspace and a
+  // customer workspace they hold no membership in.
+  let db: Db;
+  let svc: WorkspaceService;
+  let calls: Array<{ method: string; path: string }>;
+  let workspaces: IamWorkspace[];
+  const STAFF_SUB = 'sub-staff';
+  const staffToken = signJwtHs256({ sub: STAFF_SUB, account_id: 'acc-staff', email: 's@staff.test', name: 'Staff', exp: 4102444800 }, SECRET);
+  const staffReq = (workspace?: string): ReqLike => ({
+    headers: { authorization: `Bearer ${staffToken}`, ...(workspace ? { [WORKSPACE_HEADER]: workspace } : {}) },
+  });
+  const customerToken = signJwtHs256({ sub: SUB, account_id: IAM_ACCOUNT, email: 'a@x.com', name: 'A', exp: 4102444800 }, SECRET);
+  const customerReq = (): ReqLike => ({ headers: { authorization: `Bearer ${customerToken}` } });
+
+  beforeEach(async () => {
+    db = await createDb('file::memory:');
+    await migrate(db);
+    calls = [];
+    workspaces = [
+      { id: WS_OWN, name: 'Mine', account_id: IAM_ACCOUNT, is_active: true, users: [{ id: 'wu1', user_id: SUB, type: 'OWNER', is_active: true, roles: [] }] },
+      { id: 'ws-staff', name: 'Staff HQ', account_id: 'acc-staff', is_active: true, users: [{ id: 'wu-s', user_id: STAFF_SUB, type: 'OWNER', is_active: true, roles: [] }] },
+      { id: 'ws-other', name: 'Other Corp', account_id: 'acc-other', is_active: true, users: [{ id: 'wu-o', user_id: 'sub-o', type: 'OWNER', is_active: true, roles: [] }] },
+    ];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? 'GET';
+      calls.push({ method, path: url.pathname });
+      if (method === 'GET' && url.pathname.startsWith('/iam/account/')) return json({ id: url.pathname.split('/').pop(), feature_flags: {} });
+      if (method === 'PUT' && url.pathname.startsWith('/iam/account/')) return json({});
+      if (method === 'GET' && url.pathname === '/iam/workspace/search') {
+        const q = (url.searchParams.get('query') ?? '').toLowerCase();
+        const rows = q ? workspaces.filter((w) => w.name.toLowerCase().includes(q)) : workspaces;
+        return json({ data: rows, total: rows.length, totalPages: 1 });
+      }
+      if (method === 'GET' && url.pathname.startsWith('/iam/workspace/')) {
+        const w = workspaces.find((x) => x.id === url.pathname.split('/').pop());
+        return w ? json(w) : new Response('nf', { status: 404 });
+      }
+      return new Response('nope', { status: 404 });
+    };
+    const projection = new WorkspaceProjection(
+      db,
+      new IamWorkspacesClient({ baseUrl: 'https://iam.test/iam', fetchImpl }),
+      { staffDomains: ['staff.test'] },
+    );
+    const provider = new WorkOsAuthProvider(
+      db,
+      { JWT_SECRET: SECRET, JWT_ISSUER: undefined, JWT_AUDIENCE: undefined, SEED_DEMO_FORM: false, ONBOARDING_WIZARD: false },
+      undefined,
+      projection,
+    );
+    svc = new WorkspaceService(db, provider, new AuthService(db, provider), projection);
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('a customer searches only their own workspaces; staff get the estate too, own rows first', async () => {
+    const mine = await svc.search(customerReq(), { query: '' });
+    expect(mine.staff).toBe(false);
+    expect(mine.rows.map((r) => r.name)).toEqual(['Mine']);
+
+    const all = await svc.search(staffReq(), { query: '' });
+    expect(all.staff).toBe(true);
+    expect(all.rows.map((r) => r.name)).toEqual(['Staff HQ', 'Mine', 'Other Corp']);
+    expect(all.rows[0]!.accountId).not.toBeNull(); // own: projected
+    expect(all.rows[1]!.accountId).toBeNull(); // estate: not yet
+    expect(all.rows[1]!.workspaceId).toBe(WS_OWN);
+
+    const some = await svc.search(staffReq(), { query: 'other' });
+    expect(some.rows.map((r) => r.name)).toEqual(['Other Corp']);
+    // Nothing was projected by LOOKING: the customer's own and the staff person's
+    // own workspaces exist locally (their lists projected them); Other Corp does not.
+    const other = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = 'ws-other'`);
+    expect(other).toBeUndefined();
+    const n = await db.get<{ n: number }>(sql`SELECT COUNT(*) AS n FROM account`);
+    expect(Number(n!.n)).toBe(2);
+  });
+
+  it('entering an estate workspace mints an admin grant that is off the roster and never pruned; a customer cannot', async () => {
+    await expect(svc.enterEstateWorkspace(customerReq(), 'ws-other')).rejects.toBeInstanceOf(ForbiddenException);
+
+    const { accountId } = await svc.enterEstateWorkspace(staffReq(), WS_OWN);
+    const row = await db.get<{ role: string; access_grant: string | null; status: string }>(
+      sql`SELECT role, access_grant, status FROM member WHERE account_id = ${accountId} AND external_id = ${STAFF_SUB}`,
+    );
+    expect(row).toMatchObject({ role: 'admin', access_grant: 'staff', status: 'active' });
+    // No onboarding stamp on the customer's account, no demo form.
+    const acc = await db.get<{ onboarding_completed_at: number | null }>(sql`SELECT onboarding_completed_at FROM account WHERE id = ${accountId}`);
+    expect(acc!.onboarding_completed_at).toBeNull();
+
+    // The staff person can act in it (header check passes) and sees it in their list, marked.
+    const list = await svc.list(staffReq());
+    const entry = list.find((w) => w.accountId === accountId)!;
+    expect(entry.role).toBe('admin');
+    expect(entry.accessGrant).toBe('staff');
+    // Their own workspace lists first.
+    expect(list[0]!.accountName).toBe('Staff HQ');
+
+    // The customer's roster does not show them, and the count does not include them.
+    await svc.list(customerReq());
+    const roster = await svc.roster(customerReq());
+    expect(roster.map((m) => m.email)).toEqual(['a@x.com']);
+    const mine = await svc.list(customerReq());
+    expect(mine[0]!.memberCount).toBe(1);
+
+    // A later refresh of the staff person's memberships (the estate workspace is
+    // not among them) leaves the grant alone.
+    await svc.refresh(staffReq());
+    const again = await db.get<{ status: string }>(sql`SELECT status FROM member WHERE account_id = ${accountId} AND external_id = ${STAFF_SUB}`);
+    expect(again!.status).toBe('active');
+    // Idempotent.
+    expect((await svc.enterEstateWorkspace(staffReq(), WS_OWN)).accountId).toBe(accountId);
+  });
+
+  it('a grant turns into a real membership when upstream later names them, and search stops listing it as estate', async () => {
+    const { accountId } = await svc.enterEstateWorkspace(staffReq(), WS_OWN);
+    workspaces[0]!.users!.push({ id: 'wu-s2', user_id: STAFF_SUB, type: 'MEMBER', is_active: true, roles: [] });
+    await svc.refresh(staffReq());
+    const row = await db.get<{ role: string; access_grant: string | null }>(
+      sql`SELECT role, access_grant FROM member WHERE account_id = ${accountId} AND external_id = ${STAFF_SUB}`,
+    );
+    expect(row).toEqual({ role: 'member', access_grant: null });
+    const res = await svc.search(staffReq(), { query: 'mine' });
+    expect(res.rows).toHaveLength(1);
+    expect(res.rows[0]!.accountId).toBe(accountId);
+    expect(res.rows[0]!.accessGrant).toBeNull();
   });
 });
 

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -31,6 +31,7 @@ import {
   getAccountMember,
   getMemberIdentity,
   getMemberUpstreamRef,
+  grantStaffAccess,
   humanHasCompletedOnboarding,
   listMembers,
   listWorkspacesForIdentity,
@@ -39,6 +40,9 @@ import {
   renameAccount,
   sql,
   wouldOrphanWorkspace,
+  type AccessGrant,
+  type AccountRole,
+  type MemberStatus,
   type MemberView,
   type WorkspaceRow,
 } from '@quill/db';
@@ -56,6 +60,21 @@ import {
   userNameOf,
 } from './iam-workspaces';
 import type { WorkspaceProjection } from './workspace-projection';
+
+/** One row of `WorkspaceService.search`: a local workspace, or an estate one not yet projected. */
+export interface WorkspaceSearchRow {
+  /** Upstream workspace id; set only for estate rows the caller holds no local row in. */
+  workspaceId: string | null;
+  /** Local account id; null for an estate row (enter it through `enterEstateWorkspace`). */
+  accountId: string | null;
+  name: string;
+  role: AccountRole;
+  status: MemberStatus;
+  accessGrant: AccessGrant | null;
+  memberCount: number;
+  /** Estate rows only: whether the workspace already has a local account (someone here opened it). */
+  localExists?: boolean;
+}
 
 @Injectable()
 export class WorkspaceService {
@@ -195,6 +214,138 @@ export class WorkspaceService {
     return identity ? listWorkspacesForIdentity(this.db, identity) : [];
   }
 
+  // --- Staff: the whole estate ----------------------------------------------
+
+  /** True when the caller's email domain is one the deployment lists as staff (identity-backed only). */
+  async isStaff(req: ReqLike): Promise<boolean> {
+    const up = await this.upstream(req);
+    return !!(up && this.projection && this.projection.isStaff(up.email));
+  }
+
+  /**
+   * Type-to-find over the workspaces the caller may enter.
+   *
+   * For everyone: their own list (the projection), filtered by name. For the
+   * deployment's STAFF, additionally the whole estate as the identity service
+   * answers its search (the same call the Dapta app's sidebar makes), so a
+   * workspace they never opened here is one keystroke away. Rows carry the
+   * local `accountId` when the caller already holds a row there (a membership
+   * or an earlier grant); otherwise `null`, and entering it goes through
+   * `enterEstateWorkspace`, which mints the grant.
+   */
+  async search(
+    req: ReqLike,
+    input: { query: string; page?: number; limit?: number },
+  ): Promise<{ rows: WorkspaceSearchRow[]; staff: boolean; total: number; totalPages: number; page: number }> {
+    const q = input.query.trim().toLowerCase();
+    const mine = await this.list(req);
+    const mineFiltered = q ? mine.filter((w) => w.accountName.toLowerCase().includes(q)) : mine;
+    const own: WorkspaceSearchRow[] = mineFiltered.map((w) => ({
+      workspaceId: null,
+      accountId: w.accountId,
+      name: w.accountName,
+      role: w.role,
+      status: w.status,
+      accessGrant: w.accessGrant,
+      memberCount: w.memberCount,
+    }));
+
+    const up = await this.upstream(req);
+    if (!up || !this.projection || !this.projection.isStaff(up.email)) {
+      return { rows: own, staff: false, total: own.length, totalPages: 1, page: 1 };
+    }
+
+    // Staff: the estate page from upstream, minus what the own list already
+    // shows (matched by upstream workspace id), so a workspace never appears
+    // twice. Own rows first: they are the ones the person actually works in.
+    const page = await this.projection.iam.searchWorkspaces(up.bearer, {
+      query: q,
+      page: input.page,
+      limit: input.limit,
+    });
+    const ownWsIds = new Set<string>();
+    if (mineFiltered.length) {
+      const ids = mineFiltered.map((w) => sql`${w.accountId}`);
+      const rows = await this.db.all<{ external_id: string | null }>(
+        sql`SELECT external_id FROM account WHERE id IN (${sql.join(ids, sql`, `)})`,
+      );
+      for (const r of rows) if (r.external_id) ownWsIds.add(r.external_id);
+    }
+    const estate: WorkspaceSearchRow[] = [];
+    for (const ws of page.rows) {
+      if (ownWsIds.has(ws.id)) continue;
+      const local = await getAccountByExternalId(this.db, ws.id);
+      estate.push({
+        workspaceId: ws.id,
+        accountId: null,
+        name: ws.name,
+        role: 'admin',
+        status: 'active',
+        accessGrant: 'staff',
+        memberCount: (ws.users ?? []).filter((u) => u.is_active !== false).length,
+        localExists: !!local,
+      });
+    }
+    return {
+      rows: [...(input.page && input.page > 1 ? [] : own), ...estate],
+      staff: true,
+      total: page.total,
+      totalPages: page.totalPages,
+      page: page.page,
+    };
+  }
+
+  /**
+   * A STAFF caller is about to open an estate workspace they hold no upstream
+   * membership in. The workspace is re-read upstream (never trusted from the
+   * client), projected locally if unseen (no onboarding stamp, no demo form,
+   * no signup event) and the caller gets an `admin` row marked
+   * `access_grant = 'staff'`. A caller who DOES hold a membership there is
+   * simply projected as such. Returns the local account id to switch into.
+   */
+  async enterEstateWorkspace(req: ReqLike, workspaceId: string): Promise<{ accountId: string }> {
+    const up = await this.upstream(req);
+    if (!up || !this.projection) {
+      throw new ForbiddenException({ error: 'FORBIDDEN', message: 'Requires the identity service.' });
+    }
+    if (!this.projection.isStaff(up.email)) {
+      throw new ForbiddenException({ error: 'WORKSPACE_FORBIDDEN', message: 'You are not a member of that workspace.' });
+    }
+    let ws;
+    try {
+      ws = await this.projection.iam.getWorkspace(up.bearer, workspaceId);
+    } catch (err) {
+      if (err instanceof IamHttpError && (err.status === 403 || err.status === 404)) {
+        throw new ForbiddenException({ error: 'WORKSPACE_FORBIDDEN', message: 'You are not a member of that workspace.' });
+      }
+      throw err;
+    }
+    if (!ws || ws.is_active === false) {
+      throw new ForbiddenException({ error: 'WORKSPACE_FORBIDDEN', message: 'You are not a member of that workspace.' });
+    }
+    const identity = { externalId: up.sub, email: up.email, displayName: up.displayName };
+    const me = (ws.users ?? []).find((u) => u.user_id === up.sub);
+    let accountId: string;
+    if (me && me.is_active !== false) {
+      // A real membership upstream: project it as such, no grant needed.
+      await this.projection.ensure(up, { force: true });
+      const local = await getAccountByExternalId(this.db, ws.id);
+      if (!local) throw new BadRequestException({ error: 'WORKSPACE_NOT_VISIBLE', message: 'Try refreshing.' });
+      accountId = local.id;
+    } else {
+      accountId = (
+        await grantStaffAccess(this.db, identity, {
+          workspaceId: ws.id,
+          workspaceName: ws.name,
+          iamAccountId: ws.account_id ?? null,
+        })
+      ).accountId;
+      this.log.log(`staff grant: ${up.email ?? up.sub} entered workspace ${ws.id} as admin`);
+    }
+    await this.projection.rememberLastWorkspace(up, accountId);
+    return { accountId };
+  }
+
   // --- Members via the identity service ------------------------------------
 
   /** True when this deployment routes member management upstream. */
@@ -332,6 +483,7 @@ export class WorkspaceService {
         role: input.role === 'admin' ? 'admin' : 'member',
         status: 'invited',
         createdAt: Date.now(),
+        accessGrant: null,
       };
     } catch (err) {
       // 409, or a 400 whose body says "already": the address is taken. Any

--- a/apps/web/app/admin/account/workspaces/workspace-cards.tsx
+++ b/apps/web/app/admin/account/workspaces/workspace-cards.tsx
@@ -175,6 +175,16 @@ export function WorkspaceCards({
                             {labels.invited}
                           </span>
                         ) : null}
+                        {/* In it by the staff grant, not by membership. Same
+                            copy as the rail switcher's badge. */}
+                        {w.accessGrant === 'staff' ? (
+                          <span
+                            data-testid="workspace-staff-badge"
+                            className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-muted-foreground"
+                          >
+                            {labels.createDialog.staff}
+                          </span>
+                        ) : null}
                       </div>
                       <p className="mt-0.5 truncate font-mono text-xs text-faint" title={w.accountCode}>
                         {w.accountCode}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -86,6 +86,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
         accountNav={adminMessages.account.nav}
         workspaces={workspaces}
         currentAccountId={me.accountId}
+        staff={me.staff}
         user={{ displayName: me.displayName, email: me.email }}
       >
         {children}

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
 import { unstable_rethrow } from 'next/navigation';
 import { setWorkspace } from '@/lib/auth-session';
-import { adminApi, ApiError } from '@/lib/admin-api';
+import { adminApi, ApiError, type WorkspaceSearchRow } from '@/lib/admin-api';
 
 /**
  * Enter a different workspace.
@@ -33,6 +33,43 @@ export async function switchWorkspaceAction(accountId: string): Promise<{ error?
 
   await setWorkspace(id);
   // Every admin page is scoped to the account, so all of it is now stale.
+  revalidatePath('/admin', 'layout');
+  redirect('/admin');
+}
+
+/**
+ * Type-to-find over the workspaces the caller may enter (the switcher's search
+ * box). Own workspaces always; the deployment's staff also get the estate. A
+ * failure is an empty result, never an error the menu has to explain.
+ */
+export async function searchWorkspacesAction(
+  q: string,
+): Promise<{ rows: WorkspaceSearchRow[]; staff: boolean }> {
+  try {
+    const res = await adminApi.searchWorkspaces(q.slice(0, 120));
+    return { rows: res.rows, staff: res.staff };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { rows: [], staff: false };
+  }
+}
+
+/**
+ * Staff only: enter an estate workspace the caller holds no membership in. The
+ * API re-reads the workspace upstream, projects it, mints the access grant and
+ * remembers the choice; then this is a plain switch.
+ */
+export async function enterEstateWorkspaceAction(workspaceId: string): Promise<{ error?: string }> {
+  const id = workspaceId.trim();
+  if (!id) return { error: 'unknown' };
+  let accountId: string;
+  try {
+    accountId = (await adminApi.enterEstateWorkspace(id)).accountId;
+  } catch (e) {
+    unstable_rethrow(e);
+    return { error: 'forbidden' };
+  }
+  await setWorkspace(accountId);
   revalidatePath('/admin', 'layout');
   redirect('/admin');
 }

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -183,6 +183,7 @@ export function AdminShell({
   themePref = 'dark',
   workspaces = [],
   currentAccountId,
+  staff = false,
   children,
 }: {
   user: ShellUser | null;
@@ -198,6 +199,8 @@ export function AdminShell({
   workspaces?: Workspace[];
   /** The account these pages are currently scoped to. */
   currentAccountId?: string;
+  /** Staff of the deployment: the switcher's search reaches the whole estate. */
+  staff?: boolean;
   children: ReactNode;
 }) {
   const pathname = usePathname();
@@ -346,6 +349,7 @@ export function AdminShell({
             workspaces={workspaces}
             currentAccountId={currentAccountId}
             collapsed={railCollapsed}
+            staff={staff}
             m={messages.workspaces}
           />
         ) : null}
@@ -392,6 +396,7 @@ export function AdminShell({
           <WorkspaceSwitcher
             workspaces={workspaces}
             currentAccountId={currentAccountId}
+            staff={staff}
             m={messages.workspaces}
           />
         ) : null}

--- a/apps/web/components/workspace-switcher.tsx
+++ b/apps/web/components/workspace-switcher.tsx
@@ -1,51 +1,102 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import type { FormsMessages } from '@quill/shared';
-import type { Workspace } from '@/lib/admin-api';
-import { refreshWorkspacesAction, switchWorkspaceAction } from '@/app/admin/workspace-actions';
+import type { MemberStatus, Workspace, WorkspaceSearchRow } from '@/lib/admin-api';
+import {
+  enterEstateWorkspaceAction,
+  refreshWorkspacesAction,
+  searchWorkspacesAction,
+  switchWorkspaceAction,
+} from '@/app/admin/workspace-actions';
 import { AnchoredMenu } from '@/components/ui/anchored-menu';
 import { CreateWorkspaceDialog } from '@/components/create-workspace-dialog';
-import { callAction } from '@/lib/call-action';
+import { callAction, isTransportError } from '@/lib/call-action';
 
 type Messages = FormsMessages['admin']['chrome']['workspaces'];
+
+/** The search box appears from this many workspaces (the Dapta app shows its own from six). */
+const SEARCH_FROM = 6;
+/** Keystrokes settle for this long before the estate is asked. */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * One line of the menu, whichever list it came from: the caller's own
+ * workspaces (`accountId` set, entered with a plain switch) or, for the
+ * deployment's staff, an estate workspace never opened here (`accountId`
+ * null, `workspaceId` set, entered through the staff grant).
+ */
+interface Row {
+  key: string;
+  accountId: string | null;
+  workspaceId: string | null;
+  name: string;
+  status: MemberStatus;
+  /** Shows the "Staff" badge: in it by grant, or an estate row. */
+  staff: boolean;
+  estate: boolean;
+}
 
 /**
  * Which workspace you are in, how to change it, and how to make a new one.
  *
- * Always rendered — even with a single membership — because the menu is also
+ * Always rendered, even with a single membership, because the menu is also
  * where "New workspace" lives, and that entry point must exist BEFORE there is
  * a second workspace to switch to. Opening the menu re-reads the list from the
  * identity service (when there is one), so a workspace created or joined in the
  * Dapta app appears without waiting for the projection's TTL.
  *
- * Switching is a server action: it rewrites the signed session cookie and
- * reloads. It grants nothing on its own — the API re-checks membership on every
- * request — so the worst a tampered choice can do is 403.
+ * Type-to-find. From six workspaces (or always for the deployment's staff) a
+ * search box sits above the list and takes the caret when the menu opens. An
+ * empty query shows the list as is. A query filters the list client-side at
+ * once (name contains, case-insensitive) and, for staff, also asks the server
+ * after a short debounce: the reply's own rows merge into the list, and the
+ * estate rows (workspaces the person holds no membership in) follow under an
+ * "All workspaces" eyebrow. Replies are tagged with the query they answered, so
+ * a slow reply for an older query is never painted over a newer one.
  *
- * The panel renders through AnchoredMenu — a portal to document.body — because
+ * Switching is a server action: it rewrites the signed session cookie and
+ * reloads. It grants nothing on its own; the API re-checks membership (or the
+ * staff grant) on every request, so the worst a tampered choice can do is 403.
+ *
+ * The panel renders through AnchoredMenu, a portal to document.body, because
  * the rail clips it (overflow-y-auto) and, more importantly, buries it: the
  * rail is its own stacking context, so anything positioned inside <main> paints
  * over it no matter what z-index the panel carries. See anchored-menu.tsx.
  *
  * WAI-ARIA menu-button pattern, matching AppSwitcher: Escape and outside click
- * dismiss, and focus lands on the first item when it opens.
+ * dismiss. Focus lands on the search box when there is one, otherwise on the
+ * first item; ArrowDown/ArrowUp walk the items (and back up into the box) and
+ * Enter in the box picks the first visible row.
  */
 export function WorkspaceSwitcher({
   workspaces,
   currentAccountId,
   collapsed = false,
+  staff = false,
   m,
 }: {
   workspaces: Workspace[];
   currentAccountId: string;
   collapsed?: boolean;
+  /** Staff of the deployment: the search box is always shown and reaches the whole estate. */
+  staff?: boolean;
   m: Messages;
 }) {
   const [open, setOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [pending, start] = useTransition();
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const close = useCallback(() => setOpen(false), []);
   // One refresh per open, never per render: the action revalidates the layout,
   // which re-renders this component with the fresh list.
@@ -60,8 +111,120 @@ export function WorkspaceSwitcher({
     void callAction(() => refreshWorkspacesAction());
   }, [open]);
 
+  const showSearch = staff || workspaces.length >= SEARCH_FROM;
+
+  // ---- type-to-find ------------------------------------------------------
+  const [query, setQuery] = useState('');
+  const needle = query.trim().toLowerCase();
+  // The server's answer, tagged with the query it answered. Only the answer to
+  // the CURRENT query is ever painted; anything else is a stale reply.
+  const [results, setResults] = useState<{ q: string; rows: WorkspaceSearchRow[] } | null>(null);
+  const [searching, setSearching] = useState(false);
+  // Monotonic request counter: a reply is applied only if nothing newer was
+  // sent after it, so a slow answer cannot overwrite a fast one.
+  const requestRef = useRef(0);
+
+  // Reset the box when the menu closes, so it reopens clean.
+  useEffect(() => {
+    if (open) return;
+    setQuery('');
+    setResults(null);
+    setSearching(false);
+    requestRef.current += 1;
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !staff || !needle) {
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const q = needle;
+    const timer = setTimeout(() => {
+      const id = ++requestRef.current;
+      void (async () => {
+        const res = await callAction(() => searchWorkspacesAction(q));
+        if (id !== requestRef.current) return;
+        setResults({ q, rows: isTransportError(res) ? [] : res.rows });
+        setSearching(false);
+      })();
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [open, staff, needle]);
+
+  // Focus the search box once the panel is on screen. AnchoredMenu keeps the
+  // panel `visibility: hidden` until it has measured and placed itself, and a
+  // hidden input ignores `.focus()` without a word, so this retries for a few
+  // frames instead of firing once into the void.
+  useEffect(() => {
+    if (!open || !showSearch) return;
+    let frame = 0;
+    let tries = 0;
+    const attempt = () => {
+      const el = inputRef.current;
+      if (el) {
+        el.focus();
+        if (document.activeElement === el) return;
+      }
+      if (++tries < 10) frame = requestAnimationFrame(attempt);
+    };
+    attempt();
+    return () => cancelAnimationFrame(frame);
+  }, [open, showSearch]);
+
   const current = workspaces.find((w) => w.accountId === currentAccountId);
   const label = current?.accountName ?? m.unknown;
+
+  // Own workspaces first (the prop list, filtered client-side, plus any own row
+  // the server matched that the list does not carry yet), then estate rows.
+  const { own, estate } = useMemo(() => {
+    const ownRows: Row[] = [];
+    const seenAccounts = new Set<string>();
+    for (const w of workspaces) {
+      if (needle && !w.accountName.toLowerCase().includes(needle)) continue;
+      seenAccounts.add(w.accountId);
+      ownRows.push({
+        key: `a:${w.accountId}`,
+        accountId: w.accountId,
+        workspaceId: null,
+        name: w.accountName,
+        status: w.status,
+        staff: w.accessGrant === 'staff',
+        estate: false,
+      });
+    }
+    const estateRows: Row[] = [];
+    const seenWorkspaces = new Set<string>();
+    const fresh = results && results.q === needle && needle ? results.rows : [];
+    for (const r of fresh) {
+      if (r.accountId) {
+        if (seenAccounts.has(r.accountId)) continue;
+        seenAccounts.add(r.accountId);
+        ownRows.push({
+          key: `a:${r.accountId}`,
+          accountId: r.accountId,
+          workspaceId: r.workspaceId,
+          name: r.name,
+          status: r.status,
+          staff: r.accessGrant === 'staff',
+          estate: false,
+        });
+        continue;
+      }
+      if (!r.workspaceId || seenWorkspaces.has(r.workspaceId)) continue;
+      seenWorkspaces.add(r.workspaceId);
+      estateRows.push({
+        key: `w:${r.workspaceId}`,
+        accountId: null,
+        workspaceId: r.workspaceId,
+        name: r.name,
+        status: r.status,
+        staff: true,
+        estate: true,
+      });
+    }
+    return { own: ownRows, estate: estateRows };
+  }, [workspaces, needle, results]);
 
   function choose(accountId: string) {
     if (accountId === currentAccountId) {
@@ -71,6 +234,95 @@ export function WorkspaceSwitcher({
     start(async () => {
       await callAction(() => switchWorkspaceAction(accountId));
     });
+  }
+
+  function pick(row: Row) {
+    if (row.accountId) {
+      choose(row.accountId);
+      return;
+    }
+    const workspaceId = row.workspaceId;
+    if (!workspaceId) return;
+    start(async () => {
+      await callAction(() => enterEstateWorkspaceAction(workspaceId));
+    });
+  }
+
+  // Roving focus over the real buttons: ArrowDown/ArrowUp walk every
+  // `[role="menuitem"]` in DOM order; ArrowUp from the first climbs back into
+  // the search box when there is one.
+  function onListKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+    );
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement | null;
+    const at = active ? items.indexOf(active) : -1;
+    e.preventDefault();
+    if (e.key === 'ArrowDown') {
+      items[at < 0 || at === items.length - 1 ? 0 : at + 1]?.focus();
+      return;
+    }
+    if (at <= 0) {
+      if (inputRef.current) inputRef.current.focus();
+      else items[items.length - 1]?.focus();
+      return;
+    }
+    items[at - 1]?.focus();
+  }
+
+  // Enter picks the first visible row. Arrows bubble to the wrapper
+  // (onListKeyDown). Everything else is plain typing: nothing global listens
+  // for letters, and Escape must keep bubbling so AnchoredMenu can close.
+  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    const first = own[0] ?? estate[0];
+    if (first) pick(first);
+  }
+
+  const showEmpty =
+    !!needle && own.length === 0 && (!staff || (!searching && estate.length === 0));
+
+  const rowClass =
+    'flex items-center gap-2 px-2.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none';
+
+  function renderRow(row: Row) {
+    const active = row.accountId !== null && row.accountId === currentAccountId;
+    return (
+      <button
+        key={row.key}
+        type="button"
+        role="menuitem"
+        data-testid="workspace-option"
+        data-account-id={row.accountId ?? undefined}
+        data-workspace-id={row.workspaceId ?? undefined}
+        onClick={() => pick(row)}
+        className={rowClass}
+      >
+        <i
+          aria-hidden
+          className={`pi ${active ? 'pi-check text-primary' : 'pi-circle-off opacity-0'}`}
+          style={{ fontSize: 11 }}
+        />
+        <span className="min-w-0 flex-1 truncate">{row.name}</span>
+        {/* An invitation you have not opened yet. Naming it is the difference
+            between "why are there two?" and "ah, that one is waiting for me." */}
+        {row.status === 'invited' && !row.estate ? (
+          <span className="shrink-0 rounded-sm bg-secondary/15 px-1.5 py-0.5 text-2xs font-medium text-secondary">
+            {m.invited}
+          </span>
+        ) : null}
+        {/* In it by the staff grant, not by membership: neutral, so it never
+            reads as an invitation or a warning. */}
+        {row.staff ? (
+          <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+            {m.staff}
+          </span>
+        ) : null}
+      </button>
+    );
   }
 
   return (
@@ -109,62 +361,94 @@ export function WorkspaceSwitcher({
       </button>
 
       {/* Matches the trigger in the expanded rail; in the collapsed rail the
-          trigger is a 48px square, so the floor keeps the names readable. */}
+          trigger is a 48px square, so the floor keeps the names readable. With
+          a search box the floor is wider still, so a query has room to be
+          read back. */}
       <AnchoredMenu
         anchorRef={triggerRef}
         open={open}
         onClose={close}
         label={m.menuLabel}
         width="anchor"
-        minWidth={200}
-        autoFocus
+        minWidth={showSearch ? 240 : 200}
+        autoFocus={!showSearch}
         className="flex flex-col overflow-hidden py-1"
         testId="workspace-switcher-menu"
       >
-        <p className="px-2.5 py-1 text-2xs font-medium uppercase tracking-wide text-faint">
-          {m.eyebrow}
-        </p>
-        {workspaces.map((w) => {
-          const active = w.accountId === currentAccountId;
-          return (
-            <button
-              key={w.accountId}
-              type="button"
-              role="menuitem"
-              onClick={() => choose(w.accountId)}
-              className="flex items-center gap-2 px-2.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
-            >
+        <div ref={listRef} onKeyDown={onListKeyDown} className="flex flex-col">
+          {showSearch ? (
+            <label className="relative mx-2 my-1 block">
               <i
                 aria-hidden
-                className={`pi ${active ? 'pi-check text-primary' : 'pi-circle-off opacity-0'}`}
-                style={{ fontSize: 11 }}
+                className="pi pi-search pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+                style={{ fontSize: 12 }}
               />
-              <span className="min-w-0 flex-1 truncate">{w.accountName}</span>
-              {/* An invitation you have not opened yet. Naming it is the
-                  difference between "why are there two?" and "ah, that one is
-                  waiting for me." */}
-              {w.status === 'invited' ? (
-                <span className="shrink-0 rounded-sm bg-secondary/15 px-1.5 py-0.5 text-2xs font-medium text-secondary">
-                  {m.invited}
-                </span>
-              ) : null}
-            </button>
-          );
-        })}
-        <div className="my-1 border-t border-border" />
-        <button
-          type="button"
-          role="menuitem"
-          data-testid="workspace-create"
-          onClick={() => {
-            setOpen(false);
-            setCreating(true);
-          }}
-          className="flex items-center gap-2 px-2.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
-        >
-          <i aria-hidden className="pi pi-plus text-muted-foreground" style={{ fontSize: 11 }} />
-          <span className="min-w-0 flex-1 truncate">{m.create}</span>
-        </button>
+              <input
+                ref={inputRef}
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder={m.search}
+                aria-label={m.search}
+                autoComplete="off"
+                spellCheck={false}
+                data-testid="workspace-search-input"
+                className="w-full rounded-md border border-input bg-background py-1.5 pl-7 pr-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+          ) : null}
+
+          <p className="px-2.5 py-1 text-2xs font-medium uppercase tracking-wide text-faint">
+            {m.eyebrow}
+          </p>
+          {own.map(renderRow)}
+
+          {estate.length > 0 ? (
+            <>
+              <p className="mt-1 px-2.5 py-1 text-2xs font-medium uppercase tracking-wide text-faint">
+                {m.estate}
+              </p>
+              {estate.map(renderRow)}
+            </>
+          ) : null}
+
+          {staff && needle && searching ? (
+            <p
+              role="status"
+              className="flex items-center gap-2 px-2.5 py-1.5 text-sm text-muted-foreground"
+              data-testid="workspace-searching"
+            >
+              <i aria-hidden className="pi pi-spinner pi-spin" style={{ fontSize: 11 }} />
+              <span>{m.searching}</span>
+            </p>
+          ) : null}
+
+          {showEmpty ? (
+            <p
+              role="status"
+              className="px-2.5 py-1.5 text-sm text-muted-foreground"
+              data-testid="workspace-search-empty"
+            >
+              {m.searchEmpty}
+            </p>
+          ) : null}
+
+          <div className="my-1 border-t border-border" />
+          <button
+            type="button"
+            role="menuitem"
+            data-testid="workspace-create"
+            onClick={() => {
+              setOpen(false);
+              setCreating(true);
+            }}
+            className={rowClass}
+          >
+            <i aria-hidden className="pi pi-plus text-muted-foreground" style={{ fontSize: 11 }} />
+            <span className="min-w-0 flex-1 truncate">{m.create}</span>
+          </button>
+        </div>
       </AnchoredMenu>
 
       <CreateWorkspaceDialog open={creating} onClose={() => setCreating(false)} m={m} />

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -110,6 +110,33 @@ export interface Workspace {
   status: MemberStatus;
   /** Active members in that workspace. */
   memberCount: number;
+  /** `'staff'` when the person is in it by access grant (deployment staff), not by membership. */
+  accessGrant: 'staff' | null;
+}
+
+/**
+ * One row of the type-to-find search: a workspace of the caller's own list, or
+ * (staff only) one of the estate they never opened here (`accountId` null:
+ * enter it with `enterEstateWorkspace`).
+ */
+export interface WorkspaceSearchRow {
+  workspaceId: string | null;
+  accountId: string | null;
+  name: string;
+  role: AccountRole;
+  status: MemberStatus;
+  accessGrant: 'staff' | null;
+  memberCount: number;
+  localExists?: boolean;
+}
+
+export interface WorkspaceSearchResponse {
+  rows: WorkspaceSearchRow[];
+  /** Whether the caller is staff of the deployment (the estate is searchable). */
+  staff: boolean;
+  total: number;
+  totalPages: number;
+  page: number;
 }
 
 /** Why a webhook test delivery failed — mirrors `WebhookPingReason` in the API. */
@@ -163,6 +190,10 @@ export interface Me {
    * campaign, which is most of the reason to measure it.
    */
   attribution: Record<string, string | number | null | undefined> | null;
+  /** `'staff'` when the caller is in this workspace by access grant, not by membership. */
+  accessGrant: 'staff' | null;
+  /** Staff of the deployment (by email domain, identity-backed only): may search and enter the whole estate. */
+  staff: boolean;
 }
 
 /**
@@ -598,6 +629,12 @@ export const adminApi = {
     req<{ accountId: string; name: string }>('PATCH', '/v1/workspaces/current', { name }, opts),
   /** Tell the API the caller is about to open this workspace (membership re-checked; remembered upstream). */
   enterWorkspace: (accountId: string) => req<{ ok: true }>('POST', `/v1/workspaces/${accountId}/enter`),
+  /** Type-to-find: own workspaces filtered by name; staff also get the estate. */
+  searchWorkspaces: (q: string, page = 1) =>
+    req<WorkspaceSearchResponse>('GET', `/v1/workspaces/search?q=${encodeURIComponent(q)}&page=${page}`),
+  /** Staff only: open an estate workspace (an access grant is minted); returns the local account id. */
+  enterEstateWorkspace: (workspaceId: string) =>
+    req<{ accountId: string }>('POST', `/v1/workspaces/estate/${encodeURIComponent(workspaceId)}/enter`),
   /** Send one sample delivery to a form's webhook (admin-only, SSRF-guarded server-side). */
   pingWebhook: (id: string) =>
     req<WebhookPingResult>('POST', `/v1/forms/${id}/destinations/webhook/ping`),

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -222,6 +222,21 @@ export const serverEnvSchema = z.object({
   // read from / written to the IAM with the caller's bearer, and the local
   // account/member rows are a projection. Unset = local-only workspaces.
   IAM_BASE_URL: z.string().url().optional(),
+  // Staff of the deployment, by email domain (comma-separated, no `@`). With
+  // the identity service configured, a person whose email is on one of these
+  // domains may search the WHOLE estate and enter any workspace, as an admin,
+  // the way the Dapta app lets its team; the row minted for that carries
+  // `member.access_grant = 'staff'` and is never shown on the team's roster.
+  // Unset (the default, every fork) = nobody is staff.
+  IAM_STAFF_DOMAINS: z
+    .string()
+    .optional()
+    .transform((v) =>
+      (v ?? '')
+        .split(',')
+        .map((d) => d.trim().toLowerCase().replace(/^@/, ''))
+        .filter(Boolean),
+    ),
   IAM_API_KEY: z.string().optional(),
   DAPTA_SYNC_FLOW_URL: z.string().url().optional(),
   DAPTA_SYNC_FLOW_KEY: z.string().optional(),

--- a/packages/db/migrations/postgres/0016_member_access_grant.sql
+++ b/packages/db/migrations/postgres/0016_member_access_grant.sql
@@ -1,0 +1,17 @@
+-- Staff access grants: additive.
+--
+-- A member row can now say WHY the person is in the workspace when the identity
+-- service holds no membership for them:
+--
+--   member.access_grant  — NULL for a real membership (invited, accepted, or
+--                          projected from the identity service); 'staff' for a
+--                          row minted because the person's email domain is one
+--                          the deployment lists as staff (IAM_STAFF_DOMAINS),
+--                          who may enter any workspace of the estate the way the
+--                          Dapta app lets them.
+--
+-- Grant rows are excluded from rosters and member counts (a customer's team
+-- list never shows staff), never carry `iam_workspace_user_id`, never stamp
+-- onboarding on the accounts they create, and are never pruned by the
+-- membership projection (their lifecycle is the grant's, not upstream's).
+ALTER TABLE member ADD COLUMN IF NOT EXISTS access_grant TEXT;

--- a/packages/db/migrations/sqlite/0016_member_access_grant.sql
+++ b/packages/db/migrations/sqlite/0016_member_access_grant.sql
@@ -1,0 +1,2 @@
+-- Staff access grants: additive. See the Postgres twin for the why.
+ALTER TABLE member ADD COLUMN access_grant TEXT;

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -100,6 +100,8 @@ export interface MeView {
    * un-sliceable by campaign, which is most of the reason to measure it.
    */
   attribution: Attribution | null;
+  /** `'staff'` when the caller is in this workspace by access grant, not by membership (0016). */
+  accessGrant: 'staff' | null;
 }
 
 /** The authenticated host's identity for the dashboard header + settings. */
@@ -115,9 +117,10 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     status: string;
     onboarding_completed_at: number | null;
     attribution: unknown;
+    access_grant: string | null;
   }>(
     sql`SELECT a.code, a.name, a.vanity_slug, a.onboarding_completed_at, a.attribution,
-               m.handle, m.display_name, m.email, m.role, m.status
+               m.handle, m.display_name, m.email, m.role, m.status, m.access_grant
         FROM account a JOIN member m ON m.account_id = a.id
         WHERE a.id = ${accountId} AND m.id = ${memberId} LIMIT 1`,
   );
@@ -142,6 +145,7 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     // a stale blob must not throw inside the request that renders every
     // dashboard page. Unreadable tags degrade to "not known", never to a 500.
     attribution: parseAttributionColumn(row.attribution),
+    accessGrant: row.access_grant === 'staff' ? 'staff' : null,
   };
 }
 

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -23,6 +23,9 @@ export type AccountRole = (typeof ACCOUNT_ROLES)[number];
 export const MEMBER_STATUSES = ['active', 'invited', 'disabled'] as const;
 export type MemberStatus = (typeof MEMBER_STATUSES)[number];
 
+/** Why a member row exists when the identity service holds no membership: staff of the deployment. */
+export type AccessGrant = 'staff';
+
 export interface MemberView {
   id: string;
   email: string | null;
@@ -32,6 +35,8 @@ export interface MemberView {
   role: AccountRole;
   status: MemberStatus;
   createdAt: number;
+  /** `null` for a real membership; `'staff'` for a domain-based access grant (0016). */
+  accessGrant: AccessGrant | null;
 }
 
 interface MemberDbRow {
@@ -43,6 +48,7 @@ interface MemberDbRow {
   role: string;
   status: string;
   created_at: number;
+  access_grant: string | null;
 }
 
 function toMemberView(r: MemberDbRow): MemberView {
@@ -55,15 +61,21 @@ function toMemberView(r: MemberDbRow): MemberView {
     role: (r.role as AccountRole) ?? 'member',
     status: (r.status as MemberStatus) ?? 'active',
     createdAt: r.created_at,
+    accessGrant: r.access_grant === 'staff' ? 'staff' : null,
   };
 }
 
-const MEMBER_COLS = sql`id, email, display_name, handle, avatar_url, role, status, created_at`;
+const MEMBER_COLS = sql`id, email, display_name, handle, avatar_url, role, status, created_at, access_grant`;
 
-/** All members of an account, oldest first (owner typically leads). */
+/**
+ * The ROSTER of an account, oldest first (owner typically leads). Access-grant
+ * rows are not on it: a customer's team list never shows the deployment's
+ * staff, and a staff row is not something the team can manage.
+ */
 export async function listMembers(db: Db, accountId: string): Promise<MemberView[]> {
   const rows = await db.all<MemberDbRow>(
-    sql`SELECT ${MEMBER_COLS} FROM member WHERE account_id = ${accountId} ORDER BY created_at ASC, id ASC`,
+    sql`SELECT ${MEMBER_COLS} FROM member WHERE account_id = ${accountId} AND access_grant IS NULL
+        ORDER BY created_at ASC, id ASC`,
   );
   return rows.map(toMemberView);
 }
@@ -272,6 +284,8 @@ export interface WorkspaceRow {
   status: MemberStatus;
   /** How many ACTIVE members the workspace has (the account-settings cards show it). */
   memberCount: number;
+  /** `'staff'` when the person is in this workspace by access grant, not by membership. */
+  accessGrant: AccessGrant | null;
 }
 
 /**
@@ -333,13 +347,15 @@ export async function listWorkspacesForIdentity(
     role: string;
     status: string;
     member_count: number | string;
+    access_grant: string | null;
   }>(
-    sql`SELECT a.id AS account_id, a.code, a.name, m.id AS member_id, m.role, m.status,
-               (SELECT COUNT(*) FROM member mm WHERE mm.account_id = a.id AND mm.status = 'active') AS member_count
+    sql`SELECT a.id AS account_id, a.code, a.name, m.id AS member_id, m.role, m.status, m.access_grant,
+               (SELECT COUNT(*) FROM member mm
+                 WHERE mm.account_id = a.id AND mm.status = 'active' AND mm.access_grant IS NULL) AS member_count
         FROM member m JOIN account a ON a.id = m.account_id
         WHERE m.status IN ('active', 'invited')
           AND (${sql.join(conds, sql` OR `)})
-        ORDER BY a.name ASC, a.created_at ASC`,
+        ORDER BY (m.access_grant IS NOT NULL) ASC, a.name ASC, a.created_at ASC`,
   );
 
   // The same account can match on both keys (one row, two predicates) — and in
@@ -363,6 +379,7 @@ export async function listWorkspacesForIdentity(
         : 'active',
       // Postgres returns COUNT(*) as a bigint string; SQLite as a number.
       memberCount: Number(r.member_count ?? 0),
+      accessGrant: r.access_grant === 'staff' ? 'staff' : null,
     });
   }
   return out;

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -72,6 +72,8 @@ export const member = pgTable(
     lastSeenAt: bigint('last_seen_at', { mode: 'number' }),
     /** The upstream `workspace_users.id` for this membership (see 0015); NULL when the identity service does not know it. */
     iamWorkspaceUserId: text('iam_workspace_user_id'),
+    /** NULL for a real membership; 'staff' for a domain-based access grant (0016). */
+    accessGrant: text('access_grant'),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
   },
   (t) => ({

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -82,6 +82,8 @@ export const member = sqliteTable(
     lastSeenAt: integer('last_seen_at'),
     /** The upstream `workspace_users.id` for this membership (see 0015); NULL when the identity service does not know it. */
     iamWorkspaceUserId: text('iam_workspace_user_id'),
+    /** NULL for a real membership; 'staff' for a domain-based access grant (0016). */
+    accessGrant: text('access_grant'),
     createdAt: integer('created_at').notNull(),
   },
   (t) => ({

--- a/packages/db/src/workspaces.spec.ts
+++ b/packages/db/src/workspaces.spec.ts
@@ -20,9 +20,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { createDb, sql, type Db } from './client';
 import { migrate } from './migrate';
-import { listWorkspacesForIdentity } from './members';
+import { listMembers, listWorkspacesForIdentity } from './members';
 import {
   createLocalWorkspace,
+  grantStaffAccess,
   humanHasCompletedOnboarding,
   pickHomeAccount,
   projectMemberships,
@@ -214,5 +215,46 @@ describe('pickHomeAccount + createLocalWorkspace', () => {
     created.push(local.accountId);
     const list = await listWorkspacesForIdentity(db, { externalId: SUB, email: null });
     expect(list.find((w) => w.accountId === local.accountId)!.role).toBe('owner');
+  });
+});
+
+describe('grantStaffAccess (both dialects)', () => {
+  it('mints an admin grant row that is off the roster and count, keeps the owner first for home, and is not pruned', async () => {
+    const wsId = `ws-${randomUUID()}`;
+    const staff = { externalId: `staff-${randomUUID()}`, email: 's@example.test', displayName: 'S' };
+    const staffHome = `ws-${randomUUID()}`;
+    // The staff person's own workspace first, then the grant.
+    await projectMemberships(db, staff, [
+      { workspaceId: staffHome, workspaceName: 'HQ', iamAccountId: 'acc-s', workspaceUserId: 'wu-s', role: 'owner', active: true },
+    ]);
+    const { accountId, memberId } = await grantStaffAccess(db, staff, { workspaceId: wsId, workspaceName: 'Cust', iamAccountId: 'acc-c' });
+    await ids([wsId, staffHome]);
+    const same = await grantStaffAccess(db, staff, { workspaceId: wsId, workspaceName: 'Cust', iamAccountId: 'acc-c' });
+    expect(same.memberId).toBe(memberId);
+
+    // The customer's owner arrives later: still the FIRST member, still gets onboarding owed.
+    const owner = { externalId: `own-${randomUUID()}`, email: 'o@example.test', displayName: 'O' };
+    const res = await projectMemberships(db, owner, [
+      { workspaceId: wsId, workspaceName: 'Cust', iamAccountId: 'acc-c', workspaceUserId: 'wu-o', role: 'owner', active: true },
+    ], { inheritOnboarding: true });
+    expect(res.created[0]!.isFirstMember).toBe(true);
+    const acc = await db.get<{ onboarding_completed_at: number | null }>(sql`SELECT onboarding_completed_at FROM account WHERE id = ${accountId}`);
+    expect(acc!.onboarding_completed_at).toBeNull(); // the account pre-existed (grant), so no stamp: the wizard is still owed
+
+    // Roster and count exclude the grant; the owner's list shows one member.
+    expect((await listMembers(db, accountId)).map((m) => m.email)).toEqual(['o@example.test']);
+    const ownerList = await listWorkspacesForIdentity(db, { externalId: owner.externalId, email: null });
+    expect(ownerList[0]!.memberCount).toBe(1);
+    // The staff list shows both, own first, the grant marked.
+    const staffList = await listWorkspacesForIdentity(db, { externalId: staff.externalId, email: null });
+    expect(staffList.map((w) => [w.accountName, w.accessGrant])).toEqual([['HQ', null], ['Cust', 'staff']]);
+    // Home falls back to the real membership.
+    expect((await pickHomeAccount(db, staff.externalId, null))!.accountId).not.toBe(accountId);
+    // A membership refresh that does not name the grant leaves it active.
+    await projectMemberships(db, staff, [
+      { workspaceId: staffHome, workspaceName: 'HQ', iamAccountId: 'acc-s', workspaceUserId: 'wu-s', role: 'owner', active: true },
+    ]);
+    const g = await db.get<{ status: string }>(sql`SELECT status FROM member WHERE id = ${memberId}`);
+    expect(g!.status).toBe('active');
   });
 });

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -15,7 +15,7 @@
 import { randomUUID } from 'node:crypto';
 import { sql, type Db } from './client';
 import { deriveUniqueHandle, insertAccountWithShortCode } from './short-links';
-import { ACCOUNT_ROLES, type AccountRole } from './members';
+import { ACCOUNT_ROLES, type AccessGrant, type AccountRole } from './members';
 
 /** One upstream membership, as the API layer hands it to the projection. */
 export interface ProjectedMembership {
@@ -29,6 +29,13 @@ export interface ProjectedMembership {
   role: AccountRole;
   /** Upstream `is_active` on the membership row. */
   active: boolean;
+  /**
+   * `'staff'` when this is not a membership upstream at all but an access grant
+   * (the person's email domain is one the deployment lists as staff). Grant
+   * rows never stamp onboarding on the accounts they create, are excluded from
+   * rosters and counts, and are not pruned by a later membership projection.
+   */
+  accessGrant?: AccessGrant | null;
 }
 
 /** The identity being projected — always the authenticated principal, never the request. */
@@ -43,7 +50,13 @@ export interface ProjectionResult {
   /** Local account ids for every ACTIVE upstream membership, in input order. */
   accountIds: string[];
   /** Local `(accountId, memberId)` pairs whose member row was CREATED by this run. */
-  created: Array<{ accountId: string; memberId: string; role: AccountRole; isFirstMember: boolean }>;
+  created: Array<{
+    accountId: string;
+    memberId: string;
+    role: AccountRole;
+    isFirstMember: boolean;
+    accessGrant: AccessGrant | null;
+  }>;
   /** Local account ids that were CREATED by this run (a workspace never seen before). */
   createdAccounts: string[];
 }
@@ -152,7 +165,16 @@ export async function projectMemberships(
   db: Db,
   identity: ProjectedIdentity,
   memberships: ProjectedMembership[],
-  opts: { inheritOnboarding?: boolean; now?: number } = {},
+  opts: {
+    inheritOnboarding?: boolean;
+    now?: number;
+    /**
+     * Whether rows this identity holds in projected accounts that `memberships`
+     * does not name are set `disabled` (default). A single-workspace grant
+     * (`grantStaffAccess`) passes false: it adds one row, it is not the list.
+     */
+    pruneMissing?: boolean;
+  } = {},
 ): Promise<ProjectionResult> {
   const now = opts.now ?? Date.now();
   const result: ProjectionResult = { accountIds: [], created: [], createdAccounts: [] };
@@ -161,6 +183,7 @@ export async function projectMemberships(
   for (const m of memberships) {
     if (!m.active) continue;
     const role: AccountRole = (ACCOUNT_ROLES as readonly string[]).includes(m.role) ? m.role : 'member';
+    const grant: AccessGrant | null = m.accessGrant === 'staff' ? 'staff' : null;
 
     let account = await getAccountByExternalId(db, m.workspaceId);
     let accountCreated = false;
@@ -173,7 +196,9 @@ export async function projectMemberships(
       if (!account) throw new Error(`projection: could not create account for workspace ${m.workspaceId}`);
       accountCreated = true;
       result.createdAccounts.push(account.id);
-      if (opts.inheritOnboarding) {
+      // A grant never stamps onboarding: the account belongs to whoever owns
+      // the workspace upstream, and THEIR first login must still get the wizard.
+      if (opts.inheritOnboarding && !grant) {
         await db.run(
           sql`UPDATE account SET onboarding_completed_at = ${now}
               WHERE id = ${account.id} AND onboarding_completed_at IS NULL`,
@@ -194,10 +219,12 @@ export async function projectMemberships(
       // Upstream is the authority on role and on being active. `disabled`
       // locally is revived here on purpose: the identity service says this
       // membership is active NOW, and it is the only place a membership can be
-      // revoked or restored from.
+      // revoked or restored from. A real membership also clears an earlier
+      // grant (the person was staff-granted, then actually invited).
       await db.run(
         sql`UPDATE member SET role = ${role}, status = 'active',
               iam_workspace_user_id = COALESCE(${m.workspaceUserId}, iam_workspace_user_id),
+              access_grant = ${grant},
               email = COALESCE(email, ${identity.email}),
               display_name = COALESCE(display_name, ${identity.displayName})
             WHERE id = ${existing.id} AND account_id = ${account.id}`,
@@ -217,27 +244,30 @@ export async function projectMemberships(
         await db.run(
           sql`UPDATE member SET external_id = ${identity.externalId}, status = 'active', role = ${role},
                 iam_workspace_user_id = COALESCE(${m.workspaceUserId}, iam_workspace_user_id),
+                access_grant = ${grant},
                 display_name = COALESCE(display_name, ${identity.displayName})
               WHERE id = ${invited.id} AND account_id = ${account.id}`,
         );
       } else {
+        // "First member" counts real memberships only: a staff grant that got
+        // here first must not steal the owner's welcome (demo form, signup).
         const others = await db.get<{ id: string }>(
-          sql`SELECT id FROM member WHERE account_id = ${account.id} LIMIT 1`,
+          sql`SELECT id FROM member WHERE account_id = ${account.id} AND access_grant IS NULL LIMIT 1`,
         );
         const id = randomUUID();
         const handle = await deriveUniqueHandle(db, account.id, identity.displayName, identity.email);
         await db.run(
           sql`INSERT INTO member (id, account_id, external_id, email, display_name, handle, role, status,
-                iam_workspace_user_id, created_at)
+                iam_workspace_user_id, access_grant, created_at)
               VALUES (${id}, ${account.id}, ${identity.externalId}, ${identity.email}, ${identity.displayName},
-                ${handle}, ${role}, 'active', ${m.workspaceUserId}, ${now})
+                ${handle}, ${role}, 'active', ${m.workspaceUserId}, ${grant}, ${now})
               ON CONFLICT (account_id, external_id) DO NOTHING`,
         );
         const row = await db.get<{ id: string }>(
           sql`SELECT id FROM member WHERE account_id = ${account.id} AND external_id = ${identity.externalId} LIMIT 1`,
         );
         if (row && row.id === id) {
-          result.created.push({ accountId: account.id, memberId: id, role, isFirstMember: !others || accountCreated });
+          result.created.push({ accountId: account.id, memberId: id, role, isFirstMember: !others, accessGrant: grant });
         }
       }
     }
@@ -247,17 +277,57 @@ export async function projectMemberships(
 
   // Memberships upstream no longer names (or names as inactive): disable the
   // local rows this identity holds in PROJECTED accounts only. A purely local
-  // account (never synced) is outside the identity service's authority.
-  const held = await db.all<{ id: string; account_id: string }>(
-    sql`SELECT m.id, m.account_id FROM member m JOIN account a ON a.id = m.account_id
-        WHERE m.external_id = ${identity.externalId} AND m.status = 'active' AND a.synced_at IS NOT NULL`,
-  );
-  for (const h of held) {
-    if (seenAccountIds.has(h.account_id)) continue;
-    await db.run(sql`UPDATE member SET status = 'disabled' WHERE id = ${h.id} AND account_id = ${h.account_id}`);
+  // account (never synced) is outside the identity service's authority, and so
+  // is a grant row: upstream never named it, so its absence says nothing.
+  if (opts.pruneMissing !== false) {
+    const held = await db.all<{ id: string; account_id: string }>(
+      sql`SELECT m.id, m.account_id FROM member m JOIN account a ON a.id = m.account_id
+          WHERE m.external_id = ${identity.externalId} AND m.status = 'active' AND a.synced_at IS NOT NULL
+            AND m.access_grant IS NULL`,
+    );
+    for (const h of held) {
+      if (seenAccountIds.has(h.account_id)) continue;
+      await db.run(sql`UPDATE member SET status = 'disabled' WHERE id = ${h.id} AND account_id = ${h.account_id}`);
+    }
   }
 
   return result;
+}
+
+/**
+ * Let a STAFF identity into one workspace it holds no upstream membership in:
+ * the account is projected (created if unseen, without an onboarding stamp)
+ * and the person gets an `admin` row marked `access_grant = 'staff'`. Nothing
+ * else this identity holds is touched. Idempotent. Returns the local ids.
+ */
+export async function grantStaffAccess(
+  db: Db,
+  identity: ProjectedIdentity,
+  workspace: { workspaceId: string; workspaceName: string; iamAccountId: string | null },
+  opts: { now?: number } = {},
+): Promise<{ accountId: string; memberId: string }> {
+  await projectMemberships(
+    db,
+    identity,
+    [
+      {
+        workspaceId: workspace.workspaceId,
+        workspaceName: workspace.workspaceName,
+        iamAccountId: workspace.iamAccountId,
+        workspaceUserId: null,
+        role: 'admin',
+        active: true,
+        accessGrant: 'staff',
+      },
+    ],
+    { inheritOnboarding: false, pruneMissing: false, now: opts.now },
+  );
+  const row = await db.get<{ account_id: string; id: string }>(
+    sql`SELECT m.account_id, m.id FROM member m JOIN account a ON a.id = m.account_id
+        WHERE a.external_id = ${workspace.workspaceId} AND m.external_id = ${identity.externalId} LIMIT 1`,
+  );
+  if (!row) throw new Error(`grant: no member row for ${identity.externalId} in ${workspace.workspaceId}`);
+  return { accountId: row.account_id, memberId: row.id };
 }
 
 /**
@@ -278,10 +348,13 @@ export async function pickHomeAccount(
     );
     if (preferred) return { accountId: preferred.account_id, memberId: preferred.member_id };
   }
+  // A real membership beats a grant as the fallback home: staff who never
+  // opened anything land in their own workspace, not in a customer's.
   const row = await db.get<{ account_id: string; member_id: string }>(
     sql`SELECT m.account_id, m.id AS member_id FROM member m JOIN account a ON a.id = m.account_id
         WHERE m.external_id = ${externalId} AND m.status = 'active'
-        ORDER BY (m.last_seen_at IS NULL) ASC, m.last_seen_at DESC, m.created_at ASC LIMIT 1`,
+        ORDER BY (m.access_grant IS NOT NULL) ASC, (m.last_seen_at IS NULL) ASC, m.last_seen_at DESC, m.created_at ASC
+        LIMIT 1`,
   );
   return row ? { accountId: row.account_id, memberId: row.member_id } : null;
 }

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -174,6 +174,14 @@ export interface FormsMessages {
         createErrorInvalid: string;
         createErrorForbidden: string;
         createErrorFailed: string;
+        /** Type-to-find inside the menu (shown from six workspaces, or always for staff). */
+        search: string;
+        searching: string;
+        searchEmpty: string;
+        /** Marks a workspace the person is in by access grant (deployment staff), or an estate row. */
+        staff: string;
+        /** Eyebrow over estate rows the person never opened here (staff only). */
+        estate: string;
       };
     };
     /** The dashboard home (/admin) — greeting, public link, stats, quick actions. */
@@ -1733,6 +1741,11 @@ export const en: FormsMessages = {
         createErrorInvalid: 'Give the workspace a name (up to 80 characters).',
         createErrorForbidden: 'Your account cannot create workspaces.',
         createErrorFailed: 'Could not create the workspace. Try again.',
+        search: 'Find a workspace',
+        searching: 'Searching',
+        searchEmpty: 'No workspace matches that.',
+        staff: 'Staff',
+        estate: 'All workspaces',
       },
     },
     home: {
@@ -3181,6 +3194,11 @@ export const es: FormsMessages = {
         createErrorInvalid: 'Ponle un nombre al workspace (hasta 80 caracteres).',
         createErrorForbidden: 'Tu cuenta no puede crear workspaces.',
         createErrorFailed: 'No se pudo crear el workspace. Intenta de nuevo.',
+        search: 'Buscar workspace',
+        searching: 'Buscando',
+        searchEmpty: 'Ningún workspace coincide.',
+        staff: 'Staff',
+        estate: 'Todos los workspaces',
       },
     },
     home: {


### PR DESCRIPTION
## What

Two things the Dapta app already does, brought to Forms:

1. **Type to find a workspace.** The switcher's menu has a search box (from six workspaces, or always for staff). Typing filters your own workspaces instantly; ArrowDown/ArrowUp walk the rows, Enter picks the first, Escape closes. Own workspaces list first.
2. **Staff see the whole estate.** `IAM_STAFF_DOMAINS` (comma-separated email domains; unset = nobody, so forks are unaffected) names the deployment's staff. With the identity service configured, a person on one of those domains also searches the estate the way the Dapta app's sidebar does (`GET /workspace/search?query=`, which the identity service already answers estate-wide for them; verified live on dev with a staff bearer) and can enter any workspace of it.

## How access is granted (and kept honest)

Nothing is projected by looking. Entering an estate workspace re-reads it upstream, projects it if unseen (no onboarding stamp, no demo form, no signup event) and mints an `admin` row marked `member.access_grant = 'staff'` (migration 0016, `member.access_grant`, both dialects, additive).

Grant rows:
- are off the roster and out of the member count (a customer's team list never shows Dapta staff);
- never send the wizard to the staff member (the account still owes it to its owner);
- are never pruned by the staff person's own membership projection;
- become a real membership the moment upstream names the person;
- rank after real memberships as the fallback home.

"First member" (demo form, signup event) counts real memberships only, so a customer whose account a staff grant created ahead of them still gets their demo form and their onboarding.

## Surface

- API: `GET /v1/workspaces/search?q=&page=` (everyone: own list filtered; staff: plus estate rows with `accountId: null`), `POST /v1/workspaces/estate/:workspaceId/enter` (staff only), `/v1/me` carries `staff` and `accessGrant`.
- Web: search box in the switcher (rail + drawer), Staff badge on grant rows in the switcher and on the Account settings cards.
- Config: `IAM_STAFF_DOMAINS` in `packages/config` + `.env.example`. **Ops:** dev/prd need `IAM_STAFF_DOMAINS=daptatech.com` set on the API (Felipe); until then nobody is staff and the switcher only searches your own workspaces.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (api 398, web 476, db 195), db suite also on Postgres (0016 applied), publish gate + dash-check green.
- Service tests: a customer's search returns only their own workspaces; staff get own + estate (nothing projected by searching); entering an estate workspace mints the admin grant, off the roster, count unchanged, not pruned by a later refresh, idempotent; a later upstream membership clears the grant. Db test on both dialects for the grant lifecycle and the owner-first-member rule.
- Production build on the QA harness with 7 local workspaces: search box appears, focused on open, filters, ArrowDown/ArrowUp/Enter work (Enter switches to the first match), `v9-rail-menus` + `v12-account-settings` e2e green.
- Not exercised live: the estate enter path against dev IAM (needs `IAM_STAFF_DOMAINS` on the dev API and a staff session there); the search call itself was verified against dev IAM.

## Changeset

`.changeset/staff-workspace-access.md` (`@quill/db`, `@quill/config`, `@quill/shared` minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
