### PR TITLE
fix(api): staff refresh stops paging the estate; staff search by email and form name

### DIFF
--- a/.changeset/staff-refresh-no-estate-paging.md
+++ b/.changeset/staff-refresh-no-estate-paging.md
@@ -1,0 +1,11 @@
+---
+'@quill/api': patch
+'@quill/db': patch
+'@quill/web': patch
+'@quill/shared': patch
+---
+
+Staff requests stop crawling, and the staff search finds workspaces by what staff actually hold.
+
+- A staff person's workspace refresh no longer pages through the whole estate (to a staff token the unscoped upstream search answers with every workspace there is; reading thousands of rows on every TTL and every switcher open made each request take 10 to 50 seconds). It now reads the workspaces of their own upstream account (the search scoped with `accountId`) plus, in parallel, every workspace this database already knows them in, so revoked memberships are still disabled and a grant whose workspace now names them still becomes the real membership. A membership in someone else's account that was never projected is found when they enter it from the estate search, which projects that one workspace directly.
+- The staff search also matches the accounts this database already projected by workspace name, member email or form name (the identity service only knows names, and staff usually hold a form link or the customer's address). Such rows say why they matched (the email, or "Form: name"), in the switcher and on the Account settings cards.

--- a/apps/api/src/iam-workspaces.ts
+++ b/apps/api/src/iam-workspaces.ts
@@ -231,6 +231,36 @@ export class IamWorkspacesClient {
   }
 
   /**
+   * Every workspace of ONE upstream account that `sub` is a member of (or owns).
+   * Same search endpoint, scoped with `accountId`: for the deployment's staff
+   * the unscoped search is the whole estate, and paging through thousands of
+   * rows to find the handful they actually belong to is what made every staff
+   * request crawl. Scoped, it is a page or two.
+   */
+  async listAccountWorkspaces(bearer: string, sub: string, accountId: string): Promise<IamWorkspace[]> {
+    const out: IamWorkspace[] = [];
+    const seen = new Set<string>();
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      const res = await this.call<{ data?: IamWorkspace[]; totalPages?: number; total?: number }>(
+        bearer,
+        'GET',
+        `/workspace/search?page=${page}&limit=${PAGE_SIZE}&accountId=${encodeURIComponent(accountId)}`,
+      );
+      const rows = Array.isArray(res?.data) ? res.data : [];
+      for (const ws of rows) {
+        if (!ws || typeof ws.id !== 'string' || seen.has(ws.id)) continue;
+        seen.add(ws.id);
+        if (ws.is_active === false) continue;
+        const me = membershipOf(ws, sub);
+        if (me || ws.isOwner === true) out.push(ws);
+      }
+      const totalPages = typeof res?.totalPages === 'number' ? res.totalPages : 1;
+      if (rows.length < PAGE_SIZE || page >= totalPages) break;
+    }
+    return out;
+  }
+
+  /**
    * One page of the workspace search as the upstream answers it, membership NOT
    * applied: for the deployment's staff the identity service answers with the
    * whole estate, and that is exactly the list they get to search (the same

--- a/apps/api/src/workspace-projection.ts
+++ b/apps/api/src/workspace-projection.ts
@@ -18,6 +18,7 @@ import type { Db } from '@quill/db';
 import {
   getAccountByExternalId,
   humanHasCompletedOnboarding,
+  listWorkspacesForIdentity,
   pickHomeAccount,
   projectMemberships,
   rebindLegacyAccount,
@@ -25,6 +26,7 @@ import {
   type ProjectedMembership,
 } from '@quill/db';
 import {
+  IamHttpError,
   IamUnavailableError,
   IamWorkspacesClient,
   membershipOf,
@@ -56,6 +58,8 @@ export interface ProjectionState {
 }
 
 const DEFAULT_TTL_MS = 60_000;
+/** How many already-projected memberships a staff refresh re-reads upstream (in parallel). */
+const STAFF_KNOWN_LIMIT = 25;
 
 export class WorkspaceProjection {
   private readonly log = new Logger('WorkspaceProjection');
@@ -127,9 +131,13 @@ export class WorkspaceProjection {
     now: number,
   ): Promise<ProjectionState> {
     let workspaces: IamWorkspace[];
+    // Whether a membership the upstream stopped naming may be disabled below.
+    // False only when the staff path could not re-read one of the person's
+    // known workspaces: then "not in the list" proves nothing.
+    let pruneMissing = true;
     let featureFlags: Record<string, unknown> | null = null;
     try {
-      const [account, wss] = await Promise.all([
+      const [account, mine] = await Promise.all([
         this.iam.getAccount(id.bearer, id.iamAccountId).catch((err) => {
           // The person's account row is nice-to-have (last_workspace); a
           // failure there must not fail the workspace list.
@@ -137,9 +145,12 @@ export class WorkspaceProjection {
           this.log.warn(`IAM account read failed for ${id.iamAccountId}: ${String(err)}`);
           return null;
         }),
-        this.iam.listMyWorkspaces(id.bearer, id.sub),
+        this.isStaff(id.email)
+          ? this.staffMemberships(id)
+          : this.iam.listMyWorkspaces(id.bearer, id.sub).then((wss) => ({ workspaces: wss, complete: true })),
       ]);
-      workspaces = wss;
+      workspaces = mine.workspaces;
+      pruneMissing = mine.complete;
       featureFlags =
         account?.feature_flags && typeof account.feature_flags === 'object' ? account.feature_flags : null;
     } catch (err) {
@@ -183,7 +194,7 @@ export class WorkspaceProjection {
       this.db,
       { externalId: id.sub, email: id.email, displayName: id.displayName },
       memberships,
-      { inheritOnboarding, now },
+      { inheritOnboarding, now, pruneMissing },
     );
 
     for (const c of result.created) {
@@ -249,6 +260,97 @@ export class WorkspaceProjection {
     } catch (err) {
       this.log.warn(`last_workspace write failed for ${id.sub}: ${String(err)}`);
     }
+  }
+
+  /**
+   * Project ONE upstream workspace the person is a real member of, without
+   * touching any other row (no pruning). Used when staff enter an estate
+   * workspace that turns out to name them: their refresh no longer reads the
+   * estate (see `staffMemberships`), so a membership in someone else's account
+   * that was never projected is found exactly here, and from then on it is a
+   * known row the refresh re-reads.
+   */
+  async projectOne(id: UpstreamIdentity, ws: IamWorkspace): Promise<void> {
+    const me = membershipOf(ws, id.sub);
+    const inheritOnboarding = await humanHasCompletedOnboarding(this.db, id.sub);
+    await projectMemberships(
+      this.db,
+      { externalId: id.sub, email: id.email, displayName: id.displayName },
+      [
+        {
+          workspaceId: ws.id,
+          workspaceName: ws.name,
+          iamAccountId: ws.account_id ?? null,
+          workspaceUserId: me?.id ?? null,
+          role: me ? roleFromIam(me) : 'owner',
+          active: me ? me.is_active !== false : true,
+        },
+      ],
+      { inheritOnboarding, now: this.now(), pruneMissing: false },
+    );
+    this.invalidate(id.sub);
+  }
+
+  /**
+   * The memberships of one of the deployment's STAFF, without reading the
+   * estate. To a staff token the unscoped upstream search answers with every
+   * workspace there is, and paging through all of it on every refresh (every
+   * TTL, every switcher open) is what made each staff request take tens of
+   * seconds. Instead:
+   *
+   *   1. the workspaces of the person's OWN upstream account (the search,
+   *      scoped with `accountId`: a page or two), and
+   *   2. every other workspace this database already knows them in (a
+   *      membership projected earlier, or a staff grant), re-read one by one,
+   *      in parallel, so a membership revoked upstream is still disabled and
+   *      a grant whose workspace now names them becomes the real membership.
+   *
+   * What this cannot see: a membership in someone ELSE's account that was never
+   * projected here. Staff reach those through the estate search, and entering
+   * one re-reads it upstream and projects the real membership when there is
+   * one (`enterEstateWorkspace`), so it joins the list from then on.
+   *
+   * `complete` is false when one of the re-reads failed for a reason other than
+   * "gone" (404): the caller then skips pruning, because a workspace absent
+   * from this list might simply not have answered.
+   */
+  private async staffMemberships(id: UpstreamIdentity): Promise<{ workspaces: IamWorkspace[]; complete: boolean }> {
+    const own = await this.iam.listAccountWorkspaces(id.bearer, id.sub, id.iamAccountId);
+    const seen = new Set(own.map((w) => w.id));
+    const known = (await listWorkspacesForIdentity(this.db, { externalId: id.sub, email: id.email }))
+      .filter((r) => !!r.workspaceId && !seen.has(r.workspaceId as string))
+      // A pre-0015 row carries the upstream ACCOUNT id, not a workspace; the
+      // legacy rebind below handles it, a workspace read would only 404.
+      .filter((r) => r.workspaceId !== id.iamAccountId)
+      .map((r) => r.workspaceId as string);
+    if (known.length > STAFF_KNOWN_LIMIT) {
+      this.log.warn(`staff ${id.sub} holds ${known.length} projected memberships; re-reading the first ${STAFF_KNOWN_LIMIT}`);
+    }
+    const reads = await Promise.all(
+      known.slice(0, STAFF_KNOWN_LIMIT).map((wsId) =>
+        this.iam.getWorkspace(id.bearer, wsId).then(
+          (ws): { ws: IamWorkspace | null; failed: boolean } => ({ ws, failed: false }),
+          (err: unknown) => {
+            if (err instanceof IamUnavailableError) throw err;
+            // Gone upstream: a real "not yours any more", prune applies.
+            if (err instanceof IamHttpError && err.status === 404) return { ws: null, failed: false };
+            this.log.warn(`staff workspace re-read failed for ${wsId}: ${String(err)}`);
+            return { ws: null, failed: true };
+          },
+        ),
+      ),
+    );
+    let complete = known.length <= STAFF_KNOWN_LIMIT;
+    for (const r of reads) {
+      if (r.failed) complete = false;
+      const ws = r.ws;
+      if (!ws || typeof ws.id !== 'string' || seen.has(ws.id)) continue;
+      seen.add(ws.id);
+      if (ws.is_active === false) continue;
+      const me = membershipOf(ws, id.sub);
+      if (me || ws.isOwner === true) own.push(ws);
+    }
+    return { workspaces: own, complete };
   }
 
   /**

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -369,8 +369,10 @@ describe('WorkspaceService (IAM-backed) — staff of the deployment', () => {
   // customer workspace they hold no membership in.
   let db: Db;
   let svc: WorkspaceService;
-  let calls: Array<{ method: string; path: string }>;
+  let calls: Array<{ method: string; path: string; search?: string }>;
   let workspaces: IamWorkspace[];
+  // Workspace ids whose single read answers 500 (a flaky upstream row).
+  let broken: Set<string>;
   const STAFF_SUB = 'sub-staff';
   const staffToken = signJwtHs256({ sub: STAFF_SUB, account_id: 'acc-staff', email: 's@staff.test', name: 'Staff', exp: 4102444800 }, SECRET);
   const staffReq = (workspace?: string): ReqLike => ({
@@ -383,6 +385,7 @@ describe('WorkspaceService (IAM-backed) — staff of the deployment', () => {
     db = await createDb('file::memory:');
     await migrate(db);
     calls = [];
+    broken = new Set();
     workspaces = [
       { id: WS_OWN, name: 'Mine', account_id: IAM_ACCOUNT, is_active: true, users: [{ id: 'wu1', user_id: SUB, type: 'OWNER', is_active: true, roles: [] }] },
       { id: 'ws-staff', name: 'Staff HQ', account_id: 'acc-staff', is_active: true, users: [{ id: 'wu-s', user_id: STAFF_SUB, type: 'OWNER', is_active: true, roles: [] }] },
@@ -391,16 +394,21 @@ describe('WorkspaceService (IAM-backed) — staff of the deployment', () => {
     const fetchImpl: typeof fetch = async (input, init) => {
       const url = new URL(String(input));
       const method = init?.method ?? 'GET';
-      calls.push({ method, path: url.pathname });
+      calls.push({ method, path: url.pathname, search: url.search });
       if (method === 'GET' && url.pathname.startsWith('/iam/account/')) return json({ id: url.pathname.split('/').pop(), feature_flags: {} });
       if (method === 'PUT' && url.pathname.startsWith('/iam/account/')) return json({});
       if (method === 'GET' && url.pathname === '/iam/workspace/search') {
+        // As the real one: a staff token sees the estate; `accountId` scopes it.
         const q = (url.searchParams.get('query') ?? '').toLowerCase();
-        const rows = q ? workspaces.filter((w) => w.name.toLowerCase().includes(q)) : workspaces;
+        const acc = url.searchParams.get('accountId');
+        let rows = q ? workspaces.filter((w) => w.name.toLowerCase().includes(q)) : workspaces;
+        if (acc) rows = rows.filter((w) => w.account_id === acc);
         return json({ data: rows, total: rows.length, totalPages: 1 });
       }
       if (method === 'GET' && url.pathname.startsWith('/iam/workspace/')) {
-        const w = workspaces.find((x) => x.id === url.pathname.split('/').pop());
+        const id = url.pathname.split('/').pop() ?? '';
+        if (broken.has(id)) return new Response('boom', { status: 500 });
+        const w = workspaces.find((x) => x.id === id);
         return w ? json(w) : new Response('nf', { status: 404 });
       }
       return new Response('nope', { status: 404 });
@@ -494,6 +502,71 @@ describe('WorkspaceService (IAM-backed) — staff of the deployment', () => {
     expect(res.rows).toHaveLength(1);
     expect(res.rows[0]!.accountId).toBe(accountId);
     expect(res.rows[0]!.accessGrant).toBeNull();
+  });
+
+  it('staff search also matches the projected accounts by member email or form name, and says why', async () => {
+    // The customer has been here (their list projected "Mine") and built a form.
+    await svc.list(customerReq());
+    const mine = await db.get<{ id: string }>(sql`SELECT id FROM account WHERE external_id = ${WS_OWN}`);
+    await db.run(
+      sql`INSERT INTO form (id, account_id, name, slug, config, created_at, updated_at)
+          VALUES ('f-katagi', ${mine!.id}, 'Katagi Leads demo', 'katagi-leads-demo', '{}', 1, 1)`,
+    );
+    // Upstream knows no workspace called "katagi"; the local form does.
+    const byForm = await svc.search(staffReq(), { query: 'katagi' });
+    expect(byForm.rows.map((r) => r.name)).toEqual(['Mine']);
+    expect(byForm.rows[0]).toMatchObject({
+      workspaceId: WS_OWN,
+      accountId: null,
+      accessGrant: 'staff',
+      localExists: true,
+      hint: { kind: 'form', value: 'Katagi Leads demo' },
+    });
+    // By the owner's address.
+    const byEmail = await svc.search(staffReq(), { query: 'a@x.c' });
+    expect(byEmail.rows.map((r) => r.name)).toEqual(['Mine']);
+    expect(byEmail.rows[0]!.hint).toEqual({ kind: 'email', value: 'a@x.com' });
+    // By name, the upstream and the local hit are the same workspace: once, no hint.
+    const byName = await svc.search(staffReq(), { query: 'mine' });
+    expect(byName.rows.filter((r) => r.workspaceId === WS_OWN)).toHaveLength(1);
+    expect(byName.rows[0]!.hint ?? null).toBeNull();
+  });
+
+  it('a staff refresh never pages the estate: own account scoped, known memberships re-read one by one', async () => {
+    await svc.list(staffReq());
+    const searches = calls.filter((c) => c.path === '/iam/workspace/search');
+    expect(searches.length).toBeGreaterThan(0);
+    // Every search the refresh made was scoped to the staff person's account.
+    expect(searches.every((c) => (c.search ?? '').includes('accountId=acc-staff'))).toBe(true);
+    expect(calls.some((c) => c.path.startsWith('/iam/workspace/') && c.path !== '/iam/workspace/search')).toBe(false);
+
+    // The staff person is later made a real member of Other Corp upstream and
+    // enters it through the estate: projected as a membership.
+    workspaces[2]!.users!.push({ id: 'wu-s2', user_id: STAFF_SUB, type: 'MEMBER', is_active: true, roles: [] });
+    await svc.enterEstateWorkspace(staffReq(), 'ws-other');
+    calls.length = 0;
+    await svc.refresh(staffReq());
+    // Known membership outside the own account: re-read by id, still no estate paging.
+    expect(calls.some((c) => c.path === '/iam/workspace/ws-other')).toBe(true);
+    expect(calls.filter((c) => c.path === '/iam/workspace/search').every((c) => (c.search ?? '').includes('accountId='))).toBe(true);
+    let names = (await svc.list(staffReq())).map((w) => w.accountName).sort();
+    expect(names).toEqual(['Other Corp', 'Staff HQ']);
+
+    // Revoked upstream: the re-read no longer names them, the row is disabled.
+    workspaces[2]!.users = workspaces[2]!.users!.filter((u) => u.user_id !== STAFF_SUB);
+    await svc.refresh(staffReq());
+    names = (await svc.list(staffReq())).map((w) => w.accountName);
+    expect(names).toEqual(['Staff HQ']);
+  });
+
+  it('a staff refresh that cannot re-read a known workspace keeps it (no pruning on a 500)', async () => {
+    workspaces[2]!.users!.push({ id: 'wu-s2', user_id: STAFF_SUB, type: 'MEMBER', is_active: true, roles: [] });
+    await svc.enterEstateWorkspace(staffReq(), 'ws-other');
+    expect((await svc.list(staffReq())).map((w) => w.accountName).sort()).toEqual(['Other Corp', 'Staff HQ']);
+    broken.add('ws-other');
+    await svc.refresh(staffReq());
+    // Absent from the refreshed list (it did not answer), but NOT disabled.
+    expect((await svc.list(staffReq())).map((w) => w.accountName).sort()).toEqual(['Other Corp', 'Staff HQ']);
   });
 });
 

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -28,6 +28,7 @@ import {
   createLocalWorkspace,
   findMembership,
   getAccountByExternalId,
+  searchProjectedAccounts,
   getAccountMember,
   getMemberIdentity,
   getMemberUpstreamRef,
@@ -74,6 +75,12 @@ export interface WorkspaceSearchRow {
   memberCount: number;
   /** Estate rows only: whether the workspace already has a local account (someone here opened it). */
   localExists?: boolean;
+  /**
+   * Staff rows matched locally by something other than the workspace name: the
+   * member email or the form name that matched, so the person sees WHY this
+   * workspace answered their query.
+   */
+  hint?: { kind: 'email' | 'form'; value: string } | null;
 }
 
 @Injectable()
@@ -255,19 +262,40 @@ export class WorkspaceService {
       return { rows: own, staff: false, total: own.length, totalPages: 1, page: 1 };
     }
 
-    // Staff: the estate page from upstream, minus what the own list already
-    // shows (matched by upstream workspace id), so a workspace never appears
-    // twice. Own rows first: they are the ones the person actually works in.
-    const page = await this.projection.iam.searchWorkspaces(up.bearer, {
-      query: q,
-      page: input.page,
-      limit: input.limit,
-    });
-    const ownWsIds = new Set<string>();
-    for (const w of mineFiltered) if (w.workspaceId) ownWsIds.add(w.workspaceId);
+    // Staff: two sources, in parallel. (1) The accounts THIS database already
+    // projected, matched by workspace name, member email or form name: the
+    // identity service knows workspaces by name only, and staff rarely hold
+    // the name; they hold a form link or the customer's address. (2) The
+    // estate page from upstream (name match). Both minus what the own list
+    // already shows, never a workspace twice. Own rows first: they are the
+    // ones the person actually works in; then the local hits (Forms users,
+    // the ones staff come here for); then the rest of the estate.
+    const firstPage = !input.page || input.page <= 1;
+    const [localHits, page] = await Promise.all([
+      firstPage && q ? searchProjectedAccounts(this.db, q, { limit: input.limit }) : Promise.resolve([]),
+      this.projection.iam.searchWorkspaces(up.bearer, { query: q, page: input.page, limit: input.limit }),
+    ]);
+    const seen = new Set<string>();
+    for (const w of mineFiltered) if (w.workspaceId) seen.add(w.workspaceId);
     const estate: WorkspaceSearchRow[] = [];
+    for (const hit of localHits) {
+      if (seen.has(hit.workspaceId)) continue;
+      seen.add(hit.workspaceId);
+      estate.push({
+        workspaceId: hit.workspaceId,
+        accountId: null,
+        name: hit.name,
+        role: 'admin',
+        status: 'active',
+        accessGrant: 'staff',
+        memberCount: hit.memberCount,
+        localExists: true,
+        hint: hit.hint,
+      });
+    }
     for (const ws of page.rows) {
-      if (ownWsIds.has(ws.id)) continue;
+      if (seen.has(ws.id)) continue;
+      seen.add(ws.id);
       const local = await getAccountByExternalId(this.db, ws.id);
       estate.push({
         workspaceId: ws.id,
@@ -281,7 +309,7 @@ export class WorkspaceService {
       });
     }
     return {
-      rows: [...(input.page && input.page > 1 ? [] : own), ...estate],
+      rows: [...(firstPage ? own : []), ...estate],
       staff: true,
       total: page.total,
       totalPages: page.totalPages,
@@ -321,8 +349,10 @@ export class WorkspaceService {
     const me = (ws.users ?? []).find((u) => u.user_id === up.sub);
     let accountId: string;
     if (me && me.is_active !== false) {
-      // A real membership upstream: project it as such, no grant needed.
-      await this.projection.ensure(up, { force: true });
+      // A real membership upstream: project it as such, no grant needed. This
+      // ONE workspace, directly: a staff refresh does not read the estate, so
+      // a membership in someone else's account is not found any other way.
+      await this.projection.projectOne(up, ws);
       const local = await getAccountByExternalId(this.db, ws.id);
       if (!local) throw new BadRequestException({ error: 'WORKSPACE_NOT_VISIBLE', message: 'Try refreshing.' });
       accountId = local.id;

--- a/apps/web/app/admin/account/workspaces/workspace-cards.tsx
+++ b/apps/web/app/admin/account/workspaces/workspace-cards.tsx
@@ -397,9 +397,15 @@ export function WorkspaceCards({
                               {labels.createDialog.staff}
                             </span>
                           </div>
-                          <p className="mt-0.5 truncate font-mono text-xs text-faint" title={workspaceId}>
-                            {workspaceId}
-                          </p>
+                          {r.hint ? (
+                            <p className="mt-0.5 truncate text-xs text-faint" data-testid="workspace-card-hint">
+                              {r.hint.kind === 'form' ? t(labels.createDialog.hintForm, { name: r.hint.value }) : r.hint.value}
+                            </p>
+                          ) : (
+                            <p className="mt-0.5 truncate font-mono text-xs text-faint" title={workspaceId}>
+                              {workspaceId}
+                            </p>
+                          )}
                         </div>
                       </div>
                       <dl className="flex flex-col gap-1 text-sm">

--- a/apps/web/components/workspace-switcher.tsx
+++ b/apps/web/components/workspace-switcher.tsx
@@ -9,7 +9,7 @@ import {
   useTransition,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
-import type { FormsMessages } from '@quill/shared';
+import { t, type FormsMessages } from '@quill/shared';
 import type { MemberStatus, Workspace, WorkspaceSearchRow } from '@/lib/admin-api';
 import {
   enterEstateWorkspaceAction,
@@ -43,6 +43,8 @@ interface Row {
   /** Shows the "Staff" badge: in it by grant, or an estate row. */
   staff: boolean;
   estate: boolean;
+  /** Why an estate row matched when its name did not (staff search). */
+  hint?: { kind: 'email' | 'form'; value: string } | null;
 }
 
 /**
@@ -221,6 +223,7 @@ export function WorkspaceSwitcher({
         status: r.status,
         staff: true,
         estate: true,
+        hint: r.hint ?? null,
       });
     }
     return { own: ownRows, estate: estateRows };
@@ -306,7 +309,16 @@ export function WorkspaceSwitcher({
           className={`pi ${active ? 'pi-check text-primary' : 'pi-circle-off opacity-0'}`}
           style={{ fontSize: 11 }}
         />
-        <span className="min-w-0 flex-1 truncate">{row.name}</span>
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate">{row.name}</span>
+          {/* Matched by a member's email or a form's name, not by the workspace
+              name: say so, or the row reads as a wrong answer. */}
+          {row.hint ? (
+            <span className="truncate text-2xs text-faint" data-testid="workspace-option-hint">
+              {row.hint.kind === 'form' ? t(m.hintForm, { name: row.hint.value }) : row.hint.value}
+            </span>
+          ) : null}
+        </span>
         {/* An invitation you have not opened yet. Naming it is the difference
             between "why are there two?" and "ah, that one is waiting for me." */}
         {row.status === 'invited' && !row.estate ? (

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -135,6 +135,8 @@ export interface WorkspaceSearchRow {
   accessGrant: 'staff' | null;
   memberCount: number;
   localExists?: boolean;
+  /** Staff rows matched by something other than the name: the email or form name that did. */
+  hint?: { kind: 'email' | 'form'; value: string } | null;
 }
 
 export interface WorkspaceSearchResponse {

--- a/packages/db/src/workspaces.spec.ts
+++ b/packages/db/src/workspaces.spec.ts
@@ -29,6 +29,7 @@ import {
   projectMemberships,
   projectRoster,
   rebindLegacyAccount,
+  searchProjectedAccounts,
 } from './workspaces';
 
 let db: Db;
@@ -277,5 +278,51 @@ describe('grantStaffAccess (both dialects)', () => {
     ]);
     const g = await db.get<{ status: string }>(sql`SELECT status FROM member WHERE id = ${memberId}`);
     expect(g!.status).toBe('active');
+  });
+});
+
+describe('searchProjectedAccounts (both dialects)', () => {
+  it('matches by workspace name, member email or form name; names the reason; skips local-only accounts', async () => {
+    const tag = randomUUID().slice(0, 8);
+    const wsA = `ws-${randomUUID()}`, wsB = `ws-${randomUUID()}`;
+    const owner = { externalId: `sub-${tag}-a`, email: `zed-${tag}@seika.test`, displayName: 'Zed' };
+    await projectMemberships(db, owner, [
+      { workspaceId: wsA, workspaceName: `Henry Bravo ${tag}`, iamAccountId: 'acc-a', workspaceUserId: 'wu-a', role: 'owner', active: true },
+    ]);
+    await projectMemberships(db, { externalId: `sub-${tag}-b`, email: `other-${tag}@example.com`, displayName: 'B' }, [
+      { workspaceId: wsB, workspaceName: `Bravo Corp ${tag}`, iamAccountId: 'acc-b', workspaceUserId: 'wu-b', role: 'owner', active: true },
+    ]);
+    await ids([wsA, wsB]);
+    const a = created[0]!;
+    const now = Date.now();
+    await db.run(
+      sql`INSERT INTO form (id, account_id, name, slug, config, created_at, updated_at)
+          VALUES (${randomUUID()}, ${a}, ${`Katagi Leads demo ${tag}`}, ${`katagi-${tag}`}, '{}', ${now}, ${now})`,
+    );
+    // A local-only account (never projected) with a matching name: not a workspace anyone is granted into.
+    const local = randomUUID();
+    created.push(local);
+    await db.run(sql`INSERT INTO account (id, code, name, created_at) VALUES (${local}, ${`c${local.slice(0, 8)}`}, ${`Bravo local ${tag}`}, ${now})`);
+
+    // By name: both projected accounts, the local-only one left out; no hint (the name matched).
+    const byName = await searchProjectedAccounts(db, tag);
+    expect(byName.map((h) => h.name).sort()).toEqual([`Bravo Corp ${tag}`, `Henry Bravo ${tag}`]);
+    expect(byName.every((h) => h.hint === null)).toBe(true);
+    expect(byName.find((h) => h.name === `Henry Bravo ${tag}`)!.workspaceId).toBe(wsA);
+    expect(byName.find((h) => h.name === `Henry Bravo ${tag}`)!.memberCount).toBe(1);
+
+    // By the owner's email: the hint says which address matched.
+    const byEmail = await searchProjectedAccounts(db, `zed-${tag}@seika`);
+    expect(byEmail.map((h) => h.name)).toEqual([`Henry Bravo ${tag}`]);
+    expect(byEmail[0]!.hint).toEqual({ kind: 'email', value: `zed-${tag}@seika.test` });
+
+    // By a form's name: the hint is the form.
+    const byForm = await searchProjectedAccounts(db, `katagi leads`);
+    expect(byForm.some((h) => h.workspaceId === wsA)).toBe(true);
+    expect(byForm.find((h) => h.workspaceId === wsA)!.hint).toEqual({ kind: 'form', value: `Katagi Leads demo ${tag}` });
+
+    // LIKE wildcards are literal; blank is nothing.
+    expect(await searchProjectedAccounts(db, `%${tag}%`)).toEqual([]);
+    expect(await searchProjectedAccounts(db, '   ')).toEqual([]);
   });
 });

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -72,6 +72,89 @@ export async function getAccountByExternalId(
   return r ? { id: r.id, name: r.name, iamAccountId: r.iam_account_id ?? null } : null;
 }
 
+/** One projected account the staff search matched locally. */
+export interface ProjectedAccountHit {
+  /** Local account id. */
+  id: string;
+  /** The upstream workspace id (`account.external_id`). */
+  workspaceId: string;
+  name: string;
+  /** Active real members (grants excluded). */
+  memberCount: number;
+  /** When the NAME did not match: the member email or form name that did. */
+  hint: { kind: 'email' | 'form'; value: string } | null;
+}
+
+/** `%`/`_` are LIKE wildcards; a search for them must mean them. */
+function likePattern(q: string): string {
+  return `%${q.toLowerCase().replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+}
+
+/**
+ * Staff search over the accounts this database already projected from the
+ * identity service: by workspace name, by a member's email, or by one of its
+ * FORMS' names. The identity service knows workspaces by name only, and a
+ * workspace is rarely what the deployment's staff remember: they hold a
+ * submission email, a form link, the customer's address. Local-only accounts
+ * (no `external_id`) are not workspaces anyone can be granted into, so they
+ * are left out.
+ */
+export async function searchProjectedAccounts(
+  db: Db,
+  query: string,
+  opts: { limit?: number } = {},
+): Promise<ProjectedAccountHit[]> {
+  const q = query.trim();
+  if (!q) return [];
+  const pat = likePattern(q);
+  const limit = Math.max(1, Math.min(50, opts.limit ?? 20));
+  const rows = await db.all<{
+    id: string;
+    external_id: string;
+    name: string;
+    member_count: number | string;
+    name_hit: number | boolean;
+    email_hit: string | null;
+    form_hit: string | null;
+  }>(
+    sql`SELECT a.id, a.external_id, a.name,
+               (SELECT COUNT(*) FROM member mm
+                 WHERE mm.account_id = a.id AND mm.status = 'active' AND mm.access_grant IS NULL) AS member_count,
+               (lower(a.name) LIKE ${pat} ESCAPE '\\') AS name_hit,
+               (SELECT m.email FROM member m
+                 WHERE m.account_id = a.id AND m.access_grant IS NULL AND m.email IS NOT NULL
+                   AND lower(m.email) LIKE ${pat} ESCAPE '\\'
+                 ORDER BY (m.role = 'owner') DESC, m.created_at ASC LIMIT 1) AS email_hit,
+               (SELECT f.name FROM form f
+                 WHERE f.account_id = a.id AND lower(f.name) LIKE ${pat} ESCAPE '\\'
+                 ORDER BY f.created_at DESC LIMIT 1) AS form_hit
+        FROM account a
+        WHERE a.external_id IS NOT NULL
+          AND (lower(a.name) LIKE ${pat} ESCAPE '\\'
+            OR EXISTS (SELECT 1 FROM member m2
+                        WHERE m2.account_id = a.id AND m2.access_grant IS NULL AND m2.email IS NOT NULL
+                          AND lower(m2.email) LIKE ${pat} ESCAPE '\\')
+            OR EXISTS (SELECT 1 FROM form f2
+                        WHERE f2.account_id = a.id AND lower(f2.name) LIKE ${pat} ESCAPE '\\'))
+        ORDER BY (lower(a.name) LIKE ${pat} ESCAPE '\\') DESC, a.name ASC
+        LIMIT ${limit}`,
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    workspaceId: r.external_id,
+    name: r.name,
+    memberCount: Number(r.member_count ?? 0),
+    hint:
+      r.name_hit === true || r.name_hit === 1
+        ? null
+        : r.email_hit
+          ? { kind: 'email', value: r.email_hit }
+          : r.form_hit
+            ? { kind: 'form', value: r.form_hit }
+            : null,
+  }));
+}
+
 /**
  * Rebind a pre-0015 account (whose `external_id` still holds the upstream
  * ACCOUNT id) onto the upstream WORKSPACE it should have meant all along.

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -192,6 +192,8 @@ export interface FormsMessages {
         staff: string;
         /** Eyebrow over estate rows the person never opened here (staff only). */
         estate: string;
+        /** Staff search: why a row matched when its name did not. `{name}` is the form. */
+        hintForm: string;
       };
     };
     /** The dashboard home (/admin) — greeting, public link, stats, quick actions. */
@@ -1768,6 +1770,7 @@ export const en: FormsMessages = {
         searchEmpty: 'No workspace matches that.',
         staff: 'Staff',
         estate: 'All workspaces',
+        hintForm: 'Form: {name}',
       },
     },
     home: {
@@ -3232,6 +3235,7 @@ export const es: FormsMessages = {
         searchEmpty: 'Ningún workspace coincide.',
         staff: 'Staff',
         estate: 'Todos los workspaces',
+        hintForm: 'Formulario: {name}',
       },
     },
     home: {


### PR DESCRIPTION
## Why

In prod every staff (`@daptatech.com`) request took 10 to 50 s (`/v1/me` 9.7 s cold, `/v1/workspaces/search?q=katagi` 52 s). Root cause: to a staff token the unscoped IAM `/workspace/search` answers with the **whole estate**, and `listMyWorkspaces` paged through all of it (up to 20 pages x 100 rows, ~1.5 s per IAM call) on every projection refresh: every 60 s TTL expiry and every switcher open (`force`). Customers were never affected (their unscoped search is already only theirs).

Also: "Katagi Leads demo" is a **form** name, not a workspace; the workspace is `henry@seika.ai` upstream (`Henry Bravo` locally). The IAM search only knows workspace names, so neither the form name nor the email found it.

## What

- `WorkspaceProjection.staffMemberships`: for staff, the refresh reads the workspaces of the person's own upstream account (`/workspace/search?accountId=`, a page or two) plus, in parallel, every workspace this DB already knows them in (memberships and grants, `/workspace/{id}`), so revoked memberships still get disabled and a grant whose workspace now names them still upgrades. A re-read failing with anything but 404 disables pruning for that pass (`complete=false`). Bounded at 25 re-reads.
- `projectOne`: `enterEstateWorkspace` projects a real membership in someone else's account directly (the refresh no longer discovers it from the estate). From then on it is a known row the refresh re-reads.
- `searchProjectedAccounts` (db): staff search also matches the projected accounts by workspace name, member email or form name; rows carry `hint` (`{kind:'email'|'form', value}`) when the name itself did not match. Merged into `WorkspaceService.search` (own rows, then local hits, then the rest of the IAM page; never a workspace twice). Switcher rows and Account settings estate cards show the hint (`Form: Katagi Leads demo`, or the email).

## Not changed

- IAM latency itself (~1 to 1.7 s per call): the search box still costs one IAM call per debounced query.
- Local vs upstream name drift (`Henry Bravo` vs `henry@seika.ai`): separate issue, not touched.

## Verified

- `@quill/db` 197, `@quill/api` 401 (new: scoped-search-only refresh, re-read + revoke, no prune on 500, local hits by form/email with hint), `@quill/web` 508.
- e2e on the QA harness: v12 + v9, 16/16.
- Postgres run of the new db helper relies on CI (no Docker on this machine).
- Prod numbers above measured with a read-only staff bearer before the change; to re-measure after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)