### PR TITLE
fix(web): sign-out follows the IdP logout so the shared Dapta session ends too

### DIFF
--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -4,38 +4,66 @@ import { NextRequest } from 'next/server';
 const getSession = vi.fn();
 const clearSession = vi.fn();
 const revokeUpstreamSession = vi.fn();
-vi.mock('@/lib/auth-session', () => ({
-  getSession: (...a: unknown[]) => getSession(...a),
-  clearSession: (...a: unknown[]) => clearSession(...a),
-  revokeUpstreamSession: (...a: unknown[]) => revokeUpstreamSession(...a),
-}));
+vi.mock('@/lib/auth-session', async () => {
+  // idpLogoutTarget is pure; the real one runs so the tests exercise the actual
+  // return_to construction instead of a mirror of it.
+  const actual = await vi.importActual<typeof import('@/lib/auth-session')>('@/lib/auth-session');
+  return {
+    idpLogoutTarget: actual.idpLogoutTarget,
+    getSession: (...a: unknown[]) => getSession(...a),
+    clearSession: (...a: unknown[]) => clearSession(...a),
+    revokeUpstreamSession: (...a: unknown[]) => revokeUpstreamSession(...a),
+  };
+});
 
 import { GET } from './route';
 
-const req = () => new NextRequest('https://forms.example.com/api/auth/logout');
+const req = (path = '/api/auth/logout') => new NextRequest(`https://forms.example.com${path}`);
 const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
 
 describe('GET /api/auth/logout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv('PUBLIC_APP_URL', '');
-    revokeUpstreamSession.mockResolvedValue(undefined);
+    revokeUpstreamSession.mockResolvedValue(null);
   });
 
-  it('reads the session, clears the cookie, revokes upstream, lands locally', async () => {
+  it('follows the IdP logout URL with return_to so WorkOS ends the browser session too', async () => {
     getSession.mockResolvedValue(workosSession);
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
 
     const res = await GET(req());
 
+    const target = new URL(res.headers.get('location')!);
+    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
+    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
     // Read-then-clear: the revoke needs the session id the cookie carried.
     expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
     expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
-    // Never WorkOS — the browser stays on our origin (skipIdpRedirect contract).
+  });
+
+  it('reason=expired skips the WorkOS hop: an expiry must not end the whole Dapta session', async () => {
+    getSession.mockResolvedValue(workosSession);
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+
+    const res = await GET(req('/api/auth/logout?reason=expired'));
+
+    expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
+    expect(clearSession).toHaveBeenCalled();
     expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
   });
 
-  it('cleans up and lands locally even when there is no session at all', async () => {
+  it('lands locally when the IAM hands back no logout URL', async () => {
+    getSession.mockResolvedValue(workosSession);
+
+    const res = await GET(req());
+
+    expect(clearSession).toHaveBeenCalled();
+    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  it('cleans up and lands locally when there is no session at all', async () => {
     getSession.mockResolvedValue(null);
 
     const res = await GET(req());

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,25 +1,34 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { clearSession, getSession, revokeUpstreamSession } from '@/lib/auth-session';
+import { clearSession, getSession, idpLogoutTarget, revokeUpstreamSession } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
 /**
- * Logout — Orbit-parity contract (skipIdpRedirect = true): revoke upstream
- * best-effort (see `revokeUpstreamSession`), ALWAYS clear our cookie, land on
- * /login?signedout=1 — the browser never visits WorkOS. The login page
- * suppresses its auto-redirect for that param, otherwise logout would bounce
- * straight back into /admin.
+ * Logout: revoke upstream best-effort (see `revokeUpstreamSession`), ALWAYS
+ * clear our cookie, then follow the IdP logout URL so WorkOS ends the browser
+ * session too and returns the person to /login?signedout=1 (whose param
+ * suppresses the login page's auto-redirect). Without the WorkOS hop the shared
+ * Dapta session survives and the next "sign in" silently re-authenticates the
+ * same person.
  *
- * Server ACTIONS don't come through here — `signOutAction` and `hostFetch`
- * revoke + clear inline, because an action `redirect()` into a route handler
- * soft-navigates and strands the URL bar on /api/auth/logout. This route serves
- * the contexts that cannot touch the cookie themselves: the 401 path inside a
- * Server Component render (`admin-api.ts`, where `cookies().delete()` throws)
- * and direct navigation.
+ * `?reason=expired` skips the WorkOS hop (Orbit's skipIdpRedirect = true):
+ * it marks a session-expiry logout, not a person asking to leave, and a Forms
+ * token expiring must not end their whole Dapta platform session.
+ *
+ * The explicit sign-out button does NOT come through here: `signOutAction` and
+ * `hostFetch` revoke + clear inline, because an action `redirect()` into a
+ * route handler soft-navigates and strands the URL bar on /api/auth/logout.
+ * This route serves the contexts that cannot touch the cookie themselves: the
+ * 401 path inside a Server Component render (`admin-api.ts`, where
+ * `cookies().delete()` throws, arriving with ?reason=expired) and direct
+ * navigation (full logout).
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const origin = requestOrigin(req);
   const session = await getSession();
   await clearSession();
-  await revokeUpstreamSession(session);
+  const logoutUrl = await revokeUpstreamSession(session);
+  const expired = req.nextUrl.searchParams.get('reason') === 'expired';
+  const idp = expired ? null : idpLogoutTarget(logoutUrl, origin);
+  if (idp) return NextResponse.redirect(idp);
   return NextResponse.redirect(new URL('/login?signedout=1', origin));
 }

--- a/apps/web/app/login/actions.spec.ts
+++ b/apps/web/app/login/actions.spec.ts
@@ -1,23 +1,33 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getSession = vi.fn();
 const clearSession = vi.fn();
 const revokeUpstreamSession = vi.fn();
 const setSession = vi.fn();
 const authProvider = vi.fn();
-vi.mock('@/lib/auth-session', () => ({
-  getSession: (...a: unknown[]) => getSession(...a),
-  clearSession: (...a: unknown[]) => clearSession(...a),
-  revokeUpstreamSession: (...a: unknown[]) => revokeUpstreamSession(...a),
-  setSession: (...a: unknown[]) => setSession(...a),
-  authProvider: () => authProvider(),
-}));
+vi.mock('@/lib/auth-session', async () => {
+  // idpLogoutTarget is pure; the real one runs so the tests exercise the actual
+  // return_to construction instead of a mirror of it.
+  const actual = await vi.importActual<typeof import('@/lib/auth-session')>('@/lib/auth-session');
+  return {
+    idpLogoutTarget: actual.idpLogoutTarget,
+    getSession: (...a: unknown[]) => getSession(...a),
+    clearSession: (...a: unknown[]) => clearSession(...a),
+    revokeUpstreamSession: (...a: unknown[]) => revokeUpstreamSession(...a),
+    setSession: (...a: unknown[]) => setSession(...a),
+    authProvider: () => authProvider(),
+  };
+});
 
 const redirect = vi.fn((url: string) => {
   // Mirror Next's real behavior: redirect() throws, ending the action.
   throw new Error(`NEXT_REDIRECT:${url}`);
 });
 vi.mock('next/navigation', () => ({ redirect: (url: string) => redirect(url) }));
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+  headers: vi.fn(async () => new Headers({ host: 'forms.example.com', 'x-forwarded-proto': 'https' })),
+}));
 
 import { signOutAction } from './actions';
 
@@ -26,19 +36,46 @@ const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess
 describe('signOutAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv('PUBLIC_APP_URL', 'https://forms.example.com');
+    revokeUpstreamSession.mockResolvedValue(null);
   });
 
-  it('workos: reads the session before clearing, revokes upstream, lands on /login?signedout=1', async () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('workos: follows the IdP logout URL with return_to back to the local landing', async () => {
     authProvider.mockReturnValue('workos');
     getSession.mockResolvedValue(workosSession);
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
 
-    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+    await expect(signOutAction()).rejects.toThrow(
+      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=sess_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
+    );
 
     // Read-then-clear: clearing first hands the revoke a null session (the
     // pre-#82 bug that left the upstream WorkOS session alive).
     expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
     expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
+  });
+
+  it('workos: lands locally signed out when the IAM hands back no logout URL', async () => {
+    authProvider.mockReturnValue('workos');
+    getSession.mockResolvedValue(workosSession);
+    revokeUpstreamSession.mockResolvedValue(null);
+
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    expect(clearSession).toHaveBeenCalled();
+  });
+
+  it('workos: lands locally on an unparseable logout URL instead of failing the sign-out', async () => {
+    authProvider.mockReturnValue('workos');
+    getSession.mockResolvedValue(workosSession);
+    revokeUpstreamSession.mockResolvedValue('/relative-not-a-url');
+
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
   });
 
   it('workos: still clears and lands locally when the session is already gone', async () => {

--- a/apps/web/app/login/actions.ts
+++ b/apps/web/app/login/actions.ts
@@ -1,7 +1,16 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { setSession, clearSession, getSession, authProvider, revokeUpstreamSession } from '@/lib/auth-session';
+import { headers } from 'next/headers';
+import {
+  setSession,
+  clearSession,
+  getSession,
+  authProvider,
+  revokeUpstreamSession,
+  idpLogoutTarget,
+} from '@/lib/auth-session';
+import { originFrom } from '@/lib/request-origin';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -22,23 +31,31 @@ export async function signInAction(
 }
 
 /**
- * Logout (AUTH-WEB-CONTRACT §2/§3.5) — Orbit-parity contract: read the session,
- * clear the cookie, tell the IAM to revoke upstream (best-effort, see
- * `revokeUpstreamSession`), and land on /login?signedout=1. The order matters:
- * the session must be READ before `clearSession()` lands its Set-Cookie, or the
- * revoke has no session id — that gap once left the upstream WorkOS session
- * alive and "sign in" silently re-authenticated the same person into /admin.
+ * Logout (AUTH-WEB-CONTRACT §2/§3.5): read the session, clear the cookie, tell
+ * the IAM to revoke upstream, then FOLLOW the returned IdP logout URL (Orbit's
+ * skipIdpRedirect = false case, "logout completo"). The browser hop through
+ * WorkOS is not optional for the sign-out button: the AuthKit session cookie
+ * lives on WorkOS's domain, and with the shared Dapta session still alive the
+ * next "sign in" silently re-authenticates the same person back into /admin,
+ * with no way to switch accounts. WorkOS sends the browser back to
+ * /login?signedout=1 via return_to (the URL must stay allowlisted under
+ * "Logout redirect URIs" in the WorkOS dashboard).
  *
- * Inline rather than via /api/auth/logout: an action `redirect()` into a route
- * handler soft-navigates, leaving the URL bar stranded on /api/auth/logout
- * while the login page renders. The browser never visits WorkOS
- * (skipIdpRedirect = true in Orbit's terms) — /login?signedout=1 is the landing,
- * and its param is what suppresses the login page's auto-redirect.
+ * The order matters: the session must be READ before `clearSession()` lands its
+ * Set-Cookie, or the revoke has no session id. That gap once left the upstream
+ * WorkOS session alive (the pre-#82 bug). Local cleanup always runs, whatever
+ * the IAM call does; when no logout URL comes back (IAM down, unparseable URL,
+ * no session id) the person still lands signed out on /login?signedout=1, whose
+ * param suppresses the login page's auto-redirect.
  */
 export async function signOutAction(): Promise<void> {
   const session = await getSession();
   await clearSession();
-  await revokeUpstreamSession(session);
+  const logoutUrl = await revokeUpstreamSession(session);
+  const hdrs = await headers();
+  const origin = originFrom((n) => hdrs.get(n));
+  const idp = origin ? idpLogoutTarget(logoutUrl, origin) : null;
+  if (idp) redirect(idp);
   // Keyed on the configured provider, not the (possibly already-null) session:
   // in workos mode a bare /login auto-redirects straight back into the IAM.
   redirect(authProvider() === 'workos' ? '/login?signedout=1' : '/login');

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -64,7 +64,10 @@ async function req<T>(method: string, path: string, body?: unknown, opts: ReqOpt
     // hands that route a null session and silently skips the single-logout (see
     // `signOutAction`). This path only appeared to work because `delete()` throws
     // during a Server Component render; from a Server Action it lands and breaks.
-    if (authProvider() === 'workos') redirect('/api/auth/logout');
+    // ?reason=expired: this is a token expiring mid-render, not a person asking
+    // to leave, so the route must not bounce the browser through the WorkOS
+    // logout and end their whole Dapta platform session.
+    if (authProvider() === 'workos') redirect('/api/auth/logout?reason=expired');
     try {
       await clearSession();
     } catch {

--- a/apps/web/lib/auth-session-revoke.spec.ts
+++ b/apps/web/lib/auth-session-revoke.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('next/headers', () => ({ cookies: vi.fn() }));
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
 
-import { revokeUpstreamSession, type Session } from './auth-session';
+import { idpLogoutTarget, revokeUpstreamSession, type Session } from './auth-session';
 
 const workosSession: Session = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
 
@@ -36,6 +36,18 @@ describe('revokeUpstreamSession', () => {
     expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('authorization');
   });
 
+  it('returns the IdP logout URL from logoutUrl', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ logoutUrl: 'https://api.workos.com/logout?x=1' }) });
+
+    await expect(revokeUpstreamSession(workosSession)).resolves.toBe('https://api.workos.com/logout?x=1');
+  });
+
+  it('returns the IdP logout URL from the logoutURL spelling too', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ logoutURL: 'https://api.workos.com/logout?x=2' }) });
+
+    await expect(revokeUpstreamSession(workosSession)).resolves.toBe('https://api.workos.com/logout?x=2');
+  });
+
   it('still POSTs an empty body when the workos session has no session id', async () => {
     await revokeUpstreamSession({ provider: 'workos', accessToken: 'tok' });
 
@@ -45,15 +57,22 @@ describe('revokeUpstreamSession', () => {
     );
   });
 
-  it('swallows a rejected fetch — local cleanup must never be hostage to the IAM', async () => {
+  it('resolves null on a rejected fetch — local cleanup must never be hostage to the IAM', async () => {
     fetchMock.mockRejectedValue(new Error('iam down'));
 
-    await expect(revokeUpstreamSession(workosSession)).resolves.toBeUndefined();
+    await expect(revokeUpstreamSession(workosSession)).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves null on a non-ok IAM answer without retrying', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+    await expect(revokeUpstreamSession(workosSession)).resolves.toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('skips the IAM for a local session', async () => {
-    await revokeUpstreamSession({ provider: 'local', email: 'a@b.c' });
+    await expect(revokeUpstreamSession({ provider: 'local', email: 'a@b.c' })).resolves.toBeNull();
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -61,8 +80,36 @@ describe('revokeUpstreamSession', () => {
   it('skips the IAM when IAM_BASE_URL is not configured', async () => {
     vi.stubEnv('IAM_BASE_URL', '');
 
-    await revokeUpstreamSession(workosSession);
+    await expect(revokeUpstreamSession(workosSession)).resolves.toBeNull();
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('idpLogoutTarget', () => {
+  it('appends return_to pointing at the local signed-out landing', () => {
+    const target = idpLogoutTarget(
+      'https://api.workos.com/user_management/sessions/logout?session_id=sess_123',
+      'https://forms.example.com',
+    );
+
+    const url = new URL(target!);
+    expect(url.origin + url.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
+    expect(url.searchParams.get('session_id')).toBe('sess_123');
+    expect(url.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  it('overwrites a preexisting return_to', () => {
+    const target = idpLogoutTarget(
+      'https://api.workos.com/logout?return_to=https%3A%2F%2Felsewhere.example',
+      'https://forms.example.com',
+    );
+
+    expect(new URL(target!).searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  it('returns null for an absent or unparseable logout URL', () => {
+    expect(idpLogoutTarget(null, 'https://forms.example.com')).toBeNull();
+    expect(idpLogoutTarget('/relative-not-a-url', 'https://forms.example.com')).toBeNull();
   });
 });

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -75,29 +75,62 @@ export async function getSession(): Promise<Session | null> {
 }
 
 /**
- * Best-effort upstream revoke — Orbit-parity contract (skipIdpRedirect = true):
- * POST {IAM}/auth/logout?redirect=false so the IAM revokes the WorkOS session
- * server-side. Deliberately unauthenticated: /auth/logout is a public IAM route
- * (like login/refresh), and sending an expired Bearer is what creates
- * logout -> 401 -> logout loops. Fired even without a session id ({} body) —
- * the IAM can still invalidate server-side state. The response's
- * logoutUrl/logoutURL is the WorkOS single-logout URL — unused by design; a
- * future "switch account" flow (skipIdpRedirect = false) is the only consumer.
+ * Best-effort upstream revoke (Orbit contract): POST {IAM}/auth/logout with
+ * redirect=false so the IAM revokes the WorkOS session server-side and hands
+ * back the IdP logout URL instead of redirecting anyone itself. Deliberately
+ * unauthenticated: /auth/logout is a public IAM route (like login/refresh),
+ * and sending an expired Bearer is what creates logout -> 401 -> logout loops.
+ * Fired even without a session id ({} body): the IAM can still invalidate
+ * server-side state.
+ *
+ * Returns the WorkOS logout URL (the IAM serializes it as logoutUrl or
+ * logoutURL) or null. Server-side revocation alone is NOT a browser logout:
+ * the AuthKit session cookie lives on WorkOS's domain and only dies when the
+ * browser visits this URL. Callers choose per Orbit's skipIdpRedirect switch:
+ * the explicit sign-out button follows it (a Forms logout must also end the
+ * shared Dapta session, or the next "sign in" silently re-authenticates the
+ * same person); the 401 expiry paths ignore it (a Forms token expiring must
+ * not log the person out of the whole Dapta platform).
+ *
  * Never throws and never hangs past its timeout: the caller's local cleanup
  * must not be hostage to the IAM being up.
  */
-export async function revokeUpstreamSession(session: Session | null): Promise<void> {
+export async function revokeUpstreamSession(session: Session | null): Promise<string | null> {
   const iam = process.env.IAM_BASE_URL?.replace(/\/$/, '');
-  if (!iam || session?.provider !== 'workos') return;
+  if (!iam || session?.provider !== 'workos') return null;
   const sessionId = session.sessionId;
   const body = sessionId ? { workos_session_id: sessionId, session_id: sessionId } : {};
-  await fetch(`${iam}/auth/logout?redirect=false`, {
+  const res = await fetch(`${iam}/auth/logout?redirect=false`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
     cache: 'no-store',
     signal: AbortSignal.timeout(5000),
   }).catch(() => null);
+  if (!res?.ok) return null;
+  const out = (await res.json().catch(() => null)) as { logoutUrl?: unknown; logoutURL?: unknown } | null;
+  const url = out?.logoutUrl ?? out?.logoutURL;
+  return typeof url === 'string' && url ? url : null;
+}
+
+/**
+ * The IdP logout redirect for the sign-out button: the IAM's logout URL with
+ * return_to pointing back at our login landing, so WorkOS ends the browser
+ * session and sends the person to /login?signedout=1 instead of stranding
+ * them on a blank api.workos.com page. The URL must be allowlisted under
+ * "Logout redirect URIs" in the WorkOS dashboard or WorkOS ignores it.
+ * Null when the logout URL is absent or unparseable (NextResponse.redirect
+ * and the action redirect would both throw on it): callers land locally.
+ */
+export function idpLogoutTarget(logoutUrl: string | null, origin: string): string | null {
+  if (!logoutUrl) return null;
+  try {
+    const target = new URL(logoutUrl);
+    target.searchParams.set('return_to', new URL('/login?signedout=1', origin).toString());
+    return target.toString();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -163,11 +196,15 @@ export async function hostFetch(path: string, init?: RequestInit): Promise<Respo
     cache: 'no-store',
   });
   if (res.status === 401) {
-    // Same shape as `signOutAction` (Orbit-parity): read the session BEFORE
+    // Same shape as `signOutAction` (Orbit contract): read the session BEFORE
     // clearing (the revoke needs its id), clear unconditionally, revoke
-    // best-effort. Inline rather than via /api/auth/logout — an action
+    // best-effort. Inline rather than via /api/auth/logout, because an action
     // `redirect()` into a route handler strands the URL bar there. And per the
     // contract, a 401 anywhere never re-enters logout: one revoke, then /login.
+    // The returned IdP logout URL is deliberately ignored here (Orbit's
+    // skipIdpRedirect = true): a Forms token expiring must not bounce the
+    // browser through WorkOS and end the person's whole Dapta session. Only
+    // the explicit sign-out button does that.
     const session = await getSession();
     await clearSession();
     await revokeUpstreamSession(session);

--- a/apps/web/lib/request-origin.ts
+++ b/apps/web/lib/request-origin.ts
@@ -13,19 +13,32 @@ import type { NextRequest } from 'next/server';
  * not set it (where there is no fronting proxy to spoof through).
  */
 export function requestOrigin(req: NextRequest): string {
+  return originFrom((n) => req.headers.get(n)) ?? new URL(req.url).origin;
+}
+
+/**
+ * Same trust order as `requestOrigin`, for callers that hold `headers()` instead
+ * of a `NextRequest` (server actions have no request object). Null when nothing
+ * trustworthy resolves; a caller building an OAuth or IdP redirect should then
+ * skip the redirect rather than guess an origin.
+ */
+export function originFrom(get: (name: string) => string | null | undefined): string | null {
   const configured = process.env.PUBLIC_APP_URL?.trim();
   if (configured) {
     try {
       return new URL(configured).origin;
     } catch {
-      // Misconfigured PUBLIC_APP_URL — fall through to header/req.url derivation
-      // rather than crash the auth route.
+      // Misconfigured PUBLIC_APP_URL: fall through to header derivation rather
+      // than crash the auth path.
     }
   }
-  const proto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
-  const host = selfHost((n) => req.headers.get(n));
+  const proto = get('x-forwarded-proto')?.split(',')[0]?.trim();
+  const host = selfHost(get);
   if (proto && host) return `${proto}://${host}`;
-  return new URL(req.url).origin;
+  // A bare self-host/dev clone with no proxy in front: the Host header is the
+  // only signal there is, and plain http is the only scheme it can be serving.
+  if (host) return `http://${host}`;
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Problem

After #103 (Orbit-parity logout, `skipIdpRedirect = true` everywhere), sign-out on forms.dapta.dev lands on `/login?signedout=1` correctly, but the next "Continue with Dapta" silently re-authenticates the same person back into `/admin`. There is no way to switch accounts short of logging out of Dapta itself.

Root cause: server-side revocation at the IAM is not a browser logout. The AuthKit session cookie lives on WorkOS's domain and only dies when the browser visits the WorkOS logout URL.

## Fix

Apply Orbit's other documented mode (`skipIdpRedirect = false`, the "logout completo" case in Kare's specs) exactly where a person explicitly asks to leave, and keep `true` for expiries:

- `revokeUpstreamSession()` now returns the IdP logout URL (accepts both `logoutUrl` and `logoutURL` spellings); new `idpLogoutTarget()` appends `return_to` → `/login?signedout=1`.
- `signOutAction` and direct `GET /api/auth/logout` **follow** that URL: WorkOS ends the browser session and returns the person to our login landing.
- The 401 expiry paths (`hostFetch`, `admin-api`) deliberately **skip** the WorkOS hop: a Forms token expiring must not end the person's whole Dapta platform session. `admin-api`'s render-time path tags itself `?reason=expired` so the shared route can tell the two apart.
- Everything else from #103 stands: `redirect=false`, no Bearer on the logout POST, unconditional local cleanup (5s bound), action paths redirect to a page so the URL bar never strands on `/api/auth/logout`.
- New `originFrom()` in `request-origin.ts` gives server actions an origin with the same trust order as `requestOrigin` (`PUBLIC_APP_URL` first, headers only as self-host fallback).

## Ops prerequisite

The `return_to` URL must be allowlisted under **"Logout redirect URIs"** in the WorkOS dashboard. The entry added for #86 covers prd — **do not clean it up** (reverses the note on #103). Confirm dev's URL (`https://forms.dapta.dev/login?signedout=1`) is allowlisted too, or WorkOS will ignore the `return_to` and strand the browser on api.workos.com after ending the session.

## Verification

- 20 unit tests across the three specs; full `pnpm test` / `typecheck` / `lint` / publish-gate / dash-check green.
- Offline E2E against the stub IAM, which now emulates the WorkOS logout endpoint (records the visit, 302s to `return_to`) and serializes the URL as `logoutURL` to exercise the dual-spelling support. Sign out from `/admin`: stub log shows `POST /auth/logout?redirect=false` with both ids and no `authorization` header, then a visit to the IdP logout with the correct `return_to`, and the browser ends on `/login?signedout=1` with a clean URL bar. Direct `GET /api/auth/logout` and `?reason=expired` both land locally when no session exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)