### PR TITLE
docs: no dash in the iam-workspaces changeset; check the release range before a release PR

### DIFF
--- a/.changeset/iam-workspaces.md
+++ b/.changeset/iam-workspaces.md
@@ -14,7 +14,7 @@ here, and a workspace created here was invisible upstream. From migration 0015 o
 on login (at most once per TTL), on demand when the switcher opens, and after
 every write, which goes upstream first.
 
-- `packages/db/src/workspaces.ts` — `projectMemberships`, `projectRoster`,
+- `packages/db/src/workspaces.ts`: `projectMemberships`, `projectRoster`,
   `rebindLegacyAccount`, `pickHomeAccount`, `createLocalWorkspace`,
   `humanHasCompletedOnboarding`. Three additive columns: `account.iam_account_id`,
   `account.synced_at`, `member.iam_workspace_user_id`.
@@ -29,7 +29,7 @@ every write, which goes upstream first.
   their email and their acceptance live upstream; removals and role changes go
   upstream first. Pending invitations are listed and can be resent.
 - Roles: `OWNER` → owner, `MEMBER` holding `workspace_admin` → admin, any other →
-  member — one function (`roleFromIam`) so a future `forms` permission component
+  member; one function (`roleFromIam`) so a future `forms` permission component
   changes exactly one place.
 - Onboarding is per person, not per workspace: someone who finished the wizard is
   not sent through it again for a workspace projected from upstream.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,24 @@ first. Run it with a base to see exactly what CI will say:
 bash scripts/dash-check.sh origin/develop
 ```
 
+**The release PR (`develop` into `main`) is charged for everything develop
+added since the last release**, not for one feature. A dash that reached
+develop before this gate ran on PRs (or through a merge nobody re-checked) is
+invisible on every feature PR and fails only on the release, where the fix is
+a detour: a second PR into develop, then the release re-runs. It happened on
+2026-08-18 with `.changeset/iam-workspaces.md` (merged one PR before the CI job
+existed). So, before opening the release PR, run the check with main as the
+base and fix what it reports in a small PR to develop first:
+
+```bash
+bash scripts/dash-check.sh origin/main
+```
+
+And when you write a changeset, remember it is the one file the whole-tree
+copy scan does NOT read (it is docs scope, diff-only): the base rule above,
+"no em dash in anything a person outside the team reads", is the only thing
+keeping it clean, and it becomes the public CHANGELOG the moment it ships.
+
 **What the check does NOT read: comments and `*.spec.ts` titles.** Both are
 advisory per the rule above, in every scope, so a dashed code comment or test
 title will never fail CI. That is a deliberate ceiling, not an oversight: the


### PR DESCRIPTION
Unblocks the release PR #127, whose typography gate failed on two em dashes in `.changeset/iam-workspaces.md` (merged in #117, one PR before #118 put the check in CI, so no feature PR ever ran on it; the release PR is charged for everything develop added since main).

- `.changeset/iam-workspaces.md`: the two dashes become a colon and a semicolon. `bash scripts/dash-check.sh origin/main` is clean after this.
- `CLAUDE.md`: adds the missing step to the "Check before you push" section: run the check with `origin/main` as the base before opening a release PR and land fixes in a small PR to develop first; and notes that changesets are docs scope (diff-only), so the whole-tree copy scan never reads them.

Once this merges into develop, #127 picks it up automatically (its head is `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)