### PR TITLE
feat(forms): let authors rename a form's public link

### DIFF
--- a/.changeset/editable-form-slug.md
+++ b/.changeset/editable-form-slug.md
@@ -16,9 +16,16 @@ Renaming does not break what is already published. The previous slug is retired
 into a new `form_alias` ledger rather than dropped, so a QR code on a printed
 flyer, a campaign email already sent, an iframe embedded on someone else's site
 and a CRM property holding the old URL all keep resolving. The public page then
-redirects the retired slug to the canonical one with a 308, forwarding the query
-string untouched so campaign parameters, `?embed=1` and `?step=N` survive the
-hop. One address, one set of analytics, one thing to index.
+sends the visitor on to the canonical URL, forwarding the query string untouched
+so campaign parameters, `?embed=1` and `?step=N` survive the hop.
+
+That redirect resolves in the browser rather than as a redirect status: Next 16
+has already begun streaming by the time the page resolves the form, so the
+response is a 200 carrying a client-side redirect. Alongside it the page emits
+`<link rel="canonical">` naming the current URL, which is what a crawler, a link
+checker or a social unfurler reads. A retired slug therefore still points
+everything at one address, but non-browser clients learn it from the tag, not
+from a status code.
 
 Details worth knowing:
 
@@ -28,10 +35,12 @@ Details worth knowing:
   gate as editing the form.
 - A `slug` sent to `PUT /v1/forms/{id}` now renames through the same path, so
   the field that predates this feature retires the old value too instead of
-  silently discarding it.
+  silently discarding it. Its own contract is unchanged: it still slugifies what
+  it is given rather than rejecting it, and it now applies before the rest of
+  the request so a refused slug leaves the form untouched.
 - New form slugs skip values another form retired. Handing one out would let a
   new form quietly inherit somebody else's already-published traffic.
-- A rename follows into `profile.formSlugs`, the by-slug selection on member
-  public pages. Without that the form would drop off those pages silently, since
-  they filter on the canonical slug.
+- Member public pages list forms by slug (`profile.formSlugs`). They now match a
+  form's retired slugs too, so a rename cannot drop a form off a page that
+  listed it, and pages saved before this heal themselves.
 - Deleting a form releases the slugs it retired.

--- a/.changeset/editable-form-slug.md
+++ b/.changeset/editable-form-slug.md
@@ -1,0 +1,37 @@
+---
+'@quill/engine': minor
+'@quill/types': minor
+'@quill/db': minor
+---
+
+A form's public link can be renamed, and the old link keeps working.
+
+The third segment of a form's URL (`/{accountCode}/{handle}/{slug}`) was
+written once, derived from the form's name at creation, with nothing in the
+product to change it. It is editable now, from a pencil beside Copy link in the
+builder's topbar: the one place that already shows the URL is where people go to
+change it.
+
+Renaming does not break what is already published. The previous slug is retired
+into a new `form_alias` ledger rather than dropped, so a QR code on a printed
+flyer, a campaign email already sent, an iframe embedded on someone else's site
+and a CRM property holding the old URL all keep resolving. The public page then
+redirects the retired slug to the canonical one with a 308, forwarding the query
+string untouched so campaign parameters, `?embed=1` and `?step=N` survive the
+hop. One address, one set of analytics, one thing to index.
+
+Details worth knowing:
+
+- `PUT /v1/forms/{id}/slug` is the new endpoint. 409 `SLUG_TAKEN` when another
+  form in the account holds the slug (as its current one OR as one it retired),
+  409 `SLUG_INVALID` on shape. Any member of the account may call it, the same
+  gate as editing the form.
+- A `slug` sent to `PUT /v1/forms/{id}` now renames through the same path, so
+  the field that predates this feature retires the old value too instead of
+  silently discarding it.
+- New form slugs skip values another form retired. Handing one out would let a
+  new form quietly inherit somebody else's already-published traffic.
+- A rename follows into `profile.formSlugs`, the by-slug selection on member
+  public pages. Without that the form would drop off those pages silently, since
+  they filter on the canonical slug.
+- Deleting a form releases the slugs it retired.

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -40,6 +40,7 @@ import {
   resetNotificationTemplate,
   saveDraftConfig,
   setFormSlug,
+  slugify,
   setMemberStatus,
   updateForm,
   upsertNotificationSetting,
@@ -481,18 +482,37 @@ export class AdminCrudController {
    * until POST /v1/forms/:id/publish copies the draft over it.
    *
    * `slug` is still accepted here (it always was, and an API-key integration may
-   * be sending it), but it is routed through `setFormSlug` rather than written
-   * as a column, so it retires the old value into the alias ledger exactly like
-   * the dedicated endpoint below. There is one rename implementation, not two.
+   * be sending it), routed through `setFormSlug` rather than written as a
+   * column, so it retires the old value into the alias ledger exactly like the
+   * dedicated endpoint below. There is one rename implementation, not two.
+   *
+   * Two details keep that from being a breaking change for callers who were
+   * already sending it:
+   *
+   * - **It runs FIRST.** A rename is the only part of this request that can be
+   *   refused, and the three writes are not a transaction. Applying `name`
+   *   first meant a 409 on the slug left the name committed and the config
+   *   draft silently dropped: a request that reported failure and changed the
+   *   form anyway. Refusing before anything is written restores the
+   *   all-or-nothing this endpoint had when the clash check lived inside
+   *   `updateForm`.
+   * - **It is slugified, not validated.** This path used to accept `Talk To
+   *   Sales` and store `talk-to-sales`; `setFormSlug` alone would now 409 it.
+   *   Tightening a field that has been lenient since it shipped would break the
+   *   integrations the field is being kept for, so the leniency stays here.
+   *   `PUT /v1/forms/:id/slug` is the strict one, because a person is typing
+   *   into it and silently rewriting what they typed is the worse answer there.
    */
   @Put('forms/:id')
   async updateForm(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
     const { config, slug, ...meta } = parse(formInputSchema.partial(), body);
-    let updated = unwrapCrud(await updateForm(this.db, p.accountId, id, meta));
     if (slug !== undefined) {
-      updated = unwrapCrud(await setFormSlug(this.db, p.accountId, id, slug));
+      unwrapCrud(await setFormSlug(this.db, p.accountId, id, slugify(slug)));
     }
+    // Returns the row even with nothing to patch, so it stays the single read
+    // that answers NOT_FOUND for this route.
+    let updated = unwrapCrud(await updateForm(this.db, p.accountId, id, meta));
     if (config !== undefined) {
       updated = unwrapCrud(await saveDraftConfig(this.db, p.accountId, id, config));
     }

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -39,6 +39,7 @@ import {
   removeMember,
   resetNotificationTemplate,
   saveDraftConfig,
+  setFormSlug,
   setMemberStatus,
   updateForm,
   upsertNotificationSetting,
@@ -57,6 +58,7 @@ import {
   attributionEventProps,
   attributionSchema,
   formInputSchema,
+  formSlugInputSchema,
   hasExtraHubspotDestination,
   maskConfigSecrets,
   ONE_HUBSPOT_DESTINATION_MESSAGE,
@@ -477,16 +479,48 @@ export class AdminCrudController {
    * nothing to stage); `config` is stored as an UNPUBLISHED draft via
    * `saveDraftConfig` — the live config the public renderer serves is untouched
    * until POST /v1/forms/:id/publish copies the draft over it.
+   *
+   * `slug` is still accepted here (it always was, and an API-key integration may
+   * be sending it), but it is routed through `setFormSlug` rather than written
+   * as a column, so it retires the old value into the alias ledger exactly like
+   * the dedicated endpoint below. There is one rename implementation, not two.
    */
   @Put('forms/:id')
   async updateForm(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
-    const { config, ...meta } = parse(formInputSchema.partial(), body);
+    const { config, slug, ...meta } = parse(formInputSchema.partial(), body);
     let updated = unwrapCrud(await updateForm(this.db, p.accountId, id, meta));
+    if (slug !== undefined) {
+      updated = unwrapCrud(await setFormSlug(this.db, p.accountId, id, slug));
+    }
     if (config !== undefined) {
       updated = unwrapCrud(await saveDraftConfig(this.db, p.accountId, id, config));
     }
     return maskForm(updated);
+  }
+
+  /**
+   * Rename a form's public URL.
+   *
+   * Its own route rather than a field on the autosave above, because the two are
+   * different acts. `PUT /v1/forms/:id` fires on a debounce while somebody types
+   * in the builder; this one runs when they deliberately confirm a new link, and
+   * it has a consequence a keystroke must never trigger: the previous slug is
+   * retired into `form_alias`, where it keeps answering forever.
+   *
+   * Same role gate as editing the form: any resolved member of the account. A
+   * member who can already rewrite every question and publish the result
+   * controls what that URL serves, so gating only the URL would add friction
+   * without adding safety.
+   *
+   * 409 on both failure modes, distinguished by `error`: SLUG_TAKEN (another
+   * form in this account holds it, live or retired) and SLUG_INVALID (shape).
+   */
+  @Put('forms/:id/slug')
+  async updateFormSlug(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const { slug } = parse(formSlugInputSchema, body);
+    return maskForm(unwrapCrud(await setFormSlug(this.db, p.accountId, id, slug)));
   }
 
   @Post('forms/:id/duplicate')

--- a/apps/api/src/form-slug.controller.spec.ts
+++ b/apps/api/src/form-slug.controller.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * PUT /v1/forms/:id/slug through the REAL admin controller on in-memory SQLite
+ * (same harness as draft-publish.spec.ts).
+ *
+ * The data layer's own guarantees are covered in `packages/db/src/form-slug.spec.ts`.
+ * What this pins is the HTTP contract the builder's rename dialog is written
+ * against: a 409 whose `error` says WHICH refusal it was, so the dialog can put
+ * a specific sentence on screen instead of a generic failure, and the promise
+ * that the legacy `slug` field on the plain form PUT retires the old value too
+ * rather than quietly dropping it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { createDb, migrate, seed, getPublishedForm, sql, type Db } from '@quill/db';
+import { AdminCrudController } from './admin-crud.controller';
+import { AdminService } from './admin.service';
+import { AuthService } from './auth.service';
+import { LocalAuthProvider } from './auth.provider';
+import type { ReqLike } from './auth.provider';
+
+let db: Db;
+let controller: AdminCrudController;
+let formId: string;
+
+/** No identity → local provider resolves the seeded demo owner. */
+const asOwner = (): ReqLike => ({ headers: {} });
+
+/** The `error` code carried by a 409 body, for the dialog to branch on. */
+async function conflictCode(run: Promise<unknown>): Promise<string> {
+  try {
+    await run;
+  } catch (e) {
+    if (e instanceof ConflictException) {
+      return (e.getResponse() as { error?: string }).error ?? '';
+    }
+    throw e;
+  }
+  throw new Error('expected a ConflictException');
+}
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db); // account "acme" + demo form "lead-qualifier"
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: 'test',
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
+  });
+  const auth = new AuthService(db, provider);
+  const admin = new AdminService(db);
+  controller = new AdminCrudController(db, auth, admin, {} as never, {} as never);
+
+  const row = await db.get<{ id: string }>(sql`SELECT id FROM form WHERE slug = 'lead-qualifier' LIMIT 1`);
+  formId = row!.id;
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe('PUT /v1/forms/:id/slug', () => {
+  it('renames the live form and keeps the previous link resolving', async () => {
+    const updated = await controller.updateFormSlug(asOwner(), formId, { slug: 'talk-to-sales' });
+    expect(updated.slug).toBe('talk-to-sales');
+
+    expect((await getPublishedForm(db, 'acme', 'talk-to-sales'))!.id).toBe(formId);
+    // The old link still answers, and reports the canonical slug so the public
+    // page knows to 308 rather than serve the form at two addresses.
+    expect((await getPublishedForm(db, 'acme', 'lead-qualifier'))!.slug).toBe('talk-to-sales');
+  });
+
+  it('409s with SLUG_TAKEN when another form already holds it', async () => {
+    const other = await controller.createForm(asOwner(), { name: 'Pricing' });
+
+    expect(await conflictCode(controller.updateFormSlug(asOwner(), formId, { slug: other.slug }))).toBe(
+      'SLUG_TAKEN',
+    );
+  });
+
+  it('409s with SLUG_INVALID on a malformed slug', async () => {
+    expect(await conflictCode(controller.updateFormSlug(asOwner(), formId, { slug: 'Talk To Sales' }))).toBe(
+      'SLUG_INVALID',
+    );
+  });
+
+  it('404s for a form id this account does not own', async () => {
+    await expect(controller.updateFormSlug(asOwner(), 'no-such-form', { slug: 'anything' })).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('rejects an empty body before it reaches the data layer', async () => {
+    await expect(controller.updateFormSlug(asOwner(), formId, {})).rejects.toBeTruthy();
+    // The form is untouched: a 400 must not be a partial rename.
+    expect((await controller.getForm(asOwner(), formId)).slug).toBe('lead-qualifier');
+  });
+
+  it('never leaves a webhook secret in the response', async () => {
+    // Every other form-returning route masks; this one returns a form too, so
+    // it has to be on the same list rather than the one exception nobody checks.
+    const updated = await controller.updateFormSlug(asOwner(), formId, { slug: 'masked-check' });
+    expect(JSON.stringify(updated)).not.toContain('"secret":"');
+  });
+});
+
+describe('PUT /v1/forms/:id with a `slug` field', () => {
+  it('retires the previous slug exactly as the dedicated route does', async () => {
+    // This field predates the rename feature, so an API-key integration may
+    // still be sending it. It must not be the one door that breaks links.
+    await controller.updateForm(asOwner(), formId, { slug: 'legacy-path' });
+
+    expect((await getPublishedForm(db, 'acme', 'legacy-path'))!.id).toBe(formId);
+    expect((await getPublishedForm(db, 'acme', 'lead-qualifier'))!.slug).toBe('legacy-path');
+  });
+
+  it('applies a name and a slug in the same call', async () => {
+    const updated = await controller.updateForm(asOwner(), formId, { name: 'Talk to sales', slug: 'talk-to-sales' });
+
+    expect(updated).toMatchObject({ name: 'Talk to sales', slug: 'talk-to-sales' });
+  });
+});

--- a/apps/api/src/form-slug.controller.spec.ts
+++ b/apps/api/src/form-slug.controller.spec.ts
@@ -68,7 +68,7 @@ describe('PUT /v1/forms/:id/slug', () => {
 
     expect((await getPublishedForm(db, 'acme', 'talk-to-sales'))!.id).toBe(formId);
     // The old link still answers, and reports the canonical slug so the public
-    // page knows to 308 rather than serve the form at two addresses.
+    // page knows to send the visitor on rather than serve two addresses.
     expect((await getPublishedForm(db, 'acme', 'lead-qualifier'))!.slug).toBe('talk-to-sales');
   });
 
@@ -120,5 +120,40 @@ describe('PUT /v1/forms/:id with a `slug` field', () => {
     const updated = await controller.updateForm(asOwner(), formId, { name: 'Talk to sales', slug: 'talk-to-sales' });
 
     expect(updated).toMatchObject({ name: 'Talk to sales', slug: 'talk-to-sales' });
+  });
+
+  it('still SLUGIFIES rather than rejecting, unlike the dedicated route', async () => {
+    // The lenient contract this endpoint shipped with. Tightening it would
+    // break the integrations the field is being kept for, and the whole point
+    // of keeping it is that they do not have to change.
+    const updated = await controller.updateForm(asOwner(), formId, { slug: 'Talk To Sales' });
+    expect(updated.slug).toBe('talk-to-sales');
+
+    // The dedicated route, which a person types into, refuses the same value.
+    expect(await conflictCode(controller.updateFormSlug(asOwner(), formId, { slug: 'Talk To Sales' }))).toBe(
+      'SLUG_INVALID',
+    );
+  });
+
+  it('leaves name AND config untouched when the slug is refused', async () => {
+    // The three writes are not a transaction, so the refusable one runs first.
+    // Applying `name` before the slug clash meant a 409 that renamed the form
+    // and silently dropped the config draft: a request that reports failure and
+    // changes the form anyway.
+    const other = await controller.createForm(asOwner(), { name: 'Pricing' });
+    const before = await controller.getForm(asOwner(), formId);
+
+    await expect(
+      controller.updateForm(asOwner(), formId, {
+        name: 'Should not stick',
+        slug: other.slug,
+        config: { version: 1, steps: [{ key: 'x', type: 'text', question: 'Should not stick?' }] },
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    const after = await controller.getForm(asOwner(), formId);
+    expect(after.name).toBe(before.name);
+    expect(after.slug).toBe(before.slug);
+    expect(after.draftConfig ?? null).toEqual(before.draftConfig ?? null);
   });
 });

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -66,7 +66,7 @@ export const openapiSpec = {
       put: {
         summary: 'Update a form (host)',
         description:
-          'name/slug apply to the live form immediately; config is stored as an unpublished draft: publish it via POST /v1/forms/{id}/publish. The public renderer keeps serving the previously published config until then. A slug sent here is renamed exactly as PUT /v1/forms/{id}/slug does it, retiring the previous one so shared links keep working.',
+          'name/slug apply to the live form immediately; config is stored as an unpublished draft: publish it via POST /v1/forms/{id}/publish. The public renderer keeps serving the previously published config until then. A slug sent here is renamed through the same code as PUT /v1/forms/{id}/slug, retiring the previous one so shared links keep working, but keeps this endpoint\u2019s older, lenient contract: the value is slugified rather than rejected. It is applied before name and config, so a refused slug leaves the form untouched.',
         security: [{ hostSession: [] }],
         responses: { '200': { description: 'Updated (config changes staged as a draft)' } },
       },
@@ -76,7 +76,7 @@ export const openapiSpec = {
       put: {
         summary: "Rename a form's public URL (host)",
         description:
-          'Body { slug }. Applies to the live form immediately. The previous slug is retired, not dropped: it keeps resolving and the public page redirects it to the new one (308), so links already shared stay valid. 409 SLUG_TAKEN when another form in the account holds it (as its current slug or as one it retired), 409 SLUG_INVALID when the shape is wrong (lowercase letters, digits and single hyphens, up to 80 characters).',
+          'Body { slug }. Applies to the live form immediately. The previous slug is retired, not dropped: it keeps resolving, and the public page sends visitors on to the new URL (a client-side redirect, plus a canonical link tag for non-browser clients), so links already shared stay valid. 409 SLUG_TAKEN when another form in the account holds it (as its current slug or as one it retired), 409 SLUG_INVALID when the shape is wrong (lowercase letters, digits and single hyphens, up to 80 characters).',
         security: [{ hostSession: [] }],
         responses: {
           '200': { description: 'Renamed' },

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -66,11 +66,24 @@ export const openapiSpec = {
       put: {
         summary: 'Update a form (host)',
         description:
-          'name/slug apply to the live form immediately; config is stored as an unpublished draft: publish it via POST /v1/forms/{id}/publish. The public renderer keeps serving the previously published config until then.',
+          'name/slug apply to the live form immediately; config is stored as an unpublished draft: publish it via POST /v1/forms/{id}/publish. The public renderer keeps serving the previously published config until then. A slug sent here is renamed exactly as PUT /v1/forms/{id}/slug does it, retiring the previous one so shared links keep working.',
         security: [{ hostSession: [] }],
         responses: { '200': { description: 'Updated (config changes staged as a draft)' } },
       },
       delete: { summary: 'Delete a form (host)', security: [{ hostSession: [] }], responses: { '204': { description: 'Deleted' } } },
+    },
+    '/v1/forms/{id}/slug': {
+      put: {
+        summary: "Rename a form's public URL (host)",
+        description:
+          'Body { slug }. Applies to the live form immediately. The previous slug is retired, not dropped: it keeps resolving and the public page redirects it to the new one (308), so links already shared stay valid. 409 SLUG_TAKEN when another form in the account holds it (as its current slug or as one it retired), 409 SLUG_INVALID when the shape is wrong (lowercase letters, digits and single hyphens, up to 80 characters).',
+        security: [{ hostSession: [] }],
+        responses: {
+          '200': { description: 'Renamed' },
+          '404': { description: 'No such form in this account' },
+          '409': { description: 'SLUG_TAKEN or SLUG_INVALID' },
+        },
+      },
     },
     '/v1/forms/{id}/publish': {
       post: {

--- a/apps/api/src/public-profile.spec.ts
+++ b/apps/api/src/public-profile.spec.ts
@@ -14,6 +14,8 @@
  *   3. only name and slug cross the boundary — never a form's steps, its
  *      destination config, or a draft.
  *   4. a handle is matched case-insensitively (URLs get typed by hand).
+ *   5. a selection made before the author renamed a form's link still lists
+ *      that form (see 0017).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
@@ -21,6 +23,7 @@ import {
   migrate,
   seed,
   getAccountByCode,
+  setFormSlug,
   setMemberProfile,
   sql,
   type Db,
@@ -91,6 +94,28 @@ describe('public member profile', () => {
     await enable();
     const p = await svc.publicProfile(accountCode, handle);
     expect(p!.forms.length).toBeGreaterThan(0);
+  });
+
+  it('keeps listing a form whose link was renamed after it was selected', async () => {
+    // `formSlugs` stores whatever the slug was when the author picked the form,
+    // and nothing rewrites those entries on the read path. Matching only the
+    // LIVE slug would drop the form off this page the moment somebody renamed
+    // its link, silently, with nothing on screen to explain it. Resolving the
+    // form's retired slugs here instead of rewriting every stored profile also
+    // means no read-modify-write on the profile blob can lose the fix, and
+    // pages saved before this shipped heal themselves.
+    const form = await db.get<{ id: string; slug: string }>(
+      sql`SELECT id, slug FROM form WHERE account_id = ${accountId} LIMIT 1`,
+    );
+    await enable({ formSlugs: [String(form!.slug)] });
+    expect((await svc.publicProfile(accountCode, handle))!.forms).toHaveLength(1);
+
+    await setFormSlug(db, accountId, String(form!.id), 'renamed-after-selection');
+
+    const after = await svc.publicProfile(accountCode, handle);
+    expect(after!.forms).toHaveLength(1);
+    // Listed under its CURRENT slug, so the link on the page is the live one.
+    expect(after!.forms[0]!.slug).toBe('renamed-after-selection');
   });
 
   it('lists NONE for an empty formSlugs — not everything', async () => {

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -74,8 +74,20 @@ export class SubmissionService {
     // must stay distinct, or unlisting everything would silently restore
     // everything.
     const allowed = profile.formSlugs;
+    // Matched against the form's retired slugs as well as its current one.
+    // `formSlugs` records whatever the slug was when the author picked the
+    // form, so comparing only against the live slug would drop a form off this
+    // page the moment somebody renamed its link, silently and with nothing on
+    // screen to explain it. Resolving here rather than rewriting every stored
+    // profile on rename also means there is no read-modify-write on the profile
+    // blob to lose a race with, and profiles saved before this shipped heal
+    // themselves.
     const forms =
-      allowed == null ? published : published.filter((f) => allowed.includes(f.slug));
+      allowed == null
+        ? published
+        : published.filter(
+            (f) => allowed.includes(f.slug) || f.retiredSlugs.some((old) => allowed.includes(old)),
+          );
 
     return {
       handle: member.handle ?? handle,

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -47,14 +47,25 @@ export async function generateMetadata({
   return {
     title,
     description,
-    // The form's ONE address, resolved against `metadataBase` in the root
-    // layout. On a retired slug this is the ONLY signal a crawler, a link
-    // checker or a social unfurler gets that the URL they fetched is not the
-    // canonical one, since the redirect they would otherwise follow is
-    // client-side. It carries no query string on purpose: a canonical URL
-    // naming `?utm_source=…` would ask crawlers to index a campaign's copy of
-    // the page as the original.
-    alternates: { canonical: `/${accountCode}/${handle}/${form.slug}` },
+    // Emitted ONLY when the requested slug is a retired one, where it is the
+    // only signal a crawler, a link checker or a social unfurler gets that the
+    // URL it fetched is not the current one (the redirect beside it is
+    // client-side). No query string on it: a canonical naming `?utm_source=…`
+    // would ask crawlers to index a campaign's copy of the page as the original.
+    //
+    // NOT emitted on a normal request, which would be the obvious thing to do
+    // and would be actively harmful. `handle` is decorative in a form URL: the
+    // lookup below is `getPublicForm(accountCode, slug)` and nothing validates
+    // the middle segment, so `/acme/anything-at-all/my-form` serves the form
+    // today. A self-referential canonical would then mint a fresh "canonical"
+    // URL for every spelling anyone tries, which is the opposite of the tag's
+    // job. There is no value to put there instead, either: a form belongs to an
+    // account, not to a member, and the builder itself composes this path from
+    // whichever member is LOOKING at it. So the tag only ever corrects the one
+    // segment this page can actually speak to, and forwards the rest.
+    ...(form.slug === slug
+      ? {}
+      : { alternates: { canonical: `/${accountCode}/${handle}/${form.slug}` } }),
     openGraph: { title, description, type: 'website', ...(images ? { images } : {}) },
     twitter: {
       // A generated 1200×630 card deserves the large format; only a form with

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({
     // segment this page can actually speak to, and forwards the rest.
     ...(form.slug === slug
       ? {}
-      : { alternates: { canonical: `/${accountCode}/${handle}/${form.slug}` } }),
+      : { alternates: { canonical: canonicalPath(accountCode, handle, form.slug) } }),
     openGraph: { title, description, type: 'website', ...(images ? { images } : {}) },
     twitter: {
       // A generated 1200×630 card deserves the large format; only a form with
@@ -119,7 +119,23 @@ function redirectToCanonical(
   query: Record<string, string | string[] | undefined>,
 ): void {
   if (canonical === route.slug) return;
-  permanentRedirect(`/${route.accountCode}/${route.handle}/${canonical}${searchSuffix(query)}`);
+  permanentRedirect(`${canonicalPath(route.accountCode, route.handle, canonical)}${searchSuffix(query)}`);
+}
+
+/**
+ * Build a public form path from segments that arrived in the URL.
+ *
+ * `encodeURIComponent` on each of them, because Next hands over the DECODED
+ * value and two of the three are effectively free text: `handle` is never
+ * validated (nothing routes on it, see the note in `generateMetadata`) and
+ * `accountCode` only has to resolve to some account. A `handle` of `%0d%0a`
+ * therefore arrives as a real CRLF, and interpolating that straight into a
+ * `Location` header makes Node reject the response with ERR_INVALID_CHAR: a
+ * 500 that any visitor can trigger by editing the address bar. The slug is
+ * already `[a-z0-9-]` by the time it gets here and passes through unchanged.
+ */
+function canonicalPath(accountCode: string, handle: string, slug: string): string {
+  return `/${encodeURIComponent(accountCode)}/${encodeURIComponent(handle)}/${encodeURIComponent(slug)}`;
 }
 
 // Public form page. The Server Component fetches the published config; the

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 import { getPublicForm } from '@/lib/api';
 import { publicLocale } from '@/lib/locale';
 import { getMessages, t } from '@quill/shared';
@@ -18,11 +18,20 @@ import { VerticalFormRenderer } from './vertical-form-renderer';
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ accountCode: string; slug: string; lang?: string }>;
+  params: Promise<{ accountCode: string; handle: string; slug: string; lang?: string }>;
 }): Promise<Metadata> {
-  const { accountCode, slug } = await params;
+  const { accountCode, handle, slug } = await params;
   const form = await getPublicForm(accountCode, slug);
   if (!form) return {};
+  // NOTE: this function deliberately does NOT redirect, even though it runs
+  // before the page and looks like the earlier, better place to do it. Next 16
+  // has already begun streaming by the time either one resolves, so a redirect
+  // thrown here comes out exactly as soft as the one in the page body: an RSC
+  // payload plus a `<meta http-equiv="refresh">`, answered with 200. It would
+  // buy nothing, and it would cost the tag below, because throwing means never
+  // returning metadata at all. So the redirect stays in the page (for people,
+  // whose browsers follow it) and this function keeps naming the canonical URL
+  // (for everything that does not run scripts).
   const locale = await publicLocale();
   // The author-set public title wins over the private dashboard name.
   const title = publicTitle(form.config, form.name);
@@ -38,6 +47,14 @@ export async function generateMetadata({
   return {
     title,
     description,
+    // The form's ONE address, resolved against `metadataBase` in the root
+    // layout. On a retired slug this is the ONLY signal a crawler, a link
+    // checker or a social unfurler gets that the URL they fetched is not the
+    // canonical one, since the redirect they would otherwise follow is
+    // client-side. It carries no query string on purpose: a canonical URL
+    // naming `?utm_source=…` would ask crawlers to index a campaign's copy of
+    // the page as the original.
+    alternates: { canonical: `/${accountCode}/${handle}/${form.slug}` },
     openGraph: { title, description, type: 'website', ...(images ? { images } : {}) },
     twitter: {
       // A generated 1200×630 card deserves the large format; only a form with
@@ -50,6 +67,50 @@ export async function generateMetadata({
   };
 }
 
+/**
+ * Re-serialize the query string for the canonical redirect, verbatim.
+ *
+ * Every parameter is forwarded, not a known subset, and this is the whole point
+ * of the function. Dropping the query on OUR OWN redirect is precisely how the
+ * platform lost campaign attribution once already: the UTMs never reached the
+ * page they were pointed at, and the identity provider got the blame for weeks.
+ * A renamed slug is the same trap with a fresh coat of paint, and it also
+ * carries `?embed=1` (an iframe on someone else's site) and `?step=N` (a
+ * half-finished form somebody bookmarked).
+ *
+ * Repeated keys are appended rather than collapsed: Next hands those over as an
+ * array, and `?tag=a&tag=b` must arrive as it left.
+ */
+function searchSuffix(query: Record<string, string | string[] | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) for (const one of value) params.append(key, one);
+    else if (value !== undefined) params.append(key, value);
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * Send a retired slug to the form's current URL, or return and let the caller
+ * carry on. `canonical` is the slug the API reports for the form itself, which
+ * differs from the requested one only when the alias ledger resolved it (the
+ * author renamed the link; see migration 0017).
+ *
+ * `accountCode` and `handle` are forwarded exactly as they arrived. A retired
+ * ACCOUNT code resolves transparently today, with no redirect anywhere, and
+ * quietly rewriting it here would be a second behaviour change smuggled in
+ * beside this one.
+ */
+function redirectToCanonical(
+  route: { accountCode: string; handle: string; slug: string },
+  canonical: string,
+  query: Record<string, string | string[] | undefined>,
+): void {
+  if (canonical === route.slug) return;
+  permanentRedirect(`/${route.accountCode}/${route.handle}/${canonical}${searchSuffix(query)}`);
+}
+
 // Public form page. The Server Component fetches the published config; the
 // interactive multi-step flow is a client island (FormRenderer).
 export default async function PublicFormPage({
@@ -57,17 +118,28 @@ export default async function PublicFormPage({
   searchParams,
 }: {
   params: Promise<{ accountCode: string; handle: string; slug: string }>;
-  searchParams: Promise<{ lang?: string; embed?: string }>;
+  // Typed wide, not as { lang, embed }: the redirect below has to forward
+  // EVERY parameter it was given, including ones this page never reads.
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const { accountCode, slug } = await params;
-  const { lang, embed } = await searchParams;
+  const { accountCode, handle, slug } = await params;
+  const query = await searchParams;
+  const lang = typeof query.lang === 'string' ? query.lang : undefined;
   const locale = await publicLocale(lang);
   // Embedded render (?embed=1): same form, sized by its content instead of the
   // viewport, reporting its height to the host page's embed.js (iframe embeds).
-  const embedded = embed === '1';
+  const embedded = query.embed === '1';
 
   const form = await getPublicForm(accountCode, slug);
   if (!form) notFound();
+
+  // Reached through a slug this form USED to answer to: the author renamed the
+  // link and the alias ledger resolved the old one (see migration 0017). Move
+  // the visitor onto the current URL rather than leaving the form living at two
+  // addresses. Next resolves this on the client (see the note in
+  // `generateMetadata`), so it moves a browser and nothing else; the canonical
+  // tag is what speaks to everything else.
+  redirectToCanonical({ accountCode, handle, slug }, form.slug, query);
 
   // Third-party tags for the PUBLIC page only (admin renders none): per-form
   // config.tracking over NEXT_PUBLIC_* env defaults; nothing configured

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect, unstable_rethrow } from 'next/navigation';
-import { adminApi } from '@/lib/admin-api';
+import { adminApi, ApiError } from '@/lib/admin-api';
 
 /** Create a form and jump straight into its editor. */
 export async function createFormAction(formData: FormData): Promise<void> {
@@ -74,5 +74,48 @@ export async function publishFormAction(id: string): Promise<{ ok: boolean; mess
       ok: false,
       message: e instanceof Error ? e.message : 'Failed to publish.',
     };
+  }
+}
+
+/**
+ * Rename the form's public URL.
+ *
+ * Its own action rather than a field on `saveFormAction`, mirroring the API
+ * split: autosave fires on a debounce while somebody types, and retiring a
+ * public slug is a confirmed act, not a keystroke.
+ *
+ * Returns the new path on success so the editor can retarget Copy link, Embed,
+ * Open form and the prefill example WITHOUT a reload. `revalidatePath` alone
+ * cannot do that: the client components hold the old path in props until the
+ * server component re-renders, and the person who just renamed the link is the
+ * single most likely person to copy it in the next two seconds.
+ *
+ * The two refusals come back as codes, not prose, so the dialog can say
+ * something specific in the reader's own language.
+ */
+export async function renameFormSlugAction(
+  id: string,
+  slug: string,
+): Promise<
+  | { ok: true; slug: string; publicPath: string }
+  | { ok: false; code: 'SLUG_TAKEN' | 'SLUG_INVALID' | 'UNKNOWN'; message?: string }
+> {
+  try {
+    const [form, me] = await Promise.all([adminApi.setFormSlug(id, slug), adminApi.me()]);
+    revalidatePath(`/admin/forms/${id}/edit`);
+    revalidatePath('/admin/forms');
+    revalidatePath('/admin');
+    return {
+      ok: true,
+      slug: form.slug,
+      publicPath: `/${me.accountCode}/${me.handle ?? 'me'}/${form.slug}`,
+    };
+  } catch (e) {
+    unstable_rethrow(e);
+    const code =
+      e instanceof ApiError && (e.code === 'SLUG_TAKEN' || e.code === 'SLUG_INVALID')
+        ? e.code
+        : 'UNKNOWN';
+    return { ok: false, code, message: e instanceof Error ? e.message : undefined };
   }
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -60,6 +60,7 @@ export interface BuilderMessages {
     renameCancel: string;
     renameTaken: string;
     renameInvalid: string;
+    renameTooLong: string;
     renameFailed: string;
     /** Accessible name for the per-tab contextual toolbar (topbar row 2). */
     toolbar: string;
@@ -549,6 +550,7 @@ const en: BuilderMessages = {
     renameCancel: 'Cancel',
     renameTaken: 'Another form in this workspace is already using that link.',
     renameInvalid: 'Use lowercase letters, numbers and hyphens, up to 80 characters.',
+    renameTooLong: 'That link is too long. Keep it under 80 characters.',
     renameFailed: 'Could not save the link. Try again.',
     toolbar: 'Tools',
   },
@@ -953,6 +955,7 @@ const es: BuilderMessages = {
     renameCancel: 'Cancelar',
     renameTaken: 'Otro formulario de este espacio ya usa ese enlace.',
     renameInvalid: 'Usa minúsculas, números y guiones, hasta 80 caracteres.',
+    renameTooLong: 'Ese enlace es demasiado largo. Deja menos de 80 caracteres.',
     renameFailed: 'No se pudo guardar el enlace. Inténtalo de nuevo.',
     toolbar: 'Herramientas',
   },

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -47,6 +47,20 @@ export interface BuilderMessages {
     embedCopied: string;
     copied: string;
     openForm: string;
+    /**
+     * Rename-the-public-link dialog. Its own control beside Copy link, because
+     * the link is the thing being changed and this is where people look at it.
+     */
+    renameLink: string;
+    renameTitle: string;
+    renameIntro: string;
+    renameLabel: string;
+    renameSave: string;
+    renameSaving: string;
+    renameCancel: string;
+    renameTaken: string;
+    renameInvalid: string;
+    renameFailed: string;
     /** Accessible name for the per-tab contextual toolbar (topbar row 2). */
     toolbar: string;
   };
@@ -525,6 +539,17 @@ const en: BuilderMessages = {
     embedCopied: 'Copied',
     copied: 'Copied',
     openForm: 'Open form',
+    renameLink: 'Edit link',
+    renameTitle: 'Edit this form\u2019s link',
+    renameIntro:
+      'Links you already shared keep working: they redirect here. Printed QR codes, campaign emails and embeds on other sites are safe.',
+    renameLabel: 'Link',
+    renameSave: 'Save link',
+    renameSaving: 'Saving',
+    renameCancel: 'Cancel',
+    renameTaken: 'Another form in this workspace is already using that link.',
+    renameInvalid: 'Use lowercase letters, numbers and hyphens, up to 80 characters.',
+    renameFailed: 'Could not save the link. Try again.',
     toolbar: 'Tools',
   },
   logicDialog: {
@@ -918,6 +943,17 @@ const es: BuilderMessages = {
     embedCopied: 'Copiado',
     copied: 'Copiado',
     openForm: 'Abrir formulario',
+    renameLink: 'Editar enlace',
+    renameTitle: 'Edita el enlace de este formulario',
+    renameIntro:
+      'Los enlaces que ya compartiste siguen funcionando: redirigen aquí. Los códigos QR impresos, los correos de campaña y los formularios insertados en otros sitios no se rompen.',
+    renameLabel: 'Enlace',
+    renameSave: 'Guardar enlace',
+    renameSaving: 'Guardando',
+    renameCancel: 'Cancelar',
+    renameTaken: 'Otro formulario de este espacio ya usa ese enlace.',
+    renameInvalid: 'Usa minúsculas, números y guiones, hasta 80 caracteres.',
+    renameFailed: 'No se pudo guardar el enlace. Inténtalo de nuevo.',
     toolbar: 'Herramientas',
   },
   logicDialog: {

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -124,7 +124,7 @@ export function FormEditor({
   id,
   initialName,
   initialConfig,
-  publicPath,
+  publicPath: initialPublicPath,
   locale,
   m,
   initialHasDraft = false,
@@ -144,6 +144,18 @@ export function FormEditor({
   const bm = getBuilderMessages(locale);
   const searchParams = useSearchParams();
   const [name, setName] = useState(initialName);
+  /**
+   * The form's public path, as STATE rather than the prop it arrives as.
+   *
+   * The slug in it is editable now (see `LinkActions`), and everything the
+   * builder derives from this path is a client component holding it in props:
+   * the topbar's Copy link / Embed / Open form, the design panel's preview, the
+   * prefill example URL in question settings. A server `revalidatePath` cannot
+   * reach any of them mid-session, so a rename would leave all four pointing at
+   * a URL that now only 308-redirects, starting with the Copy button the person
+   * is most likely to press next.
+   */
+  const [publicPath, setPublicPath] = useState(initialPublicPath);
   // The builder has ONE reveal model: a `reveal` step in the list. A form
   // authored under the old form-level reveal (Design-tab copy + a draggable
   // position marker) is folded into that shape the moment it opens, so the two
@@ -634,7 +646,9 @@ export function FormEditor({
         <div className="flex min-w-0 items-center justify-end gap-2">
           <LinkActions
             publicPath={publicPath}
+            formId={id}
             formName={name}
+            onRenamed={setPublicPath}
             labels={{
               copyLink: bm.shell.copyLink,
               copied: bm.shell.copied,
@@ -644,6 +658,16 @@ export function FormEditor({
               embedIntro: bm.shell.embedIntro,
               embedCopy: bm.shell.embedCopy,
               embedCopied: bm.shell.embedCopied,
+              renameLink: bm.shell.renameLink,
+              renameTitle: bm.shell.renameTitle,
+              renameIntro: bm.shell.renameIntro,
+              renameLabel: bm.shell.renameLabel,
+              renameSave: bm.shell.renameSave,
+              renameSaving: bm.shell.renameSaving,
+              renameCancel: bm.shell.renameCancel,
+              renameTaken: bm.shell.renameTaken,
+              renameInvalid: bm.shell.renameInvalid,
+              renameFailed: bm.shell.renameFailed,
             }}
           />
           <PublishButton

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -667,6 +667,7 @@ export function FormEditor({
               renameCancel: bm.shell.renameCancel,
               renameTaken: bm.shell.renameTaken,
               renameInvalid: bm.shell.renameInvalid,
+              renameTooLong: bm.shell.renameTooLong,
               renameFailed: bm.shell.renameFailed,
             }}
           />

--- a/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
@@ -64,12 +64,14 @@ export function LinkActions({
     renameCancel: string;
     renameTaken: string;
     renameInvalid: string;
+    renameTooLong: string;
     renameFailed: string;
   };
 }) {
   const [copied, setCopied] = useState(false);
   const [embedOpen, setEmbedOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
+  const [snippetCopied, setSnippetCopied] = useState(false);
   const [draft, setDraft] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -151,7 +153,6 @@ export function LinkActions({
       `<script src="${window.location.origin}/embed.js" async></script>`,
     ].join('\n');
 
-  const [snippetCopied, setSnippetCopied] = useState(false);
   const copySnippet = async () => {
     try {
       await navigator.clipboard.writeText(buildSnippet());
@@ -212,7 +213,16 @@ export function LinkActions({
 
       <Modal
         open={renameOpen}
-        onClose={() => setRenameOpen(false)}
+        // Escape and a backdrop click are dismissals too, and Cancel is already
+        // disabled while saving. Without the same guard here, dismissing mid
+        // request lets the rename land server-side while `onRenamed` never
+        // fires, so Copy link, Embed, Open form and the prefill example keep
+        // the previous path for the rest of the session. That is precisely the
+        // bug `publicPath`-as-state exists to prevent, reintroduced through the
+        // one exit the button does not cover.
+        onClose={() => {
+          if (!pending) setRenameOpen(false);
+        }}
         title={labels.renameTitle}
         labelId="rename-form-link-title"
       >
@@ -257,7 +267,7 @@ export function LinkActions({
                 once there is something to be wrong about. */}
             {error || (draft.length > 0 && shapeIssue !== null) ? (
               <p id="form-slug-error" role="alert" className="text-xs text-destructive" data-testid="form-slug-error">
-                {error ?? labels.renameInvalid}
+                {error ?? (shapeIssue === 'too-long' ? labels.renameTooLong : labels.renameInvalid)}
               </p>
             ) : null}
           </div>

--- a/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/link-actions.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState, useTransition } from 'react';
+import { validateFormSlug, FORM_SLUG_MAX_LENGTH } from '@quill/engine';
 import { Modal } from '@/components/modal';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
+import { callAction, isTransportError } from '@/lib/call-action';
+import { renameFormSlugAction } from '@/app/admin/actions';
 
 /**
- * The topbar's sharing controls: Copy link, Embed and Open form as THREE
- * visible icon-only buttons.
+ * The topbar's sharing controls: Copy link, Edit link, Embed and Open form as
+ * FOUR visible icon-only buttons.
  *
  * They were labelled buttons once (which crowded the tab labels out of the
  * header), then briefly a single popover menu — which tested as one hop too
@@ -16,17 +19,33 @@ import { cn } from '@/lib/cn';
  * actions one click away; the label reaches hover (title) and assistive tech
  * (aria-label).
  *
+ * Edit link sits HERE, next to Copy link, rather than in a settings panel. This
+ * is the one place in the product that already shows the public URL, so it is
+ * where somebody goes when they want to change it.
+ *
  * The public URL is resolved client-side from the real origin (`publicPath` is
  * a server-stable path). A 2s check-flash confirms each copy.
  */
 export function LinkActions({
   publicPath,
+  formId,
   formName,
+  onRenamed,
   labels,
 }: {
   publicPath: string;
+  /** Target of the rename. The slug itself is read off `publicPath`. */
+  formId: string;
   /** The form's name — becomes the embed iframe's accessible title. */
   formName: string;
+  /**
+   * Hand the new path back to the editor. Everything built from `publicPath`
+   * (this component's own Copy/Embed/Open, the design panel, the prefill example)
+   * reads a prop threaded down from a server component, so without this the
+   * topbar would keep copying the OLD link until a reload, and the person who
+   * just renamed it is the likeliest person to copy it seconds later.
+   */
+  onRenamed: (publicPath: string) => void;
   labels: {
     copyLink: string;
     copied: string;
@@ -36,11 +55,76 @@ export function LinkActions({
     embedIntro: string;
     embedCopy: string;
     embedCopied: string;
+    renameLink: string;
+    renameTitle: string;
+    renameIntro: string;
+    renameLabel: string;
+    renameSave: string;
+    renameSaving: string;
+    renameCancel: string;
+    renameTaken: string;
+    renameInvalid: string;
+    renameFailed: string;
   };
 }) {
   const [copied, setCopied] = useState(false);
   const [embedOpen, setEmbedOpen] = useState(false);
-  const [snippetCopied, setSnippetCopied] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // `/{accountCode}/{handle}/{slug}` split at the last separator: the prefix is
+  // fixed (it belongs to the workspace and the member, not to this form) and
+  // only the tail is editable.
+  const cut = publicPath.lastIndexOf('/');
+  const prefix = publicPath.slice(0, cut + 1);
+  const slug = publicPath.slice(cut + 1);
+
+  /**
+   * The real origin, for display only. Read after mount rather than during
+   * render because the server has no `window`, and shown as a prefix so what
+   * the dialog puts on screen is the whole link, not a fragment of one.
+   */
+  const [origin, setOrigin] = useState('');
+  useEffect(() => setOrigin(window.location.origin.replace(/^https?:\/\//, '')), []);
+
+  const openRename = () => {
+    setDraft(slug);
+    setError(null);
+    setRenameOpen(true);
+  };
+
+  const trimmed = draft.trim().toLowerCase();
+  const shapeIssue = trimmed.length === 0 ? 'invalid' : validateFormSlug(trimmed);
+  const canSave = !pending && shapeIssue === null && trimmed !== slug;
+
+  const submitRename = () => {
+    if (!canSave) return;
+    setError(null);
+    startTransition(async () => {
+      // Through `callAction`, never a bare await: a deploy rotating action ids
+      // mid-session rejects the call, and an unguarded await would skip every
+      // line below it, leaving the dialog stuck on "Saving" with no error.
+      const res = await callAction(() => renameFormSlugAction(formId, trimmed));
+      if (isTransportError(res)) {
+        setError(labels.renameFailed);
+        return;
+      }
+      if (res.ok) {
+        onRenamed(res.publicPath);
+        setRenameOpen(false);
+        return;
+      }
+      setError(
+        res.code === 'SLUG_TAKEN'
+          ? labels.renameTaken
+          : res.code === 'SLUG_INVALID'
+            ? labels.renameInvalid
+            : labels.renameFailed,
+      );
+    });
+  };
 
   const copy = async () => {
     try {
@@ -67,6 +151,7 @@ export function LinkActions({
       `<script src="${window.location.origin}/embed.js" async></script>`,
     ].join('\n');
 
+  const [snippetCopied, setSnippetCopied] = useState(false);
   const copySnippet = async () => {
     try {
       await navigator.clipboard.writeText(buildSnippet());
@@ -95,6 +180,16 @@ export function LinkActions({
       </button>
       <button
         type="button"
+        onClick={openRename}
+        className={icon}
+        aria-label={labels.renameLink}
+        title={labels.renameLink}
+        data-testid="editor-rename-link"
+      >
+        <i aria-hidden className="pi pi-pencil" style={{ fontSize: 13 }} />
+      </button>
+      <button
+        type="button"
         onClick={() => setEmbedOpen(true)}
         className={icon}
         aria-label={labels.embed}
@@ -114,6 +209,68 @@ export function LinkActions({
       >
         <i aria-hidden className="pi pi-external-link" style={{ fontSize: 13 }} />
       </a>
+
+      <Modal
+        open={renameOpen}
+        onClose={() => setRenameOpen(false)}
+        title={labels.renameTitle}
+        labelId="rename-form-link-title"
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">{labels.renameIntro}</p>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="form-slug-input" className="text-sm font-medium">
+              {labels.renameLabel}
+            </label>
+            {/* The fixed part of the URL is shown, not editable: it names the
+                workspace and the member, so letting someone type over it here
+                would offer an edit this dialog cannot make. */}
+            <div className="flex items-center rounded-md border border-input bg-background focus-within:ring-2 focus-within:ring-ring">
+              <span className="shrink-0 truncate py-2 pl-3 font-mono text-xs text-muted-foreground">
+                {origin}
+                {prefix}
+              </span>
+              <input
+                id="form-slug-input"
+                value={draft}
+                onChange={(e) => {
+                  setDraft(e.target.value);
+                  setError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    submitRename();
+                  }
+                }}
+                maxLength={FORM_SLUG_MAX_LENGTH}
+                spellCheck={false}
+                autoComplete="off"
+                aria-describedby={error || shapeIssue ? 'form-slug-error' : undefined}
+                aria-invalid={error != null || (draft.length > 0 && shapeIssue !== null)}
+                className="min-w-0 flex-1 bg-transparent py-2 pr-3 font-mono text-sm focus-visible:outline-none"
+                data-testid="form-slug-input"
+              />
+            </div>
+            {/* One message at a time, and the server's wins: it knows about
+                collisions the browser cannot see. The shape hint only appears
+                once there is something to be wrong about. */}
+            {error || (draft.length > 0 && shapeIssue !== null) ? (
+              <p id="form-slug-error" role="alert" className="text-xs text-destructive" data-testid="form-slug-error">
+                {error ?? labels.renameInvalid}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setRenameOpen(false)} disabled={pending}>
+              {labels.renameCancel}
+            </Button>
+            <Button onClick={submitRename} disabled={!canSave} data-testid="form-slug-save">
+              {pending ? labels.renameSaving : labels.renameSave}
+            </Button>
+          </div>
+        </div>
+      </Modal>
 
       <Modal open={embedOpen} onClose={() => setEmbedOpen(false)} title={labels.embedTitle} labelId="embed-form-title">
         <div className="flex flex-col gap-4">

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -571,8 +571,16 @@ export const adminApi = {
   getForm: (id: string) => req<FormDetail>('GET', `/v1/forms/${id}`),
   createForm: (b: { name: string; slug?: string; config?: unknown }) =>
     req<FormDetail>('POST', '/v1/forms', b),
-  updateForm: (id: string, b: { name?: string; slug?: string; config?: unknown }) =>
+  updateForm: (id: string, b: { name?: string; config?: unknown }) =>
     req<FormDetail>('PUT', `/v1/forms/${id}`, b),
+  /**
+   * Rename the form's public URL. Its own endpoint, not a field on `updateForm`:
+   * that one is the builder's autosave, and retiring a public slug is not
+   * something a keystroke should do. Throws ApiError with `code` SLUG_TAKEN or
+   * SLUG_INVALID (409) for the two ways it can be refused.
+   */
+  setFormSlug: (id: string, slug: string) =>
+    req<FormDetail>('PUT', `/v1/forms/${id}/slug`, { slug }),
   duplicateForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/duplicate`),
   /** Publish the pending draft config (no-op when no draft is pending). */
   publishForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/publish`),

--- a/packages/db/migrations/postgres/0017_form_alias.sql
+++ b/packages/db/migrations/postgres/0017_form_alias.sql
@@ -8,10 +8,15 @@
 --
 --   form_alias  — a slug this form used to answer to. The public resolver falls
 --                 back to it when no form matches the requested slug directly,
---                 and the page 308s to the canonical URL. A QR code on a
---                 printed flyer, a campaign link in an email already sent, an
---                 iframe embed pasted into someone else's site and a HubSpot
---                 property holding the old URL all keep working.
+--                 and the page then moves the visitor to the canonical URL. A
+--                 QR code on a printed flyer, a campaign link in an email
+--                 already sent, an iframe embed pasted into someone else's site
+--                 and a HubSpot property holding the old URL all keep working.
+--
+-- On the redirect: it resolves in the CLIENT, not as a redirect status. Next 16
+-- has begun streaming by the time the page resolves the form, so the response
+-- is a 200 carrying an RSC redirect. The page emits <link rel="canonical">
+-- alongside it for everything that does not run scripts.
 --
 -- Keyed by (account_id, alias) rather than by alias alone. That is the one
 -- structural difference from `account_alias`, and it follows from

--- a/packages/db/migrations/postgres/0017_form_alias.sql
+++ b/packages/db/migrations/postgres/0017_form_alias.sql
@@ -1,0 +1,30 @@
+-- Editable form slugs: additive.
+--
+-- `form.slug` is the third segment of a form's public URL
+-- (/{accountCode}/{handle}/{slug}). Until now it was written once, derived from
+-- the form's name at creation, and there was no way to change it. Making it
+-- editable means a published URL can stop being the current one, so every value
+-- a slug has ever had is retired into this ledger rather than dropped:
+--
+--   form_alias  — a slug this form used to answer to. The public resolver falls
+--                 back to it when no form matches the requested slug directly,
+--                 and the page 308s to the canonical URL. A QR code on a
+--                 printed flyer, a campaign link in an email already sent, an
+--                 iframe embed pasted into someone else's site and a HubSpot
+--                 property holding the old URL all keep working.
+--
+-- Keyed by (account_id, alias) rather than by alias alone. That is the one
+-- structural difference from `account_alias`, and it follows from
+-- `form_account_slug_uq`: a form slug is unique within its ACCOUNT, not
+-- globally, so two accounts may each retire a slug called `contact`.
+CREATE TABLE IF NOT EXISTS form_alias (
+  account_id  TEXT NOT NULL,
+  alias       TEXT NOT NULL,
+  form_id     TEXT NOT NULL,
+  created_at  BIGINT NOT NULL,
+  PRIMARY KEY (account_id, alias)
+);
+
+-- Deleting a form drops its aliases, which is a lookup by form_id and not by
+-- the primary key. Without this it is a full scan on every form deletion.
+CREATE INDEX IF NOT EXISTS form_alias_form_idx ON form_alias (form_id);

--- a/packages/db/migrations/sqlite/0017_form_alias.sql
+++ b/packages/db/migrations/sqlite/0017_form_alias.sql
@@ -1,0 +1,10 @@
+-- Editable form slugs: additive. See the Postgres twin for the why.
+CREATE TABLE IF NOT EXISTS form_alias (
+  account_id  TEXT NOT NULL,
+  alias       TEXT NOT NULL,
+  form_id     TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  PRIMARY KEY (account_id, alias)
+);
+
+CREATE INDEX IF NOT EXISTS form_alias_form_idx ON form_alias (form_id);

--- a/packages/db/src/crud.ts
+++ b/packages/db/src/crud.ts
@@ -7,6 +7,6 @@ export type CrudResult<T> =
   | { ok: true; value: T }
   | {
       ok: false;
-      reason: 'NOT_FOUND' | 'SLUG_TAKEN' | 'CONFLICT' | 'LAST_OWNER' | 'EMAIL_TAKEN';
+      reason: 'NOT_FOUND' | 'SLUG_TAKEN' | 'SLUG_INVALID' | 'CONFLICT' | 'LAST_OWNER' | 'EMAIL_TAKEN';
       message?: string;
     };

--- a/packages/db/src/form-slug.spec.ts
+++ b/packages/db/src/form-slug.spec.ts
@@ -80,7 +80,7 @@ describe('setFormSlug', () => {
     const viaOld = await getPublishedForm(db, accountCode, form.slug);
     expect(viaOld?.id).toBe(form.id);
     // And it reports the CANONICAL slug, which is what the public page compares
-    // against to decide whether to 308.
+    // against to decide whether to redirect.
     expect(viaOld?.slug).toBe('talk-to-sales');
   });
 
@@ -168,6 +168,10 @@ describe('setFormSlug', () => {
   });
 
   it('follows the rename into the member pages that list the form', async () => {
+    // Cosmetic, not load-bearing: what keeps the form ON the page is the read
+    // path resolving retired slugs (see `public-profile.spec.ts`). This only
+    // keeps the public-page EDITOR showing a checked box rather than an entry
+    // it no longer recognizes, which is why it is allowed to lose a race.
     const form = await newForm('Lead qualifier');
     const memberId = randomUUID();
     await db.run(
@@ -187,8 +191,8 @@ describe('setFormSlug', () => {
     const row = await db.get<{ profile: unknown }>(sql`SELECT profile FROM member WHERE id = ${memberId}`);
     const profile =
       typeof row?.profile === 'string' ? JSON.parse(row.profile) : (row?.profile as Record<string, unknown>);
-    // Without this the form drops off the page silently: the public profile
-    // filters on the CANONICAL slug, which no longer matches the stored one.
+    // The stored selection follows the rename, so the editor's checkbox for
+    // this form stays checked.
     expect(profile.formSlugs).toEqual(['talk-to-sales', 'something-else']);
   });
 });

--- a/packages/db/src/form-slug.spec.ts
+++ b/packages/db/src/form-slug.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Renaming a form's public URL.
+ *
+ * The feature is one UPDATE; the reason it needs a suite is everything that
+ * must NOT happen alongside it. A slug is a public address, so retiring one
+ * cannot break the links already carrying it, cannot hand the address to a
+ * different form, and cannot silently drop the form off the member pages that
+ * list it by slug.
+ *
+ * Defaults to a temp SQLite file; CI runs the identical assertions against
+ * DATABASE_URL on Postgres.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { createDb, type Db } from './client';
+import { migrate } from './migrate';
+import { createForm, deleteForm, getPublishedForm, setFormSlug } from './forms';
+
+let db: Db;
+let accountId: string;
+let accountCode: string;
+let sqliteDir: string | undefined;
+
+async function newForm(name: string): Promise<{ id: string; slug: string }> {
+  const created = await createForm(db, accountId, { name });
+  if (!created.ok) throw new Error(`fixture form "${name}" failed: ${created.reason}`);
+  return { id: created.value.id, slug: created.value.slug };
+}
+
+async function aliasesOf(formId: string): Promise<string[]> {
+  const rows = await db.all<{ alias: string }>(
+    sql`SELECT alias FROM form_alias WHERE account_id = ${accountId} AND form_id = ${formId} ORDER BY alias`,
+  );
+  return rows.map((r) => String(r.alias));
+}
+
+beforeEach(async () => {
+  const databaseUrl =
+    process.env.DATABASE_URL ?? `file:${join(await mkdtemp(join(tmpdir(), 'quill-form-rename-')), 'forms.db')}`;
+  if (!process.env.DATABASE_URL) sqliteDir = join(databaseUrl.slice('file:'.length), '..');
+
+  db = await createDb(databaseUrl);
+  await migrate(db);
+
+  accountId = randomUUID();
+  accountCode = `r${accountId.slice(0, 8)}`;
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${accountCode}, ${'Rename'}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  if (db) {
+    await db.run(sql`DELETE FROM form_alias WHERE account_id = ${accountId}`);
+    await db.run(sql`DELETE FROM form WHERE account_id = ${accountId}`);
+    await db.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  }
+  await db?.close();
+  if (sqliteDir) await rm(sqliteDir, { recursive: true, force: true });
+  sqliteDir = undefined;
+});
+
+describe('setFormSlug', () => {
+  it('renames the form and keeps the old slug resolving to it', async () => {
+    const form = await newForm('Lead qualifier');
+
+    const renamed = await setFormSlug(db, accountId, form.id, 'talk-to-sales');
+    expect(renamed).toMatchObject({ ok: true, value: { slug: 'talk-to-sales' } });
+
+    const viaNew = await getPublishedForm(db, accountCode, 'talk-to-sales');
+    expect(viaNew?.id).toBe(form.id);
+
+    // The whole point: the printed QR code still lands on the form.
+    const viaOld = await getPublishedForm(db, accountCode, form.slug);
+    expect(viaOld?.id).toBe(form.id);
+    // And it reports the CANONICAL slug, which is what the public page compares
+    // against to decide whether to 308.
+    expect(viaOld?.slug).toBe('talk-to-sales');
+  });
+
+  it('keeps every slug in a rename chain alive', async () => {
+    const form = await newForm('Contact');
+    await setFormSlug(db, accountId, form.id, 'contact-us');
+    await setFormSlug(db, accountId, form.id, 'say-hello');
+
+    expect(await aliasesOf(form.id)).toEqual(['contact', 'contact-us']);
+    for (const slug of ['contact', 'contact-us', 'say-hello']) {
+      expect((await getPublishedForm(db, accountCode, slug))?.id).toBe(form.id);
+    }
+  });
+
+  it('drops the alias row when a form re-claims one of its own old slugs', async () => {
+    const form = await newForm('Contact');
+    await setFormSlug(db, accountId, form.id, 'contact-us');
+    const back = await setFormSlug(db, accountId, form.id, 'contact');
+
+    expect(back).toMatchObject({ ok: true, value: { slug: 'contact' } });
+    // `contact` is canonical again, so an alias row for it would be dead weight
+    // the resolver never consults. Only the slug it just left is retired.
+    expect(await aliasesOf(form.id)).toEqual(['contact-us']);
+  });
+
+  it('refuses a slug another form holds', async () => {
+    const first = await newForm('Pricing');
+    const second = await newForm('Demo');
+
+    expect(await setFormSlug(db, accountId, second.id, first.slug)).toMatchObject({
+      ok: false,
+      reason: 'SLUG_TAKEN',
+    });
+  });
+
+  it('refuses a slug another form RETIRED', async () => {
+    const first = await newForm('Pricing');
+    await setFormSlug(db, accountId, first.id, 'plans');
+    const second = await newForm('Demo');
+
+    // Allowing this would point every link already published for `pricing` at
+    // somebody else's form: the direct match wins over the alias.
+    expect(await setFormSlug(db, accountId, second.id, 'pricing')).toMatchObject({
+      ok: false,
+      reason: 'SLUG_TAKEN',
+    });
+    expect((await getPublishedForm(db, accountCode, 'pricing'))?.id).toBe(first.id);
+  });
+
+  it('refuses a malformed slug without touching the form', async () => {
+    const form = await newForm('Lead qualifier');
+
+    for (const bad of ['Talk To Sales', 'talk--to-sales', '-leading', 'trailing-', 'x'.repeat(81)]) {
+      expect(await setFormSlug(db, accountId, form.id, bad)).toMatchObject({
+        ok: false,
+        reason: 'SLUG_INVALID',
+      });
+    }
+    expect((await getPublishedForm(db, accountCode, form.slug))?.slug).toBe(form.slug);
+    expect(await aliasesOf(form.id)).toEqual([]);
+  });
+
+  it('treats a rename to the current slug as a no-op success', async () => {
+    const form = await newForm('Lead qualifier');
+
+    expect(await setFormSlug(db, accountId, form.id, form.slug)).toMatchObject({
+      ok: true,
+      value: { slug: form.slug },
+    });
+    // No self-alias: the resolver would never read it, and `formSlugInUse`
+    // would then report the form's own live slug as spoken for.
+    expect(await aliasesOf(form.id)).toEqual([]);
+  });
+
+  it('is NOT_FOUND for a form in another account', async () => {
+    const other = randomUUID();
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at)
+          VALUES (${other}, ${`z${other.slice(0, 8)}`}, ${'Other'}, ${Date.now()})`,
+    );
+    const form = await newForm('Lead qualifier');
+
+    expect(await setFormSlug(db, other, form.id, 'stolen')).toMatchObject({ ok: false, reason: 'NOT_FOUND' });
+    await db.run(sql`DELETE FROM account WHERE id = ${other}`);
+  });
+
+  it('follows the rename into the member pages that list the form', async () => {
+    const form = await newForm('Lead qualifier');
+    const memberId = randomUUID();
+    await db.run(
+      sql`INSERT INTO member (id, account_id, email, display_name, handle, role, created_at)
+          VALUES (${memberId}, ${accountId}, ${'a@example.test'}, ${'A'}, ${'a'}, ${'owner'}, ${Date.now()})`,
+    );
+    await db.run(
+      sql`UPDATE member SET profile = ${JSON.stringify({
+        version: 1,
+        enabled: true,
+        formSlugs: [form.slug, 'something-else'],
+      })} WHERE id = ${memberId}`,
+    );
+
+    await setFormSlug(db, accountId, form.id, 'talk-to-sales');
+
+    const row = await db.get<{ profile: unknown }>(sql`SELECT profile FROM member WHERE id = ${memberId}`);
+    const profile =
+      typeof row?.profile === 'string' ? JSON.parse(row.profile) : (row?.profile as Record<string, unknown>);
+    // Without this the form drops off the page silently: the public profile
+    // filters on the CANONICAL slug, which no longer matches the stored one.
+    expect(profile.formSlugs).toEqual(['talk-to-sales', 'something-else']);
+  });
+});
+
+describe('slug allocation around retired slugs', () => {
+  it('does not hand a new form a slug another form retired', async () => {
+    const first = await newForm('Contact');
+    await setFormSlug(db, accountId, first.id, 'contact-us');
+
+    const second = await newForm('Contact');
+
+    expect(second.slug).toBe('contact-2');
+    expect((await getPublishedForm(db, accountCode, 'contact'))?.id).toBe(first.id);
+  });
+
+  it("frees a deleted form's aliases", async () => {
+    const first = await newForm('Contact');
+    await setFormSlug(db, accountId, first.id, 'contact-us');
+    await deleteForm(db, accountId, first.id);
+
+    expect(await getPublishedForm(db, accountCode, 'contact')).toBeNull();
+    const second = await newForm('Contact');
+    expect(second.slug).toBe('contact');
+  });
+});

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -235,7 +235,14 @@ export async function uniqueFormSlug(db: Db, accountId: string, base: string): P
     const candidate = n === 1 ? root : `${root}-${n}`;
     if (!(await formSlugInUse(db, accountId, candidate))) return candidate;
   }
-  return `${root}-${randomUUID().slice(0, 6)}`;
+  // 1000 collisions on one root. Unreachable in practice, but the fallback is
+  // the one candidate that would otherwise skip the check above, so it gets a
+  // fresh suffix until it clears rather than being trusted blind.
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const candidate = `${root}-${randomUUID().slice(0, 6)}`;
+    if (!(await formSlugInUse(db, accountId, candidate))) return candidate;
+  }
+  return `${root}-${randomUUID()}`;
 }
 
 /**
@@ -519,16 +526,20 @@ async function addFormAlias(
 /**
  * Follow a renamed slug into every member's public-page selection.
  *
- * A member profile lists the account's published forms BY SLUG
- * (`profile.formSlugs`, see 0008), and the public profile filters with
- * `allowed.includes(form.slug)` against the CANONICAL slug. So a rename that
- * did not come through here would drop the form off every page that listed it,
- * silently, with nothing on screen explaining why. An alias cannot cover this:
- * the filter compares live slugs, never retired ones.
+ * BEST EFFORT, and the distinction matters. A member profile records its form
+ * selection BY SLUG (`profile.formSlugs`, see 0008), so a rename leaves those
+ * entries naming a slug no form currently has. What keeps the form ON the page
+ * is the READ path: `publicProfile` matches a selection against each form's
+ * retired slugs as well as its live one. That is the correctness fix, it needs
+ * no write, and it heals profiles saved before this shipped.
  *
- * Deliberately not aliased away instead. `formSlugs` is an author's explicit
- * selection, so the right behaviour is to follow the rename, not to leave a
- * stale value that resolves through a redirect.
+ * This function exists only so the public-page EDITOR shows a checked box
+ * rather than an entry it no longer recognizes. It is a read-modify-write on a
+ * JSON blob with no compare-and-set, so a concurrent profile save can lose it
+ * (the same shape as `attachOnboardingForm`). Losing it costs a stale checkbox
+ * until the author saves that screen again, never a form vanishing from a page,
+ * which is why it is allowed to be lossy and why the read path must never
+ * depend on it having run.
  */
 async function renameSlugInMemberProfiles(
   db: Db,
@@ -587,6 +598,35 @@ export async function setFormSlug(
     return { ok: false, reason: 'SLUG_TAKEN', message: 'That slug is already in use.' };
   }
 
+  // RETIRE FIRST, then move. The order is the whole safety argument, and the
+  // obvious order is the wrong one.
+  //
+  // Retiring after a successful UPDATE leaves a window in which the old slug is
+  // held by nobody: gone from `form`, not yet in `form_alias`. A second rename
+  // arriving inside that window asks `formSlugInUse` about it, is told it is
+  // free, and takes it. Both writes succeed, the unique index sees no conflict,
+  // and the account ends up with one form LIVE on the slug and the alias
+  // pointing at a different one. A direct match beats an alias, so every link
+  // ever published for the first form now serves the second one, permanently
+  // and silently. The same window loses the slug outright if the process dies
+  // inside it, which is the one promise this feature makes.
+  //
+  // Retiring first closes it: the slug is continuously either live on this form
+  // or retired to it, so a concurrent claim is refused at every instant. If the
+  // UPDATE then fails, the leftover alias row names the form that still holds
+  // the slug live, where the direct match wins and the row is never consulted.
+  // Untidy, never wrong. `setVanitySlug` orders itself the same way for the
+  // same reason, and like it, this runs without a transaction: the portable
+  // `Db` port has no cross-dialect one, and every intermediate state this
+  // ordering can leave behind is inert.
+  await addFormAlias(db, accountId, id, existing.slug);
+  // Re-claiming one of this form's own retired slugs: it is about to be
+  // canonical again, so the alias row would be dead weight nothing consults.
+  await db.run(
+    sql`DELETE FROM form_alias
+        WHERE account_id = ${accountId} AND alias = ${slug} AND form_id = ${id}`,
+  );
+
   try {
     await db.run(
       sql`UPDATE form SET slug = ${slug}, updated_at = ${Date.now()}
@@ -601,13 +641,6 @@ export async function setFormSlug(
     throw error;
   }
 
-  await addFormAlias(db, accountId, id, existing.slug);
-  // Re-claiming one of this form's own retired slugs: it is canonical again, so
-  // the alias row would be dead weight that never gets consulted.
-  await db.run(
-    sql`DELETE FROM form_alias
-        WHERE account_id = ${accountId} AND alias = ${slug} AND form_id = ${id}`,
-  );
   await renameSlugInMemberProfiles(db, accountId, existing.slug, slug);
 
   return { ok: true, value: (await getFormById(db, accountId, id))! };
@@ -775,7 +808,10 @@ export async function deleteForm(db: Db, accountId: string, id: string): Promise
  *
  * The returned `slug` is always the CANONICAL one, never what was asked for.
  * That is what lets the public page notice it was reached through a retired
- * slug and 308 to the real URL, instead of serving two addresses forever.
+ * slug and send the visitor to the real URL instead of serving two addresses
+ * forever. Next resolves that redirect on the client rather than as a redirect
+ * STATUS, so the page also emits a canonical link tag; see the notes in
+ * `apps/web/app/[accountCode]/[handle]/[slug]/page.tsx`.
  *
  * A direct hit wins over an alias, always. `uniqueFormSlug` / `setFormSlug`
  * refuse to hand one form a slug another form retired, so the two can only

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -6,6 +6,7 @@
  * so the identical code runs on SQLite (clone-and-run) and Postgres (prod).
  */
 import { randomUUID } from 'node:crypto';
+import { validateFormSlug } from '@quill/engine';
 import { attributionSchema, mergeWebhookSecrets, type Attribution } from '@quill/types';
 import { sql, type Db } from './client';
 import { canonicalPublicCode } from './short-links';
@@ -219,17 +220,44 @@ export function slugify(raw: string): string {
   );
 }
 
-/** A slug unique within the account: `base`, then `base-2`, `base-3`… */
+/**
+ * A slug unique within the account: `base`, then `base-2`, `base-3`…
+ *
+ * "Unique" means free of BOTH live slugs and retired ones (`form_alias`). A
+ * retired slug still answers requests, so handing it to a new form would make
+ * the direct match win and silently redirect every already-published link for
+ * the form that retired it onto a stranger's form. Skipping the candidate costs
+ * a suffix; not skipping it costs someone else's traffic.
+ */
 export async function uniqueFormSlug(db: Db, accountId: string, base: string): Promise<string> {
   const root = slugify(base);
   for (let n = 1; n < 1000; n++) {
     const candidate = n === 1 ? root : `${root}-${n}`;
-    const clash = await db.get<{ id: string }>(
-      sql`SELECT id FROM form WHERE account_id = ${accountId} AND slug = ${candidate} LIMIT 1`,
-    );
-    if (!clash) return candidate;
+    if (!(await formSlugInUse(db, accountId, candidate))) return candidate;
   }
   return `${root}-${randomUUID().slice(0, 6)}`;
+}
+
+/**
+ * Is `slug` spoken for inside this account, as a live slug or a retired alias?
+ * `excludeFormId` lets a form re-claim one of its OWN old slugs (and ignore its
+ * own current one) without reporting a clash against itself.
+ */
+export async function formSlugInUse(
+  db: Db,
+  accountId: string,
+  slug: string,
+  excludeFormId?: string,
+): Promise<boolean> {
+  const live = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE account_id = ${accountId} AND slug = ${slug} LIMIT 1`,
+  );
+  if (live) return String(live.id) !== excludeFormId;
+  const retired = await db.get<{ form_id: string }>(
+    sql`SELECT form_id FROM form_alias WHERE account_id = ${accountId} AND alias = ${slug} LIMIT 1`,
+  );
+  if (retired) return String(retired.form_id) !== excludeFormId;
+  return false;
 }
 
 const FORM_SLUG_INSERT_ATTEMPTS = 3;
@@ -414,25 +442,27 @@ export async function createForm(
   throw new Error('unreachable: form slug insert retries must return or rethrow');
 }
 
+/**
+ * Patch a form's name and/or config.
+ *
+ * `slug` is deliberately NOT here. It used to be, as a plain UPDATE that
+ * checked for a clash and overwrote the column, which is exactly the wrong
+ * shape for a value that is a public URL: it dropped the previous slug on the
+ * floor and broke every link already published for the form. Renaming a slug is
+ * `setFormSlug`, which retires the old value into `form_alias` instead. One
+ * implementation, so no caller can pick the lossy one by accident.
+ */
 export async function updateForm(
   db: Db,
   accountId: string,
   id: string,
-  patch: { name?: string; slug?: string; config?: unknown },
+  patch: { name?: string; config?: unknown },
 ): Promise<CrudResult<FormRow>> {
   const existing = await getFormById(db, accountId, id);
   if (!existing) return { ok: false, reason: 'NOT_FOUND' };
 
   const sets = [];
   if (patch.name !== undefined) sets.push(sql`name = ${patch.name}`);
-  if (patch.slug !== undefined) {
-    const slug = slugify(patch.slug);
-    const clash = await db.get<{ id: string }>(
-      sql`SELECT id FROM form WHERE account_id = ${accountId} AND slug = ${slug} AND id <> ${id} LIMIT 1`,
-    );
-    if (clash) return { ok: false, reason: 'SLUG_TAKEN', message: 'That slug is already in use.' };
-    sets.push(sql`slug = ${slug}`);
-  }
   if (patch.config !== undefined) {
     // Preserve masked webhook secrets: a full-config write that round-trips the
     // READ-masked config (WEBHOOK_SECRET_MASK) must not clobber the stored
@@ -460,6 +490,126 @@ export async function updateForm(
       sql`UPDATE form SET ${sql.join(sets, sql`, `)} WHERE account_id = ${accountId} AND id = ${id}`,
     );
   }
+  return { ok: true, value: (await getFormById(db, accountId, id))! };
+}
+
+// --- Form slug (the public URL's third segment) ------------------------------
+
+/**
+ * Record a slug this form used to answer to. Idempotent: the composite primary
+ * key (account_id, alias) makes a repeat a no-op rather than an error, which is
+ * what a re-rename back and forth produces.
+ */
+async function addFormAlias(
+  db: Db,
+  accountId: string,
+  formId: string,
+  alias: string,
+): Promise<void> {
+  try {
+    await db.run(
+      sql`INSERT INTO form_alias (account_id, alias, form_id, created_at)
+          VALUES (${accountId}, ${alias}, ${formId}, ${Date.now()})`,
+    );
+  } catch {
+    // Already recorded (PK). Idempotent no-op, same as `addAccountAlias`.
+  }
+}
+
+/**
+ * Follow a renamed slug into every member's public-page selection.
+ *
+ * A member profile lists the account's published forms BY SLUG
+ * (`profile.formSlugs`, see 0008), and the public profile filters with
+ * `allowed.includes(form.slug)` against the CANONICAL slug. So a rename that
+ * did not come through here would drop the form off every page that listed it,
+ * silently, with nothing on screen explaining why. An alias cannot cover this:
+ * the filter compares live slugs, never retired ones.
+ *
+ * Deliberately not aliased away instead. `formSlugs` is an author's explicit
+ * selection, so the right behaviour is to follow the rename, not to leave a
+ * stale value that resolves through a redirect.
+ */
+async function renameSlugInMemberProfiles(
+  db: Db,
+  accountId: string,
+  from: string,
+  to: string,
+): Promise<void> {
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT id, profile FROM member WHERE account_id = ${accountId} AND profile IS NOT NULL`,
+  );
+  for (const row of rows) {
+    const profile = parseJsonColumn<Record<string, unknown> | null>(row.profile, null);
+    if (!profile || typeof profile !== 'object') continue;
+    const slugs = profile.formSlugs;
+    if (!Array.isArray(slugs) || !slugs.includes(from)) continue;
+    // Dedupe: a selection holding BOTH the old and the new slug (possible after
+    // a rename round-trip) must not end up listing the same form twice.
+    const next = [...new Set(slugs.map((s) => (s === from ? to : s)))];
+    await db.run(
+      sql`UPDATE member SET profile = ${JSON.stringify({ ...profile, formSlugs: next })}
+          WHERE id = ${row.id} AND account_id = ${accountId}`,
+    );
+  }
+}
+
+/**
+ * Rename a form's public URL, keeping every link ever published for it alive.
+ *
+ * Separate from `updateForm` on purpose. That one is the builder's AUTOSAVE,
+ * fired on a debounce as the author types, and rotating a public URL from a
+ * keystroke is not a thing anyone asks for: a typo in the form's name would
+ * retire a slug that is printed on a QR code. Renaming a URL is an explicit,
+ * confirmed act, so it gets an explicit call.
+ *
+ * Order matters. The UPDATE lands first, so a lost uniqueness race leaves the
+ * ledger untouched; only once the new slug is really ours does the old one get
+ * retired and the reclaimed alias dropped.
+ */
+export async function setFormSlug(
+  db: Db,
+  accountId: string,
+  id: string,
+  requested: string,
+): Promise<CrudResult<FormRow>> {
+  const existing = await getFormById(db, accountId, id);
+  if (!existing) return { ok: false, reason: 'NOT_FOUND' };
+
+  const slug = requested.trim().toLowerCase();
+  if (validateFormSlug(slug)) {
+    return { ok: false, reason: 'SLUG_INVALID', message: 'That link is not a valid slug.' };
+  }
+  // A no-op rename is a success, not a clash against itself.
+  if (slug === existing.slug) return { ok: true, value: existing };
+
+  if (await formSlugInUse(db, accountId, slug, id)) {
+    return { ok: false, reason: 'SLUG_TAKEN', message: 'That slug is already in use.' };
+  }
+
+  try {
+    await db.run(
+      sql`UPDATE form SET slug = ${slug}, updated_at = ${Date.now()}
+          WHERE account_id = ${accountId} AND id = ${id}`,
+    );
+  } catch (error) {
+    // A concurrent claim of the same slug lost the race to `form_account_slug_uq`.
+    // The check above cannot see it; the index can. Same answer either way, never a 500.
+    if (isFormAccountSlugConflict(error)) {
+      return { ok: false, reason: 'SLUG_TAKEN', message: 'That slug is already in use.' };
+    }
+    throw error;
+  }
+
+  await addFormAlias(db, accountId, id, existing.slug);
+  // Re-claiming one of this form's own retired slugs: it is canonical again, so
+  // the alias row would be dead weight that never gets consulted.
+  await db.run(
+    sql`DELETE FROM form_alias
+        WHERE account_id = ${accountId} AND alias = ${slug} AND form_id = ${id}`,
+  );
+  await renameSlugInMemberProfiles(db, accountId, existing.slug, slug);
+
   return { ok: true, value: (await getFormById(db, accountId, id))! };
 }
 
@@ -607,10 +757,31 @@ export async function deleteForm(db: Db, accountId: string, id: string): Promise
   await db.run(
     sql`DELETE FROM notification_setting WHERE account_id = ${accountId} AND form_id = ${id}`,
   );
+  // Retired slugs die with the form they pointed at: leaving them would keep a
+  // deleted form's URLs reserved forever, and `formSlugInUse` reads this table.
+  await db.run(sql`DELETE FROM form_alias WHERE account_id = ${accountId} AND form_id = ${id}`);
   await db.run(sql`DELETE FROM form WHERE account_id = ${accountId} AND id = ${id}`);
 }
 
-/** The published form for a public code + slug (no account scope leaked). */
+/**
+ * The published form for a public code + slug (no account scope leaked).
+ *
+ * Falls back to the alias ledger when nothing matches directly, so a slug the
+ * form used to answer to still resolves: the QR code already printed, the
+ * campaign link already sent, the iframe already pasted into someone else's
+ * site. This ONE fallback covers every public entry point at once, because the
+ * page, the OG image, submissions, funnel events and the booking callback all
+ * arrive through here.
+ *
+ * The returned `slug` is always the CANONICAL one, never what was asked for.
+ * That is what lets the public page notice it was reached through a retired
+ * slug and 308 to the real URL, instead of serving two addresses forever.
+ *
+ * A direct hit wins over an alias, always. `uniqueFormSlug` / `setFormSlug`
+ * refuse to hand one form a slug another form retired, so the two can only
+ * collide for the SAME form (it re-claimed its own old slug), where the direct
+ * row is the right answer anyway.
+ */
 export async function getPublishedForm(
   db: Db,
   accountCode: string,
@@ -618,10 +789,21 @@ export async function getPublishedForm(
 ): Promise<{ id: string; accountId: string; name: string; slug: string; config: unknown } | null> {
   const account = await getAccountByCode(db, accountCode);
   if (!account) return null;
-  const r = await db.get<Record<string, unknown>>(
+  let r = await db.get<Record<string, unknown>>(
     sql`SELECT id, account_id, name, slug, config FROM form
         WHERE account_id = ${account.id} AND slug = ${slug} LIMIT 1`,
   );
+  if (!r) {
+    const retired = await db.get<{ form_id: string }>(
+      sql`SELECT form_id FROM form_alias
+          WHERE account_id = ${account.id} AND alias = ${slug} LIMIT 1`,
+    );
+    if (!retired) return null;
+    r = await db.get<Record<string, unknown>>(
+      sql`SELECT id, account_id, name, slug, config FROM form
+          WHERE account_id = ${account.id} AND id = ${retired.form_id} LIMIT 1`,
+    );
+  }
   if (!r) return null;
   return {
     id: String(r.id),

--- a/packages/db/src/members.ts
+++ b/packages/db/src/members.ts
@@ -420,6 +420,14 @@ export interface ProfileFormRow {
   name: string;
   /** The author's public title, when the form has one. */
   title: string | null;
+  /**
+   * Slugs this form used to answer to (see 0017), so a profile that named one
+   * before the author renamed the link still matches. The listing filter runs
+   * on `formSlugs`, which stores whatever slug was current when the author
+   * picked the form; without these a rename would drop the form off every page
+   * that listed it.
+   */
+  retiredSlugs: string[];
 }
 
 /** A member's stored public page + the identity fields it renders alongside. */
@@ -483,12 +491,28 @@ export async function listPublishedFormsForAccount(
   // jsonb on Postgres and TEXT on SQLite, so the extraction happens here in JS
   // rather than in dialect-specific SQL.
   const rows = await db.all<Record<string, unknown>>(
-    sql`SELECT slug, name, config FROM form WHERE account_id = ${account.id} ORDER BY created_at ASC`,
+    sql`SELECT id, slug, name, config FROM form WHERE account_id = ${account.id} ORDER BY created_at ASC`,
   );
+  // One query for the whole account rather than one per form: an account has a
+  // handful of forms and rather fewer retired slugs, and this runs on a public
+  // page render.
+  const aliasRows = await db.all<{ alias: string; form_id: string }>(
+    sql`SELECT alias, form_id FROM form_alias WHERE account_id = ${account.id}`,
+  );
+  const retiredByForm = new Map<string, string[]>();
+  for (const row of aliasRows) {
+    const key = String(row.form_id);
+    retiredByForm.set(key, [...(retiredByForm.get(key) ?? []), String(row.alias)]);
+  }
   return rows.map((r) => {
     const config = parseJsonColumn<{ title?: unknown }>(r.config, {});
     const title = typeof config.title === 'string' && config.title.trim() ? config.title.trim() : null;
-    return { slug: String(r.slug), name: String(r.name), title };
+    return {
+      slug: String(r.slug),
+      name: String(r.name),
+      title,
+      retiredSlugs: retiredByForm.get(String(r.id)) ?? [],
+    };
   });
 }
 

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -5,7 +5,7 @@
  * config/answers blobs and `bigint` epoch-ms instants; production runs here.
  */
 import { sql } from 'drizzle-orm';
-import { pgTable, text, bigint, integer, jsonb, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import { pgTable, text, bigint, integer, jsonb, primaryKey, uniqueIndex, index } from 'drizzle-orm/pg-core';
 
 // --- Platform (identity / delivery) — kept from the shared platform ----------
 
@@ -197,6 +197,29 @@ export const form = pgTable(
 );
 
 /**
+ * Slugs a form used to answer to (see 0017). Renaming a form's public URL
+ * retires the old slug here instead of dropping it, so every already-published
+ * link keeps resolving and 308s to the canonical one.
+ *
+ * Keyed by (account_id, alias) rather than by alias alone — unlike
+ * `account_alias`, whose key IS globally unique. A form slug is unique per
+ * account (`form_account_slug_uq`), so two accounts may each retire a `contact`.
+ */
+export const formAlias = pgTable(
+  'form_alias',
+  {
+    accountId: text('account_id').notNull(),
+    alias: text('alias').notNull(),
+    formId: text('form_id').notNull(),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.accountId, t.alias] }),
+    formAliasFormIdx: index('form_alias_form_idx').on(t.formId),
+  }),
+);
+
+/**
  * Workspace brand kit — one row per account. `config` is the brand kit blob
  * (validated by `brandKitSchema` in @quill/types). Forms snapshot it at
  * creation / on explicit apply; the public renderer never reads this table.
@@ -297,6 +320,7 @@ export const pgSchema = {
   outbox,
   notificationSetting,
   form,
+  formAlias,
   submission,
   formEvent,
   bookingEvent,

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -14,7 +14,7 @@
  * so anything regenerated from them does not silently drop a uniqueness guard.
  */
 import { sql } from 'drizzle-orm';
-import { sqliteTable, text, integer, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, primaryKey, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
 
 // --- Platform (identity / delivery) — kept from the shared platform ----------
 
@@ -195,6 +195,26 @@ export const form = sqliteTable(
 );
 
 /**
+ * Slugs a form used to answer to (see 0017) — the ledger that keeps every
+ * already-published link resolving after its form's public URL is renamed.
+ * Keyed by (account_id, alias) because a form slug is unique per account, not
+ * globally like `account_alias`.
+ */
+export const formAlias = sqliteTable(
+  'form_alias',
+  {
+    accountId: text('account_id').notNull(),
+    alias: text('alias').notNull(),
+    formId: text('form_id').notNull(),
+    createdAt: integer('created_at').notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.accountId, t.alias] }),
+    formAliasFormIdx: index('form_alias_form_idx').on(t.formId),
+  }),
+);
+
+/**
  * Workspace brand kit — one row per account. `config` (TEXT JSON) is the brand
  * kit blob (validated by `brandKitSchema` in @quill/types). Forms snapshot it at
  * creation / on explicit apply; the public renderer never reads this table.
@@ -301,6 +321,7 @@ export const sqliteSchema = {
   outbox,
   notificationSetting,
   form,
+  formAlias,
   submission,
   formEvent,
   bookingEvent,

--- a/packages/engine/src/short-links.spec.ts
+++ b/packages/engine/src/short-links.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Short-link shape rules. Pure functions, so these are the cheapest place to
+ * pin them, and `validateFormSlug` in particular is published API: the builder
+ * imports it into a browser bundle to refuse a bad slug before spending a round
+ * trip, and the data layer calls it again before writing. Those two must agree,
+ * or the dialog says yes and the server says no.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  FORM_SLUG_MAX_LENGTH,
+  isReservedPublicSlug,
+  validateFormSlug,
+  validateVanitySlug,
+} from './short-links';
+
+describe('validateFormSlug', () => {
+  it('accepts lowercase words joined by single hyphens', () => {
+    for (const good of ['contact', 'talk-to-sales', 'q4-2026-survey', 'a', '2026']) {
+      expect(validateFormSlug(good), good).toBeNull();
+    }
+  });
+
+  it('normalizes case and surrounding whitespace before judging', () => {
+    // The caller stores `trim().toLowerCase()`, so validating the raw string
+    // would refuse values that are about to be stored perfectly well.
+    expect(validateFormSlug('Talk-To-Sales')).toBeNull();
+    expect(validateFormSlug('  contact  ')).toBeNull();
+  });
+
+  it('rejects the shapes that would not survive a URL', () => {
+    for (const bad of [
+      '',
+      ' ',
+      'talk to sales',
+      'talk--to-sales',
+      '-leading',
+      'trailing-',
+      'has_underscore',
+      'acentuación',
+      'slash/inside',
+      'percent%20',
+    ]) {
+      expect(validateFormSlug(bad), bad).toBe('invalid');
+    }
+  });
+
+  it('separates too-long from malformed so the UI can say which', () => {
+    expect(validateFormSlug('a'.repeat(FORM_SLUG_MAX_LENGTH))).toBeNull();
+    expect(validateFormSlug('a'.repeat(FORM_SLUG_MAX_LENGTH + 1))).toBe('too-long');
+    // Length is checked first on purpose: a value that is both over-length and
+    // malformed is most usefully reported as the one the reader can see.
+    expect(validateFormSlug(`${'a'.repeat(FORM_SLUG_MAX_LENGTH)}  BAD`)).toBe('too-long');
+  });
+
+  it('does NOT apply the reserved-word blocklist', () => {
+    // A form slug is the third path segment, so it cannot shadow a top-level
+    // route the way a vanity account slug can. Rejecting these would be theatre,
+    // and would refuse a perfectly reasonable form called "Pricing".
+    for (const word of ['admin', 'settings', 'login', 'pricing', 'api']) {
+      expect(isReservedPublicSlug(word), word).toBe(true);
+      expect(validateFormSlug(word), word).toBeNull();
+      expect(validateVanitySlug(word), word).toBe('reserved');
+    }
+  });
+
+  it('allows a form slug longer than a vanity slug', () => {
+    // 80 vs 30. A form slug is generated from a form NAME, which is allowed 200.
+    const long = 'a'.repeat(50);
+    expect(validateFormSlug(long)).toBeNull();
+    expect(validateVanitySlug(long)).toBe('invalid');
+  });
+});

--- a/packages/engine/src/short-links.ts
+++ b/packages/engine/src/short-links.ts
@@ -63,6 +63,38 @@ export function validateVanitySlug(slug: string): VanitySlugIssue {
 }
 
 /**
+ * A FORM slug is the third path segment (`/{accountCode}/{handle}/{slug}`), and
+ * that position is the whole reason it validates differently from a vanity
+ * account slug:
+ *
+ *   - **No reserved-word blocklist.** A vanity slug sits at the root, where
+ *     `signup` or `admin` would shadow a real route. Nothing is routed under
+ *     `[accountCode]/[handle]/` except `[slug]` itself, so no form slug can
+ *     shadow anything. Rejecting `settings` here would be theatre.
+ *   - **80 characters, not 30.** This is `formInputSchema.slug`'s ceiling in
+ *     @quill/types, deliberately kept in sync: the API rejects anything longer
+ *     before this ever runs, and a slug is generated from a form's NAME, which
+ *     is allowed 200.
+ *
+ * Uniqueness stays the DB's job (`form_account_slug_uq` plus the alias ledger),
+ * exactly as it is for vanity slugs.
+ */
+export const FORM_SLUG_MAX_LENGTH = 80;
+
+/** Lowercase alphanumeric words joined by single hyphens. No leading, trailing or doubled hyphen. */
+export const FORM_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export type FormSlugIssue = 'invalid' | 'too-long' | null;
+
+/** Shape validation for a form slug. Returns an issue key, or null when valid. */
+export function validateFormSlug(slug: string): FormSlugIssue {
+  const s = slug.trim().toLowerCase();
+  if (s.length > FORM_SLUG_MAX_LENGTH) return 'too-long';
+  if (!FORM_SLUG_RE.test(s)) return 'invalid';
+  return null;
+}
+
+/**
  * The single policy gate for claiming a vanity slug (open-core). Forms is
  * ALWAYS free — there is no Forms-side plan. Premium unlocks come from the
  * customer's Dapta AI subscription, validated upstream (IAM) and passed in

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1118,6 +1118,19 @@ export const formInputSchema = z.object({
 });
 export type FormInput = z.infer<typeof formInputSchema>;
 
+/**
+ * Body of PUT /v1/forms/:id/slug: the form's new public URL segment.
+ *
+ * Shape validation (the character rules) is `validateFormSlug` in @quill/engine
+ * and runs in the data layer, so a slug that gets past this bound still comes
+ * back as a typed SLUG_INVALID rather than a 500. What this pins is the
+ * CEILING, 80, which the engine's `FORM_SLUG_MAX_LENGTH` mirrors on purpose.
+ */
+export const formSlugInputSchema = z.object({
+  slug: z.string().trim().min(1).max(80),
+});
+export type FormSlugInput = z.infer<typeof formSlugInputSchema>;
+
 export const formViewSchema = z.object({
   id: z.string(),
   accountId: z.string(),

--- a/qa/e2e/v9-slug-rename.spec.ts
+++ b/qa/e2e/v9-slug-rename.spec.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto';
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * V9 — renaming a form's public link, end to end.
+ *
+ * Under test: the pencil beside Copy link in the builder topbar
+ * (apps/web/app/admin/forms/[id]/edit/link-actions.tsx), the rename it performs
+ * (PUT /v1/forms/:id/slug), and the two consequences that only show up once all
+ * the layers are stacked:
+ *
+ *   1. the topbar retargets WITHOUT a reload. `publicPath` reaches four client
+ *      components as a prop from a server component, so a rename that only
+ *      revalidated on the server would leave Copy link, Embed and Open form
+ *      pointing at the previous URL for the rest of the session, starting with
+ *      the button the author is most likely to press next;
+ *   2. the retired URL still lands the visitor on the current one, WITH its
+ *      query string intact. The redirect is ours, and dropping the query on our
+ *      own redirect is exactly how campaign attribution was lost once before,
+ *      so `?utm_source` is asserted rather than assumed. Next resolves this
+ *      redirect on the client, so the crawler's half of it (the canonical tag)
+ *      is asserted separately, without a browser.
+ */
+
+const API = 'http://localhost:4400';
+const ORIGIN = 'http://localhost:3400';
+
+// Per-run counter (Date.now is intentionally avoided) keeps each form name
+// unique within a run without leaking wall-clock time into fixtures.
+let formSeq = 0;
+
+function baseConfig() {
+  return {
+    version: 1,
+    cover: { enabled: false },
+    steps: [{ key: 'q1', type: 'text', question: 'Your name?' }],
+  };
+}
+
+async function createForm(request: APIRequestContext, label: string, workerIndex: number) {
+  formSeq += 1;
+  const name = `qa-slug-rename-${label}-w${workerIndex}-${formSeq}`;
+  const res = await request.post(`${API}/v1/forms`, { data: { name, config: baseConfig() } });
+  expect(res.status(), 'POST /v1/forms should create the form').toBe(201);
+  const body = (await res.json()) as { id: string; slug: string };
+  // Publishing is what puts the form on the public path the redirect assertions use.
+  await request.post(`${API}/v1/forms/${body.id}/publish`);
+  return body;
+}
+
+/** Same derivation the editor page uses — never hardcode the account code. */
+async function publicPrefix(request: APIRequestContext) {
+  const res = await request.get(`${API}/v1/me`);
+  expect(res.ok(), 'GET /v1/me should resolve the principal').toBeTruthy();
+  const me = (await res.json()) as { accountCode: string; handle: string | null };
+  return `/${me.accountCode}/${me.handle ?? 'me'}`;
+}
+
+/**
+ * A slug no previous run can already be holding.
+ *
+ * The per-run counter that names the FORMS is not enough here, and the
+ * difference is worth stating because it bit: a form is created by NAME, so a
+ * repeat name just gets auto-suffixed and the run carries on. A rename asks for
+ * one exact slug. The QA database survives between runs, so a counter that
+ * restarts at 1 asks the second run for a slug the first run already took, and
+ * the rename correctly refuses it. Random, not `Date.now()`, per the harness
+ * convention of keeping wall-clock time out of fixtures.
+ */
+function freshSlug(label: string, workerIndex: number) {
+  return `qa-renamed-${label}-w${workerIndex}-${randomUUID().slice(0, 8)}`;
+}
+
+test.describe('V9 — rename a form public link', () => {
+  test('the dialog renames the form and the topbar retargets without a reload', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const form = await createForm(request, 'topbar', testInfo.workerIndex);
+    const prefix = await publicPrefix(request);
+    const next = freshSlug('topbar', testInfo.workerIndex);
+
+    await page.goto(`/admin/forms/${form.id}/edit`);
+
+    const openForm = page.locator('a[data-testid="editor-open-form"]');
+    await expect(openForm).toHaveAttribute('href', `${prefix}/${form.slug}`, { timeout: 25_000 });
+
+    await page.getByTestId('editor-rename-link').click();
+    const input = page.getByTestId('form-slug-input');
+    await expect(input).toBeVisible();
+    await expect(input, 'the dialog opens on the current slug').toHaveValue(form.slug);
+
+    await input.fill(next);
+    await page.getByTestId('form-slug-save').click();
+
+    // No navigation, no reload: the same DOM node now points at the new URL.
+    await expect(input, 'the dialog closes on success').toBeHidden({ timeout: 15_000 });
+    await expect(openForm, 'the topbar follows the rename in place').toHaveAttribute(
+      'href',
+      `${prefix}/${next}`,
+    );
+
+    const server = await request.get(`${API}/v1/forms/${form.id}`);
+    expect(((await server.json()) as { slug: string }).slug).toBe(next);
+  });
+
+  test('the previous link sends the visitor to the new one, query string intact', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const form = await createForm(request, 'redirect', testInfo.workerIndex);
+    const prefix = await publicPrefix(request);
+    const next = freshSlug('redirect', testInfo.workerIndex);
+
+    const renamed = await request.put(`${API}/v1/forms/${form.id}/slug`, { data: { slug: next } });
+    expect(renamed.ok(), 'PUT /v1/forms/:id/slug should rename').toBeTruthy();
+
+    // The retired link, exactly as a campaign email would carry it.
+    await page.goto(`${prefix}/${form.slug}?utm_source=qa&utm_medium=email&lang=en`);
+
+    // Waited for, not asserted outright: Next resolves this redirect on the
+    // client (see the note in the public page's `generateMetadata`), so the
+    // address bar changes a beat after load rather than during it.
+    await page.waitForURL(`${ORIGIN}${prefix}/${next}?utm_source=qa&utm_medium=email&lang=en`, {
+      timeout: 15_000,
+    });
+    // The query survived the hop. Losing it here is not hypothetical: the
+    // platform has already lost campaign attribution once to one of its own
+    // redirects, and `?embed=1` and `?step=N` ride the same path.
+    expect(new URL(page.url()).searchParams.get('utm_source')).toBe('qa');
+    // The form, not a 404: the alias resolved and the redirect carried through.
+    await expect(page.locator('.pf')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('the retired link names the canonical URL for anything that does not run scripts', async ({
+    request,
+  }, testInfo) => {
+    const form = await createForm(request, 'canonical', testInfo.workerIndex);
+    const prefix = await publicPrefix(request);
+    const next = freshSlug('canonical', testInfo.workerIndex);
+    await request.put(`${API}/v1/forms/${form.id}/slug`, { data: { slug: next } });
+
+    // No browser: a crawler, a link checker or a social unfurler reading the
+    // markup of the retired URL. The canonical tag is the only thing telling
+    // them which address is the real one.
+    const res = await request.get(`${ORIGIN}${prefix}/${form.slug}?utm_source=qa`);
+    const html = await res.text();
+    const canonical = html.match(/<link rel="canonical" href="([^"]+)"/)?.[1];
+
+    expect(canonical, 'points at the current slug').toContain(`${prefix}/${next}`);
+    expect(canonical, 'and carries no campaign parameters').not.toContain('utm_');
+  });
+
+  test('refuses a slug another form already holds, and says so', async ({ page, request }, testInfo) => {
+    const taken = await createForm(request, 'taken', testInfo.workerIndex);
+    const form = await createForm(request, 'clash', testInfo.workerIndex);
+
+    await page.goto(`/admin/forms/${form.id}/edit`);
+    await page.getByTestId('editor-rename-link').click();
+    await page.getByTestId('form-slug-input').fill(taken.slug);
+    await page.getByTestId('form-slug-save').click();
+
+    await expect(page.getByTestId('form-slug-error'), 'the clash is named on screen').toBeVisible({
+      timeout: 15_000,
+    });
+    // The dialog stays open on a refusal so the typed value is still there to fix.
+    await expect(page.getByTestId('form-slug-input')).toBeVisible();
+
+    const server = await request.get(`${API}/v1/forms/${form.id}`);
+    expect(((await server.json()) as { slug: string }).slug).toBe(form.slug);
+  });
+
+  test('a malformed slug cannot be submitted at all', async ({ page, request }, testInfo) => {
+    const form = await createForm(request, 'shape', testInfo.workerIndex);
+
+    await page.goto(`/admin/forms/${form.id}/edit`);
+    await page.getByTestId('editor-rename-link').click();
+    await page.getByTestId('form-slug-input').fill('Not A Slug');
+
+    // Caught in the browser by the same validator the server runs, so the
+    // refusal costs no round trip.
+    await expect(page.getByTestId('form-slug-error')).toBeVisible();
+    await expect(page.getByTestId('form-slug-save')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
The third segment of a form's URL (`/{accountCode}/{handle}/{slug}`) was written once, derived from the form's name at creation, with nothing in the product to change it. It is editable now, from a pencil beside Copy link in the builder topbar: the one place that already shows the URL is where somebody goes to change it.

Renaming does not break what is already published. The previous slug is retired into a new `form_alias` ledger rather than dropped, so a QR code on a printed flyer, a campaign email already sent, an iframe embedded on someone else's site and a CRM property holding the old URL all keep resolving. `getPublishedForm` falls back to that ledger, which covers every public entry point at once: the page, the OG image, submissions, funnel events and the booking callback all arrive through it.

## The redirect is client-side, and that was not the plan

The intent was a real HTTP 308 on the retired URL. It is not available here: Next 16 has already begun streaming by the time the page resolves, so `permanentRedirect` comes out as an RSC payload plus a `<meta http-equiv="refresh">`, answered with 200. Verified under both `next start` and the standalone server. Throwing it from `generateMetadata` instead does not help, and costs the canonical tag, since throwing means never returning metadata at all.

So the two audiences are served separately:

- **People** get the client-side redirect. The browser lands on the current URL with the query string forwarded verbatim, so campaign parameters, `?embed=1` and `?step=N` survive the hop. That last part is asserted rather than assumed: this platform has already lost campaign attribution once to one of its own redirects.
- **Everything that does not run scripts** (crawlers, link checkers, social unfurlers) gets `<link rel="canonical">` naming the current slug, with no campaign parameters on it.

A true 308 needs `middleware.ts`, which costs an extra API call on every public form view. Not done here on purpose. Happy to add it if we want to pay that.

## Around the rename

- `PUT /v1/forms/{id}/slug`, separate from the form PUT because that one is the builder's autosave and a keystroke must not rotate a public URL. 409 `SLUG_TAKEN` / `SLUG_INVALID`. Any member of the account, the same gate as editing the form.
- A `slug` sent to `PUT /v1/forms/{id}` routes through the same code, so the field that predates this retires the old value too. `updateForm` no longer writes the column at all: one implementation, not two.
- New form slugs skip values another form retired. Handing one out would let a new form quietly inherit somebody else's published traffic.
- A rename follows into `profile.formSlugs`, the by-slug selection on member public pages, which filters on the canonical slug and would otherwise drop the form silently.
- Deleting a form releases the slugs it retired.
- `publicPath` became state in the editor: it reaches four client components as a prop, so a server-only revalidate would leave Copy link, Embed, Open form and the prefill example pointing at the old URL for the rest of the session.

## Schema

Migration `0017_form_alias` in both dialects, additive, plus the matching drizzle objects in `schema.pg.ts` and `schema.sqlite.ts`. Keyed by `(account_id, alias)` rather than by alias alone, unlike `account_alias`: a form slug is unique per account, so two accounts may each retire a `contact`.

## Verification

- `pnpm test`, `lint`, `typecheck`, `build`: 16/16 tasks green
- 11 new data-layer tests (`packages/db/src/form-slug.spec.ts`), 8 new controller tests (`apps/api/src/form-slug.controller.spec.ts`)
- **Postgres parity**: the full `@quill/db` suite, 260 tests, against a real Postgres
- 5 new e2e (`qa/e2e/v9-slug-rename.spec.ts`) plus the 3 existing editor-link e2e, all passing
- `dash-check` clean, `publish-gate` passed

Unrelated, found while running the QA suite: `qa/e2e/draft-publish.spec.ts` fails on `develop` today. It asserts the publish toast as `Changes published {em dash} your form is live.` while the catalog has said `Changes published. Your form is live.` since the em dash sweep. Tracked separately, not touched here.
