### PR TITLE
docs(db): explain the migrator's transaction boundary and raw marker insert

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,3 +1,20 @@
+/**
+ * A tiny, dialect-agnostic forward migrator. Reads the numbered .sql files in
+ * migrations/<dialect>/ in filename order and applies each once, tracking
+ * applied names in a `_migrations` table. Identical semantics on SQLite and
+ * Postgres, with no drizzle-kit / engine binary needed for clone-and-run.
+ *
+ * A script and its `_migrations` marker commit in ONE native transaction, so a
+ * failure can never leave the schema changed with no record of it: SQLite uses
+ * better-sqlite3's synchronous `transaction()`, Postgres its own. When the
+ * whole attempt rolls back, `applyOrObservePeer` re-reads the marker before
+ * reporting failure, which is how a concurrent runner that won the race is told
+ * apart from a migration that is genuinely broken.
+ *
+ * The transaction is also the boundary: a migration that cannot run inside one
+ * (CREATE INDEX CONCURRENTLY, VACUUM) is unsupported here. None of the shipped
+ * scripts need that, and SELF-HOSTING.md documents it for forks.
+ */
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -17,6 +34,17 @@ function details(error: unknown): DriverError {
   return (error ?? {}) as DriverError;
 }
 
+/**
+ * The marker INSERT as raw text, for the SQLite path only.
+ *
+ * Everywhere else in this package the marker is a parameterized statement. Here
+ * it cannot be: the script and its marker must commit inside better-sqlite3's
+ * synchronous `transaction()`, and the only way in is `exec()`, which takes a
+ * SQL string and no bindings. `file` is a filename this module just read out of
+ * `migrations/<dialect>/`, never anything a request supplied, so the quote
+ * doubling is belt-and-braces rather than the thing standing between us and an
+ * injection. The Postgres path a few lines down stays parameterized.
+ */
 function markerSql(file: string): string {
   return `INSERT INTO _migrations (name, applied_at) VALUES ('${file.replaceAll("'", "''")}', ${Date.now()})`;
 }
@@ -88,6 +116,11 @@ export async function migrate(db: Db, migrationsRoot = MIGRATIONS_ROOT): Promise
       applied.push(file);
     }
   }
+  // Data fixups that portable SQL can't express (random short-code generation,
+  // handle derivation). Idempotent + cheap no-ops once applied, so they run
+  // unconditionally after the SQL migrations on both dialects. Deliberately
+  // OUTSIDE the per-script transactions above: they are not migrations and
+  // own no marker.
   await applyShortLinkFixups(db);
   return applied;
 }


### PR DESCRIPTION
Follow-up to #114.

That PR made each migration script commit together with its `_migrations` marker inside one native transaction, which is the right fix. On the way through it dropped the header comment on `migrate.ts` and the one explaining the short-link fixups. This restores both and writes down the two things a reader of the file now needs and cannot infer from the code.

## The transaction is a boundary, not just a safety net

A migration that cannot run inside one (`CREATE INDEX CONCURRENTLY`, `VACUUM`) does not belong in this directory. None of the 16 shipped scripts needs that, so nothing is broken today, but whoever writes the next one has no way to know unless it is stated. `SELF-HOSTING.md` already documents it for forks; the file itself did not.

## Why `markerSql` builds raw SQL

better-sqlite3's synchronous `transaction()` is only reachable through `exec()`, which takes a SQL string and no bindings, so the marker cannot be parameterized on that path. Reading the quote doubling without that reason invites a bug report about injection on a filename this module just read out of its own migrations directory. The Postgres path stays parameterized, and the comment says so.

It also records that the short-link fixups sit outside those transactions deliberately: they are idempotent data repairs, not migrations, and own no marker.

## Scope

Comments only. No behavior change.

## Verification

- 248 `@quill/db` tests
- `typecheck` and `lint`, 16/16
- `dash-check` clean