### PR TITLE
fix(web): build the workspace-reset redirect from the public origin

### DIFF
--- a/.changeset/workspace-reset-redirect-origin.md
+++ b/.changeset/workspace-reset-redirect-origin.md
@@ -1,0 +1,7 @@
+---
+'@quill/web': patch
+---
+
+The workspace-reset redirect lands on the public origin again.
+
+`/api/workspace/reset` (where the app sends the browser when the chosen workspace answers 403, to clear the stale cookie) built its redirect from `request.url`. Behind the deployment's proxy the standalone server sees no public Host, so that URL is `https://0.0.0.0:3000/...` and the browser was sent there verbatim. The redirect is now built from `requestOrigin` (PUBLIC_APP_URL first, forwarded headers as the self-host fallback), like every other absolute redirect in the app.

--- a/apps/web/app/api/workspace/reset/route.spec.ts
+++ b/apps/web/app/api/workspace/reset/route.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { WORKSPACE_COOKIE } from '@/lib/session';
+import { GET } from './route';
+
+/**
+ * The regression this pins: behind the deployment's proxy the standalone
+ * server sees no public Host, so `request.url` is `https://0.0.0.0:3000/...`.
+ * The redirect used to be built from it, and every WORKSPACE_FORBIDDEN reset
+ * sent the browser to https://0.0.0.0:3000/admin verbatim.
+ */
+describe('GET /api/workspace/reset', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('redirects to /admin on the configured public origin, not the pod-internal request URL', async () => {
+    vi.stubEnv('PUBLIC_APP_URL', 'https://forms.example.com');
+
+    const res = await GET(new NextRequest('https://0.0.0.0:3000/api/workspace/reset'));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('https://forms.example.com/admin');
+    // The dead workspace choice is dropped with the same response.
+    expect(res.cookies.get(WORKSPACE_COOKIE)?.value).toBe('');
+  });
+
+  it('without PUBLIC_APP_URL (self-host clone) falls back to the forwarded host', async () => {
+    vi.stubEnv('PUBLIC_APP_URL', '');
+
+    const res = await GET(
+      new NextRequest('https://0.0.0.0:3000/api/workspace/reset', {
+        headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'clone.example.com' },
+      }),
+    );
+
+    expect(res.headers.get('location')).toBe('https://clone.example.com/admin');
+  });
+});

--- a/apps/web/app/api/workspace/reset/route.ts
+++ b/apps/web/app/api/workspace/reset/route.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
+import { requestOrigin } from '@/lib/request-origin';
 import { WORKSPACE_COOKIE } from '@/lib/session';
 
 /**
@@ -13,9 +14,14 @@ import { WORKSPACE_COOKIE } from '@/lib/session';
  * A Route Handler owns its response, so the cookie deletion actually lands.
  * Clearing is unconditional and idempotent, which is what makes the loop
  * impossible rather than merely unlikely.
+ *
+ * The redirect is built from `requestOrigin` (PUBLIC_APP_URL first), NOT from
+ * `request.url`: behind the deployment's proxy the standalone server sees no
+ * public Host, so `request.url` is `https://0.0.0.0:3000/...` and the browser
+ * was sent there verbatim.
  */
-export async function GET(request: Request) {
-  const res = NextResponse.redirect(new URL('/admin', request.url));
+export async function GET(request: NextRequest) {
+  const res = NextResponse.redirect(new URL('/admin', requestOrigin(request)));
   res.cookies.delete(WORKSPACE_COOKIE);
   return res;
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next-qa/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Why

Users were intermittently landed on `https://0.0.0.0:3000/admin`. Reproducible without auth in both environments:

```
curl -s -o /dev/null -D - https://forms.dapta.ai/api/workspace/reset | grep -i location
location: https://0.0.0.0:3000/admin
```

Chain: any API answer of 403 `WORKSPACE_FORBIDDEN` on the cookie workspace sends the browser to `/api/workspace/reset` (clears the stale cookie); that route built its redirect with `new URL('/admin', request.url)`, and behind the proxy the standalone server sees no public Host, so `request.url` is `https://0.0.0.0:3000/...`. It was the only absolute redirect in the app built from `request.url`; login/callback/logout already use `requestOrigin`.

The route dates to July but was practically unreachable until the workspace projection made membership rows churn (transient `WORKSPACE_FORBIDDEN` during refresh, mostly fixed by #130); the redirect bug just made every such bounce visible.

## What

- `/api/workspace/reset` builds the redirect from `requestOrigin` (PUBLIC_APP_URL first, forwarded headers as the self-host fallback). Cookie clearing unchanged.
- Route spec pinning the regression (0.0.0.0 request URL + PUBLIC_APP_URL set → public origin; fallback via forwarded headers).

## Verified

- `@quill/web` 510 tests (2 new).
- After release, the same curl should answer `location: https://forms.dapta.ai/admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)