### PR TITLE
fix(api): preserve destination delivery state across re-enqueue

### DIFF
--- a/.changeset/destination-cancellation-boundary.md
+++ b/.changeset/destination-cancellation-boundary.md
@@ -2,18 +2,16 @@
 '@quill/db': patch
 ---
 
-Re-submitting a form no longer leaves stale destination deliveries queued, no
-longer destroys one that is already being made, and no longer loses the answers
-the respondent left last.
+Re-submitting a form no longer destroys a destination delivery that is already
+being made, and it now clears out the stale queued work it can safely reach.
 
 The outbox holds three different kinds of pending row and the cancellation path
 used to treat them as one. `deletePendingOutbox` is now `deleteUnstartedOutbox`
 and deletes only what was never handed off to a worker: `status = 'pending'` AND
 `claimed_at IS NULL` AND `attempts = 0`. `skipBackoffOutbox` settles the rows
-that were attempted and are waiting to retry (`claimed_at IS NULL` AND
-`attempts > 0`), and `listPendingOutbox` reads back everything still queued in
-one scope. All of them are scoped to one subject, kind and action exactly as
-before.
+that were attempted and are waiting to retry (`status = 'pending'` AND
+`claimed_at IS NULL` AND `attempts > 0`) by moving `status` to `skipped` and
+nothing else. Both are scoped to one subject, kind and action exactly as before.
 
 Deleting on `status = 'pending'` alone destroyed work that had already partly
 happened. A row a worker held could vanish mid-request, so nothing was left to
@@ -27,34 +25,51 @@ Leaving the attempted rows alone instead turned out to be its own bug. A queued
 row carries a frozen snapshot of the config and answers it was built from, so
 once the same session and phase come round again, every retry still on the
 schedule would deliver content the form has already replaced, and a destination
-the author had switched off went on retrying until it exhausted its attempts.
-Those rows are now settled as `skipped`. Only the status moves: the attempt
-count, the transcript, the recorded error and the timestamp are all left as they
-were, so the row still reads back in the delivery history as the failure it was
-and does not jump ahead of a genuinely newer one.
+the author had switched off had nothing left in its own config to stop it
+retrying. The rows that are unclaimed when the pass runs are now settled as
+`skipped`. Only the status moves: the attempt count, the transcript, the
+recorded error and the timestamps are all left as they were, so the row still
+reads back in the delivery history as the failure it was.
 
-The row a worker is actually holding is the one case nothing may touch, so the
-question of whether it is still worth sending moves to the moment it is sent.
-Every firing destination is queued unconditionally, and a delivery about to
-cross the wire stands down only if a row for the SAME destination, carrying a
-different key, was queued strictly later than it was. Nothing is dropped either
-way: the latest row is always delivered, and the one that stands down is the one
-it replaces. Two rows queued in the same millisecond are not ordered by anything
-the queue can trust, so neither retires the other and both go out under their own
-keys, which is what at-least-once delivery and receiver-side de-duplication are
-for.
+WHERE THE BOUNDARY SITS. Configuration decides what gets queued and what stops
+being retried. It cannot reach work a worker is already holding: that request
+may already have crossed the wire, and its row is the only record that it did,
+so settling it belongs to the worker side rather than to configuration. If the
+worker that took the lease abandons it, the row stays claimed and another worker
+may reclaim it; what configuration still cannot do is settle it. What
+configuration can do is terminally settle already-attempted, unclaimed,
+scheduled work without deleting its record.
 
-That decision needs a key that actually identifies a delivery, so the
-idempotency key is now content-addressed:
-`submission:<id>:<phase>:<type>:<destination digest>:<content digest>`, two full
-SHA-256 digests over canonical JSON. The old key ended in the destination's
-INDEX in the form config, which is not an identity: delete the first of two
-webhooks and the second inherited its key. The destination digest is an explicit
-allowlist of what the form persists about where a delivery goes and never
-includes a signing secret, which is not an identity and must not be published in
-a header. The content digest covers everything the destination receives except
-the key itself and the submission's clock reading, so an unchanged re-submit
-keeps its key and a changed one does not.
+A pass speaks for the queue as it finds it, and not for what the queue becomes
+afterwards. A row a worker is holding when the pass runs is left alone, and the
+pass cannot bound what happens to it next. That attempt may succeed, in which
+case its frozen snapshot is delivered and the row finishes `done`. It may fail,
+in which case the worker clears the claim and the row waits out a backoff,
+unclaimed and due again later. Its lease may simply expire, in which case the
+row stays claimed and another worker may reclaim it.
+
+So Dapta Forms can send the older payload after the newer one. The row the
+current pass queues is due immediately, while a held row that fails is not due
+again until its backoff elapses, which makes this a real sequence: the newer
+payload delivered, then the older one delivered on a later retry, then that
+older row marked `done`. `max_attempts` does not prevent it, because it caps
+how many further retries follow rather than un-sending the attempts already
+made. What a receiver makes of the two is outside Dapta Forms.
+
+A later pass for the same session and phase settles such a row if it has come
+back into backoff and is unclaimed by then, but no later pass is guaranteed: a
+partial phase can come round again, while a re-landed complete does not
+re-enqueue at all. That residual is bounded and deliberate: the only way to
+close it would be to let configuration settle a row a worker owns, which is
+exactly what this boundary exists to prevent.
+
+Editing a destination is therefore not a synchronous cancel of anything in
+flight, and this change does not claim to make it one. Every firing destination
+is queued unconditionally on each pass, so a request still on the wire and the
+answers the respondent just left both go out. Both rows carry the same
+positional idempotency key, which this change leaves exactly as it was; a
+webhook delivery sends that key as a header, the HubSpot adapter does not read
+it at all, and what any particular receiver does with it is outside Dapta Forms.
 
 Alongside this, the API's re-enqueue path reconsiders every destination kind the
 config contract names rather than only the kinds enabled on the current pass. A

--- a/.changeset/destination-cancellation-boundary.md
+++ b/.changeset/destination-cancellation-boundary.md
@@ -1,0 +1,63 @@
+---
+'@quill/db': patch
+---
+
+Re-submitting a form no longer leaves stale destination deliveries queued, no
+longer destroys one that is already being made, and no longer loses the answers
+the respondent left last.
+
+The outbox holds three different kinds of pending row and the cancellation path
+used to treat them as one. `deletePendingOutbox` is now `deleteUnstartedOutbox`
+and deletes only what was never handed off to a worker: `status = 'pending'` AND
+`claimed_at IS NULL` AND `attempts = 0`. `skipBackoffOutbox` settles the rows
+that were attempted and are waiting to retry (`claimed_at IS NULL` AND
+`attempts > 0`), and `listPendingOutbox` reads back everything still queued in
+one scope. All of them are scoped to one subject, kind and action exactly as
+before.
+
+Deleting on `status = 'pending'` alone destroyed work that had already partly
+happened. A row a worker held could vanish mid-request, so nothing was left to
+settle it and nothing recorded that the endpoint had been called. A row waiting
+out its backoff lost its attempt count and its transcript, which is the only
+evidence of what the endpoint said. Neither column implies the other: a first
+claim charges no attempt, and a retry clears the claim while leaving the count
+above zero.
+
+Leaving the attempted rows alone instead turned out to be its own bug. A queued
+row carries a frozen snapshot of the config and answers it was built from, so
+once the same session and phase come round again, every retry still on the
+schedule would deliver content the form has already replaced, and a destination
+the author had switched off went on retrying until it exhausted its attempts.
+Those rows are now settled as `skipped`. Only the status moves: the attempt
+count, the transcript, the recorded error and the timestamp are all left as they
+were, so the row still reads back in the delivery history as the failure it was
+and does not jump ahead of a genuinely newer one.
+
+The row a worker is actually holding is the one case nothing may touch, so the
+question of whether it is still worth sending moves to the moment it is sent.
+Every firing destination is queued unconditionally, and a delivery about to
+cross the wire stands down only if a row for the SAME destination, carrying a
+different key, was queued strictly later than it was. Nothing is dropped either
+way: the latest row is always delivered, and the one that stands down is the one
+it replaces. Two rows queued in the same millisecond are not ordered by anything
+the queue can trust, so neither retires the other and both go out under their own
+keys, which is what at-least-once delivery and receiver-side de-duplication are
+for.
+
+That decision needs a key that actually identifies a delivery, so the
+idempotency key is now content-addressed:
+`submission:<id>:<phase>:<type>:<destination digest>:<content digest>`, two full
+SHA-256 digests over canonical JSON. The old key ended in the destination's
+INDEX in the form config, which is not an identity: delete the first of two
+webhooks and the second inherited its key. The destination digest is an explicit
+allowlist of what the form persists about where a delivery goes and never
+includes a signing secret, which is not an identity and must not be published in
+a header. The content digest covers everything the destination receives except
+the key itself and the submission's clock reading, so an unchanged re-submit
+keeps its key and a changed one does not.
+
+Alongside this, the API's re-enqueue path reconsiders every destination kind the
+config contract names rather than only the kinds enabled on the current pass. A
+destination disabled, removed, or narrowed to another phase between two submits
+of one session used to drop out of that pass entirely, so the rows it left
+behind were never looked at and delivered anyway.

--- a/apps/api/src/destination-effects.spec.ts
+++ b/apps/api/src/destination-effects.spec.ts
@@ -24,7 +24,7 @@ import { destinationType } from '@quill/types';
 import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
 import { signWebhookBody } from '@quill/destinations';
 import { SubmissionService } from './submission.service';
-import { EmailEffects, OutboxSkipError } from './email-effects';
+import { EmailEffects } from './email-effects';
 import { DestinationEffects, type SubmissionDeliveryInput } from './destination-effects';
 import { OutboxWorker } from './outbox.worker';
 
@@ -58,27 +58,9 @@ function keyOf(payload: string | null): string | null {
   }
 }
 
-/**
- * Pin a row's position in the queue's own ordering.
- *
- * Two passes of one session routinely land in the same millisecond, and the
- * newest-row rule falls back to the row id on a tie, which is a random UUID.
- * Stamping `created_at` is what makes a test about ORDER assert the order it
- * means rather than whichever id sorted higher.
- */
-const stampCreatedAt = (id: string, at: number) =>
-  db.run(sql`UPDATE outbox SET created_at = ${at} WHERE id = ${id}`);
-
 /** Hand a row to a worker without racing a real claim for it. */
 const holdRow = (id: string, by = 'W#held') =>
   db.run(sql`UPDATE outbox SET claimed_at = ${Date.now()}, claimed_by = ${by} WHERE id = ${id}`);
-
-/** Hold a row on a lease old enough for a drain to reclaim it (a crashed worker). */
-const holdStale = (id: string) =>
-  db.run(
-    sql`UPDATE outbox SET claimed_at = ${Date.now() - 10 * 60_000}, claimed_by = 'W#crashed'
-        WHERE id = ${id}`,
-  );
 
 beforeEach(async () => {
   db = await createDb('file::memory:');
@@ -489,8 +471,7 @@ describe('re-enqueue reconsideration across a config change', () => {
   it('queues the newer delivery BESIDE the one a worker is already making', async () => {
     // The in-flight row cannot be cancelled, and the answers this pass carries
     // are the ones the respondent actually left, so neither may be dropped.
-    // Both are queued; which of them is still worth sending is decided at
-    // delivery time, when the row is about to cross the wire.
+    // Both are queued, and both keep the same unchanged positional key.
     await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-dup', [WEBHOOK]));
     const [queued] = await rowsFor('sub-dup');
     const claimed = (await claimDueOutbox(db, Date.now(), { workerId: 'W' })).find(
@@ -510,10 +491,17 @@ describe('re-enqueue reconsideration across a config change', () => {
       claimedAt: claimed!.claimedAt,
       claimedBy: claimed!.claimedBy,
     });
-    // ...and the newer answers are queued under their own key.
+    // ...and the newer answers are queued beside it. Both rows carry the SAME
+    // positional key, unchanged by this branch, because the submission, the
+    // phase, the type and the config index are all the same. What the far end
+    // does when it sees that key twice is the receiver's business and outside
+    // Dapta Forms; this test asserts only what the queue holds. What the queue
+    // must not do is drop either row on our side, because the held one may
+    // already have landed and the fresh one is the only copy of the latest
+    // answers.
     const fresh = rows.find((r) => r.id !== claimed!.id)!;
     expect(fresh).toMatchObject({ status: 'pending', attempts: 0, claimedAt: null });
-    expect(keyOf(fresh.payload)).not.toBe(keyOf(rows.find((r) => r.id === claimed!.id)!.payload));
+    expect(keyOf(fresh.payload)).toBe(keyOf(rows.find((r) => r.id === claimed!.id)!.payload));
     // Named by payload, not counted: the surviving unstarted row is the one
     // carrying THIS pass's answers, and the held row still carries the first's.
     expect(JSON.parse(fresh.payload!).ctx.data).toEqual({ email: 'moved@acme.io' });
@@ -546,11 +534,19 @@ describe('re-enqueue reconsideration across a config change', () => {
     // destinations are queued again under the new answers.
     expect(after).toHaveLength(3);
     expect(after.find((r) => r.id === held.id)).toMatchObject({ claimedBy: 'W#held' });
-    expect(after.filter((r) => r.claimedAt === null)).toHaveLength(2);
-    expect(new Set(after.map((r) => keyOf(r.payload))).size).toBe(3);
+    const unstarted = after.filter((r) => r.claimedAt === null);
+    expect(unstarted).toHaveLength(2);
+    // The two fresh rows are the two SIBLINGS, not one destination queued
+    // twice: they carry different endpoints and different keys, so the pass
+    // never let one of them stand in for the other.
+    expect(unstarted.map((r) => JSON.parse(r.payload!).destination.settings.url).sort()).toEqual([
+      'https://first.example/hook',
+      'https://second.example/hook',
+    ]);
+    expect(new Set(unstarted.map((r) => keyOf(r.payload))).size).toBe(2);
   });
 
-  it('leaves at most one in-flight row and one unstarted row however often the session re-submits', async () => {
+  it('replaces the row the previous SEQUENTIAL pass left, rather than stacking one per submit', async () => {
     await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-rep', [WEBHOOK]));
     const [first] = await rowsFor('sub-rep');
     await claimDueOutbox(db, Date.now(), { workerId: 'W' });
@@ -563,9 +559,14 @@ describe('re-enqueue reconsideration across a config change', () => {
     );
 
     const rows = await rowsFor('sub-rep');
-    // Every pass after the first deletes the unstarted row the one before it
-    // left, so re-submitting cannot grow the queue without bound: the held row,
-    // plus the latest answers, and nothing else.
+    // Each pass deletes the unstarted row the pass before it left, so a session
+    // submitted over and over does not stack a row per submit: the held row,
+    // plus the latest answers. This is a statement about passes that RUN ONE
+    // AFTER ANOTHER, which is how a session submits. Two passes overlapping in
+    // time can both get past the delete before either enqueues, and nothing
+    // here bounds that: the queue is at-least-once, and the rows it produces
+    // carry the same unchanged positional key. Whether anything is made of that
+    // at the far end is outside Dapta Forms.
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.id)).toContain(first!.id);
     const live = rows.filter((r) => r.claimedAt === null);
@@ -592,8 +593,18 @@ describe('re-enqueue reconsideration across a config change', () => {
  * was built from. Once the same session and phase come round again that
  * snapshot is stale, so every retry still on its schedule is a scheduled
  * delivery of content the form has already replaced, and a destination the
- * author switched off keeps retrying until it burns through `max_attempts`.
- * The pass settles those rows instead of leaving them due.
+ * author switched off has nothing left in its own config to stop it retrying.
+ * The pass settles the rows that are UNCLAIMED WHEN IT RUNS, and only those. A
+ * row a worker is holding at that moment is left alone, and the pass cannot
+ * bound what happens to it next: the attempt may succeed and finish `done`, may
+ * fail and drop back into backoff unclaimed, or may lose its lease and stay
+ * claimed for another worker. Because the row this pass queues is due
+ * immediately and a backed-off retry is not, Dapta Forms can send the older
+ * payload after the newer one and then mark that older row done; `max_attempts`
+ * caps the retries that follow rather than un-sending the ones already made,
+ * and no later pass is guaranteed to settle it, since a re-landed complete does
+ * not re-enqueue. What a receiver makes of the pair is outside Dapta Forms. The
+ * tests below assert the bounded half, and claim nothing about the rest.
  */
 describe('superseding a delivery that is waiting out its retry backoff', () => {
   const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
@@ -670,7 +681,7 @@ describe('superseding a delivery that is waiting out its retry backoff', () => {
     });
   });
 
-  it('stops a WITHDRAWN destination from retrying, and the worker never calls it again', async () => {
+  it('settles the unclaimed backoff row of a WITHDRAWN destination as skipped', async () => {
     const stale = await intoBackoff('sub-wd');
 
     // The author disables the webhook, then the session is submitted again.
@@ -682,8 +693,11 @@ describe('superseding a delivery that is waiting out its retry backoff', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ id: stale, status: 'skipped', attempts: 2 });
 
-    // Nothing is due any more, so a drain long after the backoff has elapsed
-    // reaches no endpoint at all.
+    // The drain below is corroboration, not the oracle. `markOutboxRetry` put
+    // this row's next attempt in the future, so a drain now would reach no
+    // endpoint whether it had been settled or was merely not yet due; the
+    // status assertion above is what distinguishes the two. What the drain does
+    // add is that settling changed nothing else the worker looks at.
     let called = 0;
     destinations.fetchImpl = (async () => {
       called += 1;
@@ -723,31 +737,26 @@ describe('superseding a delivery that is waiting out its retry backoff', () => {
 });
 
 /**
- * What the idempotency key is derived from.
+ * What the idempotency key is, and what a delivery is allowed to depend on.
  *
- * The key used to be the destination's INDEX in the config array, which is not
- * an identity: delete the first of two webhooks and the second inherits the
- * first's key, so a queued delivery to one endpoint and a queued delivery to a
- * different endpoint became indistinguishable. It also could not tell two sends
- * apart when the answers had changed underneath them, which is the one question
- * a re-submit has to be able to ask.
+ * The key names a destination POSITIONALLY: the submission, the phase, the
+ * destination type, and the destination's index in the form config. A webhook
+ * delivery sends it as a header, the HubSpot adapter does not read it at all,
+ * and nothing inside this system reads it back. What a receiver does with it is
+ * that receiver's business and outside Dapta Forms; these tests pin only the
+ * shape we emit. Both facts were briefly given up on this branch: the key was
+ * made content-addressed, and `deliver` was made to re-read the queue to decide
+ * whether the row it had been handed was still the current one. Both are out.
  *
- * So the key is CONTENT-ADDRESSED: what is being delivered to (an explicit
- * allowlist of the destination's persisted, non-secret semantics) and what is
- * being delivered (the whole delivery context bar the key itself and the
- * submission's clock reading), each as a full SHA-256 over canonical JSON.
- * Equal keys mean equal deliveries, which is exactly what a receiver deduping
- * on the header we send it is entitled to assume.
+ * Delivery is a function of the row it was given. A claimed row's fate cannot
+ * turn on what some later pass did or did not enqueue, because a worker holding
+ * a row may already have crossed the wire, and a second opinion formed after
+ * the fact cannot unsend anything.
  */
-describe('the content-addressed delivery key', () => {
+describe('the delivery key, and what delivery may depend on', () => {
   const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
-  const KEY_SHAPE = /^submission:[^:]+:(partial|complete):(webhook|hubspot):[0-9a-f]{64}:[0-9a-f]{64}$/;
 
-  function deliveryInput(
-    submissionId: string,
-    destinationsConfig: unknown[],
-    over: Partial<SubmissionDeliveryInput> = {},
-  ): SubmissionDeliveryInput {
+  function deliveryInput(submissionId: string, destinationsConfig: unknown[]): SubmissionDeliveryInput {
     return {
       formId: 'form-1',
       formName: 'F',
@@ -760,471 +769,65 @@ describe('the content-addressed delivery key', () => {
       submittedAt: 1_700_000_000_000,
       data: { email: 'lead@acme.io' },
       config: { version: 1, steps: [], destinations: destinationsConfig },
-      ...over,
     };
   }
 
-  const keysFor = async (subjectUid: string, kind: 'webhook' | 'hubspot' = 'webhook') =>
-    (await listOutbox(db, { kind, subjectUid })).map((r) => keyOf(r.payload)!);
+  it('is the submission, the phase, the type and the config index, exactly', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-key', [WEBHOOK]));
 
-  /** The two halves of a key: what it delivers TO, and WHAT it delivers. */
-  const digests = (key: string) => {
-    const parts = key.split(':');
-    return { destination: parts[4]!, content: parts[5]! };
-  };
-
-  /** Queue one destination on its own and report the digest of its identity. */
-  const identityOf = async (
-    subjectUid: string,
-    destination: unknown,
-    kind: 'webhook' | 'hubspot' = 'webhook',
-  ) => {
-    await destinations.enqueueSubmissionDeliveries(deliveryInput(subjectUid, [destination]));
-    const [key] = await keysFor(subjectUid, kind);
-    return digests(key!).destination;
-  };
-
-  it('names the submission, the phase and the kind in the clear and digests the rest', async () => {
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-k', [WEBHOOK]));
-
-    const [key] = await keysFor('sub-k');
-    expect(key).toMatch(KEY_SHAPE);
-    expect(key!.startsWith('submission:sub-k:complete:webhook:')).toBe(true);
+    const rows = await listOutbox(db, { kind: 'webhook', subjectUid: 'sub-key' });
+    expect(rows.map((r) => keyOf(r.payload))).toEqual(['submission:sub-key:complete:webhook:0']);
   });
 
-  it('re-keys a delivery whose ANSWERS changed, and only its content half', async () => {
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-kc', [WEBHOOK]));
-    const [before] = await keysFor('sub-kc');
-
-    await destinations.enqueueSubmissionDeliveries(
-      deliveryInput('sub-kc', [WEBHOOK], { data: { email: 'moved@acme.io' } }),
-    );
-    const [after] = await keysFor('sub-kc');
-
-    expect(after).not.toBe(before);
-    expect(digests(after!).content).not.toBe(digests(before!).content);
-    expect(digests(after!).destination).toBe(digests(before!).destination);
-  });
-
-  it('gives a re-submit that changed nothing the identical key', async () => {
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-ks', [WEBHOOK]));
-    const [before] = await keysFor('sub-ks');
-
-    // A later clock reading is not a different delivery: the same answers to the
-    // same form are the same thing to send, so a retry keeps its key.
-    await destinations.enqueueSubmissionDeliveries(
-      deliveryInput('sub-ks', [WEBHOOK], { submittedAt: 1_700_000_999_999 }),
-    );
-
-    expect((await keysFor('sub-ks'))[0]).toBe(before);
-  });
-
-  it('does not depend on where a destination sits in the config array', async () => {
-    const a = { ...WEBHOOK, settings: { url: 'https://a.example/hook' } };
-    const b = { ...WEBHOOK, settings: { url: 'https://b.example/hook' } };
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-ko', [a, b]));
-    const inOrder = (await keysFor('sub-ko')).sort();
-
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-ko', [b, a]));
-
-    expect((await keysFor('sub-ko')).sort()).toEqual(inOrder);
-  });
-
-  it("never hands a removed destination's key to its neighbour", async () => {
-    const a = { ...WEBHOOK, settings: { url: 'https://a.example/hook' } };
-    const b = { ...WEBHOOK, settings: { url: 'https://b.example/hook' } };
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-kr', [a]));
-    const [keyA] = await keysFor('sub-kr');
-
-    // `a` is deleted, so `b` moves into index 0. Under a positional key it would
-    // now be indistinguishable from the delivery `a` had queued.
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-kr', [b]));
-
-    expect((await keysFor('sub-kr'))[0]).not.toBe(keyA);
-  });
-
-  it('is blind to the signing secret, so rotating it does not re-key the delivery', async () => {
-    // The key is forwarded to the receiver as a header. Anything digested into
-    // it is published, so the secret cannot be part of what identifies the
-    // destination, and rotating a secret is not a new delivery either way.
-    const withSecret = { ...WEBHOOK, settings: { ...WEBHOOK.settings, secret: 'shh-one' } };
-    const rotated = { ...WEBHOOK, settings: { ...WEBHOOK.settings, secret: 'shh-two' } };
-
-    expect(await identityOf('sub-kx1', withSecret)).toBe(await identityOf('sub-kx2', rotated));
-    expect(await identityOf('sub-kx3', WEBHOOK)).toBe(await identityOf('sub-kx1', withSecret));
-  });
-
-  it('re-keys when the URL of a destination with no id changes', async () => {
-    // A legacy webhook carries no id, so the endpoint is the only stable thing
-    // left to identify it by.
-    const moved = { ...WEBHOOK, settings: { url: 'https://elsewhere.example/hook' } };
-    expect(await identityOf('sub-ku1', WEBHOOK)).not.toBe(await identityOf('sub-ku2', moved));
-  });
-
-  it('re-keys when the id, the events or the signature header change', async () => {
-    const base = { ...WEBHOOK, id: 'wh-1' };
-    const plain = await identityOf('sub-ki0', base);
-
-    expect(await identityOf('sub-ki1', { ...base, id: 'wh-2' })).not.toBe(plain);
-    expect(await identityOf('sub-ki2', { ...base, events: ['complete'] })).not.toBe(plain);
-    expect(
-      await identityOf('sub-ki3', {
-        ...base,
-        settings: { ...base.settings, signatureHeader: 'X-Acme-Signature' },
-      }),
-    ).not.toBe(plain);
-  });
-
-  it('digests the same answers to the same key whatever order they arrive in', async () => {
-    // The answers and the CRM mappings are records built from user input, so
-    // their key order is an accident of how the form was filled in or edited.
-    // Two spellings of one object are one object, or the digest is not an
-    // identity and every re-submit re-keys itself.
-    const mapped = (fieldMappings: Record<string, string>) => ({
-      type: 'hubspot',
-      enabled: true,
-      fieldMappings,
-    });
-    await destinations.enqueueSubmissionDeliveries(
-      deliveryInput('sub-kn', [mapped({ email: 'email', role: 'jobtitle' })], {
-        data: { email: 'lead@acme.io', role: 'ops' },
-      }),
-    );
-    const [before] = await keysFor('sub-kn', 'hubspot');
-
-    await destinations.enqueueSubmissionDeliveries(
-      deliveryInput('sub-kn', [mapped({ role: 'jobtitle', email: 'email' })], {
-        data: { role: 'ops', email: 'lead@acme.io' },
-      }),
-    );
-
-    expect((await keysFor('sub-kn', 'hubspot'))[0]).toBe(before);
-  });
-
-  it('keeps two id-bearing webhooks pointed at ONE url apart', async () => {
+  it('gives each same-type sibling its own key, one per config index', async () => {
     const two = [
-      { ...WEBHOOK, id: 'wh-left' },
-      { ...WEBHOOK, id: 'wh-right' },
+      { ...WEBHOOK, settings: { url: 'https://first.example/hook' } },
+      { ...WEBHOOK, settings: { url: 'https://second.example/hook' } },
     ];
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-k2', two));
 
-    const keys = await keysFor('sub-k2');
-    expect(keys).toHaveLength(2);
-    expect(new Set(keys.map((k) => digests(k).destination)).size).toBe(2);
-  });
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-sibkey', two));
 
-  it('keeps two HubSpot destinations with different mappings apart', async () => {
-    // HubSpot holds no secret in its config, so its identity is everything the
-    // form persists about it. Two entries differing only in what they write are
-    // two different deliveries.
-    const two = [
-      { type: 'hubspot', enabled: true, fieldMappings: { email: 'email' } },
-      { type: 'hubspot', enabled: true, fieldMappings: { email: 'work_email' } },
-    ];
-    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-k3', two));
-
-    const keys = await keysFor('sub-k3', 'hubspot');
-    expect(keys).toHaveLength(2);
-    expect(new Set(keys.map((k) => digests(k).destination)).size).toBe(2);
-  });
-});
-
-/**
- * Which queued row is still worth sending, decided when it is about to be sent.
- *
- * The enqueue pass cannot answer this. It can delete what was never started and
- * settle what is waiting to retry, but a row a worker is holding is beyond its
- * reach, and declining to queue the newer answers instead would lose them: the
- * in-flight row carries a snapshot the respondent has since replaced.
- *
- * So both rows are queued, and the decision moves to the last possible moment.
- * A row about to cross the wire looks at what else is queued for the same
- * subject, kind and action, keeps only the rows delivering to the SAME
- * destination, and stands down if it is not the newest of them. Nothing is
- * lost: the row that stands down is the one another row supersedes.
- */
-describe('retiring a superseded delivery at the moment it crosses the wire', () => {
-  const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
-  let called = 0;
-  let sent: string[] = [];
-
-  beforeEach(() => {
-    called = 0;
-    sent = [];
-    destinations.fetchImpl = (async (_url: unknown, init?: { body?: unknown }) => {
-      called += 1;
-      sent.push(String(init?.body ?? ''));
-      return new Response('{}', { status: 200 });
-    }) as unknown as typeof fetch;
-  });
-
-  function deliveryInput(
-    submissionId: string,
-    destinationsConfig: unknown[],
-    data: Record<string, unknown> = { email: 'lead@acme.io' },
-  ): SubmissionDeliveryInput {
-    return {
-      formId: 'form-1',
-      formName: 'F',
-      accountId: 'acc-1',
-      submissionId,
-      sessionId: `sess-${submissionId}`,
-      score: 0,
-      outcomeLabel: null,
-      phase: 'complete',
-      submittedAt: 1_700_000_000_000,
-      data,
-      config: { version: 1, steps: [], destinations: destinationsConfig },
-    };
-  }
-
-  const rowsFor = (subjectUid: string) => listOutbox(db, { kind: 'webhook', subjectUid });
-
-  /**
-   * Queue a pass and pin the rows it added to one moment in the ordering, so
-   * "newest" means what the test says rather than whichever UUID sorted higher.
-   */
-  async function pass(
-    subjectUid: string,
-    destinationsConfig: unknown[],
-    data: Record<string, unknown>,
-    at: number,
-  ) {
-    const before = new Set((await rowsFor(subjectUid)).map((r) => r.id));
-    await destinations.enqueueSubmissionDeliveries(
-      deliveryInput(subjectUid, destinationsConfig, data),
-    );
-    const added = (await rowsFor(subjectUid)).filter((r) => !before.has(r.id));
-    for (const row of added) await stampCreatedAt(row.id, at);
-    return added;
-  }
-
-  const deliverRow = (row: { action: string; payload: string | null }) =>
-    destinations.deliver(row.action, row.payload!);
-
-  it('stands the older row down once newer answers are queued for the same destination', async () => {
-    const [first] = await pass('sub-g1', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const [second] = await pass('sub-g1', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
-
-    await expect(deliverRow(first!)).rejects.toBeInstanceOf(OutboxSkipError);
-    expect(called).toBe(0);
-
-    // The row that stood down is the OLDER one, by id, and the delivery that
-    // goes out is the one carrying the answers the respondent actually left.
-    // Counting rows would not distinguish that from the opposite mistake.
-    await expect(deliverRow(second!)).resolves.toBeDefined();
-    expect(second!.id).not.toBe(first!.id);
-    expect(sent).toHaveLength(1);
-    expect(JSON.parse(sent[0]!).data).toEqual({ email: 'second@acme.io' });
-    const survivors = await rowsFor('sub-g1');
-    expect(survivors.map((r) => r.id).sort()).toEqual([first!.id, second!.id].sort());
-  });
-
-  it('retires neither of two rows queued in the SAME instant, and delivers both', async () => {
-    // Two passes of one session can land on a single millisecond. The row id is
-    // a random UUID, so ordering by it would pick a winner at random and drop
-    // the other delivery for good. Equal timestamps are no evidence of which
-    // came later, so neither row may retire the other: both go out, under
-    // distinct keys, and the receiver deduping on the header sees two events
-    // because there genuinely were two.
-    const [first] = await pass('sub-gt', [WEBHOOK], { email: 'first@acme.io' }, 5_000);
-    await holdRow(first!.id, 'W#one');
-    const [second] = await pass('sub-gt', [WEBHOOK], { email: 'second@acme.io' }, 5_000);
-    await holdRow(second!.id, 'W#two');
-    expect(keyOf(second!.payload)).not.toBe(keyOf(first!.payload));
-
-    await expect(deliverRow(first!)).resolves.toBeDefined();
-    await expect(deliverRow(second!)).resolves.toBeDefined();
-
-    expect(sent).toHaveLength(2);
-    expect(sent.map((b) => JSON.parse(b).data.email).sort()).toEqual([
-      'first@acme.io',
-      'second@acme.io',
+    const rows = await listOutbox(db, { kind: 'webhook', subjectUid: 'sub-sibkey' });
+    expect(rows.map((r) => keyOf(r.payload)).sort()).toEqual([
+      'submission:sub-sibkey:complete:webhook:0',
+      'submission:sub-sibkey:complete:webhook:1',
     ]);
   });
 
-  it('delivers the newest row, which can never retire itself', async () => {
-    const [first] = await pass('sub-g2', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const [second] = await pass('sub-g2', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
+  it('keeps the index a destination had in the config, not its position after filtering', async () => {
+    // The disabled entry still occupies index 0, so the one that fires is 1.
+    const config = [
+      { ...WEBHOOK, enabled: false },
+      { ...WEBHOOK, settings: { url: 'https://second.example/hook' } },
+    ];
 
-    await expect(deliverRow(second!)).resolves.toBeDefined();
-    expect(called).toBe(1);
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-idx', config));
+
+    const rows = await listOutbox(db, { kind: 'webhook', subjectUid: 'sub-idx' });
+    expect(rows.map((r) => keyOf(r.payload))).toEqual(['submission:sub-idx:complete:webhook:1']);
   });
 
-  it('delivers an identical re-submit: the same key supersedes nothing', async () => {
-    const [first] = await pass('sub-g3', [WEBHOOK], { email: 'same@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const [second] = await pass('sub-g3', [WEBHOOK], { email: 'same@acme.io' }, 2_000);
-    expect(keyOf(second!.payload)).toBe(keyOf(first!.payload));
+  it('reads nothing from the database while delivering', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-noread', [WEBHOOK]));
+    const [row] = await listOutbox(db, { kind: 'webhook', subjectUid: 'sub-noread' });
+    destinations.fetchImpl = (async () =>
+      new Response('{}', { status: 200 })) as unknown as typeof fetch;
 
-    await expect(deliverRow(first!)).resolves.toBeDefined();
-    expect(called).toBe(1);
-  });
+    const handle = db as unknown as Record<'run' | 'get' | 'all', (q: unknown) => unknown>;
+    const real = { run: handle.run, get: handle.get, all: handle.all };
+    let queries = 0;
+    for (const name of ['run', 'get', 'all'] as const) {
+      handle[name] = (q: unknown) => {
+        queries += 1;
+        return real[name].call(db, q);
+      };
+    }
+    try {
+      await destinations.deliver(row!.action, row!.payload!);
+    } finally {
+      Object.assign(handle, real);
+    }
 
-  it('never lets one destination retire a same-kind sibling', async () => {
-    const a = { ...WEBHOOK, settings: { url: 'https://a.example/hook' } };
-    const b = { ...WEBHOOK, settings: { url: 'https://b.example/hook' } };
-    const firstPass = await pass('sub-g4', [a, b], { email: 'first@acme.io' }, 1_000);
-    for (const row of firstPass) await holdRow(row.id);
-    // Only `a` is re-queued, with new answers. Nothing newer exists for `b`.
-    await pass('sub-g4', [a], { email: 'second@acme.io' }, 2_000);
-
-    const held = await rowsFor('sub-g4');
-    const oldB = firstPass.find(
-      (r) => JSON.parse(r.payload!).destination.settings.url === 'https://b.example/hook',
-    )!;
-    const oldA = firstPass.find((r) => r.id !== oldB.id)!;
-    expect(held).toHaveLength(3);
-
-    await expect(deliverRow(oldB)).resolves.toBeDefined();
-    await expect(deliverRow(oldA)).rejects.toBeInstanceOf(OutboxSkipError);
-    expect(called).toBe(1);
-  });
-
-  it('ignores a queued row whose payload cannot be read', async () => {
-    const [first] = await pass('sub-g5', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const id = await enqueueOutbox(db, {
-      kind: 'webhook',
-      action: 'complete',
-      subjectUid: 'sub-g5',
-      accountId: 'acc-1',
-      payload: 'not json',
-    });
-    await stampCreatedAt(id, 9_000);
-
-    // A row that names no delivery vouches for none, so it can supersede none.
-    await expect(deliverRow(first!)).resolves.toBeDefined();
-    expect(called).toBe(1);
-  });
-
-  it('ignores a queued row carrying a legacy positional key', async () => {
-    const [first] = await pass('sub-g6', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const id = await enqueueOutbox(db, {
-      kind: 'webhook',
-      action: 'complete',
-      subjectUid: 'sub-g6',
-      accountId: 'acc-1',
-      payload: JSON.stringify({ ctx: { idempotencyKey: 'submission:sub-g6:complete:webhook:0' } }),
-    });
-    await stampCreatedAt(id, 9_000);
-
-    // The old shape names no destination this rule can compare against, so it
-    // cannot stand in for one and retire unrelated work.
-    await expect(deliverRow(first!)).resolves.toBeDefined();
-    expect(called).toBe(1);
-  });
-
-  it('ignores a key that only LOOKS like one of ours', async () => {
-    // The fingerprint filter cannot be the only check, because a string can
-    // carry this row's own destination digest and still not be a key this
-    // scheme ever minted. An extra segment is the cheapest way to be neither.
-    const [first] = await pass('sub-ga', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const mine = keyOf(first!.payload)!;
-    const id = await enqueueOutbox(db, {
-      kind: 'webhook',
-      action: 'complete',
-      subjectUid: 'sub-ga',
-      accountId: 'acc-1',
-      payload: JSON.stringify({ ctx: { idempotencyKey: `${mine}:extra` } }),
-    });
-    await stampCreatedAt(id, 9_000);
-
-    await expect(deliverRow(first!)).resolves.toBeDefined();
-    expect(called).toBe(1);
-  });
-
-  it('ignores a key of the right shape whose digests are not digests', async () => {
-    // Same segment count, same destination half, and a content half that no
-    // SHA-256 could have produced. Reading it as a delivery would let a
-    // hand-written string retire a real one.
-    const [first] = await pass('sub-gb', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id);
-    const mine = keyOf(first!.payload)!;
-    const id = await enqueueOutbox(db, {
-      kind: 'webhook',
-      action: 'complete',
-      subjectUid: 'sub-gb',
-      accountId: 'acc-1',
-      payload: JSON.stringify({
-        ctx: { idempotencyKey: [...mine.split(':').slice(0, 5), 'deadbeef'].join(':') },
-      }),
-    });
-    await stampCreatedAt(id, 9_000);
-
-    await expect(deliverRow(first!)).resolves.toBeDefined();
-    expect(called).toBe(1);
-  });
-
-  it('delivers a row whose OWN key is legacy rather than guessing what supersedes it', async () => {
-    const legacy = await enqueueOutbox(db, {
-      kind: 'webhook',
-      action: 'complete',
-      subjectUid: 'sub-g7',
-      accountId: 'acc-1',
-      payload: JSON.stringify({
-        destination: WEBHOOK,
-        ctx: {
-          idempotencyKey: 'submission:sub-g7:complete:webhook:0',
-          submissionId: 'sub-g7',
-          formId: 'form-1',
-          formName: 'F',
-          accountId: 'acc-1',
-          sessionId: 'sess-g7',
-          score: 0,
-          outcomeLabel: null,
-          phase: 'complete',
-          submittedAt: 1_700_000_000_000,
-          data: { email: 'legacy@acme.io' },
-          utm: {},
-        },
-      }),
-    });
-    await stampCreatedAt(legacy, 1_000);
-    await holdRow(legacy);
-    await pass('sub-g7', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
-
-    const row = (await rowsFor('sub-g7')).find((r) => r.id === legacy)!;
-    await expect(deliverRow(row)).resolves.toBeDefined();
-    expect(called).toBe(1);
-  });
-
-  it('settles the retired row as skipped through the worker, and calls the endpoint once', async () => {
-    const [first] = await pass('sub-g8', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    // Held by a worker that then died: the second pass cannot delete it (it is
-    // not unstarted) and the drain below can reclaim it (the lease is stale).
-    await holdStale(first!.id);
-    await pass('sub-g8', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
-    expect(await rowsFor('sub-g8')).toHaveLength(2);
-
-    const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
-    const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
-    await new OutboxWorker(db, env, email, destinations).drainOnce();
-
-    expect(called).toBe(1);
-    const rows = await rowsFor('sub-g8');
-    expect(rows.map((r) => r.status).sort()).toEqual(['done', 'skipped']);
-    // The worker's ordinary skip path records why, with no digest or key in it.
-    const retired = rows.find((r) => r.status === 'skipped')!;
-    expect(retired.id).toBe(first!.id);
-    expect(retired.lastError).toBe(
-      'superseded by a later submission of the same session and phase',
-    );
-  });
-
-  it('lets exactly one of two rows racing to deliver reach the endpoint', async () => {
-    const [first] = await pass('sub-g9', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
-    await holdRow(first!.id, 'W#one');
-    const [second] = await pass('sub-g9', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
-    await holdRow(second!.id, 'W#two');
-
-    const outcomes = await Promise.allSettled([deliverRow(first!), deliverRow(second!)]);
-
-    expect(outcomes.filter((o) => o.status === 'rejected')).toHaveLength(1);
-    expect(called).toBe(1);
+    expect(queries).toBe(0);
   });
 });

--- a/apps/api/src/destination-effects.spec.ts
+++ b/apps/api/src/destination-effects.spec.ts
@@ -9,17 +9,22 @@ import {
   createDb,
   migrate,
   seed,
+  claimDueOutbox,
+  claimIdentityOf,
+  enqueueOutbox,
   listOutbox,
+  markOutboxRetry,
   updateForm,
   getAccountByCode,
   listForms,
   sql,
   type Db,
 } from '@quill/db';
+import { destinationType } from '@quill/types';
 import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
 import { signWebhookBody } from '@quill/destinations';
 import { SubmissionService } from './submission.service';
-import { EmailEffects } from './email-effects';
+import { EmailEffects, OutboxSkipError } from './email-effects';
 import { DestinationEffects, type SubmissionDeliveryInput } from './destination-effects';
 import { OutboxWorker } from './outbox.worker';
 
@@ -42,6 +47,38 @@ async function addWebhookDestination(secret?: string) {
   ];
   await updateForm(db, account!.id, form.id, { config });
 }
+
+/** The delivery a queued row names, as its payload records it. */
+function keyOf(payload: string | null): string | null {
+  if (!payload) return null;
+  try {
+    return (JSON.parse(payload) as { ctx?: { idempotencyKey?: string } }).ctx?.idempotencyKey ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pin a row's position in the queue's own ordering.
+ *
+ * Two passes of one session routinely land in the same millisecond, and the
+ * newest-row rule falls back to the row id on a tie, which is a random UUID.
+ * Stamping `created_at` is what makes a test about ORDER assert the order it
+ * means rather than whichever id sorted higher.
+ */
+const stampCreatedAt = (id: string, at: number) =>
+  db.run(sql`UPDATE outbox SET created_at = ${at} WHERE id = ${id}`);
+
+/** Hand a row to a worker without racing a real claim for it. */
+const holdRow = (id: string, by = 'W#held') =>
+  db.run(sql`UPDATE outbox SET claimed_at = ${Date.now()}, claimed_by = ${by} WHERE id = ${id}`);
+
+/** Hold a row on a lease old enough for a drain to reclaim it (a crashed worker). */
+const holdStale = (id: string) =>
+  db.run(
+    sql`UPDATE outbox SET claimed_at = ${Date.now() - 10 * 60_000}, claimed_by = 'W#crashed'
+        WHERE id = ${id}`,
+  );
 
 beforeEach(async () => {
   db = await createDb('file::memory:');
@@ -320,5 +357,874 @@ describe('public form config', () => {
     expect((publicForm!.config as Record<string, unknown>).destinations).toBeUndefined();
     // But the steps the renderer needs are still there.
     expect(publicForm!.config.steps.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Re-enqueue reconsideration: which of the previous pass's rows a re-submit of
+ * the same session and phase is allowed to take back.
+ *
+ * The cancellation pass used to be driven by the destinations that fire on THIS
+ * pass, which is the one set that cannot describe what the PREVIOUS pass left
+ * behind. Turn a webhook off, delete it, or narrow its `events` between two
+ * submits of the same session and its kind vanishes from the pass, so the row
+ * enqueued under the old config is never reconsidered and delivers on a
+ * configuration nobody has any more. The set has to come from the destination
+ * contract itself, not from whatever happens to be enabled today.
+ */
+describe('re-enqueue reconsideration across a config change', () => {
+  const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
+
+  function deliveryInput(
+    phase: 'partial' | 'complete',
+    submissionId: string,
+    destinationsConfig: unknown[],
+    data: Record<string, unknown> = { email: 'lead@acme.io' },
+  ): SubmissionDeliveryInput {
+    return {
+      formId: 'form-1',
+      formName: 'F',
+      accountId: 'acc-1',
+      submissionId,
+      sessionId: `sess-${submissionId}`,
+      score: 0,
+      outcomeLabel: null,
+      phase,
+      submittedAt: Date.now(),
+      data,
+      config: { version: 1, steps: [], destinations: destinationsConfig },
+    };
+  }
+
+  const rowsFor = (subjectUid: string, kind: 'webhook' | 'hubspot' = 'webhook') =>
+    listOutbox(db, { kind, subjectUid });
+
+  it('cancels an unstarted delivery whose destination has since been DISABLED', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-dis', [WEBHOOK]));
+    expect(await rowsFor('sub-dis')).toHaveLength(1);
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-dis', [{ ...WEBHOOK, enabled: false }]),
+    );
+
+    expect(await rowsFor('sub-dis')).toHaveLength(0);
+  });
+
+  it('cancels an unstarted delivery whose destination has since been REMOVED', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-rm', [WEBHOOK]));
+    expect(await rowsFor('sub-rm')).toHaveLength(1);
+
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-rm', []));
+
+    expect(await rowsFor('sub-rm')).toHaveLength(0);
+  });
+
+  it('cancels an unstarted delivery whose destination no longer fires for this PHASE', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('partial', 'sub-phase', [WEBHOOK]));
+    expect(await rowsFor('sub-phase')).toHaveLength(1);
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('partial', 'sub-phase', [{ ...WEBHOOK, events: ['complete'] }]),
+    );
+
+    expect(await rowsFor('sub-phase')).toHaveLength(0);
+  });
+
+  it('cancels a disabled HUBSPOT delivery too, not just webhooks', async () => {
+    const hubspot = { type: 'hubspot', enabled: true };
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-hs', [hubspot]));
+    expect(await rowsFor('sub-hs', 'hubspot')).toHaveLength(1);
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-hs', [{ ...hubspot, enabled: false }]),
+    );
+
+    expect(await rowsFor('sub-hs', 'hubspot')).toHaveLength(0);
+  });
+
+  // Derived from the destination contract, so a new destination kind is
+  // reconsidered the moment it is added there rather than whenever somebody
+  // remembers to widen a list in this app.
+  it.each([...destinationType])(
+    'reconsiders %s, every kind the destination contract names, with nothing configured at all',
+    async (kind) => {
+      const subjectUid = `sub-all-${kind}`;
+      await enqueueOutbox(db, {
+        kind,
+        action: 'complete',
+        subjectUid,
+        accountId: 'acc-1',
+        payload: '{}',
+      });
+      expect(await rowsFor(subjectUid, kind)).toHaveLength(1);
+
+      await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', subjectUid, []));
+
+      expect(await rowsFor(subjectUid, kind)).toHaveLength(0);
+    },
+  );
+
+  it('leaves a CLAIMED delivery to the retry lifecycle, even once the destination is disabled', async () => {
+    // Settings win over a queue entry only until the entry has been handed off.
+    // After that the row may already have crossed the wire, and it is the only
+    // record that it did.
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-owned', [WEBHOOK]),
+    );
+    const [queued] = await rowsFor('sub-owned');
+    const claimed = (await claimDueOutbox(db, Date.now(), { workerId: 'W' })).find(
+      (r) => r.id === queued!.id,
+    );
+    expect(claimed).toBeDefined();
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-owned', [{ ...WEBHOOK, enabled: false }]),
+    );
+
+    const after = await rowsFor('sub-owned');
+    expect(after).toHaveLength(1);
+    expect(after[0]!.claimedBy).toBe(claimed!.claimedBy);
+  });
+
+  it('queues the newer delivery BESIDE the one a worker is already making', async () => {
+    // The in-flight row cannot be cancelled, and the answers this pass carries
+    // are the ones the respondent actually left, so neither may be dropped.
+    // Both are queued; which of them is still worth sending is decided at
+    // delivery time, when the row is about to cross the wire.
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-dup', [WEBHOOK]));
+    const [queued] = await rowsFor('sub-dup');
+    const claimed = (await claimDueOutbox(db, Date.now(), { workerId: 'W' })).find(
+      (r) => r.id === queued!.id,
+    );
+    expect(claimed).toBeDefined();
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-dup', [WEBHOOK], { email: 'moved@acme.io' }),
+    );
+
+    const rows = await rowsFor('sub-dup');
+    expect(rows).toHaveLength(2);
+    // The handed-off row is untouched down to its claim...
+    expect(rows.find((r) => r.id === claimed!.id)).toMatchObject({
+      status: 'pending',
+      claimedAt: claimed!.claimedAt,
+      claimedBy: claimed!.claimedBy,
+    });
+    // ...and the newer answers are queued under their own key.
+    const fresh = rows.find((r) => r.id !== claimed!.id)!;
+    expect(fresh).toMatchObject({ status: 'pending', attempts: 0, claimedAt: null });
+    expect(keyOf(fresh.payload)).not.toBe(keyOf(rows.find((r) => r.id === claimed!.id)!.payload));
+    // Named by payload, not counted: the surviving unstarted row is the one
+    // carrying THIS pass's answers, and the held row still carries the first's.
+    expect(JSON.parse(fresh.payload!).ctx.data).toEqual({ email: 'moved@acme.io' });
+    expect(JSON.parse(rows.find((r) => r.id === claimed!.id)!.payload!).ctx.data).toEqual({
+      email: 'lead@acme.io',
+    });
+  });
+
+  it('never lets one destination displace a same-kind sibling', async () => {
+    // Two webhooks on one form are two different deliveries. The pass treats
+    // them independently: neither one being queued, held or replaced has any
+    // bearing on the other.
+    const two = [
+      { ...WEBHOOK, settings: { url: 'https://first.example/hook' } },
+      { ...WEBHOOK, settings: { url: 'https://second.example/hook' } },
+    ];
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-sib', two));
+    const before = await rowsFor('sub-sib');
+    expect(before).toHaveLength(2);
+    // Exactly ONE of the two is in a worker's hands.
+    const held = before[0]!;
+    await holdRow(held.id);
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-sib', two, { email: 'moved@acme.io' }),
+    );
+
+    const after = await rowsFor('sub-sib');
+    // The held row survived, the unstarted sibling was replaced, and both
+    // destinations are queued again under the new answers.
+    expect(after).toHaveLength(3);
+    expect(after.find((r) => r.id === held.id)).toMatchObject({ claimedBy: 'W#held' });
+    expect(after.filter((r) => r.claimedAt === null)).toHaveLength(2);
+    expect(new Set(after.map((r) => keyOf(r.payload))).size).toBe(3);
+  });
+
+  it('leaves at most one in-flight row and one unstarted row however often the session re-submits', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-rep', [WEBHOOK]));
+    const [first] = await rowsFor('sub-rep');
+    await claimDueOutbox(db, Date.now(), { workerId: 'W' });
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-rep', [WEBHOOK], { email: 'second@acme.io' }),
+    );
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-rep', [WEBHOOK], { email: 'third@acme.io' }),
+    );
+
+    const rows = await rowsFor('sub-rep');
+    // Every pass after the first deletes the unstarted row the one before it
+    // left, so re-submitting cannot grow the queue without bound: the held row,
+    // plus the latest answers, and nothing else.
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id)).toContain(first!.id);
+    const live = rows.filter((r) => r.claimedAt === null);
+    expect(live).toHaveLength(1);
+    // And the row still queued carries the LATEST answers, not the first pass's.
+    expect(JSON.parse(live[0]!.payload!).ctx.data).toEqual({ email: 'third@acme.io' });
+  });
+
+  it('still replaces an unstarted row rather than doubling it when the destination stays enabled', async () => {
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-again', [WEBHOOK]),
+    );
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-again', [WEBHOOK]),
+    );
+    expect(await rowsFor('sub-again')).toHaveLength(1);
+  });
+});
+
+/**
+ * Superseding work that was already attempted.
+ *
+ * A row in retry backoff carries a frozen snapshot of the config and answers it
+ * was built from. Once the same session and phase come round again that
+ * snapshot is stale, so every retry still on its schedule is a scheduled
+ * delivery of content the form has already replaced, and a destination the
+ * author switched off keeps retrying until it burns through `max_attempts`.
+ * The pass settles those rows instead of leaving them due.
+ */
+describe('superseding a delivery that is waiting out its retry backoff', () => {
+  const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
+
+  function deliveryInput(
+    phase: 'partial' | 'complete',
+    submissionId: string,
+    destinationsConfig: unknown[],
+  ): SubmissionDeliveryInput {
+    return {
+      formId: 'form-1',
+      formName: 'F',
+      accountId: 'acc-1',
+      submissionId,
+      sessionId: `sess-${submissionId}`,
+      score: 0,
+      outcomeLabel: null,
+      phase,
+      submittedAt: Date.now(),
+      data: { email: 'lead@acme.io' },
+      config: { version: 1, steps: [], destinations: destinationsConfig },
+    };
+  }
+
+  const rowsFor = (subjectUid: string) => listOutbox(db, { kind: 'webhook', subjectUid });
+
+  /** Enqueue one webhook delivery and drive it into retry backoff. */
+  async function intoBackoff(subjectUid: string): Promise<string> {
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', subjectUid, [WEBHOOK]),
+    );
+    const [row] = await rowsFor(subjectUid);
+    const claimed = (await claimDueOutbox(db, Date.now(), { workerId: 'W' })).find(
+      (r) => r.id === row!.id,
+    );
+    expect(
+      await markOutboxRetry(
+        db,
+        row!.id,
+        {
+          attempts: 2,
+          error: 'HTTP 502 from https://acme.io/hook',
+          transcript: { requestBody: '{"a":1}', responseStatus: 502, responseBody: 'bad gateway' },
+        },
+        claimIdentityOf(claimed!),
+      ),
+    ).toBe(true);
+    return row!.id;
+  }
+
+  it('settles the stale attempt and queues the replacement beside it', async () => {
+    const stale = await intoBackoff('sub-bo');
+
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-bo', [WEBHOOK]));
+
+    const rows = await rowsFor('sub-bo');
+    expect(rows).toHaveLength(2);
+    // The superseded attempt keeps everything it learned, and stops being due.
+    expect(rows.find((r) => r.id === stale)).toMatchObject({
+      status: 'skipped',
+      attempts: 2,
+      responseStatus: 502,
+      responseBody: 'bad gateway',
+    });
+    // Only the status moves. The row still reads back as the failure it was,
+    // which is what an admin opening the delivery log is looking for; the
+    // supersession is not an event of its own and does not overwrite one.
+    expect(rows.find((r) => r.id === stale)!.lastError).toBe('HTTP 502 from https://acme.io/hook');
+    // The replacement is a fresh, never-handed-off row.
+    expect(rows.find((r) => r.id !== stale)).toMatchObject({
+      status: 'pending',
+      attempts: 0,
+      claimedAt: null,
+    });
+  });
+
+  it('stops a WITHDRAWN destination from retrying, and the worker never calls it again', async () => {
+    const stale = await intoBackoff('sub-wd');
+
+    // The author disables the webhook, then the session is submitted again.
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('complete', 'sub-wd', [{ ...WEBHOOK, enabled: false }]),
+    );
+
+    const rows = await rowsFor('sub-wd');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: stale, status: 'skipped', attempts: 2 });
+
+    // Nothing is due any more, so a drain long after the backoff has elapsed
+    // reaches no endpoint at all.
+    let called = 0;
+    destinations.fetchImpl = (async () => {
+      called += 1;
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
+    const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
+    await new OutboxWorker(db, env, email, destinations).drainOnce();
+
+    expect(called).toBe(0);
+    expect((await rowsFor('sub-wd'))[0]!.status).toBe('skipped');
+  });
+
+  it('leaves a claimed row out of the settlement: it is not waiting, it is running', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-run', [WEBHOOK]));
+    const [row] = await rowsFor('sub-run');
+    const claimed = (await claimDueOutbox(db, Date.now(), { workerId: 'W' })).find(
+      (r) => r.id === row!.id,
+    );
+    // Give it attempts from an earlier generation so only the claim marker can
+    // keep the settlement off it.
+    await db.run(sql`UPDATE outbox SET attempts = 2 WHERE id = ${row!.id}`);
+
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('complete', 'sub-run', [WEBHOOK]));
+
+    const rows = await rowsFor('sub-run');
+    // The running row is untouched, and the replacement is queued beside it
+    // rather than withheld: whether the running one is still worth sending is
+    // settled when it is sent, not here.
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.id === row!.id)).toMatchObject({
+      status: 'pending',
+      attempts: 2,
+      claimedBy: claimed!.claimedBy,
+    });
+  });
+});
+
+/**
+ * What the idempotency key is derived from.
+ *
+ * The key used to be the destination's INDEX in the config array, which is not
+ * an identity: delete the first of two webhooks and the second inherits the
+ * first's key, so a queued delivery to one endpoint and a queued delivery to a
+ * different endpoint became indistinguishable. It also could not tell two sends
+ * apart when the answers had changed underneath them, which is the one question
+ * a re-submit has to be able to ask.
+ *
+ * So the key is CONTENT-ADDRESSED: what is being delivered to (an explicit
+ * allowlist of the destination's persisted, non-secret semantics) and what is
+ * being delivered (the whole delivery context bar the key itself and the
+ * submission's clock reading), each as a full SHA-256 over canonical JSON.
+ * Equal keys mean equal deliveries, which is exactly what a receiver deduping
+ * on the header we send it is entitled to assume.
+ */
+describe('the content-addressed delivery key', () => {
+  const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
+  const KEY_SHAPE = /^submission:[^:]+:(partial|complete):(webhook|hubspot):[0-9a-f]{64}:[0-9a-f]{64}$/;
+
+  function deliveryInput(
+    submissionId: string,
+    destinationsConfig: unknown[],
+    over: Partial<SubmissionDeliveryInput> = {},
+  ): SubmissionDeliveryInput {
+    return {
+      formId: 'form-1',
+      formName: 'F',
+      accountId: 'acc-1',
+      submissionId,
+      sessionId: `sess-${submissionId}`,
+      score: 0,
+      outcomeLabel: null,
+      phase: 'complete',
+      submittedAt: 1_700_000_000_000,
+      data: { email: 'lead@acme.io' },
+      config: { version: 1, steps: [], destinations: destinationsConfig },
+      ...over,
+    };
+  }
+
+  const keysFor = async (subjectUid: string, kind: 'webhook' | 'hubspot' = 'webhook') =>
+    (await listOutbox(db, { kind, subjectUid })).map((r) => keyOf(r.payload)!);
+
+  /** The two halves of a key: what it delivers TO, and WHAT it delivers. */
+  const digests = (key: string) => {
+    const parts = key.split(':');
+    return { destination: parts[4]!, content: parts[5]! };
+  };
+
+  /** Queue one destination on its own and report the digest of its identity. */
+  const identityOf = async (
+    subjectUid: string,
+    destination: unknown,
+    kind: 'webhook' | 'hubspot' = 'webhook',
+  ) => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput(subjectUid, [destination]));
+    const [key] = await keysFor(subjectUid, kind);
+    return digests(key!).destination;
+  };
+
+  it('names the submission, the phase and the kind in the clear and digests the rest', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-k', [WEBHOOK]));
+
+    const [key] = await keysFor('sub-k');
+    expect(key).toMatch(KEY_SHAPE);
+    expect(key!.startsWith('submission:sub-k:complete:webhook:')).toBe(true);
+  });
+
+  it('re-keys a delivery whose ANSWERS changed, and only its content half', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-kc', [WEBHOOK]));
+    const [before] = await keysFor('sub-kc');
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('sub-kc', [WEBHOOK], { data: { email: 'moved@acme.io' } }),
+    );
+    const [after] = await keysFor('sub-kc');
+
+    expect(after).not.toBe(before);
+    expect(digests(after!).content).not.toBe(digests(before!).content);
+    expect(digests(after!).destination).toBe(digests(before!).destination);
+  });
+
+  it('gives a re-submit that changed nothing the identical key', async () => {
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-ks', [WEBHOOK]));
+    const [before] = await keysFor('sub-ks');
+
+    // A later clock reading is not a different delivery: the same answers to the
+    // same form are the same thing to send, so a retry keeps its key.
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('sub-ks', [WEBHOOK], { submittedAt: 1_700_000_999_999 }),
+    );
+
+    expect((await keysFor('sub-ks'))[0]).toBe(before);
+  });
+
+  it('does not depend on where a destination sits in the config array', async () => {
+    const a = { ...WEBHOOK, settings: { url: 'https://a.example/hook' } };
+    const b = { ...WEBHOOK, settings: { url: 'https://b.example/hook' } };
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-ko', [a, b]));
+    const inOrder = (await keysFor('sub-ko')).sort();
+
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-ko', [b, a]));
+
+    expect((await keysFor('sub-ko')).sort()).toEqual(inOrder);
+  });
+
+  it("never hands a removed destination's key to its neighbour", async () => {
+    const a = { ...WEBHOOK, settings: { url: 'https://a.example/hook' } };
+    const b = { ...WEBHOOK, settings: { url: 'https://b.example/hook' } };
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-kr', [a]));
+    const [keyA] = await keysFor('sub-kr');
+
+    // `a` is deleted, so `b` moves into index 0. Under a positional key it would
+    // now be indistinguishable from the delivery `a` had queued.
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-kr', [b]));
+
+    expect((await keysFor('sub-kr'))[0]).not.toBe(keyA);
+  });
+
+  it('is blind to the signing secret, so rotating it does not re-key the delivery', async () => {
+    // The key is forwarded to the receiver as a header. Anything digested into
+    // it is published, so the secret cannot be part of what identifies the
+    // destination, and rotating a secret is not a new delivery either way.
+    const withSecret = { ...WEBHOOK, settings: { ...WEBHOOK.settings, secret: 'shh-one' } };
+    const rotated = { ...WEBHOOK, settings: { ...WEBHOOK.settings, secret: 'shh-two' } };
+
+    expect(await identityOf('sub-kx1', withSecret)).toBe(await identityOf('sub-kx2', rotated));
+    expect(await identityOf('sub-kx3', WEBHOOK)).toBe(await identityOf('sub-kx1', withSecret));
+  });
+
+  it('re-keys when the URL of a destination with no id changes', async () => {
+    // A legacy webhook carries no id, so the endpoint is the only stable thing
+    // left to identify it by.
+    const moved = { ...WEBHOOK, settings: { url: 'https://elsewhere.example/hook' } };
+    expect(await identityOf('sub-ku1', WEBHOOK)).not.toBe(await identityOf('sub-ku2', moved));
+  });
+
+  it('re-keys when the id, the events or the signature header change', async () => {
+    const base = { ...WEBHOOK, id: 'wh-1' };
+    const plain = await identityOf('sub-ki0', base);
+
+    expect(await identityOf('sub-ki1', { ...base, id: 'wh-2' })).not.toBe(plain);
+    expect(await identityOf('sub-ki2', { ...base, events: ['complete'] })).not.toBe(plain);
+    expect(
+      await identityOf('sub-ki3', {
+        ...base,
+        settings: { ...base.settings, signatureHeader: 'X-Acme-Signature' },
+      }),
+    ).not.toBe(plain);
+  });
+
+  it('digests the same answers to the same key whatever order they arrive in', async () => {
+    // The answers and the CRM mappings are records built from user input, so
+    // their key order is an accident of how the form was filled in or edited.
+    // Two spellings of one object are one object, or the digest is not an
+    // identity and every re-submit re-keys itself.
+    const mapped = (fieldMappings: Record<string, string>) => ({
+      type: 'hubspot',
+      enabled: true,
+      fieldMappings,
+    });
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('sub-kn', [mapped({ email: 'email', role: 'jobtitle' })], {
+        data: { email: 'lead@acme.io', role: 'ops' },
+      }),
+    );
+    const [before] = await keysFor('sub-kn', 'hubspot');
+
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput('sub-kn', [mapped({ role: 'jobtitle', email: 'email' })], {
+        data: { role: 'ops', email: 'lead@acme.io' },
+      }),
+    );
+
+    expect((await keysFor('sub-kn', 'hubspot'))[0]).toBe(before);
+  });
+
+  it('keeps two id-bearing webhooks pointed at ONE url apart', async () => {
+    const two = [
+      { ...WEBHOOK, id: 'wh-left' },
+      { ...WEBHOOK, id: 'wh-right' },
+    ];
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-k2', two));
+
+    const keys = await keysFor('sub-k2');
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys.map((k) => digests(k).destination)).size).toBe(2);
+  });
+
+  it('keeps two HubSpot destinations with different mappings apart', async () => {
+    // HubSpot holds no secret in its config, so its identity is everything the
+    // form persists about it. Two entries differing only in what they write are
+    // two different deliveries.
+    const two = [
+      { type: 'hubspot', enabled: true, fieldMappings: { email: 'email' } },
+      { type: 'hubspot', enabled: true, fieldMappings: { email: 'work_email' } },
+    ];
+    await destinations.enqueueSubmissionDeliveries(deliveryInput('sub-k3', two));
+
+    const keys = await keysFor('sub-k3', 'hubspot');
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys.map((k) => digests(k).destination)).size).toBe(2);
+  });
+});
+
+/**
+ * Which queued row is still worth sending, decided when it is about to be sent.
+ *
+ * The enqueue pass cannot answer this. It can delete what was never started and
+ * settle what is waiting to retry, but a row a worker is holding is beyond its
+ * reach, and declining to queue the newer answers instead would lose them: the
+ * in-flight row carries a snapshot the respondent has since replaced.
+ *
+ * So both rows are queued, and the decision moves to the last possible moment.
+ * A row about to cross the wire looks at what else is queued for the same
+ * subject, kind and action, keeps only the rows delivering to the SAME
+ * destination, and stands down if it is not the newest of them. Nothing is
+ * lost: the row that stands down is the one another row supersedes.
+ */
+describe('retiring a superseded delivery at the moment it crosses the wire', () => {
+  const WEBHOOK = { type: 'webhook', enabled: true, settings: { url: 'https://acme.io/hook' } };
+  let called = 0;
+  let sent: string[] = [];
+
+  beforeEach(() => {
+    called = 0;
+    sent = [];
+    destinations.fetchImpl = (async (_url: unknown, init?: { body?: unknown }) => {
+      called += 1;
+      sent.push(String(init?.body ?? ''));
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  function deliveryInput(
+    submissionId: string,
+    destinationsConfig: unknown[],
+    data: Record<string, unknown> = { email: 'lead@acme.io' },
+  ): SubmissionDeliveryInput {
+    return {
+      formId: 'form-1',
+      formName: 'F',
+      accountId: 'acc-1',
+      submissionId,
+      sessionId: `sess-${submissionId}`,
+      score: 0,
+      outcomeLabel: null,
+      phase: 'complete',
+      submittedAt: 1_700_000_000_000,
+      data,
+      config: { version: 1, steps: [], destinations: destinationsConfig },
+    };
+  }
+
+  const rowsFor = (subjectUid: string) => listOutbox(db, { kind: 'webhook', subjectUid });
+
+  /**
+   * Queue a pass and pin the rows it added to one moment in the ordering, so
+   * "newest" means what the test says rather than whichever UUID sorted higher.
+   */
+  async function pass(
+    subjectUid: string,
+    destinationsConfig: unknown[],
+    data: Record<string, unknown>,
+    at: number,
+  ) {
+    const before = new Set((await rowsFor(subjectUid)).map((r) => r.id));
+    await destinations.enqueueSubmissionDeliveries(
+      deliveryInput(subjectUid, destinationsConfig, data),
+    );
+    const added = (await rowsFor(subjectUid)).filter((r) => !before.has(r.id));
+    for (const row of added) await stampCreatedAt(row.id, at);
+    return added;
+  }
+
+  const deliverRow = (row: { action: string; payload: string | null }) =>
+    destinations.deliver(row.action, row.payload!);
+
+  it('stands the older row down once newer answers are queued for the same destination', async () => {
+    const [first] = await pass('sub-g1', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const [second] = await pass('sub-g1', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
+
+    await expect(deliverRow(first!)).rejects.toBeInstanceOf(OutboxSkipError);
+    expect(called).toBe(0);
+
+    // The row that stood down is the OLDER one, by id, and the delivery that
+    // goes out is the one carrying the answers the respondent actually left.
+    // Counting rows would not distinguish that from the opposite mistake.
+    await expect(deliverRow(second!)).resolves.toBeDefined();
+    expect(second!.id).not.toBe(first!.id);
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0]!).data).toEqual({ email: 'second@acme.io' });
+    const survivors = await rowsFor('sub-g1');
+    expect(survivors.map((r) => r.id).sort()).toEqual([first!.id, second!.id].sort());
+  });
+
+  it('retires neither of two rows queued in the SAME instant, and delivers both', async () => {
+    // Two passes of one session can land on a single millisecond. The row id is
+    // a random UUID, so ordering by it would pick a winner at random and drop
+    // the other delivery for good. Equal timestamps are no evidence of which
+    // came later, so neither row may retire the other: both go out, under
+    // distinct keys, and the receiver deduping on the header sees two events
+    // because there genuinely were two.
+    const [first] = await pass('sub-gt', [WEBHOOK], { email: 'first@acme.io' }, 5_000);
+    await holdRow(first!.id, 'W#one');
+    const [second] = await pass('sub-gt', [WEBHOOK], { email: 'second@acme.io' }, 5_000);
+    await holdRow(second!.id, 'W#two');
+    expect(keyOf(second!.payload)).not.toBe(keyOf(first!.payload));
+
+    await expect(deliverRow(first!)).resolves.toBeDefined();
+    await expect(deliverRow(second!)).resolves.toBeDefined();
+
+    expect(sent).toHaveLength(2);
+    expect(sent.map((b) => JSON.parse(b).data.email).sort()).toEqual([
+      'first@acme.io',
+      'second@acme.io',
+    ]);
+  });
+
+  it('delivers the newest row, which can never retire itself', async () => {
+    const [first] = await pass('sub-g2', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const [second] = await pass('sub-g2', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
+
+    await expect(deliverRow(second!)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('delivers an identical re-submit: the same key supersedes nothing', async () => {
+    const [first] = await pass('sub-g3', [WEBHOOK], { email: 'same@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const [second] = await pass('sub-g3', [WEBHOOK], { email: 'same@acme.io' }, 2_000);
+    expect(keyOf(second!.payload)).toBe(keyOf(first!.payload));
+
+    await expect(deliverRow(first!)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('never lets one destination retire a same-kind sibling', async () => {
+    const a = { ...WEBHOOK, settings: { url: 'https://a.example/hook' } };
+    const b = { ...WEBHOOK, settings: { url: 'https://b.example/hook' } };
+    const firstPass = await pass('sub-g4', [a, b], { email: 'first@acme.io' }, 1_000);
+    for (const row of firstPass) await holdRow(row.id);
+    // Only `a` is re-queued, with new answers. Nothing newer exists for `b`.
+    await pass('sub-g4', [a], { email: 'second@acme.io' }, 2_000);
+
+    const held = await rowsFor('sub-g4');
+    const oldB = firstPass.find(
+      (r) => JSON.parse(r.payload!).destination.settings.url === 'https://b.example/hook',
+    )!;
+    const oldA = firstPass.find((r) => r.id !== oldB.id)!;
+    expect(held).toHaveLength(3);
+
+    await expect(deliverRow(oldB)).resolves.toBeDefined();
+    await expect(deliverRow(oldA)).rejects.toBeInstanceOf(OutboxSkipError);
+    expect(called).toBe(1);
+  });
+
+  it('ignores a queued row whose payload cannot be read', async () => {
+    const [first] = await pass('sub-g5', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const id = await enqueueOutbox(db, {
+      kind: 'webhook',
+      action: 'complete',
+      subjectUid: 'sub-g5',
+      accountId: 'acc-1',
+      payload: 'not json',
+    });
+    await stampCreatedAt(id, 9_000);
+
+    // A row that names no delivery vouches for none, so it can supersede none.
+    await expect(deliverRow(first!)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('ignores a queued row carrying a legacy positional key', async () => {
+    const [first] = await pass('sub-g6', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const id = await enqueueOutbox(db, {
+      kind: 'webhook',
+      action: 'complete',
+      subjectUid: 'sub-g6',
+      accountId: 'acc-1',
+      payload: JSON.stringify({ ctx: { idempotencyKey: 'submission:sub-g6:complete:webhook:0' } }),
+    });
+    await stampCreatedAt(id, 9_000);
+
+    // The old shape names no destination this rule can compare against, so it
+    // cannot stand in for one and retire unrelated work.
+    await expect(deliverRow(first!)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('ignores a key that only LOOKS like one of ours', async () => {
+    // The fingerprint filter cannot be the only check, because a string can
+    // carry this row's own destination digest and still not be a key this
+    // scheme ever minted. An extra segment is the cheapest way to be neither.
+    const [first] = await pass('sub-ga', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const mine = keyOf(first!.payload)!;
+    const id = await enqueueOutbox(db, {
+      kind: 'webhook',
+      action: 'complete',
+      subjectUid: 'sub-ga',
+      accountId: 'acc-1',
+      payload: JSON.stringify({ ctx: { idempotencyKey: `${mine}:extra` } }),
+    });
+    await stampCreatedAt(id, 9_000);
+
+    await expect(deliverRow(first!)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('ignores a key of the right shape whose digests are not digests', async () => {
+    // Same segment count, same destination half, and a content half that no
+    // SHA-256 could have produced. Reading it as a delivery would let a
+    // hand-written string retire a real one.
+    const [first] = await pass('sub-gb', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id);
+    const mine = keyOf(first!.payload)!;
+    const id = await enqueueOutbox(db, {
+      kind: 'webhook',
+      action: 'complete',
+      subjectUid: 'sub-gb',
+      accountId: 'acc-1',
+      payload: JSON.stringify({
+        ctx: { idempotencyKey: [...mine.split(':').slice(0, 5), 'deadbeef'].join(':') },
+      }),
+    });
+    await stampCreatedAt(id, 9_000);
+
+    await expect(deliverRow(first!)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('delivers a row whose OWN key is legacy rather than guessing what supersedes it', async () => {
+    const legacy = await enqueueOutbox(db, {
+      kind: 'webhook',
+      action: 'complete',
+      subjectUid: 'sub-g7',
+      accountId: 'acc-1',
+      payload: JSON.stringify({
+        destination: WEBHOOK,
+        ctx: {
+          idempotencyKey: 'submission:sub-g7:complete:webhook:0',
+          submissionId: 'sub-g7',
+          formId: 'form-1',
+          formName: 'F',
+          accountId: 'acc-1',
+          sessionId: 'sess-g7',
+          score: 0,
+          outcomeLabel: null,
+          phase: 'complete',
+          submittedAt: 1_700_000_000_000,
+          data: { email: 'legacy@acme.io' },
+          utm: {},
+        },
+      }),
+    });
+    await stampCreatedAt(legacy, 1_000);
+    await holdRow(legacy);
+    await pass('sub-g7', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
+
+    const row = (await rowsFor('sub-g7')).find((r) => r.id === legacy)!;
+    await expect(deliverRow(row)).resolves.toBeDefined();
+    expect(called).toBe(1);
+  });
+
+  it('settles the retired row as skipped through the worker, and calls the endpoint once', async () => {
+    const [first] = await pass('sub-g8', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    // Held by a worker that then died: the second pass cannot delete it (it is
+    // not unstarted) and the drain below can reclaim it (the lease is stale).
+    await holdStale(first!.id);
+    await pass('sub-g8', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
+    expect(await rowsFor('sub-g8')).toHaveLength(2);
+
+    const env = { OUTBOX_WORKER_ENABLED: false, OUTBOX_POLL_MS: 5000, NODE_ENV: 'test' } as never;
+    const email = new EmailEffects(new SubmissionNotifier(new LogOnlyEmailProvider()), db);
+    await new OutboxWorker(db, env, email, destinations).drainOnce();
+
+    expect(called).toBe(1);
+    const rows = await rowsFor('sub-g8');
+    expect(rows.map((r) => r.status).sort()).toEqual(['done', 'skipped']);
+    // The worker's ordinary skip path records why, with no digest or key in it.
+    const retired = rows.find((r) => r.status === 'skipped')!;
+    expect(retired.id).toBe(first!.id);
+    expect(retired.lastError).toBe(
+      'superseded by a later submission of the same session and phase',
+    );
+  });
+
+  it('lets exactly one of two rows racing to deliver reach the endpoint', async () => {
+    const [first] = await pass('sub-g9', [WEBHOOK], { email: 'first@acme.io' }, 1_000);
+    await holdRow(first!.id, 'W#one');
+    const [second] = await pass('sub-g9', [WEBHOOK], { email: 'second@acme.io' }, 2_000);
+    await holdRow(second!.id, 'W#two');
+
+    const outcomes = await Promise.allSettled([deliverRow(first!), deliverRow(second!)]);
+
+    expect(outcomes.filter((o) => o.status === 'rejected')).toHaveLength(1);
+    expect(called).toBe(1);
   });
 });

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -1,8 +1,11 @@
+import { createHash } from 'node:crypto';
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import {
-  deletePendingOutbox,
+  deleteUnstartedOutbox,
   enqueueOutbox,
+  listPendingOutbox,
   resolveProviderToken,
+  skipBackoffOutbox,
   type Db,
   type OutboxKind,
 } from '@quill/db';
@@ -15,19 +18,52 @@ import {
 } from '@quill/destinations';
 import {
   destinationFiresForPhase,
+  destinationType,
   formConfigSchema,
   formDestinationSchema,
   type FormDestination,
+  type HubspotDestination,
+  type WebhookDestination,
 } from '@quill/types';
 import type { ServerEnv } from '@quill/config/env';
+import { OutboxSkipError } from './email-effects';
 import { HubspotPortalResolver, mirrorGuidFor } from './hubspot-portal';
 import { DB, ENV } from './tokens';
+
+/**
+ * Every destination kind the form config can name, as queue kinds.
+ *
+ * Read off the destination contract instead of restated here, so the two cannot
+ * drift: `satisfies` proves at COMPILE TIME that each destination type is a kind
+ * the queue accepts, and a destination kind added to the contract joins the
+ * cancellation pass below without anyone remembering to widen a list.
+ */
+const DESTINATION_OUTBOX_KINDS = destinationType satisfies readonly OutboxKind[];
+
+/**
+ * Why a delivery stood down instead of being made. This reaches the admin's
+ * delivery log verbatim, so it is copy. It names no key and no digest: the row
+ * it lands on is not the place to publish either.
+ */
+const SUPERSEDED_REASON = 'superseded by a later submission of the same session and phase';
 
 /** The delivery snapshot serialized into an outbox row (config + context). */
 interface DestinationOutboxPayload {
   destination: FormDestination;
   ctx: DestinationContext;
 }
+
+/**
+ * WHAT is being delivered: the whole context bar its own key and the clock.
+ *
+ * `idempotencyKey` is derived from this, so it cannot be part of it. The
+ * submission's `submittedAt` is left out because a re-submit that changed no
+ * answer is not a different delivery, and including the clock would give every
+ * pass a key of its own and defeat the whole comparison. Everything else the
+ * destination receives is in here, the account included: a delivery to another
+ * tenant is a different delivery even if it happens to carry the same answers.
+ */
+type DeliveryContent = Omit<DestinationContext, 'idempotencyKey' | 'submittedAt'>;
 
 /** What a persisted submission hands the effects layer to fan out to destinations. */
 export interface SubmissionDeliveryInput {
@@ -76,42 +112,51 @@ export class DestinationEffects {
    */
   async enqueueSubmissionDeliveries(input: SubmissionDeliveryInput): Promise<void> {
     try {
-      const destinations = extractDestinations(input.config);
-      const enabled = destinations
-        .map((destination, index) => ({ destination, index }))
-        .filter(({ destination }) => destination.enabled !== false)
+      const enabled = extractDestinations(input.config)
+        .filter((destination) => destination.enabled !== false)
         // Per-event trigger filter: a destination with an `events` list only fires
         // for the phases it names (webhook `events:['complete']` skips partials, and
         // vice versa). Absent/empty `events` fires on BOTH phases (back-compat), and
         // destinations without the field (e.g. HubSpot) always pass — the helper
-        // returns true. Mapping happens BEFORE this filter so the idempotency key
-        // keeps each destination's ORIGINAL config-array index.
-        .filter(({ destination }) => destinationFiresForPhase(destination, input.phase));
+        // returns true.
+        .filter((destination) => destinationFiresForPhase(destination, input.phase));
 
-      // A re-submit of the same session+phase replaces every not-yet-sent
-      // delivery: cancel pending rows ONCE per kind BEFORE the enqueue loop.
-      // Deleting inside the loop would cancel a sibling destination of the same
-      // type that was just enqueued (two webhooks are legal — only the last one
-      // would ever deliver).
-      const kinds = new Set<OutboxKind>(
-        enabled.map(({ destination }) => destination.type as OutboxKind),
-      );
-      for (const kind of kinds) {
-        await deletePendingOutbox(this.db, {
-          subjectUid: input.submissionId,
-          kind,
-          action: input.phase,
-        });
+      // A re-submit of the same session+phase reconsiders what the PREVIOUS
+      // pass left queued, for EVERY destination kind rather than the ones
+      // firing now. Deriving the set from `enabled` asked the one question that
+      // cannot describe the previous pass: a destination disabled, deleted, or
+      // narrowed to another phase drops out of `enabled`, so its leftovers were
+      // never looked at and delivered under a config nobody had any more.
+      //
+      // The three pending states are three different facts and get three
+      // different answers, in this order:
+      //
+      //   NEVER HANDED OFF   deleted. Nothing happened, so nothing is lost.
+      //   WAITING TO RETRY   settled `skipped`. It DID happen, so it keeps
+      //                      everything it recorded, but its payload is a
+      //                      snapshot this pass has just replaced and every
+      //                      remaining retry would deliver stale content.
+      //   IN FLIGHT          untouched. A worker holds it and may already have
+      //                      reached the endpoint, so only that worker may
+      //                      settle it. Whether it is still the delivery worth
+      //                      making is decided when it is made: see
+      //                      {@link DestinationEffects.deliver}.
+      //
+      // Running both writes per kind BEFORE the enqueue loop is what keeps a
+      // sibling destination of the same kind safe: doing it inside the loop
+      // would clear a row this same pass had just written.
+      for (const kind of DESTINATION_OUTBOX_KINDS) {
+        const scope = { subjectUid: input.submissionId, kind, action: input.phase };
+        await deleteUnstartedOutbox(this.db, scope);
+        await skipBackoffOutbox(this.db, scope);
       }
 
-      for (const { destination, index } of enabled) {
-        const kind = destination.type as OutboxKind;
-        // Per-destination identity: the config-array index disambiguates two
-        // destinations of the same type, so each delivery carries its own
-        // idempotency key (receivers de-dup per destination, not per type).
-        const idempotencyKey = `submission:${input.submissionId}:${input.phase}:${destination.type}:${index}`;
-        const ctx: DestinationContext = {
-          idempotencyKey,
+      for (const destination of enabled) {
+        // Every firing destination is queued, unconditionally. The answers this
+        // pass carries are the ones the respondent actually left, and declining
+        // to queue them because an older delivery is still on the wire would
+        // discard the newer of the two for good.
+        const content: DeliveryContent = {
           submissionId: input.submissionId,
           formId: input.formId,
           formName: input.formName,
@@ -120,13 +165,17 @@ export class DestinationEffects {
           score: input.score,
           outcomeLabel: input.outcomeLabel,
           phase: input.phase,
-          submittedAt: input.submittedAt,
           data: input.data,
           utm: extractUtm(input.data),
         };
+        const ctx: DestinationContext = {
+          idempotencyKey: deliveryKeyOf(destination, content),
+          ...content,
+          submittedAt: input.submittedAt,
+        };
         const payload: DestinationOutboxPayload = { destination, ctx };
         await enqueueOutbox(this.db, {
-          kind,
+          kind: destination.type,
           action: input.phase,
           subjectUid: input.submissionId,
           accountId: input.accountId,
@@ -144,10 +193,21 @@ export class DestinationEffects {
    * time — it is never stored in the payload) and delivers. A THROWN transport
    * error propagates so the worker retries; a permanent no-op (delivered:false)
    * resolves so the row is marked done.
+   *
+   * Stands the row down first if a later pass has queued a delivery that
+   * replaces it. That question cannot be answered at enqueue time, because the
+   * row it would have to cancel may be in a worker's hands; here it can, and
+   * this is the last moment before anything crosses the wire.
    */
   /** Returns what crossed the wire, for the queue to record. */
   async deliver(action: string, payloadJson: string): Promise<DeliveryTranscript> {
     const { destination, ctx } = JSON.parse(payloadJson) as DestinationOutboxPayload;
+    if (await this.isSuperseded(action, destination, ctx)) {
+      this.log.log(
+        `destination ${destination.type} (${ctx.submissionId}/${action}) superseded, not delivered`,
+      );
+      throw new OutboxSkipError(SUPERSEDED_REASON);
+    }
     // ctx.accountId is the form's account — resolve that account's HubSpot token
     // (else the env fallback) at delivery time.
     const spec = await this.toSpec(destination, ctx.accountId);
@@ -169,6 +229,63 @@ export class DestinationEffects {
       responseStatus: result.responseStatus,
       responseBody: result.responseBody,
     };
+  }
+
+  /**
+   * Has a later pass replaced this delivery?
+   *
+   * Only rows for the SAME DESTINATION count. Two webhooks on one form are two
+   * different deliveries, and letting one answer for the other would mean
+   * whichever was queued last silently cancelled its sibling. The destination
+   * half of the key is exactly that test, so the comparison is between rows
+   * that already agree on where they are going and differ only in what they
+   * carry.
+   *
+   * LATER MEANS A LATER CLOCK READING, STRICTLY. The rows carrying this exact
+   * key are this delivery, however many of them there are; anything else under
+   * the same destination is a rival. This row stands down only when the newest
+   * rival was queued strictly after the newest copy of itself. Equal timestamps
+   * are not evidence of order: two passes of one session land on the same
+   * millisecond often enough, and there is nothing else to appeal to, because
+   * the row id is a random UUID and ranking by it would pick the survivor by
+   * coin toss and drop a real delivery. A tie therefore retires nothing and
+   * both rows go out, each under its own key, which is precisely the case
+   * at-least-once delivery and receiver-side de-duplication exist to absorb.
+   *
+   * Every no is a delivery that happens, so every unreadable row is a no: a
+   * payload that will not parse, or a key from before this shape existed, names
+   * no destination this can compare against and therefore supersedes nothing.
+   * The alternative, treating an unknown row as possibly newer, would let one
+   * unreadable payload silently stop a form from delivering at all. For the
+   * same reason a row whose OWN key is unreadable is delivered rather than
+   * guessed about, and so is one that finds no copy of itself still queued.
+   */
+  private async isSuperseded(
+    action: string,
+    destination: FormDestination,
+    ctx: DestinationContext,
+  ): Promise<boolean> {
+    const mine = parseDeliveryKey(ctx.idempotencyKey);
+    if (!mine) return false;
+    const queued = await listPendingOutbox(this.db, {
+      subjectUid: ctx.submissionId,
+      kind: destination.type,
+      action,
+    });
+    let ownNewest: number | null = null;
+    let rivalNewest: number | null = null;
+    for (const row of queued) {
+      const key = idempotencyKeyOf(row.payload);
+      const parsed = parseDeliveryKey(key);
+      if (!parsed || parsed.destination !== mine.destination) continue;
+      if (key === ctx.idempotencyKey) {
+        ownNewest = ownNewest === null ? row.createdAt : Math.max(ownNewest, row.createdAt);
+      } else {
+        rivalNewest = rivalNewest === null ? row.createdAt : Math.max(rivalNewest, row.createdAt);
+      }
+    }
+    if (ownNewest === null || rivalNewest === null) return false;
+    return rivalNewest > ownNewest;
   }
 
   /** Resolve a stored destination config into a delivery spec (inject secrets). */
@@ -223,6 +340,230 @@ export class DestinationEffects {
     };
   }
 
+}
+
+/**
+ * The delivery a queued row names, or null when it names none.
+ *
+ * Null is the safe answer and has to be. A payload that will not parse, or that
+ * carries no key, vouches for no particular delivery, and reading it as one
+ * would let a single unreadable row retire work it says nothing about.
+ */
+function idempotencyKeyOf(payload: string | null): string | null {
+  if (!payload) return null;
+  try {
+    const parsed = JSON.parse(payload) as { ctx?: { idempotencyKey?: unknown } };
+    const key = parsed.ctx?.idempotencyKey;
+    return typeof key === 'string' && key !== '' ? key : null;
+  } catch {
+    return null;
+  }
+}
+
+// --- The delivery key --------------------------------------------------------
+
+/**
+ * JSON with exactly one spelling per value: object keys sorted at every depth.
+ *
+ * A digest is only an identity if equal inputs digest equally, and two configs
+ * that differ only in the order a key was typed in are the same config. Arrays
+ * keep their order, because an array's order is content. `undefined` members are
+ * dropped rather than rendered, so an absent field and a field set to nothing
+ * cannot digest differently.
+ */
+function canonicalJson(value: unknown): string {
+  const canonical = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(canonical);
+    if (v !== null && typeof v === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(v as Record<string, unknown>).sort()) {
+        const member = (v as Record<string, unknown>)[key];
+        if (member === undefined) continue;
+        out[key] = canonical(member);
+      }
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(canonical(value)) ?? 'null';
+}
+
+const sha256Hex = (input: string): string => createHash('sha256').update(input, 'utf8').digest('hex');
+
+/**
+ * Nothing left over.
+ *
+ * Assigning a destructuring rest to this compiles only while the rest is empty,
+ * so every field the schema persists has to be NAMED in the destructuring above
+ * it. That is the whole enforcement: add a field to a destination in
+ * `@quill/types` and this file stops compiling until somebody decides, in
+ * writing, whether the new field belongs to the destination's identity. Without
+ * it a new field is silently absent from the digest, which is the failure mode
+ * that matters — two destinations that now differ would keep colliding on one
+ * key, and one would retire the other's deliveries.
+ */
+type NothingLeftOver = Record<PropertyKey, never>;
+
+/**
+ * WHERE a webhook delivery is going, as an explicit allowlist.
+ *
+ * INCLUDED: the minted id when there is one and only then the URL (the id
+ * survives an endpoint move, which is what makes it the better name; a legacy
+ * destination has none, and then the endpoint is all there is to go on), the
+ * signature header, and the phases it subscribes to.
+ *
+ * EXCLUDED, each on purpose:
+ *   enabled    only enabled destinations are ever queued, and switching one off
+ *              and on again does not make it a different destination.
+ *   secret     NEVER. The key is forwarded to the receiver as a header, so
+ *              anything digested into it is published, and a hash of a secret
+ *              is an offline oracle for guessing it. Rotating a secret is also
+ *              simply not a new delivery.
+ *   timeoutMs  a transport parameter. It changes how long we wait, not where
+ *              the request goes or what is in it.
+ */
+function webhookIdentity(destination: WebhookDestination): unknown {
+  const { type, id, enabled, events, settings, ...unhandled } = destination;
+  const { url, secret, signatureHeader, timeoutMs, ...unhandledSettings } = settings;
+  const destinationIsExhaustive: NothingLeftOver = unhandled;
+  const settingsAreExhaustive: NothingLeftOver = unhandledSettings;
+  void destinationIsExhaustive;
+  void settingsAreExhaustive;
+  void enabled;
+  void secret;
+  void timeoutMs;
+  return {
+    type,
+    ref: id ?? url,
+    signatureHeader: signatureHeader ?? null,
+    events: events ?? null,
+  };
+}
+
+/**
+ * WHERE a HubSpot delivery is going, as an explicit allowlist.
+ *
+ * HubSpot keeps no secret in the form config (the private-app token is server
+ * side), so everything the form persists about what this destination writes is
+ * part of what it IS: two entries differing only in a property mapping are two
+ * different deliveries. `enabled` is excluded for the same reason as a
+ * webhook's. The composite fields go in whole rather than field by field, so a
+ * property added inside one is included automatically rather than silently
+ * dropped; the guard below covers the levels that ARE taken apart.
+ */
+function hubspotIdentity(destination: HubspotDestination): unknown {
+  const {
+    type,
+    enabled,
+    settings,
+    fieldMappings,
+    utmMappings,
+    valueMaps,
+    staticProperties,
+    scoreProperty,
+    dateProperty,
+    outcomeProperty,
+    inferCompanyFromEmail,
+    bookingSync,
+    ...unhandled
+  } = destination;
+  const { note, formGuid, formActivity, formSignature, ...unhandledSettings } = settings;
+  const destinationIsExhaustive: NothingLeftOver = unhandled;
+  const settingsAreExhaustive: NothingLeftOver = unhandledSettings;
+  void destinationIsExhaustive;
+  void settingsAreExhaustive;
+  void enabled;
+  return {
+    type,
+    note: note ?? null,
+    formGuid: formGuid ?? null,
+    formActivity: formActivity ?? null,
+    formSignature: formSignature ?? null,
+    fieldMappings: fieldMappings ?? null,
+    utmMappings: utmMappings ?? null,
+    valueMaps: valueMaps ?? null,
+    staticProperties: staticProperties ?? null,
+    scoreProperty: scoreProperty ?? null,
+    dateProperty: dateProperty ?? null,
+    outcomeProperty: outcomeProperty ?? null,
+    inferCompanyFromEmail: inferCompanyFromEmail ?? null,
+    bookingSync: bookingSync ?? null,
+  };
+}
+
+/**
+ * WHERE a delivery is going, as an explicit allowlist of the destination's
+ * persisted semantics.
+ *
+ * An allowlist, not a subtraction, and that direction is the point: the key is
+ * forwarded to the receiver as a header, so everything digested into it is
+ * PUBLISHED, and a field added to the config schema later must not find its way
+ * in here by default. The two helpers make that a compile-time obligation
+ * rather than a convention somebody has to remember.
+ */
+function destinationIdentity(destination: FormDestination): unknown {
+  return destination.type === 'webhook'
+    ? webhookIdentity(destination)
+    : hubspotIdentity(destination);
+}
+
+/** The literal that opens every submission delivery key. */
+const DELIVERY_KEY_PREFIX = 'submission';
+/** A full SHA-256, lower-case hex. Anything shorter is a different scheme. */
+const DIGEST_SHAPE = /^[0-9a-f]{64}$/;
+
+/**
+ * The stable name of one delivery:
+ * `submission:<id>:<phase>:<type>:<destination digest>:<content digest>`.
+ *
+ * The readable half is what a person debugging needs; the two digests are what
+ * make it an identity. Equal keys mean the same answers going to the same
+ * destination, which is exactly the promise a receiver deduping on the header
+ * we send it is entitled to rely on, and the promise the positional key it
+ * replaced could not keep: delete the first of two webhooks and the second
+ * inherited its index, and with it its key.
+ */
+function deliveryKeyOf(destination: FormDestination, content: DeliveryContent): string {
+  return [
+    DELIVERY_KEY_PREFIX,
+    content.submissionId,
+    content.phase,
+    destination.type,
+    sha256Hex(canonicalJson(destinationIdentity(destination))),
+    sha256Hex(canonicalJson(content)),
+  ].join(':');
+}
+
+/** The two halves a key names, once it is known to be one of ours. */
+interface DeliveryKey {
+  /** Digest of the destination: whether two rows deliver to the SAME place. */
+  destination: string;
+  /** Digest of the delivery context: whether they carry the same thing. */
+  content: string;
+}
+
+/**
+ * Read a key, or refuse it.
+ *
+ * Strict on purpose, because the only caller uses the answer to decide whether
+ * a delivery still happens. Every segment is checked — the count, the prefix,
+ * the phase, a destination type the contract names, and two FULL digests — so
+ * that a key from the positional scheme, a hand-written string, or anything
+ * else that merely starts with `submission:` cannot pass itself off as one of
+ * ours and retire a real delivery.
+ */
+function parseDeliveryKey(key: string | null): DeliveryKey | null {
+  if (!key) return null;
+  const parts = key.split(':');
+  if (parts.length !== 6) return null;
+  const [prefix, submissionId, phase, type, destination, content] = parts as [
+    string, string, string, string, string, string,
+  ];
+  if (prefix !== DELIVERY_KEY_PREFIX || submissionId === '') return null;
+  if (phase !== 'partial' && phase !== 'complete') return null;
+  if (!(destinationType as readonly string[]).includes(type)) return null;
+  if (!DIGEST_SHAPE.test(destination) || !DIGEST_SHAPE.test(content)) return null;
+  return { destination, content };
 }
 
 /** Read the destinations array from a stored config, tolerating legacy/absent. */

--- a/apps/api/src/destination-effects.ts
+++ b/apps/api/src/destination-effects.ts
@@ -1,9 +1,7 @@
-import { createHash } from 'node:crypto';
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import {
   deleteUnstartedOutbox,
   enqueueOutbox,
-  listPendingOutbox,
   resolveProviderToken,
   skipBackoffOutbox,
   type Db,
@@ -22,11 +20,8 @@ import {
   formConfigSchema,
   formDestinationSchema,
   type FormDestination,
-  type HubspotDestination,
-  type WebhookDestination,
 } from '@quill/types';
 import type { ServerEnv } from '@quill/config/env';
-import { OutboxSkipError } from './email-effects';
 import { HubspotPortalResolver, mirrorGuidFor } from './hubspot-portal';
 import { DB, ENV } from './tokens';
 
@@ -40,30 +35,11 @@ import { DB, ENV } from './tokens';
  */
 const DESTINATION_OUTBOX_KINDS = destinationType satisfies readonly OutboxKind[];
 
-/**
- * Why a delivery stood down instead of being made. This reaches the admin's
- * delivery log verbatim, so it is copy. It names no key and no digest: the row
- * it lands on is not the place to publish either.
- */
-const SUPERSEDED_REASON = 'superseded by a later submission of the same session and phase';
-
 /** The delivery snapshot serialized into an outbox row (config + context). */
 interface DestinationOutboxPayload {
   destination: FormDestination;
   ctx: DestinationContext;
 }
-
-/**
- * WHAT is being delivered: the whole context bar its own key and the clock.
- *
- * `idempotencyKey` is derived from this, so it cannot be part of it. The
- * submission's `submittedAt` is left out because a re-submit that changed no
- * answer is not a different delivery, and including the clock would give every
- * pass a key of its own and defeat the whole comparison. Everything else the
- * destination receives is in here, the account included: a delivery to another
- * tenant is a different delivery even if it happens to carry the same answers.
- */
-type DeliveryContent = Omit<DestinationContext, 'idempotencyKey' | 'submittedAt'>;
 
 /** What a persisted submission hands the effects layer to fan out to destinations. */
 export interface SubmissionDeliveryInput {
@@ -112,14 +88,17 @@ export class DestinationEffects {
    */
   async enqueueSubmissionDeliveries(input: SubmissionDeliveryInput): Promise<void> {
     try {
-      const enabled = extractDestinations(input.config)
-        .filter((destination) => destination.enabled !== false)
+      const destinations = extractDestinations(input.config);
+      const enabled = destinations
+        .map((destination, index) => ({ destination, index }))
+        .filter(({ destination }) => destination.enabled !== false)
         // Per-event trigger filter: a destination with an `events` list only fires
         // for the phases it names (webhook `events:['complete']` skips partials, and
         // vice versa). Absent/empty `events` fires on BOTH phases (back-compat), and
         // destinations without the field (e.g. HubSpot) always pass — the helper
-        // returns true.
-        .filter((destination) => destinationFiresForPhase(destination, input.phase));
+        // returns true. Mapping happens BEFORE this filter so the idempotency key
+        // keeps each destination's ORIGINAL config-array index.
+        .filter(({ destination }) => destinationFiresForPhase(destination, input.phase));
 
       // A re-submit of the same session+phase reconsiders what the PREVIOUS
       // pass left queued, for EVERY destination kind rather than the ones
@@ -132,15 +111,31 @@ export class DestinationEffects {
       // different answers, in this order:
       //
       //   NEVER HANDED OFF   deleted. Nothing happened, so nothing is lost.
-      //   WAITING TO RETRY   settled `skipped`. It DID happen, so it keeps
+      //   WAITING TO RETRY   settled `skipped`, if it is unclaimed at the
+      //                      moment this pass runs. It DID happen, so it keeps
       //                      everything it recorded, but its payload is a
       //                      snapshot this pass has just replaced and every
       //                      remaining retry would deliver stale content.
       //   IN FLIGHT          untouched. A worker holds it and may already have
-      //                      reached the endpoint, so only that worker may
-      //                      settle it. Whether it is still the delivery worth
-      //                      making is decided when it is made: see
-      //                      {@link DestinationEffects.deliver}.
+      //                      reached the endpoint, so settling it belongs to
+      //                      the worker side, not to this pass. If that worker
+      //                      abandons its lease the row stays claimed and
+      //                      another may reclaim it; either way, not us.
+      //
+      // THIS PASS SPEAKS FOR THE QUEUE AS IT FINDS IT, not for what the queue
+      // becomes afterwards, and it cannot bound what a held row does next. That
+      // attempt may succeed and finish `done`, may fail and drop back into
+      // backoff unclaimed, or may lose its lease and stay claimed for another
+      // worker. Because the row queued just below is due immediately and a
+      // backed-off retry is not, Dapta Forms can send the OLDER payload after
+      // this pass's newer one and then mark that older row done. `max_attempts`
+      // caps how many further retries follow; it does not un-send the ones
+      // already made. A later pass for the same submission and phase settles
+      // such a row if it is unclaimed by then, but there may be no later pass:
+      // partials can come round again, while a re-landed complete does not
+      // re-enqueue at all. What a receiver makes of the two is outside Dapta
+      // Forms. The residual is the price of not touching a row somebody else
+      // owns, and it is deliberate.
       //
       // Running both writes per kind BEFORE the enqueue loop is what keeps a
       // sibling destination of the same kind safe: doing it inside the loop
@@ -151,12 +146,18 @@ export class DestinationEffects {
         await skipBackoffOutbox(this.db, scope);
       }
 
-      for (const destination of enabled) {
+      for (const { destination, index } of enabled) {
         // Every firing destination is queued, unconditionally. The answers this
         // pass carries are the ones the respondent actually left, and declining
         // to queue them because an older delivery is still on the wire would
         // discard the newer of the two for good.
-        const content: DeliveryContent = {
+        //
+        // Per-destination identity: the config-array index disambiguates two
+        // destinations of the same type, so each delivery carries its own
+        // idempotency key (receivers de-dup per destination, not per type).
+        const idempotencyKey = `submission:${input.submissionId}:${input.phase}:${destination.type}:${index}`;
+        const ctx: DestinationContext = {
+          idempotencyKey,
           submissionId: input.submissionId,
           formId: input.formId,
           formName: input.formName,
@@ -165,13 +166,9 @@ export class DestinationEffects {
           score: input.score,
           outcomeLabel: input.outcomeLabel,
           phase: input.phase,
+          submittedAt: input.submittedAt,
           data: input.data,
           utm: extractUtm(input.data),
-        };
-        const ctx: DestinationContext = {
-          idempotencyKey: deliveryKeyOf(destination, content),
-          ...content,
-          submittedAt: input.submittedAt,
         };
         const payload: DestinationOutboxPayload = { destination, ctx };
         await enqueueOutbox(this.db, {
@@ -193,21 +190,10 @@ export class DestinationEffects {
    * time — it is never stored in the payload) and delivers. A THROWN transport
    * error propagates so the worker retries; a permanent no-op (delivered:false)
    * resolves so the row is marked done.
-   *
-   * Stands the row down first if a later pass has queued a delivery that
-   * replaces it. That question cannot be answered at enqueue time, because the
-   * row it would have to cancel may be in a worker's hands; here it can, and
-   * this is the last moment before anything crosses the wire.
    */
   /** Returns what crossed the wire, for the queue to record. */
   async deliver(action: string, payloadJson: string): Promise<DeliveryTranscript> {
     const { destination, ctx } = JSON.parse(payloadJson) as DestinationOutboxPayload;
-    if (await this.isSuperseded(action, destination, ctx)) {
-      this.log.log(
-        `destination ${destination.type} (${ctx.submissionId}/${action}) superseded, not delivered`,
-      );
-      throw new OutboxSkipError(SUPERSEDED_REASON);
-    }
     // ctx.accountId is the form's account — resolve that account's HubSpot token
     // (else the env fallback) at delivery time.
     const spec = await this.toSpec(destination, ctx.accountId);
@@ -229,63 +215,6 @@ export class DestinationEffects {
       responseStatus: result.responseStatus,
       responseBody: result.responseBody,
     };
-  }
-
-  /**
-   * Has a later pass replaced this delivery?
-   *
-   * Only rows for the SAME DESTINATION count. Two webhooks on one form are two
-   * different deliveries, and letting one answer for the other would mean
-   * whichever was queued last silently cancelled its sibling. The destination
-   * half of the key is exactly that test, so the comparison is between rows
-   * that already agree on where they are going and differ only in what they
-   * carry.
-   *
-   * LATER MEANS A LATER CLOCK READING, STRICTLY. The rows carrying this exact
-   * key are this delivery, however many of them there are; anything else under
-   * the same destination is a rival. This row stands down only when the newest
-   * rival was queued strictly after the newest copy of itself. Equal timestamps
-   * are not evidence of order: two passes of one session land on the same
-   * millisecond often enough, and there is nothing else to appeal to, because
-   * the row id is a random UUID and ranking by it would pick the survivor by
-   * coin toss and drop a real delivery. A tie therefore retires nothing and
-   * both rows go out, each under its own key, which is precisely the case
-   * at-least-once delivery and receiver-side de-duplication exist to absorb.
-   *
-   * Every no is a delivery that happens, so every unreadable row is a no: a
-   * payload that will not parse, or a key from before this shape existed, names
-   * no destination this can compare against and therefore supersedes nothing.
-   * The alternative, treating an unknown row as possibly newer, would let one
-   * unreadable payload silently stop a form from delivering at all. For the
-   * same reason a row whose OWN key is unreadable is delivered rather than
-   * guessed about, and so is one that finds no copy of itself still queued.
-   */
-  private async isSuperseded(
-    action: string,
-    destination: FormDestination,
-    ctx: DestinationContext,
-  ): Promise<boolean> {
-    const mine = parseDeliveryKey(ctx.idempotencyKey);
-    if (!mine) return false;
-    const queued = await listPendingOutbox(this.db, {
-      subjectUid: ctx.submissionId,
-      kind: destination.type,
-      action,
-    });
-    let ownNewest: number | null = null;
-    let rivalNewest: number | null = null;
-    for (const row of queued) {
-      const key = idempotencyKeyOf(row.payload);
-      const parsed = parseDeliveryKey(key);
-      if (!parsed || parsed.destination !== mine.destination) continue;
-      if (key === ctx.idempotencyKey) {
-        ownNewest = ownNewest === null ? row.createdAt : Math.max(ownNewest, row.createdAt);
-      } else {
-        rivalNewest = rivalNewest === null ? row.createdAt : Math.max(rivalNewest, row.createdAt);
-      }
-    }
-    if (ownNewest === null || rivalNewest === null) return false;
-    return rivalNewest > ownNewest;
   }
 
   /** Resolve a stored destination config into a delivery spec (inject secrets). */
@@ -340,230 +269,6 @@ export class DestinationEffects {
     };
   }
 
-}
-
-/**
- * The delivery a queued row names, or null when it names none.
- *
- * Null is the safe answer and has to be. A payload that will not parse, or that
- * carries no key, vouches for no particular delivery, and reading it as one
- * would let a single unreadable row retire work it says nothing about.
- */
-function idempotencyKeyOf(payload: string | null): string | null {
-  if (!payload) return null;
-  try {
-    const parsed = JSON.parse(payload) as { ctx?: { idempotencyKey?: unknown } };
-    const key = parsed.ctx?.idempotencyKey;
-    return typeof key === 'string' && key !== '' ? key : null;
-  } catch {
-    return null;
-  }
-}
-
-// --- The delivery key --------------------------------------------------------
-
-/**
- * JSON with exactly one spelling per value: object keys sorted at every depth.
- *
- * A digest is only an identity if equal inputs digest equally, and two configs
- * that differ only in the order a key was typed in are the same config. Arrays
- * keep their order, because an array's order is content. `undefined` members are
- * dropped rather than rendered, so an absent field and a field set to nothing
- * cannot digest differently.
- */
-function canonicalJson(value: unknown): string {
-  const canonical = (v: unknown): unknown => {
-    if (Array.isArray(v)) return v.map(canonical);
-    if (v !== null && typeof v === 'object') {
-      const out: Record<string, unknown> = {};
-      for (const key of Object.keys(v as Record<string, unknown>).sort()) {
-        const member = (v as Record<string, unknown>)[key];
-        if (member === undefined) continue;
-        out[key] = canonical(member);
-      }
-      return out;
-    }
-    return v;
-  };
-  return JSON.stringify(canonical(value)) ?? 'null';
-}
-
-const sha256Hex = (input: string): string => createHash('sha256').update(input, 'utf8').digest('hex');
-
-/**
- * Nothing left over.
- *
- * Assigning a destructuring rest to this compiles only while the rest is empty,
- * so every field the schema persists has to be NAMED in the destructuring above
- * it. That is the whole enforcement: add a field to a destination in
- * `@quill/types` and this file stops compiling until somebody decides, in
- * writing, whether the new field belongs to the destination's identity. Without
- * it a new field is silently absent from the digest, which is the failure mode
- * that matters — two destinations that now differ would keep colliding on one
- * key, and one would retire the other's deliveries.
- */
-type NothingLeftOver = Record<PropertyKey, never>;
-
-/**
- * WHERE a webhook delivery is going, as an explicit allowlist.
- *
- * INCLUDED: the minted id when there is one and only then the URL (the id
- * survives an endpoint move, which is what makes it the better name; a legacy
- * destination has none, and then the endpoint is all there is to go on), the
- * signature header, and the phases it subscribes to.
- *
- * EXCLUDED, each on purpose:
- *   enabled    only enabled destinations are ever queued, and switching one off
- *              and on again does not make it a different destination.
- *   secret     NEVER. The key is forwarded to the receiver as a header, so
- *              anything digested into it is published, and a hash of a secret
- *              is an offline oracle for guessing it. Rotating a secret is also
- *              simply not a new delivery.
- *   timeoutMs  a transport parameter. It changes how long we wait, not where
- *              the request goes or what is in it.
- */
-function webhookIdentity(destination: WebhookDestination): unknown {
-  const { type, id, enabled, events, settings, ...unhandled } = destination;
-  const { url, secret, signatureHeader, timeoutMs, ...unhandledSettings } = settings;
-  const destinationIsExhaustive: NothingLeftOver = unhandled;
-  const settingsAreExhaustive: NothingLeftOver = unhandledSettings;
-  void destinationIsExhaustive;
-  void settingsAreExhaustive;
-  void enabled;
-  void secret;
-  void timeoutMs;
-  return {
-    type,
-    ref: id ?? url,
-    signatureHeader: signatureHeader ?? null,
-    events: events ?? null,
-  };
-}
-
-/**
- * WHERE a HubSpot delivery is going, as an explicit allowlist.
- *
- * HubSpot keeps no secret in the form config (the private-app token is server
- * side), so everything the form persists about what this destination writes is
- * part of what it IS: two entries differing only in a property mapping are two
- * different deliveries. `enabled` is excluded for the same reason as a
- * webhook's. The composite fields go in whole rather than field by field, so a
- * property added inside one is included automatically rather than silently
- * dropped; the guard below covers the levels that ARE taken apart.
- */
-function hubspotIdentity(destination: HubspotDestination): unknown {
-  const {
-    type,
-    enabled,
-    settings,
-    fieldMappings,
-    utmMappings,
-    valueMaps,
-    staticProperties,
-    scoreProperty,
-    dateProperty,
-    outcomeProperty,
-    inferCompanyFromEmail,
-    bookingSync,
-    ...unhandled
-  } = destination;
-  const { note, formGuid, formActivity, formSignature, ...unhandledSettings } = settings;
-  const destinationIsExhaustive: NothingLeftOver = unhandled;
-  const settingsAreExhaustive: NothingLeftOver = unhandledSettings;
-  void destinationIsExhaustive;
-  void settingsAreExhaustive;
-  void enabled;
-  return {
-    type,
-    note: note ?? null,
-    formGuid: formGuid ?? null,
-    formActivity: formActivity ?? null,
-    formSignature: formSignature ?? null,
-    fieldMappings: fieldMappings ?? null,
-    utmMappings: utmMappings ?? null,
-    valueMaps: valueMaps ?? null,
-    staticProperties: staticProperties ?? null,
-    scoreProperty: scoreProperty ?? null,
-    dateProperty: dateProperty ?? null,
-    outcomeProperty: outcomeProperty ?? null,
-    inferCompanyFromEmail: inferCompanyFromEmail ?? null,
-    bookingSync: bookingSync ?? null,
-  };
-}
-
-/**
- * WHERE a delivery is going, as an explicit allowlist of the destination's
- * persisted semantics.
- *
- * An allowlist, not a subtraction, and that direction is the point: the key is
- * forwarded to the receiver as a header, so everything digested into it is
- * PUBLISHED, and a field added to the config schema later must not find its way
- * in here by default. The two helpers make that a compile-time obligation
- * rather than a convention somebody has to remember.
- */
-function destinationIdentity(destination: FormDestination): unknown {
-  return destination.type === 'webhook'
-    ? webhookIdentity(destination)
-    : hubspotIdentity(destination);
-}
-
-/** The literal that opens every submission delivery key. */
-const DELIVERY_KEY_PREFIX = 'submission';
-/** A full SHA-256, lower-case hex. Anything shorter is a different scheme. */
-const DIGEST_SHAPE = /^[0-9a-f]{64}$/;
-
-/**
- * The stable name of one delivery:
- * `submission:<id>:<phase>:<type>:<destination digest>:<content digest>`.
- *
- * The readable half is what a person debugging needs; the two digests are what
- * make it an identity. Equal keys mean the same answers going to the same
- * destination, which is exactly the promise a receiver deduping on the header
- * we send it is entitled to rely on, and the promise the positional key it
- * replaced could not keep: delete the first of two webhooks and the second
- * inherited its index, and with it its key.
- */
-function deliveryKeyOf(destination: FormDestination, content: DeliveryContent): string {
-  return [
-    DELIVERY_KEY_PREFIX,
-    content.submissionId,
-    content.phase,
-    destination.type,
-    sha256Hex(canonicalJson(destinationIdentity(destination))),
-    sha256Hex(canonicalJson(content)),
-  ].join(':');
-}
-
-/** The two halves a key names, once it is known to be one of ours. */
-interface DeliveryKey {
-  /** Digest of the destination: whether two rows deliver to the SAME place. */
-  destination: string;
-  /** Digest of the delivery context: whether they carry the same thing. */
-  content: string;
-}
-
-/**
- * Read a key, or refuse it.
- *
- * Strict on purpose, because the only caller uses the answer to decide whether
- * a delivery still happens. Every segment is checked — the count, the prefix,
- * the phase, a destination type the contract names, and two FULL digests — so
- * that a key from the positional scheme, a hand-written string, or anything
- * else that merely starts with `submission:` cannot pass itself off as one of
- * ours and retire a real delivery.
- */
-function parseDeliveryKey(key: string | null): DeliveryKey | null {
-  if (!key) return null;
-  const parts = key.split(':');
-  if (parts.length !== 6) return null;
-  const [prefix, submissionId, phase, type, destination, content] = parts as [
-    string, string, string, string, string, string,
-  ];
-  if (prefix !== DELIVERY_KEY_PREFIX || submissionId === '') return null;
-  if (phase !== 'partial' && phase !== 'complete') return null;
-  if (!(destinationType as readonly string[]).includes(type)) return null;
-  if (!DIGEST_SHAPE.test(destination) || !DIGEST_SHAPE.test(content)) return null;
-  return { destination, content };
 }
 
 /** Read the destinations array from a stored config, tolerating legacy/absent. */

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -175,8 +175,9 @@ export class SubmissionService {
     // The pass itself is safe to repeat: it deletes what was never started,
     // settles what is waiting to retry, and queues the current answers for
     // every firing destination. What it cannot do is reach a request a worker
-    // is already making, so whether THAT one is still the delivery worth making
-    // is decided when it is made, not here.
+    // is already making. That one is settled on the worker side, and may still
+    // deliver its older payload after this pass's, so a config edit here is
+    // never a synchronous cancel of a delivery in flight.
     if (!reCompleted)
       await this.destinations?.enqueueSubmissionDeliveries({
       formId: form.id,

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -171,9 +171,12 @@ export class SubmissionService {
     // internally guarded so it cannot throw) — the actual delivery happens later
     // in the worker, so the submission is never blocked or failed by a slow/failing
     // destination. Enqueued for BOTH phases; adapters decide phase behavior.
-    // Skipped on a re-landed complete (same reasoning as the emails above):
-    // enqueue cancels only PENDING rows, so once the worker drained the first
-    // delivery a second enqueue is a duplicate webhook/CRM activity, not a retry.
+    // Skipped on a re-landed complete (same reasoning as the emails above).
+    // The pass itself is safe to repeat: it deletes what was never started,
+    // settles what is waiting to retry, and queues the current answers for
+    // every firing destination. What it cannot do is reach a request a worker
+    // is already making, so whether THAT one is still the delivery worth making
+    // is decided when it is made, not here.
     if (!reCompleted)
       await this.destinations?.enqueueSubmissionDeliveries({
       formId: form.id,

--- a/packages/db/src/outbox.spec.ts
+++ b/packages/db/src/outbox.spec.ts
@@ -13,6 +13,9 @@ import {
   enqueueOutbox,
   claimIdentityOf,
   claimDueOutbox,
+  deleteUnstartedOutbox,
+  listPendingOutbox,
+  skipBackoffOutbox,
   markOutboxRetry,
   markOutboxDone,
   markOutboxFailed,
@@ -834,5 +837,457 @@ describe('summarizeFailedDeliveriesByForm', () => {
     });
     await db.run(sql`UPDATE outbox SET status = 'failed' WHERE id = ${id}`);
     expect(await summarizeFailedDeliveriesByForm(db, ACC, 'webhook')).toEqual([]);
+  });
+});
+
+/**
+ * The cancellation boundary: which rows a caller may still take back.
+ *
+ * `status = 'pending'` was never the right line. It is true of three different
+ * situations, and only one of them is cancellable:
+ *
+ *   - NEVER HANDED OFF. Enqueued, unclaimed, zero attempts. Nothing has happened
+ *     yet, so deleting it undoes nothing.
+ *   - IN FLIGHT. A worker holds the lease right now. The external effect may
+ *     already have crossed the wire; the row is the only record that it did, and
+ *     the only thing that can settle it.
+ *   - WAITING OUT A BACKOFF. Attempted at least once, claim cleared, due again
+ *     later. At-least-once means the earlier attempt may well have landed.
+ *
+ * Deleting either of the last two cancels a delivery that already partly
+ * happened and destroys its log. Once a row is attempted, the retry lifecycle
+ * owns it through to a terminal state.
+ *
+ * Each protection below is its own test on purpose: the in-flight row carries
+ * zero attempts and the backoff row carries no claim, so neither predicate can
+ * stand in for the other and dropping either one fails exactly one of them.
+ */
+describe('deleteUnstartedOutbox', () => {
+  const SUBJECT = 'sub-cancel';
+  const ACCOUNT = 'acc-cancel';
+  const NOW = 9_000_000;
+
+  const enqueue = (
+    over: { kind?: OutboxKind; action?: string; subjectUid?: string } = {},
+  ): Promise<string> =>
+    enqueueOutbox(db, {
+      kind: over.kind ?? 'webhook',
+      action: over.action ?? 'complete',
+      subjectUid: over.subjectUid ?? SUBJECT,
+      accountId: ACCOUNT,
+      now: NOW,
+    });
+
+  const cancel = () =>
+    deleteUnstartedOutbox(db, { subjectUid: SUBJECT, kind: 'webhook', action: 'complete' });
+
+  const idsLeft = async (): Promise<string[]> => (await listOutbox(db)).map((r) => r.id).sort();
+
+  it('deletes a row that was never handed off to a worker', async () => {
+    const unstarted = await enqueue();
+    expect(await idsLeft()).toEqual([unstarted]);
+
+    await cancel();
+
+    expect(await idsLeft()).toEqual([]);
+  });
+
+  it('keeps a CLAIMED row: a worker holds the lease and may already have delivered', async () => {
+    const inFlight = await enqueue();
+    const [claimed] = await claimDueOutbox(db, NOW, { workerId: 'A' });
+    expect(claimed?.id).toBe(inFlight);
+    // A first claim charges no attempt, so `attempts = 0` cannot protect this
+    // row. Only the claim marker separates it from a never-handed-off row.
+    expect(claimed!.attempts).toBe(0);
+    expect(claimed!.claimedAt).toBe(NOW);
+
+    await cancel();
+
+    expect(await idsLeft()).toEqual([inFlight]);
+  });
+
+  it('keeps a row waiting out its RETRY BACKOFF: it was already attempted once', async () => {
+    const attempted = await enqueue();
+    const [claimed] = await claimDueOutbox(db, NOW, { workerId: 'A' });
+    expect(
+      await markOutboxRetry(
+        db,
+        attempted,
+        { attempts: 1, error: 'HTTP 500', now: NOW },
+        claimIdentityOf(claimed!),
+      ),
+    ).toBe(true);
+    // A retry CLEARS the claim so the row is reclaimable, so `claimed_at IS NULL`
+    // cannot protect it. Only the attempt count separates it.
+    expect((await listOutbox(db)).find((r) => r.id === attempted)).toMatchObject({
+      status: 'pending',
+      attempts: 1,
+      claimedAt: null,
+    });
+
+    await cancel();
+
+    expect(await idsLeft()).toEqual([attempted]);
+  });
+
+  it('keeps every settled row: done, failed and skipped are the delivery log', async () => {
+    const settle = async (as: 'done' | 'failed' | 'skipped') => {
+      const id = await enqueue();
+      const row = (await claimDueOutbox(db, NOW, { workerId: 'A' })).find((r) => r.id === id);
+      const claim = claimIdentityOf(row!);
+      const applied =
+        as === 'done'
+          ? await markOutboxDone(db, id, NOW, undefined, claim)
+          : as === 'failed'
+            ? await markOutboxFailed(db, id, { attempts: 5, error: 'gave up', now: NOW }, claim)
+            : await markOutboxSkipped(db, id, { reason: 'no target', now: NOW }, claim);
+      expect(applied).toBe(true);
+      return id;
+    };
+    const settled = [await settle('done'), await settle('failed'), await settle('skipped')];
+
+    await cancel();
+
+    expect(await idsLeft()).toEqual([...settled].sort());
+  });
+
+  it('cancels within the exact subject_uid + kind + action scope and nothing wider', async () => {
+    const target = await enqueue();
+    const otherKind = await enqueue({ kind: 'hubspot' });
+    const otherAction = await enqueue({ action: 'partial' });
+    const otherSubject = await enqueue({ subjectUid: 'sub-other' });
+
+    await cancel();
+
+    expect(await idsLeft()).toEqual([otherAction, otherKind, otherSubject].sort());
+    expect(await idsLeft()).not.toContain(target);
+  });
+
+  it('keeps a same-subject webhook ping: a test delivery is not a queued send', async () => {
+    // The admin's "Send test" is synchronous and recorded terminal, and a queued
+    // row would still carry the ping action rather than a submission phase.
+    const recordedPing = await recordSettledDelivery(db, {
+      kind: 'webhook',
+      action: WEBHOOK_PING_ACTION,
+      accountId: ACCOUNT,
+      subjectUid: SUBJECT,
+      payload: JSON.stringify({ ctx: { formId: 'form-1' } }),
+      status: 'done',
+      now: NOW,
+    });
+    const pendingPing = await enqueue({ action: WEBHOOK_PING_ACTION });
+    await enqueue();
+
+    await cancel();
+
+    expect(await idsLeft()).toEqual([pendingPing, recordedPing].sort());
+  });
+});
+
+/**
+ * The middle state, and the one the delete above deliberately cannot touch: a
+ * row that WAS attempted, failed, and is sitting out its backoff waiting to be
+ * tried again.
+ *
+ * Deleting it is wrong for the reasons `deleteUnstartedOutbox` documents. But
+ * leaving it entirely alone turned out to be wrong too. Its payload is a frozen
+ * snapshot of a form config and a set of answers that a later pass has already
+ * replaced, so every remaining retry is a scheduled delivery of superseded
+ * content, and a destination the author disabled or deleted keeps retrying
+ * until it exhausts `max_attempts`. Settling it as `skipped` closes both: the
+ * row stops being due, keeps everything it recorded about what it attempted,
+ * and stays in the delivery history with a reason rather than vanishing.
+ *
+ * Both fences are load-bearing and neither implies the other. `attempts > 0` is
+ * what separates it from a never-started row, which is the delete's business
+ * and must survive this. `claimed_at IS NULL` is what separates it from a row
+ * a worker holds RIGHT NOW, which may already have crossed the wire and can
+ * carry attempts of its own from an earlier generation.
+ */
+describe('skipBackoffOutbox', () => {
+  const SUBJECT = 'sub-supersede';
+  const ACCOUNT = 'acc-supersede';
+  const FORM = 'form-supersede';
+  const NOW = 11_000_000;
+
+  const enqueue = (
+    over: { kind?: OutboxKind; action?: string; subjectUid?: string } = {},
+  ): Promise<string> =>
+    enqueueOutbox(db, {
+      kind: over.kind ?? 'webhook',
+      action: over.action ?? 'complete',
+      subjectUid: over.subjectUid ?? SUBJECT,
+      accountId: ACCOUNT,
+      payload: JSON.stringify({ ctx: { formId: FORM } }),
+      now: NOW,
+    });
+
+  const supersede = (): Promise<number> =>
+    skipBackoffOutbox(db, { subjectUid: SUBJECT, kind: 'webhook', action: 'complete' });
+
+  const rowById = async (id: string) => (await listOutbox(db)).find((r) => r.id === id);
+
+  /** Drive a row into retry backoff: attempted, claim cleared, due again later. */
+  async function intoBackoff(id: string): Promise<void> {
+    const row = (await claimDueOutbox(db, NOW, { workerId: 'A' })).find((r) => r.id === id);
+    expect(
+      await markOutboxRetry(
+        db,
+        id,
+        {
+          attempts: 3,
+          error: 'HTTP 502 from https://x.test/hook',
+          now: NOW,
+          transcript: { requestBody: '{"a":1}', responseStatus: 502, responseBody: 'bad gateway' },
+        },
+        claimIdentityOf(row!),
+      ),
+    ).toBe(true);
+  }
+
+  it('settles a backoff row as skipped and moves nothing else about it', async () => {
+    const id = await enqueue();
+    await intoBackoff(id);
+
+    expect(await supersede()).toBe(1);
+
+    expect(await rowById(id)).toMatchObject({
+      status: 'skipped',
+      // Everything the attempt recorded survives verbatim: the count, what
+      // crossed the wire, the error the endpoint gave, and when that happened.
+      // The row is a record of a delivery that was tried, and being superseded
+      // is not a second thing that happened to it.
+      attempts: 3,
+      requestBody: '{"a":1}',
+      responseStatus: 502,
+      responseBody: 'bad gateway',
+      lastError: 'HTTP 502 from https://x.test/hook',
+      updatedAt: NOW,
+    });
+  });
+
+  it('does not displace a genuinely newer failure in the delivery history', async () => {
+    // The history is ordered by `updated_at`, so touching that column would
+    // float every superseded row to the top of the admin's list and bury the
+    // failure someone actually needs to see.
+    const superseded = await enqueue();
+    await intoBackoff(superseded);
+    const later = await enqueue({ subjectUid: 'sub-other' });
+    const claimed = (await claimDueOutbox(db, NOW + 1_000, { workerId: 'B' })).find(
+      (r) => r.id === later,
+    );
+    await markOutboxFailed(
+      db,
+      later,
+      { attempts: 5, error: 'gave up', now: NOW + 1_000 },
+      claimIdentityOf(claimed!),
+    );
+
+    expect(await supersede()).toBe(1);
+
+    const history = await listFormDeliveries(db, ACCOUNT, FORM, { limit: 10 });
+    expect(history.map((r) => r.id)).toEqual([later, superseded]);
+  });
+
+  it('leaves a NEVER-STARTED row alone: nothing was attempted, so nothing is superseded', async () => {
+    // This row is the delete's business. `claimed_at IS NULL` is true of it too,
+    // so only the attempt count keeps this statement off it.
+    const id = await enqueue();
+
+    expect(await supersede()).toBe(0);
+
+    expect(await rowById(id)).toMatchObject({ status: 'pending', attempts: 0, lastError: null });
+  });
+
+  it('leaves a CLAIMED row alone even when it already carries attempts', async () => {
+    const id = await enqueue();
+    await intoBackoff(id);
+    const [reclaimed] = await claimDueOutbox(db, NOW + 60_000, { workerId: 'B' });
+    expect(reclaimed?.id).toBe(id);
+    // Attempts survive a reclaim, so the attempt count cannot protect this row.
+    expect(reclaimed!.attempts).toBe(3);
+
+    expect(await supersede()).toBe(0);
+
+    expect(await rowById(id)).toMatchObject({
+      status: 'pending',
+      attempts: 3,
+      claimedBy: reclaimed!.claimedBy,
+    });
+  });
+
+  it('leaves every settled row alone: done, failed and skipped are terminal', async () => {
+    const settle = async (as: 'done' | 'failed' | 'skipped') => {
+      const id = await enqueue();
+      const row = (await claimDueOutbox(db, NOW, { workerId: 'A' })).find((r) => r.id === id);
+      const claim = claimIdentityOf(row!);
+      const applied =
+        as === 'done'
+          ? await markOutboxDone(db, id, NOW, undefined, claim)
+          : as === 'failed'
+            ? await markOutboxFailed(db, id, { attempts: 5, error: 'gave up', now: NOW }, claim)
+            : await markOutboxSkipped(db, id, { reason: 'no target', now: NOW }, claim);
+      expect(applied).toBe(true);
+      return id;
+    };
+    const done = await settle('done');
+    const failed = await settle('failed');
+
+    expect(await supersede()).toBe(0);
+
+    expect(await rowById(done)).toMatchObject({ status: 'done', lastError: null });
+    expect(await rowById(failed)).toMatchObject({ status: 'failed', lastError: 'gave up' });
+  });
+
+  it('settles the whole matching set in one statement and reports how many', async () => {
+    for (const _ of [0, 1, 2]) {
+      const id = await enqueue();
+      await intoBackoff(id);
+      void _;
+    }
+
+    expect(await supersede()).toBe(3);
+    expect((await listOutbox(db)).every((r) => r.status === 'skipped')).toBe(true);
+  });
+
+  it('stays inside the exact subject_uid + kind + action scope', async () => {
+    const target = await enqueue();
+    await intoBackoff(target);
+    const others: string[] = [];
+    for (const over of [
+      { kind: 'hubspot' as OutboxKind },
+      { action: 'partial' },
+      { subjectUid: 'sub-other' },
+      { action: WEBHOOK_PING_ACTION },
+    ]) {
+      const id = await enqueue(over);
+      await intoBackoff(id);
+      others.push(id);
+    }
+
+    expect(await supersede()).toBe(1);
+
+    expect((await rowById(target))?.status).toBe('skipped');
+    for (const id of others) expect((await rowById(id))?.status).toBe('pending');
+  });
+});
+
+/**
+ * Reading the queue from the delivery side.
+ *
+ * A row about to cross the wire has to know what ELSE is still queued for the
+ * same subject, kind and action, because that is the only way to tell whether
+ * the snapshot it carries has since been replaced. It needs the payload to know
+ * which delivery each row names, and `created_at` to know which of them is the
+ * latest; it needs nothing else, and this runs on the delivery path, so nothing
+ * else is selected.
+ */
+describe('listPendingOutbox', () => {
+  const SUBJECT = 'sub-pending';
+  const ACCOUNT = 'acc-pending';
+  const NOW = 12_000_000;
+
+  const enqueue = (
+    over: {
+      kind?: OutboxKind;
+      action?: string;
+      subjectUid?: string;
+      payload?: string;
+      now?: number;
+    } = {},
+  ): Promise<string> =>
+    enqueueOutbox(db, {
+      kind: over.kind ?? 'webhook',
+      action: over.action ?? 'complete',
+      subjectUid: over.subjectUid ?? SUBJECT,
+      accountId: ACCOUNT,
+      payload: over.payload ?? JSON.stringify({ ctx: { idempotencyKey: 'key-a' } }),
+      now: over.now ?? NOW,
+    });
+
+  const pending = () =>
+    listPendingOutbox(db, { subjectUid: SUBJECT, kind: 'webhook', action: 'complete' });
+
+  it('returns each pending row as an id, a payload and when it was queued', async () => {
+    const id = await enqueue();
+
+    const rows = await pending();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      id,
+      payload: JSON.stringify({ ctx: { idempotencyKey: 'key-a' } }),
+      createdAt: NOW,
+    });
+    // Narrow on purpose: no status, attempts, transcript or account come back.
+    expect(Object.keys(rows[0]!).sort()).toEqual(['createdAt', 'id', 'payload']);
+  });
+
+  it('reads all three pending states, because all three are still queued work', async () => {
+    // Never handed off, waiting out a backoff, and held by a worker are three
+    // different facts about ONE thing: a delivery that has not happened yet.
+    const unstarted = await enqueue({ now: NOW + 3 });
+    const backoff = await enqueue({ now: NOW + 1 });
+    const inFlight = await enqueue({ now: NOW + 2 });
+    const claimed = await claimDueOutbox(db, NOW + 10, { workerId: 'A', limit: 50 });
+    await markOutboxRetry(
+      db,
+      backoff,
+      { attempts: 1, error: 'boom', now: NOW + 10 },
+      claimIdentityOf(claimed.find((r) => r.id === backoff)!),
+    );
+    await db.run(sql`UPDATE outbox SET claimed_at = NULL, claimed_by = NULL WHERE id = ${unstarted}`);
+
+    expect((await pending()).map((r) => r.id)).toEqual([backoff, inFlight, unstarted]);
+  });
+
+  it('leaves out every settled row: done, failed and skipped are not queued', async () => {
+    const settle = async (as: 'done' | 'failed' | 'skipped') => {
+      const id = await enqueue();
+      const row = (await claimDueOutbox(db, NOW, { workerId: 'A' })).find((r) => r.id === id);
+      const claim = claimIdentityOf(row!);
+      const applied =
+        as === 'done'
+          ? await markOutboxDone(db, id, NOW, undefined, claim)
+          : as === 'failed'
+            ? await markOutboxFailed(db, id, { attempts: 5, error: 'gave up', now: NOW }, claim)
+            : await markOutboxSkipped(db, id, { reason: 'no target', now: NOW }, claim);
+      expect(applied).toBe(true);
+      return id;
+    };
+    await settle('done');
+    await settle('failed');
+    await settle('skipped');
+
+    expect(await pending()).toEqual([]);
+  });
+
+  it('orders by when the row was queued, and makes no claim about a tie', async () => {
+    // Recency is a timestamp here, never a position. The row id is a random
+    // UUID, so sorting by it would invent an order between two rows queued in
+    // the same millisecond and hand a caller a winner that means nothing. The
+    // reader reports `created_at` and leaves a tie a tie.
+    const same = [await enqueue(), await enqueue(), await enqueue()];
+    const later = await enqueue({ now: NOW + 1 });
+
+    const rows = await pending();
+    expect(rows.map((r) => r.createdAt)).toEqual([NOW, NOW, NOW, NOW + 1]);
+    expect(rows[3]!.id).toBe(later);
+    expect(
+      rows
+        .slice(0, 3)
+        .map((r) => r.id)
+        .sort(),
+    ).toEqual([...same].sort());
+  });
+
+  it('stays inside the exact subject_uid + kind + action scope', async () => {
+    const target = await enqueue();
+    await enqueue({ kind: 'hubspot' });
+    await enqueue({ action: 'partial' });
+    await enqueue({ subjectUid: 'sub-other' });
+    await enqueue({ action: WEBHOOK_PING_ACTION });
+
+    expect((await pending()).map((r) => r.id)).toEqual([target]);
   });
 });

--- a/packages/db/src/outbox.spec.ts
+++ b/packages/db/src/outbox.spec.ts
@@ -14,7 +14,6 @@ import {
   claimIdentityOf,
   claimDueOutbox,
   deleteUnstartedOutbox,
-  listPendingOutbox,
   skipBackoffOutbox,
   markOutboxRetry,
   markOutboxDone,
@@ -993,10 +992,21 @@ describe('deleteUnstartedOutbox', () => {
  * leaving it entirely alone turned out to be wrong too. Its payload is a frozen
  * snapshot of a form config and a set of answers that a later pass has already
  * replaced, so every remaining retry is a scheduled delivery of superseded
- * content, and a destination the author disabled or deleted keeps retrying
- * until it exhausts `max_attempts`. Settling it as `skipped` closes both: the
+ * content, and a destination the author disabled or deleted has nothing left in
+ * its own config to stop it retrying. Settling it as `skipped` closes both: the
  * row stops being due, keeps everything it recorded about what it attempted,
  * and stays in the delivery history with a reason rather than vanishing.
+ *
+ * It closes them for the rows it can SEE, which is the rows unclaimed at the
+ * moment the statement runs. A row a worker holds is out of reach by design,
+ * and this statement has no say in what becomes of it: the attempt may succeed
+ * and finish `done`, may fail and drop back into backoff unclaimed, or may lose
+ * its lease and stay claimed for another worker to reclaim. A caller's freshly
+ * queued row is due immediately and a backed-off retry is not, so the older
+ * snapshot really can be sent after the newer one and then marked done;
+ * `max_attempts` caps the retries that follow rather than un-sending the ones
+ * already made, and no later call is guaranteed to arrive and settle it.
+ * Nothing below asserts otherwise.
  *
  * Both fences are load-bearing and neither implies the other. `attempts > 0` is
  * what separates it from a never-started row, which is the delete's business
@@ -1169,125 +1179,5 @@ describe('skipBackoffOutbox', () => {
 
     expect((await rowById(target))?.status).toBe('skipped');
     for (const id of others) expect((await rowById(id))?.status).toBe('pending');
-  });
-});
-
-/**
- * Reading the queue from the delivery side.
- *
- * A row about to cross the wire has to know what ELSE is still queued for the
- * same subject, kind and action, because that is the only way to tell whether
- * the snapshot it carries has since been replaced. It needs the payload to know
- * which delivery each row names, and `created_at` to know which of them is the
- * latest; it needs nothing else, and this runs on the delivery path, so nothing
- * else is selected.
- */
-describe('listPendingOutbox', () => {
-  const SUBJECT = 'sub-pending';
-  const ACCOUNT = 'acc-pending';
-  const NOW = 12_000_000;
-
-  const enqueue = (
-    over: {
-      kind?: OutboxKind;
-      action?: string;
-      subjectUid?: string;
-      payload?: string;
-      now?: number;
-    } = {},
-  ): Promise<string> =>
-    enqueueOutbox(db, {
-      kind: over.kind ?? 'webhook',
-      action: over.action ?? 'complete',
-      subjectUid: over.subjectUid ?? SUBJECT,
-      accountId: ACCOUNT,
-      payload: over.payload ?? JSON.stringify({ ctx: { idempotencyKey: 'key-a' } }),
-      now: over.now ?? NOW,
-    });
-
-  const pending = () =>
-    listPendingOutbox(db, { subjectUid: SUBJECT, kind: 'webhook', action: 'complete' });
-
-  it('returns each pending row as an id, a payload and when it was queued', async () => {
-    const id = await enqueue();
-
-    const rows = await pending();
-
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toEqual({
-      id,
-      payload: JSON.stringify({ ctx: { idempotencyKey: 'key-a' } }),
-      createdAt: NOW,
-    });
-    // Narrow on purpose: no status, attempts, transcript or account come back.
-    expect(Object.keys(rows[0]!).sort()).toEqual(['createdAt', 'id', 'payload']);
-  });
-
-  it('reads all three pending states, because all three are still queued work', async () => {
-    // Never handed off, waiting out a backoff, and held by a worker are three
-    // different facts about ONE thing: a delivery that has not happened yet.
-    const unstarted = await enqueue({ now: NOW + 3 });
-    const backoff = await enqueue({ now: NOW + 1 });
-    const inFlight = await enqueue({ now: NOW + 2 });
-    const claimed = await claimDueOutbox(db, NOW + 10, { workerId: 'A', limit: 50 });
-    await markOutboxRetry(
-      db,
-      backoff,
-      { attempts: 1, error: 'boom', now: NOW + 10 },
-      claimIdentityOf(claimed.find((r) => r.id === backoff)!),
-    );
-    await db.run(sql`UPDATE outbox SET claimed_at = NULL, claimed_by = NULL WHERE id = ${unstarted}`);
-
-    expect((await pending()).map((r) => r.id)).toEqual([backoff, inFlight, unstarted]);
-  });
-
-  it('leaves out every settled row: done, failed and skipped are not queued', async () => {
-    const settle = async (as: 'done' | 'failed' | 'skipped') => {
-      const id = await enqueue();
-      const row = (await claimDueOutbox(db, NOW, { workerId: 'A' })).find((r) => r.id === id);
-      const claim = claimIdentityOf(row!);
-      const applied =
-        as === 'done'
-          ? await markOutboxDone(db, id, NOW, undefined, claim)
-          : as === 'failed'
-            ? await markOutboxFailed(db, id, { attempts: 5, error: 'gave up', now: NOW }, claim)
-            : await markOutboxSkipped(db, id, { reason: 'no target', now: NOW }, claim);
-      expect(applied).toBe(true);
-      return id;
-    };
-    await settle('done');
-    await settle('failed');
-    await settle('skipped');
-
-    expect(await pending()).toEqual([]);
-  });
-
-  it('orders by when the row was queued, and makes no claim about a tie', async () => {
-    // Recency is a timestamp here, never a position. The row id is a random
-    // UUID, so sorting by it would invent an order between two rows queued in
-    // the same millisecond and hand a caller a winner that means nothing. The
-    // reader reports `created_at` and leaves a tie a tie.
-    const same = [await enqueue(), await enqueue(), await enqueue()];
-    const later = await enqueue({ now: NOW + 1 });
-
-    const rows = await pending();
-    expect(rows.map((r) => r.createdAt)).toEqual([NOW, NOW, NOW, NOW + 1]);
-    expect(rows[3]!.id).toBe(later);
-    expect(
-      rows
-        .slice(0, 3)
-        .map((r) => r.id)
-        .sort(),
-    ).toEqual([...same].sort());
-  });
-
-  it('stays inside the exact subject_uid + kind + action scope', async () => {
-    const target = await enqueue();
-    await enqueue({ kind: 'hubspot' });
-    await enqueue({ action: 'partial' });
-    await enqueue({ subjectUid: 'sub-other' });
-    await enqueue({ action: WEBHOOK_PING_ACTION });
-
-    expect((await pending()).map((r) => r.id)).toEqual([target]);
   });
 });

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -193,16 +193,19 @@ const UNSTARTED_OUTBOX = sql`status = 'pending' AND claimed_at IS NULL AND attem
  * are handled elsewhere and on purpose, because both have already done
  * something: {@link skipBackoffOutbox} settles an attempted row that is waiting
  * to retry, keeping everything it recorded, and a row a worker is currently
- * holding is left strictly alone, because only that worker may settle it.
+ * holding is left strictly alone, because settling it belongs to the worker
+ * side and not to this path. If the worker that took the lease abandons it, the
+ * row stays claimed and another worker may reclaim it; what none of them is is
+ * a caller of this function.
  *
  * WHERE THE SETTINGS BOUNDARY SITS. Configuration decides what is queued and
  * what stops being retried. It does not reach a request that is in flight. An
  * edit to a destination is never a synchronous cancel: it takes effect on this
  * path only when the subject comes round again, and even then a delivery a
- * worker has already picked up runs to its own terminal state, because it may
+ * worker has already picked up is settled on the worker side, because it may
  * already have crossed the wire and this row is the only record that it did.
- * Whether that delivery is still the current one is a question for the moment
- * it is made, off {@link listPendingOutbox}, not for this pass.
+ * Where such a row goes next, and whether a later call ever gets to settle it,
+ * is spelled out under {@link skipBackoffOutbox}.
  */
 export async function deleteUnstartedOutbox(
   db: Db,
@@ -224,7 +227,7 @@ export async function deleteUnstartedOutbox(
  * belongs to the delete and must survive this statement untouched.
  * `claimed_at IS NULL` is what keeps it off a row a worker holds right now,
  * which is not waiting for anything: it is running, it may already have crossed
- * the wire, and only its own worker may settle it.
+ * the wire, and its settlement belongs to the worker side rather than here.
  */
 const RETRY_BACKOFF_OUTBOX = sql`status = 'pending' AND claimed_at IS NULL AND attempts > 0`;
 
@@ -237,7 +240,32 @@ const RETRY_BACKOFF_OUTBOX = sql`status = 'pending' AND claimed_at IS NULL AND a
  * snapshot describes something the caller has already replaced, so every retry
  * still on the schedule would deliver superseded content. A destination that
  * was switched off or deleted in the meantime is the sharper version of the
- * same problem, because nothing else will ever stop it retrying.
+ * same problem, because nothing in its own config will stop it retrying.
+ *
+ * WHAT THIS SETTLES IS WHAT IS UNCLAIMED WHEN IT RUNS, and nothing beyond that.
+ * A row a worker holds is not in this set and cannot be put in it, and this
+ * statement has no say in what becomes of it afterwards. That attempt may
+ * SUCCEED, in which case its snapshot is delivered and the row finishes `done`.
+ * It may FAIL, in which case `markOutboxRetry` clears the claim and the row
+ * waits out a backoff, unclaimed but due again later. Its LEASE MAY EXPIRE
+ * without either, in which case the row stays claimed and another worker may
+ * reclaim it. All three happen after this statement has returned.
+ *
+ * SO THE OLDER SNAPSHOT CAN BE SENT AFTER THE NEWER ONE. The row a caller
+ * queues alongside this cleanup is due immediately, while a held row that fails
+ * is not due again until its backoff elapses, so a form really can produce this
+ * sequence: the newer payload delivered, then the older one delivered on a
+ * later retry, then that older row marked `done`. `max_attempts` does not
+ * prevent it. It stops FURTHER retries after attempts have already been made,
+ * which is a ceiling on how many go out, not a veto on any of them. What a
+ * receiver makes of the two is outside this repository.
+ *
+ * A later call for the same subject, kind and action settles such a row if it
+ * is back in backoff and unclaimed by then, but nothing guarantees a later call
+ * arrives, and for the submission `complete` action there is none by
+ * construction: a re-landed complete does not re-enqueue. That residual is
+ * bounded and deliberate: closing it would mean letting configuration settle a
+ * row a worker owns, which is the one thing this boundary exists to prevent.
  *
  * `skipped` rather than deleted, and rather than `failed`. The attempt really
  * happened and the record of it is the point of the table, so `failed` would
@@ -267,57 +295,6 @@ export async function skipBackoffOutbox(
   );
   return settled.length;
 }
-
-/** STILL QUEUED: not yet settled, whichever of the three pending states it is in. */
-const PENDING_OUTBOX = sql`status = 'pending'`;
-
-/** A queued row, in the only three terms a delivery needs to compare rows. */
-export interface PendingOutboxRow {
-  id: string;
-  /** The serialized snapshot, which is what names the delivery being made. */
-  payload: string | null;
-  /** When the row was queued: what makes one of two snapshots the later one. */
-  createdAt: number;
-}
-
-/**
- * Everything still queued in one scope, oldest first.
- *
- * Read from the DELIVERY side, not the enqueue side. A row about to cross the
- * wire is the last point at which anyone can still ask whether the snapshot it
- * carries is the current one, and the only way to answer is to look at what
- * else is queued for the same subject, kind and action. All three pending
- * states belong in the answer: a row waiting to be picked up, one waiting out a
- * backoff and one another worker is holding are three facts about the same
- * thing, a delivery that has not happened yet.
- *
- * RECENCY IS `created_at` AND NOTHING ELSE. The rows come back in that order as
- * a convenience, but the order is not the answer: `id` is a random UUID, so
- * sorting by it to break a tie would manufacture a "latest" between two rows
- * queued in the same millisecond, and a caller reading the last row would act
- * on a coin toss. The timestamp is reported instead, and a caller that finds a
- * tie is meant to treat it as one.
- *
- * Deliberately narrow: nothing here needs the transcript, the attempt count or
- * the account, so none of them are read.
- */
-export async function listPendingOutbox(
-  db: Db,
-  filter: { subjectUid: string; kind: OutboxKind; action: string },
-): Promise<PendingOutboxRow[]> {
-  const rows = await db.all<Record<string, unknown>>(
-    sql`SELECT id, payload, created_at FROM outbox
-        WHERE ${PENDING_OUTBOX} AND subject_uid = ${filter.subjectUid}
-          AND kind = ${filter.kind} AND action = ${filter.action}
-        ORDER BY created_at ASC`,
-  );
-  return rows.map((r) => ({
-    id: String(r.id),
-    payload: (r.payload as string | null) ?? null,
-    createdAt: Number(r.created_at),
-  }));
-}
-
 
 function mapRow(r: Record<string, unknown>): OutboxRow {
   return {

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -165,19 +165,159 @@ export async function enqueueOutbox(db: Db, input: EnqueueOutboxInput): Promise<
 }
 
 /**
- * Delete still-PENDING rows matching a subject + kind + action — used to cancel
- * scheduled sends before they fire. Never touches rows already `done`/`failed`.
+ * NEVER HANDED OFF: the row is still exactly as `enqueueOutbox` wrote it.
+ *
+ * `status = 'pending'` on its own does not mean that. It is equally true of a
+ * row a worker is delivering RIGHT NOW (claimed, lease held) and of a row
+ * waiting out its retry backoff (attempted, claim cleared, due again later).
+ * Two more columns separate the three:
+ *
+ *   claimed_at IS NULL   nobody holds the lease, so no attempt is in flight
+ *   attempts = 0         no attempt was ever made, so nothing can have landed
+ *                        at the far end
+ *
+ * Both are load-bearing and neither implies the other: a FIRST claim charges no
+ * attempt (`claimed_at` is set while `attempts` stays 0), and `markOutboxRetry`
+ * clears the claim while leaving `attempts` above 0. Drop either column and one
+ * of the two live states starts looking cancellable.
  */
-export async function deletePendingOutbox(
+const UNSTARTED_OUTBOX = sql`status = 'pending' AND claimed_at IS NULL AND attempts = 0`;
+
+/**
+ * DELETE queued work that has not been started yet, scoped to one subject +
+ * kind + action. The first of the three moves a re-enqueue pass makes.
+ *
+ * This is the only state where deleting is honest. Nothing was attempted, so
+ * there is nothing to record and nothing anyone could have received: the row
+ * leaves no trace because it produced no event. The other two pending states
+ * are handled elsewhere and on purpose, because both have already done
+ * something: {@link skipBackoffOutbox} settles an attempted row that is waiting
+ * to retry, keeping everything it recorded, and a row a worker is currently
+ * holding is left strictly alone, because only that worker may settle it.
+ *
+ * WHERE THE SETTINGS BOUNDARY SITS. Configuration decides what is queued and
+ * what stops being retried. It does not reach a request that is in flight. An
+ * edit to a destination is never a synchronous cancel: it takes effect on this
+ * path only when the subject comes round again, and even then a delivery a
+ * worker has already picked up runs to its own terminal state, because it may
+ * already have crossed the wire and this row is the only record that it did.
+ * Whether that delivery is still the current one is a question for the moment
+ * it is made, off {@link listPendingOutbox}, not for this pass.
+ */
+export async function deleteUnstartedOutbox(
   db: Db,
   filter: { subjectUid: string; kind: OutboxKind; action: string },
 ): Promise<void> {
   await db.run(
     sql`DELETE FROM outbox
-        WHERE status = 'pending' AND subject_uid = ${filter.subjectUid}
+        WHERE ${UNSTARTED_OUTBOX} AND subject_uid = ${filter.subjectUid}
           AND kind = ${filter.kind} AND action = ${filter.action}`,
   );
 }
+
+/**
+ * WAITING OUT A BACKOFF: attempted at least once, nobody holding it, due again
+ * later.
+ *
+ * The mirror image of {@link UNSTARTED_OUTBOX}, and the reason both columns are
+ * named twice. `attempts > 0` is what keeps this off a never-started row, which
+ * belongs to the delete and must survive this statement untouched.
+ * `claimed_at IS NULL` is what keeps it off a row a worker holds right now,
+ * which is not waiting for anything: it is running, it may already have crossed
+ * the wire, and only its own worker may settle it.
+ */
+const RETRY_BACKOFF_OUTBOX = sql`status = 'pending' AND claimed_at IS NULL AND attempts > 0`;
+
+/**
+ * Settle every backoff row in one scope as `skipped`, and report how many.
+ *
+ * A queued row carries a FROZEN snapshot of the config and the answers it was
+ * built from. That is what makes retrying safe, and it is also what makes a
+ * retry go stale: once the same subject, kind and action come round again, the
+ * snapshot describes something the caller has already replaced, so every retry
+ * still on the schedule would deliver superseded content. A destination that
+ * was switched off or deleted in the meantime is the sharper version of the
+ * same problem, because nothing else will ever stop it retrying.
+ *
+ * `skipped` rather than deleted, and rather than `failed`. The attempt really
+ * happened and the record of it is the point of the table, so `failed` would
+ * claim the retries ran out, which is not what happened.
+ *
+ * ONLY `status` MOVES. The row is the record of a delivery that was attempted,
+ * and being superseded is not a second thing that happened to it: `last_error`
+ * still holds the reason the attempt failed, which is what an admin opening the
+ * delivery log came to read, and `updated_at` still holds when that happened,
+ * which is what the history is ordered by. Restamping either one would bury a
+ * genuinely newer failure under every row a busy form supersedes. `attempts`
+ * and the transcript are left alone for the same reason.
+ *
+ * One statement, whatever the size of the set, so a caller cannot interleave a
+ * claim between reading the rows and settling them.
+ */
+export async function skipBackoffOutbox(
+  db: Db,
+  filter: { subjectUid: string; kind: OutboxKind; action: string },
+): Promise<number> {
+  const settled = await db.all<{ id: string }>(
+    sql`UPDATE outbox
+        SET status = 'skipped'
+        WHERE ${RETRY_BACKOFF_OUTBOX} AND subject_uid = ${filter.subjectUid}
+          AND kind = ${filter.kind} AND action = ${filter.action}
+        RETURNING id`,
+  );
+  return settled.length;
+}
+
+/** STILL QUEUED: not yet settled, whichever of the three pending states it is in. */
+const PENDING_OUTBOX = sql`status = 'pending'`;
+
+/** A queued row, in the only three terms a delivery needs to compare rows. */
+export interface PendingOutboxRow {
+  id: string;
+  /** The serialized snapshot, which is what names the delivery being made. */
+  payload: string | null;
+  /** When the row was queued: what makes one of two snapshots the later one. */
+  createdAt: number;
+}
+
+/**
+ * Everything still queued in one scope, oldest first.
+ *
+ * Read from the DELIVERY side, not the enqueue side. A row about to cross the
+ * wire is the last point at which anyone can still ask whether the snapshot it
+ * carries is the current one, and the only way to answer is to look at what
+ * else is queued for the same subject, kind and action. All three pending
+ * states belong in the answer: a row waiting to be picked up, one waiting out a
+ * backoff and one another worker is holding are three facts about the same
+ * thing, a delivery that has not happened yet.
+ *
+ * RECENCY IS `created_at` AND NOTHING ELSE. The rows come back in that order as
+ * a convenience, but the order is not the answer: `id` is a random UUID, so
+ * sorting by it to break a tie would manufacture a "latest" between two rows
+ * queued in the same millisecond, and a caller reading the last row would act
+ * on a coin toss. The timestamp is reported instead, and a caller that finds a
+ * tie is meant to treat it as one.
+ *
+ * Deliberately narrow: nothing here needs the transcript, the attempt count or
+ * the account, so none of them are read.
+ */
+export async function listPendingOutbox(
+  db: Db,
+  filter: { subjectUid: string; kind: OutboxKind; action: string },
+): Promise<PendingOutboxRow[]> {
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT id, payload, created_at FROM outbox
+        WHERE ${PENDING_OUTBOX} AND subject_uid = ${filter.subjectUid}
+          AND kind = ${filter.kind} AND action = ${filter.action}
+        ORDER BY created_at ASC`,
+  );
+  return rows.map((r) => ({
+    id: String(r.id),
+    payload: (r.payload as string | null) ?? null,
+    createdAt: Number(r.created_at),
+  }));
+}
+
 
 function mapRow(r: Record<string, unknown>): OutboxRow {
   return {

--- a/packages/destinations/src/destination.port.ts
+++ b/packages/destinations/src/destination.port.ts
@@ -25,32 +25,13 @@ export type DestinationType = 'webhook' | 'hubspot';
  */
 export interface DestinationContext {
   /**
-   * Stable, event-specific de-duplication key.
-   *
-   * Submission deliveries use
-   * `submission:<id>:<phase>:<destinationType>:<destination digest>:<content
-   * digest>`, where each digest is a full lower-case SHA-256 hex over canonical
-   * JSON: the first of the destination's persisted, non-secret identity, the
-   * second of everything in this context except the key itself and
-   * `submittedAt`. The booking-time answers sync uses
-   * `booking:<bookingEventId>:hubspot`.
-   *
-   * EQUAL KEYS MEAN THE SAME DELIVERY. A retry reuses its key, and so does a
-   * re-submit that changed no answer, because neither is a new thing to send.
-   * Anything that changes what is sent, or where it is sent, produces a
-   * different key. That is the whole contract a receiver deduping on the
-   * forwarded header depends on, so it is content-addressed rather than
-   * positional: a key derived from a destination's index in the form config
-   * changed meaning whenever a destination was reordered or deleted.
-   *
-   * Nothing secret is digested. The key is forwarded to the receiver, so a
-   * signing secret is deliberately not part of the destination's identity; a
-   * rotated secret keeps the same key, which is also the right answer, since
-   * rotating one does not create a delivery.
-   *
-   * NOTE: the HubSpot adapter does not read it — its Note create is not
-   * idempotent, which is why every caller must make the Note the LAST side
-   * effect of a delivery (nothing retryable after).
+   * Stable, event-specific de-duplication key. Submission deliveries use
+   * `submission:<id>:<phase>:<destinationType>:<index>`; the booking-time
+   * answers sync uses `booking:<bookingEventId>:hubspot`. A retried delivery
+   * reuses the same key; distinct events get distinct keys. Webhooks forward it
+   * as a header so the RECEIVER can dedupe. NOTE: the HubSpot adapter does not
+   * read it — its Note create is not idempotent, which is why every caller must
+   * make the Note the LAST side effect of a delivery (nothing retryable after).
    */
   idempotencyKey: string;
   /** The persisted submission id (the domain anchor). */
@@ -66,10 +47,7 @@ export interface DestinationContext {
   outcomeLabel: string | null;
   /** `partial` = an intermediate save; `complete` = the final submit. */
   phase: 'partial' | 'complete';
-  /**
-   * Epoch-ms the submission reached this phase. Deliberately OUTSIDE the
-   * identity above: a later reading of the clock is not a different delivery.
-   */
+  /** Epoch-ms the submission reached this phase. */
   submittedAt: number;
   /** The submission answers: fieldName -> value. */
   data: Record<string, unknown>;

--- a/packages/destinations/src/destination.port.ts
+++ b/packages/destinations/src/destination.port.ts
@@ -25,13 +25,32 @@ export type DestinationType = 'webhook' | 'hubspot';
  */
 export interface DestinationContext {
   /**
-   * Stable, event-specific de-duplication key. Submission deliveries use
-   * `submission:<id>:<phase>:<destinationType>:<index>`; the booking-time
-   * answers sync uses `booking:<bookingEventId>:hubspot`. A retried delivery
-   * reuses the same key; distinct events get distinct keys. Webhooks forward it
-   * as a header so the RECEIVER can dedupe. NOTE: the HubSpot adapter does not
-   * read it — its Note create is not idempotent, which is why every caller must
-   * make the Note the LAST side effect of a delivery (nothing retryable after).
+   * Stable, event-specific de-duplication key.
+   *
+   * Submission deliveries use
+   * `submission:<id>:<phase>:<destinationType>:<destination digest>:<content
+   * digest>`, where each digest is a full lower-case SHA-256 hex over canonical
+   * JSON: the first of the destination's persisted, non-secret identity, the
+   * second of everything in this context except the key itself and
+   * `submittedAt`. The booking-time answers sync uses
+   * `booking:<bookingEventId>:hubspot`.
+   *
+   * EQUAL KEYS MEAN THE SAME DELIVERY. A retry reuses its key, and so does a
+   * re-submit that changed no answer, because neither is a new thing to send.
+   * Anything that changes what is sent, or where it is sent, produces a
+   * different key. That is the whole contract a receiver deduping on the
+   * forwarded header depends on, so it is content-addressed rather than
+   * positional: a key derived from a destination's index in the form config
+   * changed meaning whenever a destination was reordered or deleted.
+   *
+   * Nothing secret is digested. The key is forwarded to the receiver, so a
+   * signing secret is deliberately not part of the destination's identity; a
+   * rotated secret keeps the same key, which is also the right answer, since
+   * rotating one does not create a delivery.
+   *
+   * NOTE: the HubSpot adapter does not read it — its Note create is not
+   * idempotent, which is why every caller must make the Note the LAST side
+   * effect of a delivery (nothing retryable after).
    */
   idempotencyKey: string;
   /** The persisted submission id (the domain anchor). */
@@ -47,7 +66,10 @@ export interface DestinationContext {
   outcomeLabel: string | null;
   /** `partial` = an intermediate save; `complete` = the final submit. */
   phase: 'partial' | 'complete';
-  /** Epoch-ms the submission reached this phase. */
+  /**
+   * Epoch-ms the submission reached this phase. Deliberately OUTSIDE the
+   * identity above: a later reading of the clock is not a different delivery.
+   */
   submittedAt: number;
   /** The submission answers: fieldName -> value. */
   data: Record<string, unknown>;

--- a/qa/e2e/v2-webhook-events.spec.ts
+++ b/qa/e2e/v2-webhook-events.spec.ts
@@ -15,9 +15,11 @@ import { fileURLToPath } from 'node:url';
  *   1. events:['complete'] → a COMPLETE submit enqueues one `outbox` webhook row
  *      (kind='webhook', action='complete'); a PARTIAL submit enqueues NONE.
  *   2. events:['partial']  → the reverse: PARTIAL enqueues one row, COMPLETE none.
- *      (The pre-loop cleanup in enqueueSubmissionDeliveries only deletes pending
- *      rows for the *firing* kind+action, so the surviving row is never clobbered
- *      by the other phase — asserted per action.)
+ *      (The pre-loop reconsideration in enqueueSubmissionDeliveries runs for
+ *      every destination kind, but both of its moves are scoped to the phase
+ *      being enqueued, so the complete pass can only reach `action='complete'`
+ *      rows and the partial row survives on that action scoping, asserted per
+ *      action.)
  *   3. UI — /admin/forms/:id/integrations: the webhook card shows Partial/Complete
  *      checkboxes; unchecking one is allowed, unchecking the LAST one is blocked
  *      (≥1 stays checked).
@@ -219,9 +221,11 @@ test.describe('N6 — webhook per-event triggers', () => {
         message: 'partial phase must enqueue exactly one webhook row',
       })
       .toBe(1);
-    // ...and the COMPLETE phase enqueued NONE. Because the complete phase does
-    // not fire, its enqueue path never runs the pre-loop cleanup, so the partial
-    // row above survives untouched (distinct action, distinct row).
+    // ...and the COMPLETE phase enqueued NONE. The complete pass still runs the
+    // pre-loop reconsideration (it runs for every destination kind, whether or
+    // not one fires), but both of its moves are scoped to `action='complete'`,
+    // so neither can reach the partial row above: distinct action,
+    // distinct row.
     expect(countByAction(submissionId, 'complete'), 'complete phase must enqueue no webhook row').toBe(
       0,
     );


### PR DESCRIPTION
## Summary

- distinguish untouched, retry-backoff, and worker-held destination outbox rows during re-enqueue
- delete only untouched rows and settle unclaimed retry-backoff rows as `skipped` without erasing diagnostics
- preserve claimed work, enqueue current destinations unconditionally, and retain the existing positional delivery key

## Behavior boundary

Cleanup only acts on rows that are unclaimed when it runs. A worker-held delivery can still complete, retry, or be reclaimed after the pass. In the retry sequence, Dapta Forms can send an older payload after the newly queued payload. Receiver handling remains outside this change.

## Verification

- API destination suite: 30/30
- full API suite: 441/441
- DB SQLite suite: 261/261
- DB PostgreSQL suite after migrate and seed: 261/261
- destinations suite: 96/96
- API, DB, and destinations typechecks
- eight predicate and ordering counterfactual mutations
- `git diff --check`, typography check, and commitlint
- terminal static review: no live Medium-or-higher findings and no coverage gaps

## Scope

No schema, migration, route, DTO, resolver, worker, provider, or wire-key change.