### PR TITLE
fix(api): the booking path was dropping the invitee phone and the mirror form

### DIFF
--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -453,6 +453,127 @@ describe('booking_sync delivery', () => {
     expect(props.full_name).toBe('Ada Lovelace');
   });
 
+  // Real event types ask for the phone as a CUSTOM question, not the native SMS
+  // field, so `text_reminder_number` is absent and the number arrives only in
+  // `questions_and_answers`. The phone question is found by its text, at any
+  // position, and only an answer that parses as a number is taken.
+  it('takes the phone from a custom booking-form question when the SMS field is absent', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { '@invitee_phone': 'phone' },
+    });
+    await svc.submit('acme', 'lead-qualifier', { sessionId: 'sess-qa', data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-qa',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({
+          resource: {
+            email: 'qa@corp.io',
+            name: 'Ada Lovelace',
+            questions_and_answers: [
+              { question: 'Company', answer: 'Analytical Engines', position: 0 },
+              { question: '¿Cual es tu numero de teléfono?', answer: '+1 909-413-7555', position: 1 },
+            ],
+          },
+        }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '90' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.phone).toBe('+1 909-413-7555');
+  });
+
+  it('the native SMS field wins over a custom phone question', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { '@invitee_phone': 'phone' },
+    });
+    await svc.submit('acme', 'lead-qualifier', { sessionId: 'sess-sms', data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-sms',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({
+          resource: {
+            email: 'sms@corp.io',
+            name: 'Ada Lovelace',
+            text_reminder_number: '+57 300 111 2233',
+            questions_and_answers: [
+              { question: 'Phone number', answer: '+1 555 000 1111', position: 0 },
+            ],
+          },
+        }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '91' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.phone).toBe('+57 300 111 2233');
+  });
+
+  // Either guard alone fails on real data: some event types open with "Company"
+  // (answered with a phone once in a while) and others with free text. A phone
+  // property must never receive a company name or a paragraph.
+  it('ignores custom answers that are not a phone number behind a phone question', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { '@invitee_phone': 'phone' },
+    });
+    await svc.submit('acme', 'lead-qualifier', { sessionId: 'sess-noqa', data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-noqa',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({
+          resource: {
+            email: 'noqa@corp.io',
+            name: 'Ada Lovelace',
+            questions_and_answers: [
+              { question: 'Compañía', answer: '+1 555 123 4567', position: 0 },
+              { question: 'Phone number', answer: 'call me whenever', position: 1 },
+            ],
+          },
+        }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '92' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.phone).toBeUndefined();
+  });
+
   // Calendly always returns `name` and only sometimes the split pair.
   it('derives first/last from the full name when the provider omits the split pair', async () => {
     await setHubspotDestination(undefined, {

--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -29,6 +29,7 @@ import { OutboxWorker } from './outbox.worker';
 const EVENT_URI = 'https://api.calendly.com/scheduled_events/abc';
 const INVITEE_URI = 'https://api.calendly.com/scheduled_events/abc/invitees/def';
 const HUBSPOT_UPSERT_URL = 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert';
+const ACCOUNT_INFO_URL = 'https://api.hubapi.com/account-info/v3/details';
 
 interface RecordedCall {
   url: string;
@@ -572,6 +573,72 @@ describe('booking_sync delivery', () => {
       }
     ).inputs[0]!.properties;
     expect(props.phone).toBeUndefined();
+  });
+
+  // A scheduler-keyed form NEVER delivers at submit time (nothing to key on), so
+  // this is the only path its mirror form can be posted from. It shipped without
+  // one: the answers and the Note arrived and the "Form submission" activity
+  // never did, on every booking form in the account.
+  it('posts the mirror form submission when the destination configures one', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { role: 'role' },
+      settings: { note: true, formActivity: true, formGuid: 'guid-1' },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-mirror',
+      data: { role: 'founder' },
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-mirror',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'm@corp.io', name: 'Ada Lovelace' } }),
+      [ACCOUNT_INFO_URL]: () => jsonResponse({ portalId: 4242 }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '93' }] }),
+    });
+    await drainDue();
+
+    const mirror = calls.find((c) => c.url.includes('/submissions/v3/integration/secure/submit/'));
+    expect(mirror?.url).toContain('/4242/guid-1');
+    const fields = (mirror?.body as { fields?: Array<{ name: string; value: string }> }).fields ?? [];
+    expect(fields.find((f) => f.name === 'email')?.value).toBe('m@corp.io');
+  });
+
+  // The switch is what enables it; the guid alone survives being turned off so
+  // the same form is reused when it is turned back on.
+  it('skips the mirror when the form activity switch is off', async () => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { role: 'role' },
+      settings: { note: true, formActivity: false, formGuid: 'guid-1' },
+    });
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-nomirror',
+      data: { role: 'founder' },
+    });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId: 'sess-nomirror',
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () => jsonResponse({ resource: { email: 'n@corp.io', name: 'Ada Lovelace' } }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '94' }] }),
+    });
+    await drainDue();
+
+    expect(calls.some((c) => c.url.includes('/submissions/v3/integration/'))).toBe(false);
+    // And no portal lookup either: a form with no mirror pays for no extra call.
+    expect(calls.some((c) => c.url === ACCOUNT_INFO_URL)).toBe(false);
   });
 
   // Calendly always returns `name` and only sometimes the split pair.

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -12,6 +12,7 @@ import { createDestination } from '@quill/destinations';
 import type { ServerEnv } from '@quill/config/env';
 import { OutboxSkipError } from './email-effects';
 import { extractUtm } from './destination-effects';
+import { HubspotPortalResolver, mirrorGuidFor } from './hubspot-portal';
 import type { BookingSyncPayload } from './booking-effects';
 import { DB, ENV } from './tokens';
 
@@ -131,6 +132,8 @@ export class BookingSyncEffects {
   fetchImpl: typeof fetch = fetch;
   /** Overridable in tests to point the HubSpot client at a fake. */
   hubspotApiBase: string = HUBSPOT_API_BASE;
+  /** accountId -> the portal its HubSpot token belongs to (mirror submit URL). */
+  private readonly portals = new HubspotPortalResolver();
 
   constructor(
     @Inject(DB) private readonly db: Db,
@@ -400,6 +403,17 @@ export class BookingSyncEffects {
         )?.label ?? null)
       : null;
 
+    // The mirror form, exactly as the submit path resolves it. It was missing
+    // here, and this is the ONLY path a scheduler-keyed form ever takes: those
+    // forms got their answers and their Note but never the "Form submission"
+    // activity, because the adapter skips mirroring unless it has BOTH the guid
+    // and the portal. Resolved only when a mirror is configured, so a form
+    // without one still makes no extra call.
+    const mirrorGuid = mirrorGuidFor(destination.settings);
+    const portalId = mirrorGuid
+      ? await this.portals.resolve(payload.accountId, token, this.fetchImpl)
+      : null;
+
     // Through the factory — the same construction seam the submit path uses
     // (invariant #7); the token is injected here and never persisted.
     const adapter = createDestination(
@@ -416,6 +430,8 @@ export class BookingSyncEffects {
           outcomeProperty: destination.outcomeProperty ?? undefined,
           staticProperties: destination.staticProperties,
           inferCompanyFromEmail: destination.inferCompanyFromEmail,
+          formGuid: mirrorGuid ?? undefined,
+          portalId: portalId ?? undefined,
         },
       },
       this.fetchImpl,

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -32,7 +32,31 @@ interface CalendlyResource {
     last_name?: string;
     /** Present only when the event type asks for an SMS reminder number. */
     text_reminder_number?: string;
+    /** The booking form's custom questions, in the order the event type asks them. */
+    questions_and_answers?: { question?: string; answer?: string; position?: number }[];
   };
+}
+
+/**
+ * A custom-question answer that is a phone number, or null.
+ *
+ * `text_reminder_number` only exists when the event type uses Calendly's native
+ * SMS field, and real event types ask for the phone as a CUSTOM question instead
+ * ("What is your phone number?"), which arrives here. Guarded twice, because
+ * either check alone fails on real data: event types exist whose first question
+ * is "Company" (and people have answered it with their phone) and others with
+ * free-text "Please share anything...", so the QUESTION must ask for a phone AND
+ * the ANSWER must parse as one. Position is irrelevant: the question is found by
+ * its text, wherever the event type asks it.
+ */
+function phoneFromQuestions(
+  qa: { question?: string; answer?: string }[] | undefined,
+): string | null {
+  const asksForPhone = (q: string | undefined) =>
+    /tel[eé]fono|phone|celular|m[oó]vil|whatsapp|n[uú]mero/i.test(q ?? '');
+  const looksLikePhone = (a: string | undefined) => /^[+()\-.\s\d]{7,}$/.test((a ?? '').trim());
+  const hit = (qa ?? []).find((x) => asksForPhone(x.question) && looksLikePhone(x.answer));
+  return hit?.answer?.trim() ?? null;
 }
 
 /** What the booking page collected about the person, beyond their address. */
@@ -168,7 +192,11 @@ export class BookingSyncEffects {
           name: fetchedInvitee?.resource?.name?.trim() || null,
           firstName: fetchedInvitee?.resource?.first_name?.trim() || null,
           lastName: fetchedInvitee?.resource?.last_name?.trim() || null,
-          phone: fetchedInvitee?.resource?.text_reminder_number?.trim() || null,
+          // The structured SMS field wins; a custom question is the fallback.
+          phone:
+            fetchedInvitee?.resource?.text_reminder_number?.trim() ||
+            phoneFromQuestions(fetchedInvitee?.resource?.questions_and_answers) ||
+            null,
         };
       }
     }

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -8,7 +8,6 @@ import {
 } from '@quill/db';
 import {
   createDestination,
-  HUBSPOT_API_BASE,
   type DeliveryTranscript,
   type DestinationContext,
   type DestinationSpec,
@@ -21,6 +20,7 @@ import {
   type FormDestination,
 } from '@quill/types';
 import type { ServerEnv } from '@quill/config/env';
+import { HubspotPortalResolver, mirrorGuidFor } from './hubspot-portal';
 import { DB, ENV } from './tokens';
 
 /** The delivery snapshot serialized into an outbox row (config + context). */
@@ -61,12 +61,8 @@ export class DestinationEffects {
   fetchImpl: typeof fetch = fetch;
   /** Injectable DNS resolver for tests (webhook SSRF guard); default = Node DNS. */
   resolveDns?: DnsResolver;
-  /**
-   * accountId -> the portal its HubSpot token belongs to. The pair is stored
-   * together so a rotated token misses the cache instead of serving the
-   * previous portal's id.
-   */
-  private readonly portalIds = new Map<string, { token: string; portalId: string }>();
+  /** accountId -> the portal its HubSpot token belongs to (mirror submit URL). */
+  private readonly portals = new HubspotPortalResolver();
 
   constructor(
     @Inject(DB) private readonly db: Db,
@@ -201,8 +197,7 @@ export class DestinationEffects {
       this.env?.FORMS_ENCRYPTION_KEY,
       this.env?.HUBSPOT_PRIVATE_APP_TOKEN,
     );
-    const mirrorGuid =
-      destination.settings?.formActivity === true ? (destination.settings?.formGuid ?? null) : null;
+    const mirrorGuid = mirrorGuidFor(destination.settings);
     return {
       type: 'hubspot',
       hubspot: {
@@ -217,52 +212,17 @@ export class DestinationEffects {
         outcomeProperty: destination.outcomeProperty ?? undefined,
         staticProperties: destination.staticProperties,
         inferCompanyFromEmail: destination.inferCompanyFromEmail,
-        // The mirror form. Gated on the author's switch as well as the guid:
-        // the guid SURVIVES the switch being turned off, so that turning it back
-        // on reuses the same form instead of orphaning the activities already
-        // attached to it. Policy lives here rather than in the adapter, which
-        // simply posts when it is given somewhere to post to.
-        //
-        // The portal is resolved lazily — nothing else in the product needs it,
-        // so it is not worth a column, and a form with no mirror never pays for
-        // the lookup at all.
+        // The mirror form and the portal its submit URL carries: see
+        // `mirrorGuidFor` and `HubspotPortalResolver`, shared with the
+        // booking-time path so the two cannot disagree on what enables it.
         formGuid: mirrorGuid ?? undefined,
         portalId: mirrorGuid
-          ? ((await this.resolvePortalId(accountId, token ?? '')) ?? undefined)
+          ? ((await this.portals.resolve(accountId, token ?? '', this.fetchImpl)) ?? undefined)
           : undefined,
       },
     };
   }
 
-  /**
-   * The portal a token belongs to, cached per account.
-   *
-   * Keyed on the token as well as the account so a rotated credential cannot
-   * keep serving the previous portal's id — which would post one customer's
-   * submissions at another customer's forms. A failure returns null and the
-   * mirror submission is simply skipped; the contact still syncs.
-   */
-  private async resolvePortalId(accountId: string, token: string): Promise<string | null> {
-    if (!token) return null;
-    const cached = this.portalIds.get(accountId);
-    if (cached && cached.token === token) return cached.portalId;
-    try {
-      const res = await this.fetchImpl(`${HUBSPOT_API_BASE}/account-info/v3/details`, {
-        headers: { authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) {
-        this.log.warn(`[destinations] could not resolve HubSpot portal: HTTP ${res.status}`);
-        return null;
-      }
-      const body = (await res.json().catch(() => ({}))) as { portalId?: number | string };
-      const portalId = body.portalId == null ? null : String(body.portalId);
-      if (portalId) this.portalIds.set(accountId, { token, portalId });
-      return portalId;
-    } catch (err) {
-      this.log.warn(`[destinations] could not resolve HubSpot portal: ${String(err)}`);
-      return null;
-    }
-  }
 }
 
 /** Read the destinations array from a stored config, tolerating legacy/absent. */

--- a/apps/api/src/hubspot-portal.ts
+++ b/apps/api/src/hubspot-portal.ts
@@ -1,0 +1,66 @@
+import { Logger } from '@nestjs/common';
+import { HUBSPOT_API_BASE } from '@quill/destinations';
+
+/**
+ * The HubSpot portal a token belongs to, cached per account.
+ *
+ * The mirror form's submit URL carries the portal id, so posting the "Form
+ * submission" activity needs it and nothing else in the product does. It is
+ * therefore resolved lazily rather than stored, and a form with no mirror never
+ * pays for the lookup at all.
+ *
+ * Keyed on the token as well as the account so a rotated credential cannot keep
+ * serving the previous portal's id, which would post one customer's submissions
+ * at another customer's forms.
+ *
+ * Shared by both delivery paths on purpose. The submit-time path
+ * (`DestinationEffects`) and the booking-time path (`BookingSyncEffects`) each
+ * build the HubSpot adapter themselves, and the booking path shipped without a
+ * portal at all: every form whose contact key comes from its scheduler synced
+ * its answers and its Note but silently never posted the mirror, because the
+ * adapter skips mirroring when either the guid or the portal is missing. One
+ * resolver here is what keeps the two from drifting again.
+ *
+ * A failure returns null and the caller simply skips the mirror; the contact
+ * still syncs.
+ */
+export class HubspotPortalResolver {
+  private readonly log = new Logger('HubspotPortal');
+  private readonly portalIds = new Map<string, { token: string; portalId: string }>();
+
+  async resolve(accountId: string, token: string, fetchImpl: typeof fetch): Promise<string | null> {
+    if (!token) return null;
+    const cached = this.portalIds.get(accountId);
+    if (cached && cached.token === token) return cached.portalId;
+    try {
+      const res = await fetchImpl(`${HUBSPOT_API_BASE}/account-info/v3/details`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        this.log.warn(`could not resolve HubSpot portal: HTTP ${res.status}`);
+        return null;
+      }
+      const body = (await res.json().catch(() => ({}))) as { portalId?: number | string };
+      const portalId = body.portalId == null ? null : String(body.portalId);
+      if (portalId) this.portalIds.set(accountId, { token, portalId });
+      return portalId;
+    } catch (err) {
+      this.log.warn(`could not resolve HubSpot portal: ${String(err)}`);
+      return null;
+    }
+  }
+}
+
+/**
+ * The mirror form this destination posts to, or null.
+ *
+ * Gated on the author's switch as well as the guid: the guid SURVIVES the switch
+ * being turned off, so that turning it back on reuses the same form instead of
+ * orphaning the activities already attached to it. Policy lives here rather than
+ * in the adapter, which simply posts when it is given somewhere to post to.
+ */
+export function mirrorGuidFor(
+  settings: { formActivity?: boolean; formGuid?: string | null } | undefined,
+): string | null {
+  return settings?.formActivity === true ? (settings?.formGuid ?? null) : null;
+}


### PR DESCRIPTION
Two gaps on the same path: the booking sync is the only delivery a form whose contact key comes from its scheduler ever takes, and it was missing two things the submit path has.

## 1. The invitee phone never arrived

`booking-sync` read the phone only from `text_reminder_number`, which Calendly populates only when the event type uses its native SMS field. Real event types ask for the phone as a **custom question**, which arrives in `questions_and_answers` on the same invitee response we already fetch. The `Booking: phone` row has existed in the builder all along and no booking ever produced a value for it.

Now the custom questions are read as a fallback, guarded twice: the question's text must ask for a phone **and** the answer must parse as one. Either check alone fails on real data, where some event types open with "Company" (occasionally answered with a phone number) and others with free text. The native SMS field still wins when both are present.

## 2. The "Form submission" activity was never posted

The adapter mirrors only when it has **both** `formGuid` and `portalId`. The booking path passed neither, so scheduler-keyed forms synced their answers and their Note and silently produced no form activity: the switch on, a mirror form created in the portal, and zero submissions on it.

The portal resolver and the switch policy move to `hubspot-portal.ts`, shared by both delivery paths so they cannot disagree again about what enables the mirror. The lookup still runs only when a mirror is configured, so a form without one makes no extra call.

## Verification

Found by auditing a live account: of six forms with the mirror configured, the only one recording submissions was the only one that asks for an email directly. The other five (all scheduler-keyed, all with real traffic) sat at zero.

`pnpm --filter @quill/api test` → 406 passing, including five new cases: phone from a custom question, native SMS wins, a non-phone answer is ignored, the mirror posts on the booking path, and the mirror is skipped (with no portal lookup) when the switch is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)