### PR TITLE
feat(web): branded date picker for the analytics custom range

### DIFF
--- a/.changeset/analytics-date-picker.md
+++ b/.changeset/analytics-date-picker.md
@@ -1,0 +1,22 @@
+---
+'@quill/shared': minor
+---
+
+Branded date picker for the analytics custom range.
+
+The From and To fields behind the "Custom" chip on a form's Analytics page were
+OS-native date inputs, so their popup came from the browser: unthemed, off-brand,
+and different on every platform. They are now a token-styled trigger plus a mini
+calendar popover that follows the light and dark theme like every other admin
+control, with the accent used for the selected day and a rim on today.
+
+The calendar opens on the current value (or today), pages by month, starts the
+week on Monday for Spanish and Sunday for English, and is fully keyboard
+operable: arrows move by day and week, Home and End jump to the week's ends,
+PageUp and PageDown page months (Shift pages years), Enter picks, Escape closes
+and returns focus to the field. A clear button empties the field. Bounds are
+unchanged (From cannot pass To, To cannot pass today, all in UTC like the server),
+and Apply still swaps a reversed range before it reaches the URL.
+
+New catalog keys under `admin.datePicker` (placeholder, dialog label, previous
+and next month, clear) in both locales.

--- a/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState, useTransition } from 'react';
+import { DatePicker } from '@/components/ui/date-picker';
+import { todayUtcIso } from '@/lib/calendar-math';
 
 type Preset = 'all' | 'today' | 'week' | 'month' | 'year' | 'custom';
 
@@ -13,11 +15,15 @@ type Preset = 'all' | 'today' | 'week' | 'month' | 'year' | 'custom';
  * page.tsx so every teammate sees the same numbers regardless of where they are.
  * Writes the choice to the URL query so the server component re-fetches; a
  * Suspense boundary shows the skeleton while it does (R22). Tokens-only; 44px
- * hit targets (R28).
+ * hit targets (R28). The custom From/To fields are the branded `DatePicker`
+ * (not native date inputs), fed the server's `locale` so the first frame
+ * matches on both sides.
  */
 export function AnalyticsFilter({
   labels,
+  locale,
 }: {
+  locale: string;
   labels: {
     today: string;
     week: string;
@@ -54,7 +60,7 @@ export function AnalyticsFilter({
 
   // Today in UTC — the same reference the server resolves ranges against, so the
   // picker cannot offer a "future" that is only future in the viewer's timezone.
-  const todayUtc = new Date().toISOString().slice(0, 10);
+  const todayUtc = todayUtcIso();
 
   const applyCustom = () => {
     if (!from && !to) return;
@@ -103,31 +109,34 @@ export function AnalyticsFilter({
 
       {showCustom ? (
         <div className="flex flex-wrap items-end gap-3">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-            {labels.from}
-            <input
-              type="date"
+          <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+            <span>{labels.from}</span>
+            <DatePicker
               value={from}
+              onChange={setFrom}
               max={to || todayUtc}
-              onChange={(e) => setFrom(e.target.value)}
-              className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+              locale={locale}
+              ariaLabel={labels.from}
+              testId="analytics-from"
             />
-          </label>
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-            {labels.to}
-            <input
-              type="date"
+          </div>
+          <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+            <span>{labels.to}</span>
+            <DatePicker
               value={to}
+              onChange={setTo}
               min={from || undefined}
               max={todayUtc}
-              onChange={(e) => setTo(e.target.value)}
-              className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+              locale={locale}
+              ariaLabel={labels.to}
+              testId="analytics-to"
             />
-          </label>
+          </div>
           <button
             type="button"
             disabled={pending || (!from && !to)}
             onClick={applyCustom}
+            data-testid="analytics-apply"
             className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] disabled:opacity-60"
           >
             {labels.apply}

--- a/apps/web/app/admin/forms/[id]/analytics/page.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/page.tsx
@@ -76,6 +76,7 @@ export default async function AnalyticsPage({
           <p className="mt-1 text-muted-foreground">{m.analytics.subtitle}</p>
         </div>
         <AnalyticsFilter
+          locale={locale}
           labels={{
             today: m.analytics.rangeToday,
             week: m.analytics.rangeWeek,

--- a/apps/web/components/ui/calendar.spec.tsx
+++ b/apps/web/components/ui/calendar.spec.tsx
@@ -1,0 +1,88 @@
+/**
+ * CalendarGrid markup contract: the WAI-ARIA grid shape the DatePicker and its
+ * e2e rely on (42 gridcells, one selected, disabled past `max`, a single roving
+ * tabindex, locale-driven week start). Rendered with react-dom/server since the
+ * web vitest env has no DOM.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CalendarGrid } from './calendar';
+
+const noop = () => {};
+
+function render(over: Partial<Parameters<typeof CalendarGrid>[0]> = {}) {
+  return renderToStaticMarkup(
+    <CalendarGrid
+      view={{ year: 2026, month: 7 }}
+      value="2026-08-10"
+      focused="2026-08-10"
+      todayIso="2026-08-18"
+      max="2026-08-18"
+      locale="en"
+      weekStart={0}
+      labels={{ prevMonth: 'Previous month', nextMonth: 'Next month' }}
+      onPick={noop}
+      onFocusChange={noop}
+      onViewChange={noop}
+      {...over}
+    />,
+  );
+}
+
+const count = (html: string, needle: string): number => html.split(needle).length - 1;
+
+describe('CalendarGrid', () => {
+  it('renders 42 gridcells with exactly one selected and one tab stop', () => {
+    const html = render();
+    expect(count(html, 'role="gridcell"')).toBe(42);
+    expect(count(html, 'aria-selected="true"')).toBe(1);
+    expect(count(html, 'tabindex="0"')).toBe(1);
+    expect(html).toContain('role="grid"');
+    expect(html).toContain('aria-label="August 2026"');
+    expect(html).toContain('aria-label="Previous month"');
+    expect(html).toContain('aria-label="Next month"');
+  });
+
+  it('disables every cell after max, and only those', () => {
+    const html = render();
+    // Grid runs 2026-07-26 .. 2026-09-05; days after 08-18 are 13 in Aug + 5 in Sep.
+    expect(count(html, 'aria-disabled="true"')).toBe(13 + 5);
+    expect(html).toContain('data-iso="2026-08-19" data-testid="calendar-day"');
+    const idx = html.indexOf('data-iso="2026-08-19"');
+    const cellStart = html.lastIndexOf('<td', idx);
+    const cellOpen = html.slice(cellStart, html.indexOf('>', idx));
+    expect(cellOpen).toContain('aria-disabled="true"');
+  });
+
+  it('marks today with the accent rim and the selected day with the accent fill', () => {
+    const html = render();
+    const cellFor = (iso: string) => {
+      const idx = html.indexOf(`data-iso="${iso}"`);
+      const end = html.indexOf('</td>', idx);
+      return html.slice(idx, end);
+    };
+    expect(cellFor('2026-08-18')).toContain('shadow-[inset_0_0_0_1px_var(--primary-edge)]');
+    expect(cellFor('2026-08-10')).toContain('bg-primary');
+    expect(cellFor('2026-08-10')).toContain('text-primary-foreground');
+    expect(cellFor('2026-08-03')).not.toContain('bg-primary');
+  });
+
+  it('starts the week on Monday for Spanish', () => {
+    const html = render({ locale: 'es', weekStart: 1 });
+    const thead = html.slice(html.indexOf('<thead>'), html.indexOf('</thead>'));
+    const firstTh = thead.slice(thead.indexOf('<th'), thead.indexOf('</th>'));
+    expect(firstTh.toLowerCase()).toMatch(/lun/);
+    expect(html.indexOf('data-iso="2026-07-27"')).toBeLessThan(
+      html.indexOf('data-iso="2026-08-01"'),
+    );
+    expect(html).not.toContain('data-iso="2026-07-26"');
+  });
+
+  it('keeps a tab stop when the cursor is outside the visible month', () => {
+    const html = render({ focused: '2026-05-01' });
+    expect(count(html, 'tabindex="0"')).toBe(1);
+    const idx = html.indexOf('tabindex="0"');
+    const cellOpen = html.slice(html.lastIndexOf('<td', idx), html.indexOf('>', idx));
+    expect(cellOpen).toContain('data-iso="2026-08-10"');
+  });
+});

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import type { KeyboardEvent } from 'react';
+import { cn } from '@/lib/cn';
+import {
+  addDays,
+  addMonths,
+  daysInMonth,
+  formatMonthTitle,
+  isOutOfRange,
+  monthGrid,
+  parseIsoDate,
+  toIsoDate,
+  weekdayLabels,
+  yearMonthOf,
+  type YearMonth,
+} from '@/lib/calendar-math';
+
+/**
+ * CalendarGrid: the stateless month view behind `DatePicker`. It owns no state:
+ * the parent passes the visible month (`view`), the committed `value`, the
+ * keyboard cursor (`focused`) and gets every change back through callbacks, so
+ * the same grid can later back a range picker without a rewrite.
+ *
+ * Markup follows the WAI-ARIA grid pattern: a `<table role="grid">` whose cells
+ * are the days, a single roving `tabIndex=0` on the focused cell, arrows move by
+ * day/week, Home/End jump to the week's ends, PageUp/PageDown page months (Shift
+ * pages years), Enter/Space pick. Styling is tokens only: the accent fill is
+ * `bg-primary`, and the "today"/cursor rims use `--primary-edge` like every other
+ * selected state in the admin (see globals.css).
+ */
+
+export interface CalendarGridProps {
+  view: YearMonth;
+  /** Committed value (`YYYY-MM-DD`) or '' for none. */
+  value: string;
+  /** The roving keyboard cursor (`YYYY-MM-DD`). */
+  focused: string;
+  todayIso: string;
+  min?: string;
+  max?: string;
+  locale: string;
+  weekStart: 0 | 1;
+  labels: { prevMonth: string; nextMonth: string };
+  onPick: (iso: string) => void;
+  onFocusChange: (iso: string) => void;
+  onViewChange: (ym: YearMonth) => void;
+  testId?: string;
+}
+
+export function CalendarGrid({
+  view,
+  value,
+  focused,
+  todayIso,
+  min,
+  max,
+  locale,
+  weekStart,
+  labels,
+  onPick,
+  onFocusChange,
+  onViewChange,
+  testId,
+}: CalendarGridProps) {
+  const cells = monthGrid(view, weekStart);
+  const weekdays = weekdayLabels(locale, weekStart);
+  const monthTitle = formatMonthTitle(view, locale);
+
+  // Exactly one cell carries tabIndex=0 (roving tabindex). Normally the cursor;
+  // when the view was paged away from it with the prev/next buttons, fall back
+  // to the selected day if visible in this month, else the month's first day,
+  // so Tab can always reach the grid.
+  const inView = cells.some((c) => c.iso === focused);
+  const tabTarget = inView
+    ? focused
+    : (cells.find((c) => c.inMonth && c.iso === value)?.iso ??
+      cells.find((c) => c.inMonth)?.iso ??
+      focused);
+
+  const moveFocus = (nextIso: string) => {
+    onFocusChange(nextIso);
+    const cur = yearMonthOf(focused);
+    const next = yearMonthOf(nextIso);
+    if (cur.year !== next.year || cur.month !== next.month) onViewChange(next);
+  };
+
+  const pageMonth = (n: number) => {
+    const p = parseIsoDate(focused);
+    if (!p) return;
+    const target = addMonths({ year: p.year, month: p.month }, n);
+    // Keep the day when the target month has it, else land on its last day.
+    const last = daysInMonth(target.year, target.month);
+    moveFocus(toIsoDate(target.year, target.month, Math.min(p.day, last)));
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTableElement>) => {
+    const p = parseIsoDate(focused);
+    if (!p) return;
+    switch (e.key) {
+      case 'ArrowLeft':
+        e.preventDefault();
+        moveFocus(addDays(focused, -1));
+        return;
+      case 'ArrowRight':
+        e.preventDefault();
+        moveFocus(addDays(focused, 1));
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveFocus(addDays(focused, -7));
+        return;
+      case 'ArrowDown':
+        e.preventDefault();
+        moveFocus(addDays(focused, 7));
+        return;
+      case 'Home': {
+        e.preventDefault();
+        const dow = new Date(Date.UTC(p.year, p.month, p.day)).getUTCDay();
+        moveFocus(addDays(focused, -((dow - weekStart + 7) % 7)));
+        return;
+      }
+      case 'End': {
+        e.preventDefault();
+        const dow = new Date(Date.UTC(p.year, p.month, p.day)).getUTCDay();
+        moveFocus(addDays(focused, 6 - ((dow - weekStart + 7) % 7)));
+        return;
+      }
+      case 'PageUp':
+        e.preventDefault();
+        pageMonth(e.shiftKey ? -12 : -1);
+        return;
+      case 'PageDown':
+        e.preventDefault();
+        pageMonth(e.shiftKey ? 12 : 1);
+        return;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (!isOutOfRange(focused, min, max)) onPick(focused);
+        return;
+      default:
+        return;
+    }
+  };
+
+  const navBtn =
+    'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  return (
+    <div data-testid={testId} className="flex flex-col gap-1">
+      <div className="flex items-center justify-between px-1">
+        <button
+          type="button"
+          aria-label={labels.prevMonth}
+          onClick={() => onViewChange(addMonths(view, -1))}
+          className={navBtn}
+        >
+          <i aria-hidden className="pi pi-chevron-left" style={{ fontSize: 12 }} />
+        </button>
+        <span aria-live="polite" className="text-sm font-semibold">
+          {monthTitle}
+        </span>
+        <button
+          type="button"
+          aria-label={labels.nextMonth}
+          onClick={() => onViewChange(addMonths(view, 1))}
+          className={navBtn}
+        >
+          <i aria-hidden className="pi pi-chevron-right" style={{ fontSize: 12 }} />
+        </button>
+      </div>
+
+      <table
+        role="grid"
+        aria-label={monthTitle}
+        className="w-full border-collapse"
+        onKeyDown={onKeyDown}
+      >
+        <thead>
+          <tr>
+            {weekdays.map((w) => (
+              <th
+                key={w.long}
+                scope="col"
+                abbr={w.long}
+                className="h-8 text-center text-2xs font-semibold uppercase text-muted-foreground"
+              >
+                {w.short}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 6 }, (_, row) => (
+            <tr key={row}>
+              {cells.slice(row * 7, row * 7 + 7).map((cell) => {
+                const disabled = isOutOfRange(cell.iso, min, max);
+                const selected = cell.iso === value;
+                const isToday = cell.iso === todayIso;
+                const isFocused = cell.iso === focused;
+                return (
+                  <td
+                    key={cell.iso}
+                    role="gridcell"
+                    aria-selected={selected}
+                    aria-disabled={disabled || undefined}
+                    tabIndex={cell.iso === tabTarget ? 0 : -1}
+                    data-iso={cell.iso}
+                    data-testid="calendar-day"
+                    onClick={() => {
+                      if (disabled) return;
+                      onPick(cell.iso);
+                    }}
+                    onFocus={() => {
+                      if (!isFocused) onFocusChange(cell.iso);
+                    }}
+                    className="p-0 focus-visible:outline-none"
+                  >
+                    <span
+                      className={cn(
+                        'mx-auto flex h-9 w-9 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted',
+                        !cell.inMonth && 'text-muted-foreground/50',
+                        isToday && 'shadow-[inset_0_0_0_1px_var(--primary-edge)]',
+                        isFocused && 'bg-muted shadow-[inset_0_0_0_1px_var(--primary-edge)]',
+                        selected &&
+                          'bg-primary font-semibold text-primary-foreground hover:bg-primary',
+                        disabled &&
+                          'cursor-not-allowed text-muted-foreground/40 hover:bg-transparent',
+                      )}
+                    >
+                      {Number(cell.iso.slice(8, 10))}
+                    </span>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/ui/date-picker.spec.tsx
+++ b/apps/web/components/ui/date-picker.spec.tsx
@@ -1,0 +1,67 @@
+/**
+ * DatePicker closed-state contract: the trigger is a dialog-opening button that
+ * shows the value in the viewer's locale (or the catalog placeholder), and no
+ * calendar is in the markup until it opens. Rendered with react-dom/server since
+ * the web vitest env has no DOM; open-state behaviour lives in the e2e.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { getMessages } from '@quill/shared';
+import { DatePicker } from './date-picker';
+
+const noop = () => {};
+
+describe('DatePicker (closed)', () => {
+  it('shows the formatted date per locale', () => {
+    const en = renderToStaticMarkup(
+      <DatePicker value="2026-08-18" onChange={noop} locale="en" ariaLabel="From" testId="dp" />,
+    );
+    expect(en).toContain('Aug 18, 2026');
+    expect(en).toContain('data-testid="dp"');
+    const es = renderToStaticMarkup(
+      <DatePicker value="2026-08-18" onChange={noop} locale="es" ariaLabel="Desde" />,
+    );
+    expect(es).toMatch(/18 ago/);
+  });
+
+  it('shows the catalog placeholder when empty and no clear button', () => {
+    const en = renderToStaticMarkup(
+      <DatePicker value="" onChange={noop} locale="en" ariaLabel="From" testId="dp" />,
+    );
+    expect(en).toContain(getMessages('en').admin.datePicker.placeholder);
+    expect(en).not.toContain('data-testid="dp-clear"');
+    const es = renderToStaticMarkup(
+      <DatePicker value="" onChange={noop} locale="es" ariaLabel="Desde" />,
+    );
+    expect(es).toContain(getMessages('es').admin.datePicker.placeholder);
+  });
+
+  it('exposes a clear button when a value is set', () => {
+    const html = renderToStaticMarkup(
+      <DatePicker value="2026-08-18" onChange={noop} locale="en" ariaLabel="From" testId="dp" />,
+    );
+    expect(html).toContain('data-testid="dp-clear"');
+    // Two pickers sit side by side on the analytics page, so each clear button
+    // names its field.
+    expect(html).toContain(`aria-label="${getMessages('en').admin.datePicker.clear}: From"`);
+  });
+
+  it('announces the set value in the trigger name, not only the field label', () => {
+    const html = renderToStaticMarkup(
+      <DatePicker value="2026-08-18" onChange={noop} locale="en" ariaLabel="From" />,
+    );
+    expect(html).toContain('aria-label="From, Aug 18, 2026"');
+  });
+
+  it('is a dialog trigger, closed by default, with no calendar in the markup', () => {
+    const html = renderToStaticMarkup(
+      <DatePicker value="2026-08-18" onChange={noop} locale="en" ariaLabel="From" />,
+    );
+    expect(html).toContain('aria-haspopup="dialog"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-label="From, Aug 18, 2026"');
+    expect(html).not.toContain('role="dialog"');
+    expect(html).not.toContain('role="grid"');
+    expect(html).not.toContain('<input');
+  });
+});

--- a/apps/web/components/ui/date-picker.tsx
+++ b/apps/web/components/ui/date-picker.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { getMessages } from '@quill/shared';
+import { cn } from '@/lib/cn';
+import { CalendarGrid } from './calendar';
+import {
+  clampIso,
+  formatIsoDate,
+  todayUtcIso,
+  weekStartsOn,
+  yearMonthOf,
+  type YearMonth,
+} from '@/lib/calendar-math';
+
+/**
+ * DatePicker: a branded, token-styled date field that replaces the OS-native
+ * `<input type="date">` in the admin. Same reasoning as `Select`: the native
+ * control hands its popup to the OS (unthemed, off-brand, different in every
+ * browser), whereas this renders a token-styled trigger (`border-input` /
+ * `bg-background`) plus a mini calendar anchored under it (`border-border` /
+ * `bg-popover` / `shadow-lg`) that follows the theme with zero CSS changes.
+ *
+ * Contract mirrors the native input: `value` is a `YYYY-MM-DD` string ('' for
+ * none), `onChange` fires with the picked ISO date (or '' from the clear
+ * button), `min`/`max` are inclusive ISO bounds. Everything is UTC (see
+ * `lib/calendar-math`). `locale` comes from the server as a prop, never from
+ * `document.cookie`, so server and client render the same first frame.
+ *
+ * Not portalled: the panel is `absolute z-50` under a `relative` wrapper, which
+ * is safe wherever no ancestor clips overflow (the analytics filter qualifies).
+ * A viewport guard flips the panel to `right-0` when it would spill off-screen.
+ */
+export function DatePicker({
+  value,
+  onChange,
+  min,
+  max,
+  locale,
+  placeholder,
+  ariaLabel,
+  testId,
+  disabled = false,
+  className,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  min?: string;
+  max?: string;
+  locale: string;
+  placeholder?: string;
+  ariaLabel: string;
+  testId?: string;
+  disabled?: boolean;
+  /** Applied to the trigger button (matches the Input/Select convention). */
+  className?: string;
+}) {
+  const m = getMessages(locale).admin.datePicker;
+  const weekStart = weekStartsOn(locale);
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<YearMonth>(() => yearMonthOf(value || todayUtcIso()));
+  const [focused, setFocused] = useState<string>(value || todayUtcIso());
+  const [alignEnd, setAlignEnd] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const todayIso = todayUtcIso();
+
+  const openPanel = () => {
+    if (disabled) return;
+    const start = value || clampIso(todayIso, min, max);
+    setView(yearMonthOf(start));
+    setFocused(start);
+    setAlignEnd(false);
+    setOpen(true);
+  };
+
+  const close = (refocus = true) => {
+    setOpen(false);
+    if (refocus) triggerRef.current?.focus();
+  };
+
+  const pick = (iso: string) => {
+    onChange(iso);
+    close();
+  };
+
+  // Outside click closes without stealing focus back (the user is elsewhere).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  // Roving focus: whenever the cursor moves (keyboard or open), put DOM focus on
+  // that cell so arrows keep working and screen readers announce the day. Not
+  // keyed on `view` on purpose: paging with the prev/next buttons must leave
+  // focus on the button so a keyboard user can keep pressing it.
+  // Layout effect, not effect: crossing a month boundary unmounts the old cell,
+  // and a plain effect would let focus fall to <body> for a paint before it
+  // lands on the new one.
+  useLayoutEffect(() => {
+    if (!open) return;
+    panelRef.current?.querySelector<HTMLElement>(`[data-iso="${focused}"]`)?.focus();
+  }, [open, focused]);
+
+  // Viewport guard: measure once open and flip to the right edge if the panel
+  // would spill past the window.
+  useLayoutEffect(() => {
+    if (!open || !panelRef.current) return;
+    const rect = panelRef.current.getBoundingClientRect();
+    if (rect.right > window.innerWidth - 8) setAlignEnd(true);
+  }, [open]);
+
+  const onPanelKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        // The name carries the value too: an aria-label alone would replace
+        // the button's content, and a screen reader would hear "From" with no
+        // idea which day is set (the native input it replaces announced its
+        // value).
+        aria-label={value ? `${ariaLabel}, ${formatIsoDate(value, locale)}` : ariaLabel}
+        data-testid={testId}
+        onClick={() => (open ? close() : openPanel())}
+        className={cn(
+          'flex h-9 w-full min-w-[10.5rem] cursor-pointer items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-left text-sm text-foreground transition-colors hover:border-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60',
+          value && !disabled && 'pr-14',
+          className,
+        )}
+      >
+        {/* Server and browser can carry different ICU data ("sept" vs "sep"
+            in es): a formatted date that differs by one letter is not worth a
+            hydration warning, and the value itself is the ISO string. */}
+        <span className={cn('truncate', !value && 'text-muted-foreground')} suppressHydrationWarning>
+          {value ? formatIsoDate(value, locale) : (placeholder ?? m.placeholder)}
+        </span>
+        <i
+          aria-hidden
+          className="pi pi-calendar shrink-0 text-muted-foreground"
+          style={{ fontSize: 13 }}
+        />
+      </button>
+
+      {value && !disabled ? (
+        <button
+          type="button"
+          aria-label={`${m.clear}: ${ariaLabel}`}
+          data-testid={testId ? `${testId}-clear` : undefined}
+          onClick={() => {
+            onChange('');
+            setOpen(false);
+          }}
+          className="absolute right-8 top-1/2 inline-flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i aria-hidden className="pi pi-times" style={{ fontSize: 11 }} />
+        </button>
+      ) : null}
+
+      {open ? (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="false"
+          aria-label={m.dialogLabel}
+          data-testid={testId ? `${testId}-dialog` : undefined}
+          onKeyDown={onPanelKeyDown}
+          className={cn(
+            'absolute top-full z-50 mt-1 w-[18rem] rounded-md border border-border bg-popover p-2 text-popover-foreground shadow-lg',
+            alignEnd ? 'right-0' : 'left-0',
+          )}
+        >
+          <CalendarGrid
+            view={view}
+            value={value}
+            focused={focused}
+            todayIso={todayIso}
+            min={min}
+            max={max}
+            locale={locale}
+            weekStart={weekStart}
+            labels={{ prevMonth: m.prevMonth, nextMonth: m.nextMonth }}
+            onPick={pick}
+            onFocusChange={setFocused}
+            onViewChange={setView}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/calendar-math.spec.ts
+++ b/apps/web/lib/calendar-math.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addDays,
+  addMonths,
+  clampIso,
+  daysInMonth,
+  formatIsoDate,
+  formatMonthTitle,
+  isOutOfRange,
+  monthGrid,
+  parseIsoDate,
+  todayUtcIso,
+  toIsoDate,
+  weekdayLabels,
+  weekStartsOn,
+  yearMonthOf,
+} from './calendar-math';
+
+describe('calendar-math', () => {
+  it('parseIsoDate accepts strict YYYY-MM-DD and rejects impossible or unpadded dates', () => {
+    expect(parseIsoDate('2026-08-18')).toEqual({
+      year: 2026,
+      month: 7,
+      day: 18,
+    });
+    expect(parseIsoDate('2026-02-30')).toBeNull();
+    expect(parseIsoDate('2026-8-1')).toBeNull();
+    expect(parseIsoDate('2026-13-01')).toBeNull();
+    expect(parseIsoDate('')).toBeNull();
+    expect(parseIsoDate('2024-02-29')).toEqual({
+      year: 2024,
+      month: 1,
+      day: 29,
+    });
+    expect(parseIsoDate('2023-02-29')).toBeNull();
+  });
+
+  it('toIsoDate pads and normalises overflow through Date.UTC', () => {
+    expect(toIsoDate(2026, 7, 1)).toBe('2026-08-01');
+    expect(toIsoDate(2026, 0, 32)).toBe('2026-02-01');
+  });
+
+  it('todayUtcIso reads the UTC calendar day', () => {
+    expect(todayUtcIso(Date.UTC(2026, 7, 18, 23, 59))).toBe('2026-08-18');
+    expect(todayUtcIso(Date.UTC(2026, 7, 19, 0, 0))).toBe('2026-08-19');
+  });
+
+  it('daysInMonth handles leap years', () => {
+    expect(daysInMonth(2024, 1)).toBe(29);
+    expect(daysInMonth(2023, 1)).toBe(28);
+    expect(daysInMonth(2026, 7)).toBe(31);
+  });
+
+  it('addDays crosses year boundaries', () => {
+    expect(addDays('2026-12-31', 1)).toBe('2027-01-01');
+    expect(addDays('2027-01-01', -1)).toBe('2026-12-31');
+    expect(addDays('2026-08-18', -7)).toBe('2026-08-11');
+  });
+
+  it('addMonths rolls Dec into Jan and back', () => {
+    expect(addMonths({ year: 2026, month: 11 }, 1)).toEqual({
+      year: 2027,
+      month: 0,
+    });
+    expect(addMonths({ year: 2027, month: 0 }, -1)).toEqual({
+      year: 2026,
+      month: 11,
+    });
+    expect(addMonths({ year: 2026, month: 7 }, 12)).toEqual({
+      year: 2027,
+      month: 7,
+    });
+  });
+
+  it('yearMonthOf reads a valid ISO date', () => {
+    expect(yearMonthOf('2026-08-18')).toEqual({ year: 2026, month: 7 });
+  });
+
+  it('weekStartsOn: Spanish starts on Monday, everything else on Sunday', () => {
+    expect(weekStartsOn('es')).toBe(1);
+    expect(weekStartsOn('es-MX')).toBe(1);
+    expect(weekStartsOn('en')).toBe(0);
+    expect(weekStartsOn('fr')).toBe(0);
+  });
+
+  it('monthGrid always yields 42 cells, padded per week start', () => {
+    const sun = monthGrid({ year: 2026, month: 7 }, 0);
+    expect(sun).toHaveLength(42);
+    expect(sun[0]?.iso).toBe('2026-07-26');
+    expect(sun[0]?.inMonth).toBe(false);
+    const mon = monthGrid({ year: 2026, month: 7 }, 1);
+    expect(mon).toHaveLength(42);
+    expect(mon[0]?.iso).toBe('2026-07-27');
+    expect(monthGrid({ year: 2024, month: 1 }, 0).filter((c) => c.inMonth)).toHaveLength(29);
+    expect(monthGrid({ year: 2023, month: 1 }, 0).filter((c) => c.inMonth)).toHaveLength(28);
+  });
+
+  it('isOutOfRange and clampIso are inclusive on both ends', () => {
+    expect(isOutOfRange('2026-08-18', '2026-08-18', '2026-08-18')).toBe(false);
+    expect(isOutOfRange('2026-08-17', '2026-08-18', undefined)).toBe(true);
+    expect(isOutOfRange('2026-08-19', undefined, '2026-08-18')).toBe(true);
+    expect(isOutOfRange('2026-08-19')).toBe(false);
+    expect(clampIso('2026-08-19', undefined, '2026-08-18')).toBe('2026-08-18');
+    expect(clampIso('2026-08-01', '2026-08-05', undefined)).toBe('2026-08-05');
+    expect(clampIso('2026-08-10', '2026-08-05', '2026-08-18')).toBe('2026-08-10');
+  });
+
+  it('weekdayLabels rotate to the week start and strip trailing periods', () => {
+    const es = weekdayLabels('es', 1);
+    expect(es).toHaveLength(7);
+    expect(es[0]?.short.toLowerCase().startsWith('lun')).toBe(true);
+    expect(es[0]?.short.endsWith('.')).toBe(false);
+    const en = weekdayLabels('en', 0);
+    expect(en[0]?.short).toBe('Sun');
+    expect(en[0]?.long).toBe('Sunday');
+    expect(en[6]?.short).toBe('Sat');
+  });
+
+  it('formatIsoDate and formatMonthTitle localise in UTC', () => {
+    expect(formatIsoDate('2026-08-18', 'en')).toBe('Aug 18, 2026');
+    expect(formatIsoDate('2026-08-18', 'es')).toMatch(/18 ago/);
+    expect(formatIsoDate('not-a-date', 'en')).toBe('not-a-date');
+    expect(formatMonthTitle({ year: 2026, month: 7 }, 'en')).toBe('August 2026');
+    const es = formatMonthTitle({ year: 2026, month: 7 }, 'es');
+    expect(es.startsWith('A')).toBe(true);
+    expect(es).toMatch(/2026/);
+  });
+});

--- a/apps/web/lib/calendar-math.ts
+++ b/apps/web/lib/calendar-math.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure calendar arithmetic for the branded date picker. No React, no I/O.
+ *
+ * Everything here is UTC on purpose: the analytics range is resolved server-side
+ * as `${from}T00:00:00.000Z` .. `${to}T23:59:59.999Z` (SPEC-METRICS.md, phase 1),
+ * so the picker must reason in the same calendar or a viewer west of Greenwich
+ * would be offered a "today" the server treats as tomorrow. Dates travel as
+ * `YYYY-MM-DD` strings; the ISO shape sorts lexicographically, so range checks
+ * are plain string compares. Months are 0-11 like `Date`.
+ */
+
+export interface YearMonth {
+  year: number;
+  /** 0-11 */
+  month: number;
+}
+
+export interface CalendarDate extends YearMonth {
+  /** 1-31 */
+  day: number;
+}
+
+export interface GridCell {
+  iso: string;
+  /** False for the leading/trailing days that pad the 6x7 grid. */
+  inMonth: boolean;
+}
+
+export interface WeekdayLabel {
+  short: string;
+  long: string;
+}
+
+const ISO_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+/** Strict `YYYY-MM-DD` parse; rejects impossible dates (`2026-02-30`) and
+ *  loosely padded input (`2026-8-1`) by round-tripping through `Date.UTC`. */
+export function parseIsoDate(s: string): CalendarDate | null {
+  const m = ISO_RE.exec(s);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]) - 1;
+  const day = Number(m[3]);
+  if (month < 0 || month > 11 || day < 1) return null;
+  const d = new Date(Date.UTC(year, month, day));
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month || d.getUTCDate() !== day)
+    return null;
+  return { year, month, day };
+}
+
+export function toIsoDate(year: number, month: number, day: number): string {
+  const d = new Date(Date.UTC(year, month, day));
+  return `${String(d.getUTCFullYear()).padStart(4, '0')}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+/** Today's date in UTC, the same reference the server resolves ranges against. */
+export function todayUtcIso(now: number = Date.now()): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+export function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+export function addDays(iso: string, n: number): string {
+  const p = parseIsoDate(iso);
+  if (!p) return iso;
+  return toIsoDate(p.year, p.month, p.day + n);
+}
+
+export function addMonths({ year, month }: YearMonth, n: number): YearMonth {
+  const d = new Date(Date.UTC(year, month + n, 1));
+  return { year: d.getUTCFullYear(), month: d.getUTCMonth() };
+}
+
+export function yearMonthOf(iso: string): YearMonth {
+  const p = parseIsoDate(iso);
+  if (p) return { year: p.year, month: p.month };
+  const t = parseIsoDate(todayUtcIso());
+  return t ? { year: t.year, month: t.month } : { year: 1970, month: 0 };
+}
+
+/** 1 (Monday) for Spanish, 0 (Sunday) otherwise. */
+export function weekStartsOn(locale: string): 0 | 1 {
+  return locale.toLowerCase().startsWith('es') ? 1 : 0;
+}
+
+/** Always 42 cells (6 rows x 7), padded with the neighbouring months so the
+ *  popover never changes height while paging. */
+export function monthGrid({ year, month }: YearMonth, weekStart: 0 | 1): GridCell[] {
+  const firstDow = new Date(Date.UTC(year, month, 1)).getUTCDay();
+  const lead = (firstDow - weekStart + 7) % 7;
+  const cells: GridCell[] = [];
+  for (let i = 0; i < 42; i++) {
+    const day = i - lead + 1;
+    const d = new Date(Date.UTC(year, month, day));
+    cells.push({
+      iso: toIsoDate(year, month, day),
+      inMonth: d.getUTCMonth() === month && d.getUTCFullYear() === year,
+    });
+  }
+  return cells;
+}
+
+/** Inclusive on both ends; string compare is safe for `YYYY-MM-DD`. */
+export function isOutOfRange(iso: string, min?: string, max?: string): boolean {
+  if (min && iso < min) return true;
+  if (max && iso > max) return true;
+  return false;
+}
+
+export function clampIso(iso: string, min?: string, max?: string): string {
+  if (min && iso < min) return min;
+  if (max && iso > max) return max;
+  return iso;
+}
+
+const capitalize = (s: string): string => (s ? s.charAt(0).toLocaleUpperCase() + s.slice(1) : s);
+
+/** Column headers, rotated to `weekStart`. 2023-01-01 is a Sunday, so the seven
+ *  days from there enumerate Sun..Sat in UTC; Intl gives the locale's names and
+ *  the trailing period some locales add (`lun.`) is stripped for the header. */
+export function weekdayLabels(locale: string, weekStart: 0 | 1): WeekdayLabel[] {
+  const short = new Intl.DateTimeFormat(locale, {
+    weekday: 'short',
+    timeZone: 'UTC',
+  });
+  const long = new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    timeZone: 'UTC',
+  });
+  const out: WeekdayLabel[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(Date.UTC(2023, 0, 1 + ((i + weekStart) % 7)));
+    out.push({
+      short: capitalize(short.format(d).replace(/\.$/, '')),
+      long: capitalize(long.format(d)),
+    });
+  }
+  return out;
+}
+
+/** "August 2026" / "Agosto 2026" (Intl gives Spanish lower-case, hence the cap). */
+export function formatMonthTitle({ year, month }: YearMonth, locale: string): string {
+  const s = new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(year, month, 1)));
+  return capitalize(s);
+}
+
+/** en `Aug 18, 2026`, es `18 ago 2026`. Falls back to the raw string when it is
+ *  not a valid ISO date so a bad URL param never throws in render. */
+export function formatIsoDate(iso: string, locale: string): string {
+  const p = parseIsoDate(iso);
+  if (!p) return iso;
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(p.year, p.month, p.day)));
+}

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -111,6 +111,15 @@ export interface FormsMessages {
       search: string;
       noResults: string;
     };
+    /** Branded mini calendar (`components/ui/date-picker`) that replaces native
+     *  date inputs. */
+    datePicker: {
+      placeholder: string;
+      dialogLabel: string;
+      prevMonth: string;
+      nextMonth: string;
+      clear: string;
+    };
     /** App shell chrome shared across every admin page (sidebar/header/footer). */
     chrome: {
       collapse: string;
@@ -1694,6 +1703,13 @@ export const en: FormsMessages = {
       search: 'Search…',
       noResults: 'No results',
     },
+    datePicker: {
+      placeholder: 'Pick a date',
+      dialogLabel: 'Calendar',
+      prevMonth: 'Previous month',
+      nextMonth: 'Next month',
+      clear: 'Clear date',
+    },
     chrome: {
       collapse: 'Collapse sidebar',
       expand: 'Expand sidebar',
@@ -3146,6 +3162,13 @@ export const es: FormsMessages = {
     select: {
       search: 'Buscar…',
       noResults: 'Sin resultados',
+    },
+    datePicker: {
+      placeholder: 'Elige una fecha',
+      dialogLabel: 'Calendario',
+      prevMonth: 'Mes anterior',
+      nextMonth: 'Mes siguiente',
+      clear: 'Borrar fecha',
     },
     chrome: {
       collapse: 'Contraer barra lateral',

--- a/qa/e2e/v13-analytics-date-picker.spec.ts
+++ b/qa/e2e/v13-analytics-date-picker.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect, type Page, type Locator, type APIRequestContext } from '@playwright/test';
+
+/**
+ * V13: branded date picker on the analytics "Custom" range.
+ *
+ * The From / To fields used to be OS-native `<input type="date">`s, which hand
+ * their popup to the browser (unthemed, off-brand, different everywhere). They
+ * are now `apps/web/components/ui/date-picker.tsx`: a `<button
+ * aria-haspopup="dialog">` trigger plus a `role="dialog"` popover holding a
+ * `role="grid"` mini calendar (`components/ui/calendar.tsx`). This spec drives
+ * the analytics page end-to-end:
+ *   1. Mouse: open Custom, pick From and To through the calendars (paging back a
+ *      month first), Apply, and land on `?preset=custom&from=&to=`.
+ *   2. Keyboard: Enter opens, ArrowLeft + Enter picks, Escape closes and hands
+ *      focus back to the trigger.
+ *   3. A reversed pick (From after To) still applies with from <= to, because
+ *      the filter swaps the bounds before pushing the URL.
+ *
+ * Each test creates its own form via the admin API and navigates by the returned
+ * id, so reruns are idempotent (no Date.now, per the suite's rule).
+ */
+
+const API = 'http://localhost:4400';
+const ISO = /^\d{4}-\d{2}-\d{2}$/;
+
+let seq = 0;
+function uniqueName(label: string, workerIndex: number): string {
+  seq += 1;
+  return `qa-v13-datepicker-${label}-w${workerIndex}-${seq}`;
+}
+
+const CONFIG = {
+  cover: { enabled: true, headline: 'V13 Date Picker', ctaText: 'Start' },
+  steps: [
+    {
+      key: 'email',
+      type: 'email',
+      question: 'Your work email',
+      required: true,
+    },
+    { key: 'notes', type: 'textarea', question: 'Anything else?' },
+  ],
+};
+
+async function createForm(request: APIRequestContext, name: string): Promise<{ id: string }> {
+  const res = await request.post(`${API}/v1/forms`, {
+    data: { name, config: { version: 1, ...CONFIG } },
+  });
+  expect(res.ok(), `POST /v1/forms failed: ${res.status()}`).toBeTruthy();
+  const body = await res.json();
+  return { id: body.id };
+}
+
+async function openAnalytics(page: Page, id: string) {
+  await page.goto(`/admin/forms/${id}/analytics`);
+  // First hit may compile the route in dev; wait for the Custom chip to hydrate.
+  await expect(page.getByRole('button', { name: 'Custom', exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/** Click the Custom chip until the branded From trigger appears (a click that
+ *  lands before hydration no-ops, so retry while it stays hidden). */
+async function revealCustom(page: Page) {
+  const chip = page.getByRole('button', { name: 'Custom', exact: true });
+  const from = page.getByTestId('analytics-from');
+  for (let i = 0; i < 4; i += 1) {
+    await chip.click();
+    try {
+      await expect(from).toBeVisible({ timeout: 2500 });
+      return;
+    } catch {
+      /* likely clicked before hydration; retry */
+    }
+  }
+  await expect(from).toBeVisible();
+}
+
+/** Click-open a picker, retrying while the dialog stays closed. */
+async function openByClick(trigger: Locator, dialog: Locator) {
+  for (let i = 0; i < 4; i += 1) {
+    await trigger.click();
+    try {
+      await expect(dialog).toBeVisible({ timeout: 2500 });
+      return;
+    } catch {
+      /* likely clicked before hydration; retry */
+    }
+  }
+  await expect(dialog).toBeVisible();
+}
+
+/** The first enabled day of the visible grid (may be a padding day of the
+ *  previous month; still a valid, pickable ISO date). */
+function firstEnabledDay(dialog: Locator): Locator {
+  return dialog.locator('[data-testid="calendar-day"]:not([aria-disabled="true"])').first();
+}
+
+test.describe('V13: branded analytics date picker (no native <input type="date">)', () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test('Mouse: Custom reveals branded From/To, calendars pick dates, Apply lands on the custom URL', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const form = await createForm(request, uniqueName('mouse', testInfo.workerIndex));
+    await openAnalytics(page, form.id);
+    await revealCustom(page);
+
+    // Zero native date inputs anywhere on the page.
+    await expect(page.locator('input[type="date"]')).toHaveCount(0);
+
+    const fromTrigger = page.getByTestId('analytics-from');
+    const fromDialog = page.getByTestId('analytics-from-dialog');
+    await expect(fromTrigger).toHaveAttribute('aria-haspopup', 'dialog');
+    await expect(fromTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    // From: open, page back one month, pick the first enabled day.
+    await openByClick(fromTrigger, fromDialog);
+    await expect(fromTrigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(fromDialog.getByRole('grid')).toBeVisible();
+    await expect(fromDialog.getByTestId('calendar-day')).toHaveCount(42);
+    const fromTitleBefore = await fromDialog.getByRole('grid').getAttribute('aria-label');
+    await fromDialog.getByRole('button', { name: 'Previous month' }).click();
+    await expect(fromDialog.getByRole('grid')).not.toHaveAttribute(
+      'aria-label',
+      fromTitleBefore ?? '',
+    );
+    const fromDay = firstEnabledDay(fromDialog);
+    const fromIso = await fromDay.getAttribute('data-iso');
+    expect(fromIso).toMatch(ISO);
+    await fromDay.click();
+    await expect(fromDialog).toHaveCount(0);
+    await expect(fromTrigger).toHaveAttribute('aria-expanded', 'false');
+    // The trigger now shows a formatted date, not the placeholder.
+    await expect(fromTrigger).not.toContainText('Pick a date');
+    await expect(page.getByTestId('analytics-from-clear')).toBeVisible();
+
+    // To: open (defaults to today's month), pick the first enabled day, which is
+    // >= From because From is the To picker's `min`.
+    const toTrigger = page.getByTestId('analytics-to');
+    const toDialog = page.getByTestId('analytics-to-dialog');
+    await openByClick(toTrigger, toDialog);
+    // Days before From are disabled in the To calendar.
+    if (fromIso) {
+      const prevDay = toDialog.locator(`[data-iso="${shiftIso(fromIso, -1)}"]`);
+      if ((await prevDay.count()) > 0) {
+        await expect(prevDay).toHaveAttribute('aria-disabled', 'true');
+      }
+    }
+    await toDialog.getByRole('button', { name: 'Previous month' }).click();
+    const toDay = firstEnabledDay(toDialog);
+    const toIso = await toDay.getAttribute('data-iso');
+    expect(toIso).toMatch(ISO);
+    await toDay.click();
+    await expect(toDialog).toHaveCount(0);
+
+    // Apply: URL carries the custom range, in order.
+    await page.getByTestId('analytics-apply').click();
+    await expect(page).toHaveURL(/preset=custom&from=\d{4}-\d{2}-\d{2}&to=\d{4}-\d{2}-\d{2}/);
+    const url = new URL(page.url());
+    const from = url.searchParams.get('from') ?? '';
+    const to = url.searchParams.get('to') ?? '';
+    expect(from <= to).toBe(true);
+    expect(from).toBe(fromIso);
+    expect(to).toBe(toIso);
+  });
+
+  test('Keyboard: Enter opens, ArrowLeft + Enter picks, Escape closes and restores focus', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const form = await createForm(request, uniqueName('kbd', testInfo.workerIndex));
+    await openAnalytics(page, form.id);
+    await revealCustom(page);
+
+    const trigger = page.getByTestId('analytics-from');
+    const dialog = page.getByTestId('analytics-from-dialog');
+
+    // Gate on hydration with one mouse open, then Escape closes and refocuses.
+    await openByClick(trigger, dialog);
+    await expect(dialog.locator('[data-iso][tabindex="0"]')).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expect(trigger).toBeFocused();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Keyboard open: Enter on the focused trigger.
+    await trigger.press('Enter');
+    await expect(dialog).toBeVisible();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const focusedCell = dialog.locator('[data-iso][tabindex="0"]');
+    await expect(focusedCell).toBeFocused();
+    const startIso = await focusedCell.getAttribute('data-iso');
+    expect(startIso).toMatch(ISO);
+
+    // ArrowLeft moves the cursor one day back, Enter commits it.
+    await page.keyboard.press('ArrowLeft');
+    const moved = dialog.locator('[data-iso][tabindex="0"]');
+    await expect(moved).toBeFocused();
+    await expect(moved).toHaveAttribute('data-iso', shiftIso(startIso ?? '', -1));
+    await page.keyboard.press('Enter');
+    await expect(dialog).toHaveCount(0);
+    await expect(trigger).toBeFocused();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(trigger).not.toContainText('Pick a date');
+  });
+
+  test('Reversed range: the pickers refuse it live, and a reversed URL still applies as from <= to', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const form = await createForm(request, uniqueName('reversed', testInfo.workerIndex));
+
+    // Live, the pickers make a reversed range unreachable: once To is set, From
+    // treats it as `max`; once From is set, To treats it as `min`.
+    await openAnalytics(page, form.id);
+    await revealCustom(page);
+    const toTrigger = page.getByTestId('analytics-to');
+    const toDialog = page.getByTestId('analytics-to-dialog');
+    await openByClick(toTrigger, toDialog);
+    await toDialog.getByRole('button', { name: 'Previous month' }).click();
+    const toDay = firstEnabledDay(toDialog);
+    const toIso = (await toDay.getAttribute('data-iso')) ?? '';
+    expect(toIso).toMatch(ISO);
+    await toDay.click();
+    await expect(toDialog).toHaveCount(0);
+
+    const fromTrigger = page.getByTestId('analytics-from');
+    const fromDialog = page.getByTestId('analytics-from-dialog');
+    await openByClick(fromTrigger, fromDialog);
+    // From opens on To's month (its clamped default) and every day after To is
+    // disabled, so the day after To cannot be picked.
+    const after = fromDialog.locator(`[data-iso="${shiftIso(toIso, 1)}"]`);
+    await expect(after).toHaveAttribute('aria-disabled', 'true');
+    await after.click({ force: true });
+    await expect(fromDialog).toBeVisible();
+    await expect(fromTrigger).toContainText('Pick a date');
+    await page.keyboard.press('Escape');
+    await expect(fromDialog).toHaveCount(0);
+
+    // A reversed pair can still arrive by URL (a hand-edited or stale link). The
+    // filter seeds its state from the params and Apply swaps the bounds before
+    // pushing, so the server never sees a backwards window.
+    await page.goto(
+      `/admin/forms/${form.id}/analytics?preset=custom&from=2026-01-15&to=2026-01-05`,
+    );
+    await expect(page.getByTestId('analytics-from')).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId('analytics-from')).toContainText('Jan 15, 2026');
+    await expect(page.getByTestId('analytics-to')).toContainText('Jan 5, 2026');
+    await page.getByTestId('analytics-apply').click();
+    await expect(page).toHaveURL(/preset=custom&from=2026-01-05&to=2026-01-15/);
+  });
+});
+
+/** Shift a `YYYY-MM-DD` string by `n` days in UTC. */
+function shiftIso(iso: string, n: number): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  const t = new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, (d ?? 1) + n));
+  return t.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
Bug 5 of the 2026-08-18 UI review: the Custom range on a form's Analytics page used the OS-native `<input type="date">` (mm/dd/yyyy, type or arrow keys, unthemed popup). It now opens a branded mini calendar.

## What changed

- **`components/ui/date-picker.tsx`**: a token-styled trigger (looks like the other inputs, shows the formatted date or a placeholder, `pi-calendar`, a clear button when set) that opens a `role="dialog"` panel anchored under it (`absolute z-50`, same non-portalled pattern as `Select`; a viewport guard flips it to the right edge when it would spill). Opens on the month of the value or today, Escape and outside click close, picking a day closes and refocuses the trigger.
- **`components/ui/calendar.tsx`**: stateless month grid (`<table role="grid">`, weekday initials via Intl, 42 cells, roving tabindex). Selected day filled `bg-primary`, today with the `--primary-edge` inset ring, out-of-range days disabled, out-of-month days dimmed. Keyboard: arrows, Home/End, PageUp/PageDown (Shift = year), Enter/Space.
- **`lib/calendar-math.ts`**: all date math in UTC (`Date.UTC` / `getUTC*`), matching the server's UTC day boundaries (phase 1 of `SPEC-METRICS.md`), isolated so a future account timezone only touches this module. Week starts Monday for `es`, Sunday for `en`.
- **Analytics filter**: From/To use the picker (`analytics-from` / `analytics-to`), `locale` flows from the server page as a prop (no cookie read on the client), Apply and the reversed-range swap unchanged. `preset=custom&from=YYYY-MM-DD&to=YYYY-MM-DD` in the URL as before.
- **i18n**: `admin.datePicker` (placeholder, dialog label, prev/next month, clear) in en and es.

## Verification

- Unit: `calendar-math.spec.ts` (month grids, leap years, rollover, parse, bounds, Intl labels), `calendar.spec.tsx`, `date-picker.spec.tsx` (21 tests), also under `TZ=America/Bogota` and `TZ=Pacific/Kiritimati`. `pnpm typecheck`, `pnpm lint`, `bash scripts/dash-check.sh origin/develop`: green.
- Playwright `qa/e2e/v13-analytics-date-picker.spec.ts` (3/3) against a `next build && next start` QA instance: mouse flow, keyboard flow, reversed range.
- Manual in dark and light theme (screens attached in the review thread if useful).
- `forms-reviewer` run: no blockers; its notes (trigger name announces the value, `useLayoutEffect` for roving focus, `@quill/web` dropped from the changeset since it is an ignored package) are applied.

Changeset: `@quill/shared` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)