### PR TITLE
fix: unblock the release, a phone that was a document number, and two auth redirect regressions

### DIFF
--- a/.changeset/agents-nav-and-made-with-badge.md
+++ b/.changeset/agents-nav-and-made-with-badge.md
@@ -1,6 +1,5 @@
 ---
 '@quill/shared': minor
-'@quill/web': patch
 ---
 
 A "Dapta Agents" door in the admin rail, and the public badge signs itself as

--- a/.changeset/engine-single-choice-scoring.md
+++ b/.changeset/engine-single-choice-scoring.md
@@ -1,0 +1,13 @@
+---
+'@quill/engine': patch
+---
+
+Scoring rejects an array answer where the form asks for one choice.
+
+A choice step that is not multi-select used to score every element of an array
+answer, and a repeated token was counted once per occurrence, so a crafted or
+replayed answer could inflate the total and land the respondent in a higher
+outcome bucket. `validateAnswer` now refuses an array on a single-choice step
+and refuses repeated tokens on any choice step, and `optionPoints` returns zero
+for that shape and dedupes tokens before summing. Stored configs are untouched;
+a recomputed score for an affected submission can move down.

--- a/.changeset/no-dash-on-screen.md
+++ b/.changeset/no-dash-on-screen.md
@@ -1,6 +1,5 @@
 ---
 '@quill/types': patch
-'@quill/web': patch
 ---
 
 Remove the last two em dashes a user could see, and make the check that finds

--- a/.changeset/staff-refresh-no-estate-paging.md
+++ b/.changeset/staff-refresh-no-estate-paging.md
@@ -1,7 +1,5 @@
 ---
-'@quill/api': patch
 '@quill/db': patch
-'@quill/web': patch
 '@quill/shared': patch
 ---
 

--- a/.changeset/workspace-iam-id-urls.md
+++ b/.changeset/workspace-iam-id-urls.md
@@ -1,8 +1,6 @@
 ---
-'@quill/web': minor
-'@quill/api': patch
 '@quill/db': patch
-'@quill/shared': patch
+'@quill/shared': minor
 ---
 
 Account settings names workspaces by the same id the Dapta app does.

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -118,12 +118,23 @@ docker build -f apps/web/Dockerfile -t dapta-forms-web \
 
 ### Outbox worker upgrades
 
-Mixed outbox worker versions are unsupported. Stop every old API/worker
-replica, wait at least the stale claim lease for in-flight old claims or confirm
-the queue is drained, then start every new replica. Use the same coordination
-before rollback. Delivery stays at-least-once: crashes, effects longer than the
-lease, hung providers, and late successes after peer terminalization can
-duplicate or leave an external effect unrecorded.
+A worker settles only the row it still holds the lease on: every settlement
+carries the claim token it was issued, and a worker that lost its lease logs
+`lease lost before settlement` instead of recording a result it no longer owns.
+Versions before that fence settle by row id alone.
+
+So a rolling upgrade, where old and new replicas run side by side for a few
+minutes, is supported but unfenced for as long as it lasts: an old replica can
+still overwrite the settlement of a row a new replica has since reclaimed. That
+is the at-least-once behaviour the outbox already advertises, which is why a
+rolling deploy is safe. It is not the stronger guarantee the fence gives you
+once every replica is on the new version.
+
+A stop, drain-or-wait one full `staleClaimMs`, then start sequence avoids the
+window entirely. Prefer it when you can schedule the downtime, and use the same
+sequence on rollback. Either way delivery stays at-least-once: crashes, effects
+longer than the lease, hung providers, and late successes after peer
+terminalization can duplicate or leave an external effect unrecorded.
 
 **PostgreSQL is the source of truth** (CI and production run Postgres). SQLite is a
 portable subset for zero-infra dev and evaluation only — it is never allowed to
@@ -375,7 +386,9 @@ through the same outbox with retry + backoff).
   and idempotent), then stop every old API worker. Drain active claims or wait
   at least one full `staleClaimMs`, then start only target-version API workers.
 - **API rollback:** use the same stop/drain-or-wait/start sequence before
-  starting the rollback API workers. Do not run mixed API worker versions.
+  starting the rollback API workers. Rolling instead of stopping is safe and
+  stays at-least-once, but see "Outbox worker upgrades" for what mixed versions
+  give up while the rollout lasts.
 - **Web rollout:** web images may roll independently. Rebuild the web image when
   a `NEXT_PUBLIC_*` value changes because those values are baked at build time.
 

--- a/apps/api/src/booking-sync.spec.ts
+++ b/apps/api/src/booking-sync.spec.ts
@@ -575,6 +575,93 @@ describe('booking_sync delivery', () => {
     expect(props.phone).toBeUndefined();
   });
 
+  // The answer guard cannot catch these: a document number, a tax id and a head
+  // count all parse as a phone by digit count. Only the QUESTION separates them,
+  // and the phone upsert is destructive, so a hit here would overwrite the real
+  // number on the contact rather than sit next to it.
+  it.each([
+    ['Número de documento', '1020304050'],
+    ['Número de identificación', '80123456'],
+    ['NIT de la empresa', '9001234567'],
+    ['Número de empleados', '1500000'],
+  ])('ignores "%s", a número question that is not a phone', async (question, answer) => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { '@invitee_phone': 'phone' },
+    });
+    const sessionId = `sess-num-${question.replace(/\W+/g, '-').toLowerCase()}`;
+    await svc.submit('acme', 'lead-qualifier', { sessionId, data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId,
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({
+          resource: {
+            email: 'num@corp.io',
+            name: 'Ada Lovelace',
+            questions_and_answers: [{ question, answer, position: 0 }],
+          },
+        }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '93' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.phone).toBeUndefined();
+  });
+
+  // The qualified forms of the same word must still land: dropping the bare
+  // alternative must not cost the event types that spell it out.
+  it.each([
+    ['Número de teléfono', '+57 300 123 4567'],
+    ['¿Cuál es tu número de celular?', '3001234567'],
+    ['Número de contacto', '+1 555 000 1111'],
+  ])('still reads "%s" as the phone', async (question, answer) => {
+    await setHubspotDestination(undefined, {
+      fieldMappings: { '@invitee_phone': 'phone' },
+    });
+    const sessionId = `sess-ok-${question.replace(/\W+/g, '-').toLowerCase()}`;
+    await svc.submit('acme', 'lead-qualifier', { sessionId, data: { role: 'founder' } });
+    await svc.booking('acme', 'lead-qualifier', {
+      sessionId,
+      provider: 'calendly',
+      eventUri: EVENT_URI,
+      inviteeUri: INVITEE_URI,
+    });
+
+    const calls: RecordedCall[] = [];
+    bookingSync.fetchImpl = recordingFetch(calls, {
+      [EVENT_URI]: () => jsonResponse({ resource: { start_time: '2026-08-02T10:00:00Z' } }),
+      [INVITEE_URI]: () =>
+        jsonResponse({
+          resource: {
+            email: 'ok@corp.io',
+            name: 'Ada Lovelace',
+            questions_and_answers: [{ question, answer, position: 0 }],
+          },
+        }),
+      [HUBSPOT_UPSERT_URL]: () => jsonResponse({ results: [{ id: '94' }] }),
+    });
+    await drainDue();
+
+    const props = (
+      calls.filter((c) => c.url === HUBSPOT_UPSERT_URL).at(-1)!.body as {
+        inputs: Array<{ properties: Record<string, string> }>;
+      }
+    ).inputs[0]!.properties;
+    expect(props.phone).toBe(answer);
+  });
+
   // A scheduler-keyed form NEVER delivers at submit time (nothing to key on), so
   // this is the only path its mirror form can be posted from. It shipped without
   // one: the answers and the Note arrived and the "Form submission" activity

--- a/apps/api/src/booking-sync.ts
+++ b/apps/api/src/booking-sync.ts
@@ -38,6 +38,18 @@ interface CalendlyResource {
   };
 }
 
+const PHONE_QUESTION =
+  /tel[eé]fono|phone|celular|m[oó]vil|whatsapp|n[uú]mero\s+(?:de\s+)?(?:tel[eé]fono|celular|m[oó]vil|contacto|whatsapp)/i;
+
+/**
+ * A question asking for a "número" that is not a phone. Every other alternative
+ * above is phone-specific, but a bare "número" also opens "Número de documento",
+ * "Número de identificación" and "Número de empleados", whose answers pass the
+ * digit-count check too. The phone property upsert is destructive, so a document
+ * number reaching it OVERWRITES the real phone rather than sitting beside it.
+ */
+const NOT_PHONE_QUESTION = /documento|identificaci[oó]n|c[eé]dula|\bnit\b|empleados/i;
+
 /**
  * A custom-question answer that is a phone number, or null.
  *
@@ -48,13 +60,16 @@ interface CalendlyResource {
  * is "Company" (and people have answered it with their phone) and others with
  * free-text "Please share anything...", so the QUESTION must ask for a phone AND
  * the ANSWER must parse as one. Position is irrelevant: the question is found by
- * its text, wherever the event type asks it.
+ * its text, wherever the event type asks it. A question asking for a "número"
+ * counts only when it says which one (see NOT_PHONE_QUESTION).
  */
 function phoneFromQuestions(
   qa: { question?: string; answer?: string }[] | undefined,
 ): string | null {
-  const asksForPhone = (q: string | undefined) =>
-    /tel[eé]fono|phone|celular|m[oó]vil|whatsapp|n[uú]mero/i.test(q ?? '');
+  const asksForPhone = (q: string | undefined) => {
+    const text = q ?? '';
+    return PHONE_QUESTION.test(text) && !NOT_PHONE_QUESTION.test(text);
+  };
   const looksLikePhone = (a: string | undefined) => /^[+()\-.\s\d]{7,}$/.test((a ?? '').trim());
   const hit = (qa ?? []).find((x) => asksForPhone(x.question) && looksLikePhone(x.answer));
   return hit?.answer?.trim() ?? null;

--- a/apps/web/app/admin/account/workspaces/[id]/actions.ts
+++ b/apps/web/app/admin/account/workspaces/[id]/actions.ts
@@ -21,7 +21,7 @@ import { adminApi, ApiError, isAdminRole, type MemberStatus } from '@/lib/admin-
  * workspace id when there is one and the local account id otherwise, and the
  * actions only know the latter.
  */
-function revalidateWorkspace(_accountId: string): void {
+function revalidateWorkspace(): void {
   revalidatePath('/admin/account/workspaces/[id]', 'page');
   revalidatePath('/admin/account/workspaces');
 }
@@ -56,7 +56,7 @@ export async function inviteMemberAction(
     const me = await adminApi.me({ workspace: accountId });
     if (!isAdminRole(me.role)) return { ok: false, code: 'FAILED' };
     await adminApi.inviteMember({ email, role }, { workspace: accountId });
-    revalidateWorkspace(accountId);
+    revalidateWorkspace();
     return { ok: true };
   } catch (e) {
     unstable_rethrow(e);
@@ -111,7 +111,7 @@ export async function updateMemberRoleAction(
     if (!isAdminRole(me.role)) return { ok: false, code: 'FORBIDDEN' };
     if (id === me.memberId) return { ok: false, code: 'FORBIDDEN' };
     await adminApi.updateMember(id, { role }, { workspace: accountId });
-    revalidateWorkspace(accountId);
+    revalidateWorkspace();
     return { ok: true };
   } catch (e) {
     unstable_rethrow(e);
@@ -135,7 +135,7 @@ export async function setMemberStatusAction(
     if (!isAdminRole(me.role)) return { ok: false, code: 'FORBIDDEN' };
     if (id === me.memberId) return { ok: false, code: 'FORBIDDEN' };
     await adminApi.updateMember(id, { status }, { workspace: accountId });
-    revalidateWorkspace(accountId);
+    revalidateWorkspace();
     return { ok: true };
   } catch (e) {
     unstable_rethrow(e);
@@ -158,7 +158,7 @@ export async function removeMemberAction(accountId: string, id: string): Promise
     if (!isAdminRole(me.role)) return { ok: false, code: 'FORBIDDEN' };
     if (id === me.memberId) return { ok: false, code: 'FORBIDDEN' };
     await adminApi.removeMember(id, { workspace: accountId });
-    revalidateWorkspace(accountId);
+    revalidateWorkspace();
     return { ok: true };
   } catch (e) {
     unstable_rethrow(e);

--- a/apps/web/lib/auth-session-revoke.spec.ts
+++ b/apps/web/lib/auth-session-revoke.spec.ts
@@ -112,4 +112,24 @@ describe('idpLogoutTarget', () => {
     expect(idpLogoutTarget(null, 'https://forms.example.com')).toBeNull();
     expect(idpLogoutTarget('/relative-not-a-url', 'https://forms.example.com')).toBeNull();
   });
+
+  // The value is the IAM's `logoutUrl` field verbatim and the browser is sent to
+  // it. Parseable is not the same as navigable.
+  it.each([
+    'javascript:alert(document.cookie)',
+    'data:text/html,<script>fetch("//evil.example")</script>',
+    'http://evil.example/user_management/sessions/logout',
+    'file:///etc/passwd',
+  ])('returns null for %s', (logoutUrl) => {
+    expect(idpLogoutTarget(logoutUrl, 'https://forms.example.com')).toBeNull();
+  });
+
+  // The offline harness points at a stub IAM on localhost, so http there has to
+  // keep working.
+  it('allows http on localhost for the offline harness', () => {
+    const target = idpLogoutTarget('http://localhost:4400/auth/logout', 'http://localhost:3400');
+    expect(new URL(target!).searchParams.get('return_to')).toBe(
+      'http://localhost:3400/login?signedout=1',
+    );
+  });
 });

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -126,11 +126,32 @@ export function idpLogoutTarget(logoutUrl: string | null, origin: string): strin
   if (!logoutUrl) return null;
   try {
     const target = new URL(logoutUrl);
+    if (!isBrowserNavigable(target)) return null;
     target.searchParams.set('return_to', new URL('/login?signedout=1', origin).toString());
     return target.toString();
   } catch {
     return null;
   }
+}
+
+/**
+ * Whether a URL is one we are willing to send a browser to.
+ *
+ * `revokeUpstreamSession` returns the IAM's `logoutUrl` field verbatim, and it
+ * goes straight into `NextResponse.redirect` and the action `redirect()`. The
+ * IAM is first-party and env-configured, so this is defence in depth rather
+ * than a live hole, but an unvalidated redirect target on the auth path is
+ * worth closing, and `javascript:` and `data:` are one bad response away.
+ *
+ * The scheme is all that is checked. The host deliberately is NOT pinned to
+ * `IAM_BASE_URL`: the logout URL points at the IdP (`api.workos.com`), not at
+ * the IAM, so a strict same-host pin would break sign-out outright. An
+ * allowlist would have to name both hosts and be configurable.
+ */
+function isBrowserNavigable(target: URL): boolean {
+  if (target.protocol === 'https:') return true;
+  const local = target.hostname === 'localhost' || target.hostname === '127.0.0.1';
+  return target.protocol === 'http:' && local;
 }
 
 /**

--- a/apps/web/lib/request-origin.spec.ts
+++ b/apps/web/lib/request-origin.spec.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NextRequest } from 'next/server';
+import { originFrom, requestOrigin, selfHost } from './request-origin';
+
+/** The two things `requestOrigin` reads off a request, and nothing else. */
+function request(url: string, headers: Record<string, string> = {}): NextRequest {
+  return {
+    url,
+    nextUrl: new URL(url),
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+  } as unknown as NextRequest;
+}
+
+const PUBLIC_APP_URL = process.env.PUBLIC_APP_URL;
+
+beforeEach(() => {
+  delete process.env.PUBLIC_APP_URL;
+});
+
+afterEach(() => {
+  if (PUBLIC_APP_URL === undefined) delete process.env.PUBLIC_APP_URL;
+  else process.env.PUBLIC_APP_URL = PUBLIC_APP_URL;
+});
+
+describe('requestOrigin', () => {
+  it('trusts PUBLIC_APP_URL over any header', () => {
+    process.env.PUBLIC_APP_URL = 'https://forms.example';
+    const req = request('https://forms.example/api/auth/login', {
+      'x-forwarded-host': 'evil.example',
+      host: 'evil.example',
+    });
+    expect(requestOrigin(req)).toBe('https://forms.example');
+  });
+
+  it('uses the forwarded proto and host when the proxy sends both', () => {
+    const req = request('http://10.0.0.7:3000/api/auth/login', {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'forms.example',
+    });
+    expect(requestOrigin(req)).toBe('https://forms.example');
+  });
+
+  // A deployment can forward Host and not X-Forwarded-Proto. Guessing http there
+  // downgrades the OAuth returnTo and the logout landing, and the `?session=`
+  // blob rides that redirect.
+  it('keeps the request scheme when the host is forwarded without a proto', () => {
+    const req = request('https://forms.example/api/auth/login', {
+      host: 'forms.example',
+    });
+    expect(requestOrigin(req)).toBe('https://forms.example');
+  });
+
+  it('stays on http when that is what the request itself was', () => {
+    const req = request('http://localhost:3000/api/auth/login', { host: 'localhost:3000' });
+    expect(requestOrigin(req)).toBe('http://localhost:3000');
+  });
+
+  it('falls back to the request URL when no host resolves at all', () => {
+    expect(requestOrigin(request('https://forms.example/api/auth/login'))).toBe(
+      'https://forms.example',
+    );
+  });
+});
+
+describe('originFrom', () => {
+  const get = (entries: Record<string, string>) => (k: string) => entries[k.toLowerCase()] ?? null;
+
+  // Server actions hold `headers()` and no request, so there is no scheme to
+  // read: http stays the only guess available to them.
+  it('guesses http for a caller that cannot supply a scheme', () => {
+    expect(originFrom(get({ host: 'forms.example' }))).toBe('http://forms.example');
+  });
+
+  it('uses the supplied fallback scheme when there is no forwarded proto', () => {
+    expect(originFrom(get({ host: 'forms.example' }), 'https')).toBe('https://forms.example');
+  });
+
+  it('prefers a forwarded proto over the fallback', () => {
+    expect(originFrom(get({ host: 'forms.example', 'x-forwarded-proto': 'https' }), 'http')).toBe(
+      'https://forms.example',
+    );
+  });
+
+  it('returns null when nothing trustworthy resolves', () => {
+    expect(originFrom(get({}), 'https')).toBeNull();
+  });
+});
+
+describe('selfHost', () => {
+  it('takes the first hop of a chained x-forwarded-host', () => {
+    const get = (k: string) =>
+      k.toLowerCase() === 'x-forwarded-host' ? 'a.example, b.example' : null;
+    expect(selfHost(get)).toBe('a.example');
+  });
+});

--- a/apps/web/lib/request-origin.ts
+++ b/apps/web/lib/request-origin.ts
@@ -13,7 +13,8 @@ import type { NextRequest } from 'next/server';
  * not set it (where there is no fronting proxy to spoof through).
  */
 export function requestOrigin(req: NextRequest): string {
-  return originFrom((n) => req.headers.get(n)) ?? new URL(req.url).origin;
+  const own = req.nextUrl.protocol.replace(/:$/, '') || undefined;
+  return originFrom((n) => req.headers.get(n), own) ?? new URL(req.url).origin;
 }
 
 /**
@@ -21,8 +22,16 @@ export function requestOrigin(req: NextRequest): string {
  * of a `NextRequest` (server actions have no request object). Null when nothing
  * trustworthy resolves; a caller building an OAuth or IdP redirect should then
  * skip the redirect rather than guess an origin.
+ *
+ * `fallbackProto` is the scheme to use when a host resolves but no
+ * `X-Forwarded-Proto` came with it. It is NOT a trust decision: the host is
+ * whatever the trust order already settled on, and this only picks the scheme
+ * to pair with it.
  */
-export function originFrom(get: (name: string) => string | null | undefined): string | null {
+export function originFrom(
+  get: (name: string) => string | null | undefined,
+  fallbackProto?: string,
+): string | null {
   const configured = process.env.PUBLIC_APP_URL?.trim();
   if (configured) {
     try {
@@ -36,8 +45,12 @@ export function originFrom(get: (name: string) => string | null | undefined): st
   const host = selfHost(get);
   if (proto && host) return `${proto}://${host}`;
   // A bare self-host/dev clone with no proxy in front: the Host header is the
-  // only signal there is, and plain http is the only scheme it can be serving.
-  if (host) return `http://${host}`;
+  // only signal there is. The request's OWN scheme is the next best thing and
+  // callers holding a NextRequest pass it, because a deployment that forwards
+  // Host but not X-Forwarded-Proto would otherwise downgrade an https OAuth
+  // returnTo to http. Only the server-action caller, which has no request
+  // object to read a scheme off, falls back to plain http.
+  if (host) return `${fallbackProto ?? 'http'}://${host}`;
   return null;
 }
 

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -390,28 +390,28 @@ export async function createForm(
    */
   createdBy?: string | null,
 ): Promise<CrudResult<FormRow>> {
-   const config = input.config ?? { version: 1, steps: [] };
+  const config = input.config ?? { version: 1, steps: [] };
 
-   for (let attempt = 0; attempt < FORM_SLUG_INSERT_ATTEMPTS; attempt++) {
-     const slug = await uniqueFormSlug(db, accountId, input.slug ?? input.name);
-     const id = randomUUID();
-     const now = Date.now();
-     try {
-       await db.run(
-         sql`INSERT INTO form (id, account_id, name, slug, config, created_by, created_at, updated_at)
-             VALUES (${id}, ${accountId}, ${input.name}, ${slug}, ${jsonParam(config)},
-                     ${createdBy ?? null}, ${now}, ${now})`,
-       );
-     } catch (error) {
-       if (attempt + 1 < FORM_SLUG_INSERT_ATTEMPTS && isFormAccountSlugConflict(error)) continue;
-       throw error;
-     }
+  for (let attempt = 0; attempt < FORM_SLUG_INSERT_ATTEMPTS; attempt++) {
+    const slug = await uniqueFormSlug(db, accountId, input.slug ?? input.name);
+    const id = randomUUID();
+    const now = Date.now();
+    try {
+      await db.run(
+        sql`INSERT INTO form (id, account_id, name, slug, config, created_by, created_at, updated_at)
+            VALUES (${id}, ${accountId}, ${input.name}, ${slug}, ${jsonParam(config)},
+                    ${createdBy ?? null}, ${now}, ${now})`,
+      );
+    } catch (error) {
+      if (attempt + 1 < FORM_SLUG_INSERT_ATTEMPTS && isFormAccountSlugConflict(error)) continue;
+      throw error;
+    }
 
-     const created = await getFormById(db, accountId, id);
-     return created ? { ok: true, value: created } : { ok: false, reason: 'CONFLICT' };
-   }
+    const created = await getFormById(db, accountId, id);
+    return created ? { ok: true, value: created } : { ok: false, reason: 'CONFLICT' };
+  }
 
-   throw new Error('unreachable: form slug insert retries must return or rethrow');
+  throw new Error('unreachable: form slug insert retries must return or rethrow');
 }
 
 export async function updateForm(

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,3 +1,15 @@
+/**
+ * A tiny, dialect-agnostic forward migrator. Reads the numbered .sql files in
+ * migrations/<dialect>/ in filename order and applies each once, tracking
+ * applied names in a `_migrations` table. Identical semantics on SQLite and
+ * Postgres, with no drizzle-kit or engine binary needed for clone-and-run.
+ *
+ * Each file and its `_migrations` marker are applied inside the driver's own
+ * transaction, so a file that throws leaves neither its statements nor its
+ * marker behind. A fork whose migration drives its own transaction, or uses a
+ * statement that cannot run inside one, opts out of that and may partially
+ * apply. Nothing detects it; see SELF-HOSTING.md.
+ */
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -5,6 +17,7 @@ import { sql } from 'drizzle-orm';
 import type { Db } from './client';
 import { applyShortLinkFixups } from './short-links';
 
+// src/ at runtime (tsx) or dist/ after build: migrations live one level up.
 const MIGRATIONS_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
 const SQLITE_LOCK_RETRIES = 20;
 const SQLITE_LOCK_RETRY_DELAY_MS = 10;
@@ -17,6 +30,16 @@ function details(error: unknown): DriverError {
   return (error ?? {}) as DriverError;
 }
 
+/**
+ * The SQLite marker INSERT as one literal statement.
+ *
+ * The only unparameterized write in the migrator, and it has to be: the marker
+ * is written with `sqlite.exec` inside the same `sqlite.txn` as the migration
+ * file, so the two commit together, and `exec` takes SQL text with nowhere to
+ * bind a parameter. The Postgres path a few lines below binds normally. `file`
+ * is a filename read off the repo's own migrations directory, never user input,
+ * and the quote doubling is what keeps it a literal regardless.
+ */
 function markerSql(file: string): string {
   return `INSERT INTO _migrations (name, applied_at) VALUES ('${file.replaceAll("'", "''")}', ${Date.now()})`;
 }


### PR DESCRIPTION
Review findings from PR #135 (`develop` -> `main`), fixed so the release can merge.

## The blocker

`pnpm changeset status` exited non-zero, so the release could not version:

```
Found mixed changeset agents-nav-and-made-with-badge
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

`.changeset/config.json` ignores `@quill/web` and `@quill/api`, and changesets refuses any file naming both an ignored and a released package. Four did, two of them added in this release range. Naming the ignored packages bought nothing (they are never versioned and get no changelog), so they are dropped rather than split into a second file. `workspace-iam-id-urls` carried its `minor` on `@quill/web`; `@quill/shared` carries it now, because that work adds a `workspaceId` field to the workspace rows the shared contract describes.

Separately, `fix(engine): reject invalid single-choice arrays` (b7ae567) changes computed scores, and therefore which outcome a respondent lands in, with no changeset naming `@quill/engine`. It has one now.

## A document number could overwrite a real phone

`phoneFromQuestions` matched a bare "número" in the question text, so "Número de documento", "Número de identificación" and "Número de empleados" all counted as phone questions, and their answers pass the digit-count check on the answer side. The helper's own contract says the QUESTION must ask for a phone AND the ANSWER must parse as one; that alternative broke the first half.

Both consumers were affected: the value goes to the HubSpot `phone` property, whose upsert overwrites whatever was there, and it is also written into the submission answers as `@invitee_phone`. A "número" question now counts only when it says which number it wants. Three of the four new negative cases fail against the previous helper.

## Two regressions on the auth redirect path

**https downgraded to http.** `originFrom` gained a `Host`-only fallback returning `http://<host>`, ahead of everything: `requestOrigin` used to fall through to `new URL(req.url).origin`, which carries the request's real scheme, and that line can no longer be reached when a `Host` header exists. On a deployment forwarding `Host` and not `X-Forwarded-Proto`, with no `PUBLIC_APP_URL`, the OAuth `returnTo` and the logout landing resolved to http, and the post-auth `?session=` blob rides that redirect. The scheme now falls back in three steps: `X-Forwarded-Proto`, the request's own scheme, then plain http. Only the server action in `app/login/actions.ts` reaches the last one. Trust order is untouched. `request-origin.ts` had no spec; it has one now.

**Unvalidated IdP logout target.** `idpLogoutTarget` parsed the IAM's `logoutUrl` and handed it to `NextResponse.redirect` and the action `redirect()` with no check beyond "does `new URL` throw". Parseable is not navigable. The IAM is first-party and env-configured, so this is defence in depth rather than a live hole, but none of the existing cases pinned a hostile value. Only the scheme is checked: https, or http on localhost so the offline WorkOS harness keeps working. The host is deliberately not pinned to `IAM_BASE_URL`, because the logout URL points at the IdP and not at the IAM, so a same-host pin would break sign-out.

## Docs and housekeeping

`SELF-HOSTING.md` declared mixed outbox worker versions unsupported and mandated a stop/drain/start rollout. Production runs an HPA with rolling pods, so the document told operators the deploy they actually perform is unsupported. It is not: a pre-fence replica settles by row id, so during the rollout it can overwrite a settlement for a row a new replica reclaimed. That is a duplicate delivery and a `lease lost before settlement` warning, which is the at-least-once contract the outbox already advertises. What a rolling deploy gives up is the stronger guarantee the fence provides once every replica is upgraded, not correctness. Stop/drain/start stays the recommendation when downtime can be scheduled.

Plus: `migrate.ts` gets its header docblock back (the only place the two-dialect contract was stated) now also saying where per-file atomicity ends, `markerSql` says why it is the one unparameterized write, `revalidateWorkspace` loses a parameter it stopped using, and `createForm`'s three-space indentation is fixed.

## Gates

Run locally on Node 22 against a real Postgres 16:

| Gate | Result |
|---|---|
| `pnpm changeset status` | exit 0 |
| `pnpm typecheck` | 16/16 |
| `pnpm lint` | 0 errors, 2 pre-existing warnings |
| `pnpm test` | 16/16 tasks, all suites green |
| `pnpm build` | 9/9 |
| Postgres parity (`db:migrate`, `db:seed`, `--filter @quill/db test`) | 248/248 |
| `PUBLISH_GATE_LOCAL=1 scripts/publish-gate.sh` | PASSED, gitleaks clean |
| `scripts/dash-check.sh origin/main` | clean |
| DCO + commitlint | clean |

## Not included

Two review items are deliberately left out of a release fix branch. `claimDueOutbox` now issues up to 50 serial round trips per poll where it used to claim in one statement: correct, and the fresh-token-per-row requirement justifies it, but it wants a measurement against `OUTBOX_POLL_MS`, not a blind rewrite. And `outbox.worker.ts` encodes a test seam as `this.clock === Date.now`, which works but is easy to break; changing the worker's clock handling days before a release is the wrong trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)