### PR TITLE
feat(engine,web): add the url question type

### DIFF
--- a/.changeset/url-question-type.md
+++ b/.changeset/url-question-type.md
@@ -1,0 +1,28 @@
+---
+'@quill/engine': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+A `url` question type: a single-line input that only accepts a web address.
+
+It sits in the builder's Text group ("Website"), between long text and the
+slider. It is not a contact field: `LEAD_CAPTURE_TYPES` and `isContactType` are
+unchanged, it lands in the qualification flow group, and it does not score.
+
+Validation is a pure regex, no `new URL`, so the engine stays free of platform
+APIs and both apps agree on the verdict. `acme.com`, `www.acme.com/x?y=1`,
+`https://acme.com:8443/p` and `http://x.io` pass; `acme`, `ftp://acme.com`,
+`javascript:alert(1)`, `https://` and `acme .com` are rejected with the new
+`url` validation code (`renderer.errors.url` in the catalog, en + es). Empty is
+still the required check's job, as for every other type.
+
+The stored value always carries a scheme. `normalizeUrl(raw)` trims and prepends
+`https://` when no `http(s)://` prefix is present (idempotent), and
+`canonicalizeAnswer(step, value)` applies it to `url` answers that pass the
+validator (a typo like `acme` stays as typed, so the error is about what was
+written) and is the identity for everything else. The public renderers call it at their commit
+points, right before `validateAnswerCode`, so the Enter path and the button path
+hand the same shape to the engine, the partial save and the CRM, and a HubSpot
+`website` property receives a full URL. `createEmptyStep('url')` seeds the
+placeholder `https://` to hint at that shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,20 +343,41 @@ above and the gates so CI does not surprise you.
 
 ## Common tasks (file pointers)
 
-**Add a question type, end-to-end** (order matters):
-1. `packages/engine/src/form-logic.ts` — add to `FORM_FIELD_TYPES`; add branches in
-   `validateAnswer` + `validateAnswerCode`; extend `computeScore` if it is scored.
-2. `packages/engine/src/form-config.ts` — per-type defaults in `createEmptyStep`.
-3. `packages/types/src/index.ts` — add any new step fields to `formStepSchema` (the
-   type enum is re-exported from the engine, so it updates automatically); add a new
-   `ValidationCode` if you introduced one.
-4. `packages/shared/src/i18n/index.ts` — label under `admin.editor.types` and any
-   new `renderer.errors.*` code, in **both** `en` and `es`.
-5. `apps/web/app/admin/forms/[id]/edit/_components/` — `step-list.tsx` (register in
-   `STEP_TYPES`) and `step-properties.tsx` (the editing panel); add an editor
-   component if the type needs one.
-6. `apps/web/components/public/step-input.tsx` — add a `case` to the render switch.
-7. Tests: `packages/engine/src/form-logic.spec.ts` (+ `form-config.spec.ts`).
+**Add a question type, end-to-end** (order matters; the `url` type is a complete,
+recent example of every stop on this list):
+1. `packages/engine/src/form-logic.ts`: add to `FORM_FIELD_TYPES`; add branches in
+   `validateAnswer` + `validateAnswerCode` (and a new `ValidationCode` member if the
+   type fails in a new way); extend `computeScore` if it is scored; if the stored
+   value must have a canonical shape, teach `canonicalizeAnswer` about it (the
+   renderers call it at their commit points, right before `validateAnswerCode`).
+   `packages/types` re-exports the enum into `formStepSchema.type`, so it needs no
+   edit unless the type carries new step fields.
+2. `packages/engine/src/form-config.ts`: per-type defaults in `createEmptyStep`.
+3. `packages/shared/src/i18n/index.ts`: any new `renderer.errors.*` code, in
+   **both** `en` and `es` (the renderers' `err(code)` indexes the catalog by the
+   validation code, so the key must match it exactly). `admin.editor.types` in that
+   catalog is nearly dead: only `types.slider` is read (a settings-section
+   heading), so a new type needs no entry there unless its settings section
+   reuses one.
+4. Builder, all under `apps/web/app/admin/forms/[id]/edit/_components/`:
+   `question-types.ts` (`GALLERY` entry + `iconForStep`), `builder-messages.ts`
+   (`GalleryItemId` union + `gallery.items` in `en` and `es`; the Record type
+   forces both), `question-settings.tsx` (`PLACEHOLDER_TYPES` if the public input
+   renders `step.placeholder`, plus any type-specific settings section),
+   `canvas-question.tsx` (the WYSIWYG preview branch), `logic-map.tsx`
+   (`galleryIdForStep`, or the Logic node is labelled "Short text"),
+   `advanced-settings.tsx` (`sample()` for the prefill URL example).
+5. `apps/web/components/public/step-input.tsx`: add a `case` to the render switch.
+   There is no `<form>` element in the renderers, so native input validation never
+   fires; the engine's validator is the only gate.
+6. `apps/web/app/admin/forms/[id]/integrations/auto-map.ts`: a `suggestProperty`
+   shortcut if the type maps to an obvious HubSpot contact property; and
+   `apps/api/src/integrations.controller.ts` `sampleAnswers`, so the mapping
+   preview and the webhook test body show a value of the right shape.
+7. Tests: `packages/engine/src/form-logic.spec.ts` (+ `form-config.spec.ts`),
+   `apps/web/components/public/step-input.spec.tsx`,
+   `apps/web/app/admin/forms/[id]/integrations/auto-map.spec.ts`.
+8. A changeset for `@quill/engine` (and `@quill/shared` if the catalog changed).
 
 **Add a destination adapter** (CRM/webhook sync):
 `packages/destinations/src/destination.port.ts` (extend the driver union) →

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -1053,6 +1053,9 @@ function sampleAnswers(steps: { key: string; type: string }[]): Record<string, u
       case 'phone':
         out[s.key] = '+15555550123';
         break;
+      case 'url':
+        out[s.key] = 'https://example.com';
+        break;
       case 'slider':
         out[s.key] = 5;
         break;

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   runtimeSteps,
   validateAnswerCode,
+  canonicalizeAnswer,
   resolveOutcome,
   resolveEnding,
   computeScore,
@@ -441,13 +442,19 @@ export function FormRenderer({
 
   function submitCurrent() {
     if (!step) return;
-    const check = validateAnswerCode(step, answers[step.key], answers);
+    // Commit point: store the canonical value (a url step gains its scheme
+    // here) BEFORE validating, so Enter and the button hand the same shape to
+    // the engine, the partial save and the CRM.
+    const canonical = canonicalizeAnswer(step, answers[step.key]);
+    const next = canonical === answers[step.key] ? answers : { ...answers, [step.key]: canonical };
+    if (next !== answers) setAnswers(next);
+    const check = validateAnswerCode(step, next[step.key], next);
     if (!check.ok) {
       setError(err(check.code));
       return;
     }
     setError(null);
-    void advance(answers, step);
+    void advance(next, step);
   }
 
   // Choice/dropdown selection: record the answer and auto-advance.

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -29,6 +29,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   runtimeSteps,
   validateAnswerCode,
+  canonicalizeAnswer,
   resolveOutcome,
   resolveEnding,
   computeScore,
@@ -447,6 +448,14 @@ export function VerticalFormRenderer({
     // Moving focus WITHIN the question (name's two fields) is not leaving it.
     if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
     if (step.type === 'message' || step.type === 'reveal' || step.type === 'scheduler') return;
+    // Commit point: a url step stores its canonical value (scheme included)
+    // before it is validated, so the ref, the partial save and the CRM all see
+    // the same shape. Identity for every other type.
+    const canonical = canonicalizeAnswer(step, answersRef.current[step.key]);
+    if (canonical !== answersRef.current[step.key]) {
+      answersRef.current = { ...answersRef.current, [step.key]: canonical };
+      setAnswers(answersRef.current);
+    }
     const a = answersRef.current;
     if (hasContent(step, a) || errors[step.key]) {
       const check = validateAnswerCode(step, a[step.key], a);
@@ -519,6 +528,22 @@ export function VerticalFormRenderer({
 
   /** Submit the whole page: validate the walk, scroll to the first error. */
   async function submitAll() {
+    // Commit point: canonicalize every answer (url steps gain their scheme)
+    // before the walk is validated, so a value typed and submitted without a
+    // blur still lands in its stored shape.
+    let canonicalized = false;
+    const draft: Answers = { ...answersRef.current };
+    for (const s of walk) {
+      const canonical = canonicalizeAnswer(s, draft[s.key]);
+      if (canonical !== draft[s.key]) {
+        draft[s.key] = canonical;
+        canonicalized = true;
+      }
+    }
+    if (canonicalized) {
+      answersRef.current = draft;
+      setAnswers(draft);
+    }
     const a = answersRef.current;
     const errs: Record<string, string> = {};
     let firstBad: string | null = null;

--- a/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
@@ -128,6 +128,7 @@ export function PrefillRow({
   const sample = (): string => {
     if (step.type === 'email') return 'ana%40acme.com';
     if (step.type === 'phone') return '%2B15555550123';
+    if (step.type === 'url') return 'https%3A%2F%2Facme.com';
     if (step.type === 'slider') return '5';
     const option = step.options?.[0];
     if (option) return encodeURIComponent(option.value ?? option.label ?? 'value');

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -480,6 +480,7 @@ export type GalleryItemId =
   | 'dropdown'
   | 'short'
   | 'long'
+  | 'url'
   | 'slider'
   | 'message'
   | 'reveal'
@@ -776,6 +777,7 @@ const en: BuilderMessages = {
       dropdown: { title: 'Dropdown', desc: 'Compact list' },
       short: { title: 'Short text', desc: 'One line' },
       long: { title: 'Long text', desc: 'Paragraph' },
+      url: { title: 'Website', desc: 'Validated URL' },
       slider: { title: 'Slider', desc: 'Rating scale' },
       message: { title: 'Message', desc: 'Text, no input' },
       reveal: { title: 'Reveal screen', desc: 'A short processing pause' },
@@ -1170,6 +1172,7 @@ const es: BuilderMessages = {
       dropdown: { title: 'Desplegable', desc: 'Lista compacta' },
       short: { title: 'Texto corto', desc: 'Una línea' },
       long: { title: 'Texto largo', desc: 'Párrafo' },
+      url: { title: 'Sitio web', desc: 'URL validada' },
       slider: { title: 'Deslizador', desc: 'Escala de valoración' },
       message: { title: 'Mensaje', desc: 'Texto, sin campo' },
       reveal: {

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -457,7 +457,13 @@ function QuestionEditableBody({
         ) : (
           <div className="rounded-xl border border-border bg-background px-4 py-3 text-[15px] text-muted-foreground/60">
             {step.placeholder ||
-              (step.type === 'email' ? 'you@company.com' : step.type === 'phone' ? '+1 555 000 0000' : '…')}
+              (step.type === 'email'
+                ? 'you@company.com'
+                : step.type === 'phone'
+                  ? '+1 555 000 0000'
+                  : step.type === 'url'
+                    ? 'https://example.com'
+                    : '…')}
           </div>
         )}
       </div>

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
@@ -271,6 +271,8 @@ function galleryIdForStep(step: FormStep): GalleryItemId {
       return 'slider';
     case 'textarea':
       return 'long';
+    case 'url':
+      return 'url';
     case 'message':
       return 'message';
     case 'text':

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -48,6 +48,7 @@ const ALL_ITEMS: GalleryItem[] = GALLERY_GROUPS.flatMap((g) => GALLERY[g]);
 const PLACEHOLDER_TYPES: ReadonlySet<FormStep['type']> = new Set([
   'text',
   'email',
+  'url',
   'textarea',
   'dropdown',
 ]);

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-types.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-types.ts
@@ -33,6 +33,7 @@ export const GALLERY: Record<GalleryGroup, GalleryItem[]> = {
   text: [
     { id: 'short', type: 'text', icon: 'pi-minus' },
     { id: 'long', type: 'textarea', icon: 'pi-align-left' },
+    { id: 'url', type: 'url', icon: 'pi-globe' },
     { id: 'slider', type: 'slider', icon: 'pi-sliders-h' },
   ],
   content: [
@@ -63,6 +64,8 @@ export function iconForStep(step: Pick<FormStep, 'type' | 'selectionMode'>): str
       return 'pi-align-left';
     case 'text':
       return 'pi-minus';
+    case 'url':
+      return 'pi-globe';
     case 'message':
       return 'pi-comment';
     case 'reveal':

--- a/apps/web/app/admin/forms/[id]/integrations/auto-map.spec.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/auto-map.spec.ts
@@ -56,6 +56,15 @@ describe('suggestProperty', () => {
     );
   });
 
+  it('maps a url question to website by field type alone', () => {
+    // The key/label say nothing about a website; the type is what decides.
+    expect(suggestProperty(q({ key: 'url_1', label: 'Where can we find you?', type: 'url' }), HUBSPOT)).toBe(
+      'website',
+    );
+    // A url question whose label mentions the company still lands on website.
+    expect(suggestProperty(q({ key: 'company', label: 'Company', type: 'url' }), HUBSPOT)).toBe('website');
+  });
+
   it('returns the portal casing, not the guessed lowercase', () => {
     const cased = propertyLookup([{ name: 'MobilePhone' }]);
     expect(suggestProperty(q({ key: 'phone', type: 'phone' }), cased)).toBe('MobilePhone');

--- a/apps/web/app/admin/forms/[id]/integrations/auto-map.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/auto-map.ts
@@ -34,6 +34,7 @@ export function suggestProperty(q: QuestionMeta, byLower: Map<string, string>): 
   if (type === 'email' || /\bemail\b|e\s?mail|correo/.test(hay)) return pick('email');
   if (type === 'phone' || /phone|mobile|whats\s?app|tel[eé]fono|celular|\btel\b/.test(hay))
     return pick('mobilephone', 'phone');
+  if (type === 'url') return pick('website');
   if (/last\s?name|surname|apellidos?/.test(hay)) return pick('lastname');
   if (/first\s?name|given\s?name|primer\s?nombre/.test(hay)) return pick('firstname');
   // Website before company so "company website" maps to website, not company.

--- a/apps/web/components/public/step-input.spec.tsx
+++ b/apps/web/components/public/step-input.spec.tsx
@@ -71,3 +71,20 @@ describe('multiple_choice: layout x selection mode', () => {
     expect(html).toContain('📅');
   });
 });
+
+describe('url', () => {
+  it('renders a native url input with the url keyboard and the step placeholder', () => {
+    const html = render(
+      { key: 'site', type: 'url', question: 'Your website', placeholder: 'https://' },
+      'acme.com',
+    );
+    expect(html).toContain('type="url"');
+    // React serializes these camelCased in static markup.
+    expect(html).toContain('inputMode="url"');
+    expect(html).toContain('autoComplete="url"');
+    expect(html).toContain('placeholder="https://"');
+    expect(html).toContain('aria-label="Your website"');
+    expect(html).toContain('value="acme.com"');
+    expect(html).toContain('class="pf-input"');
+  });
+});

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -10,6 +10,7 @@ import {
   resolveOptionLayout,
   resolveOptionIcon,
   optionInitials,
+  canonicalizeAnswer,
 } from '@quill/engine';
 import { getMessages } from '@quill/shared';
 import { SearchableDropdown } from './searchable-dropdown';
@@ -164,6 +165,32 @@ export function StepInput({
           className="pf-input"
           value={String(value ?? '')}
           onChange={(e) => onChange(e.target.value)}
+          placeholder={step.placeholder ?? ''}
+          aria-label={step.question ?? step.key}
+          autoFocus={autoFocus}
+        />
+      );
+
+    case 'url':
+      // Native URL validation never fires (the renderers have no <form>), so the
+      // engine's regex is the only gate. Blur normalizes the value the same way
+      // the commit points do (`canonicalizeAnswer`) so the visitor sees the
+      // stored shape (`https://acme.com`) before pressing Continue.
+      return (
+        <input
+          type="url"
+          inputMode="url"
+          autoComplete="url"
+          autoCapitalize="none"
+          spellCheck={false}
+          className="pf-input"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={(e) => {
+            const raw = e.target.value;
+            const next = canonicalizeAnswer(step, raw);
+            if (next !== raw) onChange(next);
+          }}
           placeholder={step.placeholder ?? ''}
           aria-label={step.question ?? step.key}
           autoFocus={autoFocus}

--- a/packages/engine/src/form-config.spec.ts
+++ b/packages/engine/src/form-config.spec.ts
@@ -63,6 +63,13 @@ describe('createEmptyStep', () => {
 
     const email = createEmptyStep('email');
     expect(email.flowGroup).toBe('lead_capture');
+
+    // A url step is a Text-group question, not a contact field: it qualifies,
+    // it is required like any other input, and it hints at the stored shape.
+    const url = createEmptyStep('url');
+    expect(url.placeholder).toBe('https://');
+    expect(url.flowGroup).toBe('qualification');
+    expect(url.required).toBe(true);
   });
 });
 

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -85,6 +85,11 @@ export function createEmptyStep(
   if (type === 'message') {
     base.buttonText = 'Continue';
   }
+  // A url step hints at the shape it expects; the stored value always carries a
+  // scheme (see `normalizeUrl`), so the placeholder shows one too.
+  if (type === 'url') {
+    base.placeholder = 'https://';
+  }
   // A reveal step owns its copy and duration, so a form can hold several with
   // different messages (V5-B3). Seeded enabled — an author who drops one in
   // wants it to play.

--- a/packages/engine/src/form-logic.spec.ts
+++ b/packages/engine/src/form-logic.spec.ts
@@ -3,6 +3,8 @@ import {
   visibleSteps,
   validateAnswer,
   validateAnswerCode,
+  normalizeUrl,
+  canonicalizeAnswer,
   phoneSubscriberDigits,
   computeScore,
   resolveOutcome,
@@ -300,6 +302,19 @@ describe('validateAnswer', () => {
     expect(validateAnswer(s, 'nope').ok).toBe(false);
     expect(validateAnswer(s, 'a@gmail.com').ok).toBe(false);
     expect(validateAnswer(s, 'a@acme.io').ok).toBe(true);
+  });
+
+  it('validates a url step with a pure regex (scheme optional, http(s) only)', () => {
+    const s = step({ key: 'u', type: 'url', required: true });
+    for (const ok of ['acme.com', 'www.acme.com/x?y=1', 'https://acme.com:8443/p', 'http://x.io']) {
+      expect(validateAnswer(s, ok), ok).toEqual({ ok: true });
+    }
+    for (const bad of ['acme', 'ftp://acme.com', 'javascript:alert(1)', 'https://', 'acme .com']) {
+      expect(validateAnswer(s, bad), bad).toEqual({ ok: false, error: 'Enter a valid website address.' });
+    }
+    // Empty is the required check's job, like every other type.
+    expect(validateAnswer(s, '')).toEqual({ ok: false, error: 'This field is required.' });
+    expect(validateAnswer(step({ key: 'u', type: 'url' }), '')).toEqual({ ok: true });
   });
 
   it('validates phone digit count', () => {
@@ -647,6 +662,8 @@ describe('validateAnswerCode', () => {
     expect(
       validateAnswerCode(step({ key: 'e', type: 'email', corporateEmailOnly: true }), 'a@gmail.com').code,
     ).toBe('work_email');
+    expect(validateAnswerCode(step({ key: 'u', type: 'url' }), 'acme').code).toBe('url');
+    expect(validateAnswerCode(step({ key: 'u', type: 'url' }), 'https://acme.com').ok).toBe(true);
     expect(validateAnswerCode(step({ key: 'p', type: 'phone', phoneMinDigits: 8 }), '12').code).toBe('phone');
     // E.164 value: the '+52' dial code is excluded, so 6 subscriber digits < 8.
     expect(validateAnswerCode(step({ key: 'p', type: 'phone', phoneMinDigits: 8 }), '+52551234').code).toBe('phone');
@@ -658,6 +675,39 @@ describe('validateAnswerCode', () => {
     expect(validateAnswerCode(s, undefined, { firstname: 'Ada', lastname: '' }).ok).toBe(false);
     expect(validateAnswerCode(s, undefined, { firstname: 'Ada', lastname: 'Lovelace' }).ok).toBe(true);
     expect(nameFields(s)).toEqual(['firstname', 'lastname']);
+  });
+});
+
+describe('normalizeUrl / canonicalizeAnswer', () => {
+  it('trims and prepends https:// only when no http(s) scheme is present', () => {
+    expect(normalizeUrl('  acme.com ')).toBe('https://acme.com');
+    expect(normalizeUrl('http://acme.com')).toBe('http://acme.com');
+    expect(normalizeUrl('HTTPS://acme.com/x')).toBe('HTTPS://acme.com/x');
+    expect(normalizeUrl('')).toBe('');
+    expect(normalizeUrl('   ')).toBe('');
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeUrl('www.acme.com/x?y=1');
+    expect(normalizeUrl(once)).toBe(once);
+    expect(once).toBe('https://www.acme.com/x?y=1');
+  });
+
+  it('canonicalizes only VALID url answers and leaves every other type alone', () => {
+    const url = step({ key: 'u', type: 'url' });
+    expect(canonicalizeAnswer(url, 'acme.com')).toBe('https://acme.com');
+    expect(canonicalizeAnswer(url, '')).toBe('');
+    expect(canonicalizeAnswer(url, '   ')).toBe('   ');
+    expect(canonicalizeAnswer(url, undefined)).toBeUndefined();
+    // A typo stays as typed: the error must be about what was written, not
+    // about a scheme the visitor never saw.
+    expect(canonicalizeAnswer(url, 'acme')).toBe('acme');
+    expect(canonicalizeAnswer(url, 'acme .com')).toBe('acme .com');
+    const text = step({ key: 't', type: 'text' });
+    expect(canonicalizeAnswer(text, 'acme.com')).toBe('acme.com');
+    const multi = step({ key: 'm', type: 'multiple_choice' });
+    const picked = ['a', 'b'];
+    expect(canonicalizeAnswer(multi, picked)).toBe(picked);
   });
 });
 

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -33,6 +33,7 @@ export const FORM_FIELD_TYPES = [
   'name',
   'email',
   'phone',
+  'url',
   'dropdown',
   'multiple_choice',
   'slider',
@@ -1199,6 +1200,44 @@ export function isPersonalEmail(value: AnswerValue): boolean {
 export type ValidationResult = { ok: true } | { ok: false; error: string };
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/**
+ * A web address for a `url` step: optional http(s) scheme, a dotted host with a
+ * TLD of two or more letters, optional port, optional path/query/fragment. A pure
+ * regex on purpose (no `new URL`) so the engine stays free of platform APIs and
+ * `acme.com` passes while `acme` and `ftp://acme.com` do not.
+ */
+const URL_RE = /^(?:https?:\/\/)?(?:[\p{L}\p{N}-]+\.)+[\p{L}]{2,}(?::\d{1,5})?(?:[/?#]\S*)?$/iu;
+
+/**
+ * Canonical form of a `url` answer: trimmed, always carrying a scheme (`https://`
+ * is prepended when the visitor typed none). Idempotent, so it is safe to run
+ * on every commit and on a value that was already normalized.
+ */
+export function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed === '') return trimmed;
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+/** Whether a `url` answer passes the same test the validators apply. */
+export function isValidWebUrl(raw: string): boolean {
+  return URL_RE.test(raw.trim());
+}
+
+/**
+ * The value the renderers store for a step right before validating it. Only
+ * `url` steps rewrite their answer today (see `normalizeUrl`), and only when the
+ * answer is a valid address: a typo like `acme` stays as typed so the error the
+ * visitor sees is about what they wrote, not about `https://acme`. Every other
+ * type is returned untouched.
+ */
+export function canonicalizeAnswer(step: FormStep, value: AnswerValue): AnswerValue {
+  if (step.type === 'url' && typeof value === 'string' && isValidWebUrl(value)) {
+    return normalizeUrl(value);
+  }
+  return value;
+}
+
 /** Common personal/free email domains rejected when `corporateEmailOnly`. */
 const PERSONAL_EMAIL_DOMAINS = new Set([
   'gmail.com',
@@ -1302,6 +1341,11 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
       // free-mail bases) so both validators agree on any given address.
       if (step.corporateEmailOnly && isPersonalEmail(email))
         return { ok: false, error: 'Please use your work email address.' };
+      return { ok: true };
+    }
+    case 'url': {
+      if (!URL_RE.test(String(value).trim()))
+        return { ok: false, error: 'Enter a valid website address.' };
       return { ok: true };
     }
     case 'phone': {
@@ -1830,6 +1874,7 @@ export type ValidationCode =
   | 'required'
   | 'email'
   | 'work_email'
+  | 'url'
   | 'phone'
   | 'number'
   | 'too_low'
@@ -1870,6 +1915,10 @@ export function validateAnswerCode(
       if (!EMAIL_RE.test(email)) return { ok: false, code: 'email' };
       if (step.corporateEmailOnly && isPersonalEmail(email))
         return { ok: false, code: 'work_email' };
+      return { ok: true };
+    }
+    case 'url': {
+      if (!URL_RE.test(String(value).trim())) return { ok: false, code: 'url' };
       return { ok: true };
     }
     case 'phone': {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -75,6 +75,7 @@ export interface FormsMessages {
       required: string;
       email: string;
       work_email: string;
+      url: string;
       phone: string;
       number: string;
       too_low: string;
@@ -1667,6 +1668,7 @@ export const en: FormsMessages = {
       required: 'This field is required.',
       email: 'Enter a valid email address.',
       work_email: 'Please use your work email address.',
+      url: 'Enter a valid website address.',
       phone: 'Enter a valid phone number.',
       number: 'Enter a number.',
       too_low: 'Value is too low.',
@@ -3120,6 +3122,7 @@ export const es: FormsMessages = {
       required: 'Este campo es obligatorio.',
       email: 'Introduce un correo válido.',
       work_email: 'Usa tu correo corporativo.',
+      url: 'Introduce una dirección web válida.',
       phone: 'Introduce un número de teléfono válido.',
       number: 'Introduce un número.',
       too_low: 'El valor es muy bajo.',


### PR DESCRIPTION
Bug 3 of the 2026-08-18 UI review: there was no question type that only accepts a URL. This adds `url`, end to end.

## What changed

- **Engine**: `'url'` in `FORM_FIELD_TYPES`; a pure regex validator (no `new URL`) in `validateAnswer` and `validateAnswerCode` with the new `url` validation code. `acme.com`, `www.acme.com/x?y=1`, `https://acme.com:8443/p` pass; `acme`, `ftp://acme.com`, `javascript:alert(1)`, `https://`, `acme .com` fail. Empty stays the required check's job.
- **Stored value always carries a scheme**: `normalizeUrl` (trim, prepend `https://` when missing, idempotent) and `canonicalizeAnswer(step, value)`, applied only when the answer is valid so a typo like `acme` stays as typed. Both public renderers call it at their commit points right before validating (slides: `submitCurrent`; vertical: `onQuestionBlur` and `submitAll`), and the input normalizes on blur, so Enter and the button hand the same shape to the engine, the partial save and the CRM. Verified: submitting `www.acme.com/pricing` stores `https://www.acme.com/pricing`.
- **Builder**: gallery entry "Website / Validated URL" in the Text group (`pi-globe`), `iconForStep`, `GalleryItemId` + `gallery.items` in en and es, `PLACEHOLDER_TYPES`, canvas preview fallback, `galleryIdForStep` (Logic node label), prefill sample. `createEmptyStep('url')` seeds the placeholder `https://`.
- **Public**: `<input type="url" inputMode="url" autoComplete="url" autoCapitalize="none" spellCheck={false}>`. Error copy `renderer.errors.url` in en and es.
- **HubSpot**: `auto-map.ts` suggests the `website` property by type; the API's mapping preview / webhook sample body emits a full URL for a url step.
- Not a contact field: `LEAD_CAPTURE_TYPES` and `isContactType` unchanged; it lands in the qualification flow group and does not score.
- `CLAUDE.md` "Add a question type" checklist rewritten against the files that actually exist (it pointed at `step-list.tsx` / `step-properties.tsx`, long gone).

## Verification

- `pnpm test` (engine 301, web 478, db, api, types), `pnpm typecheck`, `pnpm lint`, `bash scripts/dash-check.sh origin/develop`: green.
- Manual on a `next build && next start` QA instance: gallery tile, settings panel (type "Website", placeholder editable), published form rejects `acme` with the new message and stores the normalized value.
- `forms-reviewer` run: no blockers; ReDoS probed on 100k-char inputs (0 ms).

Changeset: `@quill/engine`, `@quill/types`, `@quill/shared` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)