### PR TITLE
feat(builder): let an option's stored value follow its label

### DIFF
--- a/.changeset/option-value-follows-label.md
+++ b/.changeset/option-value-follows-label.md
@@ -17,16 +17,23 @@ Both surfaces now go through one place, so they cannot disagree again. Rewording
 a label rewrites the value with it, until you write a value yourself, after which
 it is yours and stays exactly as you left it.
 
-Renaming a value is not a field edit, because a value is named by string from six
-other places, none of which complains when it stops matching: a branch simply
-never fires again. The rename now carries all of them, so a reworded label cannot
-silently break a form:
+Renaming a value is not a field edit, because a value is named by string from
+seven other places, none of which complains when it stops matching: a branch
+simply never fires again. The rename now carries all of them, so a reworded label
+cannot silently break a form:
 
 - `showWhen` / `hideWhen` values on any step whose condition reads this one;
 - `goto` jump values on the step that owns the options;
 - the keys of `questionVariants` and `sliderLabelVariants`, including the
   comma-joined composite keys a multi-select variant uses;
-- outcome override values.
+- outcome override values;
+- the step's `defaultValue`, which seeds the answer and simply stops seeding.
+
+Two options can legitimately hold the same value, because both Add buttons mint
+one from the list length and a delete-then-add repeats a sibling's. The rename
+therefore moves the option by position and only repoints when the token is
+actually leaving the step, so a row nobody touched is never dragged along. Add
+now dedupes, so the duplicate stops being minted in the first place.
 
 Values already out in the world do not move. Anything the live config serves,
 plus anything a HubSpot value map points at, stays put while its label is

--- a/.changeset/option-value-follows-label.md
+++ b/.changeset/option-value-follows-label.md
@@ -1,0 +1,45 @@
+---
+'@quill/engine': minor
+'@quill/shared': minor
+---
+
+An option's stored value follows its label, and every pointer follows the value.
+
+A choice option carries two strings: the label a respondent reads, and the value
+stored in the answer. The builder has always written the value for you, but only
+in the settings panel. The canvas, which is where people actually type, changed
+the label and left the value on the `option_1` / `option_2` it was created with.
+The result was a form that read properly on screen and stored answers nobody
+could read, and authors reasonably concluded the value was a box they had failed
+to fill in.
+
+Both surfaces now go through one place, so they cannot disagree again. Rewording
+a label rewrites the value with it, until you write a value yourself, after which
+it is yours and stays exactly as you left it.
+
+Renaming a value is not a field edit, because a value is named by string from six
+other places, none of which complains when it stops matching: a branch simply
+never fires again. The rename now carries all of them, so a reworded label cannot
+silently break a form:
+
+- `showWhen` / `hideWhen` values on any step whose condition reads this one;
+- `goto` jump values on the step that owns the options;
+- the keys of `questionVariants` and `sliderLabelVariants`, including the
+  comma-joined composite keys a multi-select variant uses;
+- outcome override values.
+
+Values already out in the world do not move. Anything the live config serves,
+plus anything a HubSpot value map points at, stays put while its label is
+reworded freely: answers already collected carry those tokens, and the CRM
+mapping is keyed by them. Options added afterwards are not in the live config, so
+theirs still follow, and a form still being built has nothing locked at all.
+
+The stored values now sit behind a "Stored values" disclosure rather than in a
+column beside every label. It opens on its own when a value has stopped tracking
+its label, so a value chosen deliberately, to match a CRM enum say, is never
+hidden from the person who chose it. Editing one by hand commits on blur and
+refuses a value another option on the question already stores, rather than
+silently merging two answers onto one token.
+
+Forms whose values are stuck on `option_1` heal on the next label edit: the
+created placeholder counts as unwritten, not as a value somebody chose.

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect, unstable_rethrow } from 'next/navigation';
+import { lockedOptionValues } from '@quill/engine';
 import { adminApi, ApiError } from '@/lib/admin-api';
 
 /** Create a form and jump straight into its editor. */
@@ -38,6 +39,34 @@ export async function deleteFormAction(id: string): Promise<void> {
  * immediately (metadata is not part of the draft flow). Publishing the draft is
  * a separate, explicit `publishFormAction`.
  */
+/**
+ * Re-read which option values the builder must not move.
+ *
+ * The set is computed at page load from the live config, and one thing can
+ * change it without a reload: saving a HubSpot value map in the Connect tab
+ * writes `valueMaps` to the LIVE config through its own endpoint, which the
+ * form's draft autosave never touches. Without this, mapping a value and
+ * switching straight back to Build leaves the builder still believing that value
+ * is free, and the next label edit renames it out from under the mapping - the
+ * exact outcome the lock exists to prevent. The Build tab already refetches its
+ * HubSpot data on the same trip for the same reason.
+ *
+ * Answers `ok: false` rather than an empty set when the read fails. An empty set
+ * means "nothing is locked", so returning one on a dropped request would UNLOCK
+ * the form, which is the dangerous direction to fail in.
+ */
+export async function optionLocksAction(
+  id: string,
+): Promise<{ ok: true; locks: Record<string, string[]> } | { ok: false }> {
+  try {
+    const form = await adminApi.getForm(id);
+    return { ok: true, locks: lockedOptionValues(form.config) };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}
+
 export async function saveFormAction(
   id: string,
   patch: { name?: string; config?: unknown },

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import type { FormConfig, FormStep, FormOption } from '@quill/engine';
+import type { FormConfig, FormStep } from '@quill/engine';
 import {
   nameFields,
   sliderBounds,
@@ -95,6 +95,7 @@ export function CanvasQuestion({
   total,
   device,
   onUpdate,
+  onOptionLabel,
   m,
 }: {
   config: FormConfig;
@@ -103,6 +104,12 @@ export function CanvasQuestion({
   total: number;
   device: 'desktop' | 'mobile';
   onUpdate: (patch: Partial<FormStep>) => void;
+  /**
+   * Write one option's label. Separate from `onUpdate` because the option's
+   * VALUE may follow the label, and the value is referenced from outside this
+   * step, which a step-scoped patch cannot reach. See `setOptionLabel`.
+   */
+  onOptionLabel: (optionIndex: number, label: string) => void;
   m: BuilderMessages;
 }) {
   // The author's exact color, matching the renderer and the live preview. This
@@ -207,6 +214,7 @@ export function CanvasQuestion({
           index={index}
           accent={accent}
           onUpdate={onUpdate}
+          onOptionLabel={onOptionLabel}
           m={m}
         />
 
@@ -247,6 +255,7 @@ function QuestionEditableBody({
   index,
   accent,
   onUpdate,
+  onOptionLabel,
   m,
 }: {
   config: FormConfig;
@@ -254,6 +263,7 @@ function QuestionEditableBody({
   index: number;
   accent: string;
   onUpdate: (patch: Partial<FormStep>) => void;
+  onOptionLabel: (optionIndex: number, label: string) => void;
   m: BuilderMessages;
 }) {
   const showsPoints =
@@ -268,9 +278,6 @@ function QuestionEditableBody({
     design.radius === 'sharp' ? 'rounded-[2px]' : design.radius === 'round' ? 'rounded-[14px]' : 'rounded-[8px]';
   const centred = design.contentAlign === 'center';
 
-  function updateOption(i: number, patch: Partial<FormOption>) {
-    onUpdate({ options: (step.options ?? []).map((o, oi) => (oi === i ? { ...o, ...patch } : o)) });
-  }
   function addOption() {
     const n = (step.options ?? []).length + 1;
     onUpdate({ options: [...(step.options ?? []), { label: `Option ${n}`, value: `option_${n}`, points: 0 }] });
@@ -363,7 +370,7 @@ function QuestionEditableBody({
                   )}
                   <input
                     value={opt.label}
-                    onChange={(e) => updateOption(i, { label: e.target.value })}
+                    onChange={(e) => onOptionLabel(i, e.target.value)}
                     placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
                     aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
                     className="w-full min-w-0 bg-transparent text-center text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
@@ -399,7 +406,7 @@ function QuestionEditableBody({
                   </span>
                   <input
                     value={opt.label}
-                    onChange={(e) => updateOption(i, { label: e.target.value })}
+                    onChange={(e) => onOptionLabel(i, e.target.value)}
                     placeholder={`${m.canvas.optionPlaceholder} ${i + 1}`}
                     aria-label={`${m.canvas.optionPlaceholder} ${i + 1}`}
                     className="min-w-0 flex-1 bg-transparent text-[15px] font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
@@ -487,6 +494,7 @@ export function CanvasPage({
   focusSignal = 0,
   onSelect,
   onUpdateStep,
+  onOptionLabel,
   m,
 }: {
   config: FormConfig;
@@ -496,6 +504,8 @@ export function CanvasPage({
   focusSignal?: number;
   onSelect: (index: number) => void;
   onUpdateStep: (index: number, patch: Partial<FormStep>) => void;
+  /** Write one step's option label; the value may follow it. See `setOptionLabel`. */
+  onOptionLabel: (stepIndex: number, optionIndex: number, label: string) => void;
   m: BuilderMessages;
 }) {
   // The author's exact color, like every other surface — nothing corrects a
@@ -565,6 +575,7 @@ export function CanvasPage({
                   index={i}
                   accent={accent}
                   onUpdate={(patch) => onUpdateStep(i, patch)}
+                  onOptionLabel={(optionIndex, label) => onOptionLabel(i, optionIndex, label)}
                   m={m}
                 />
               )}

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -11,6 +11,7 @@ import {
   resolveDesign,
   resolveFormLogos,
   resolveRevealPresentation,
+  uniqueKey,
 } from '@quill/engine';
 import { onAccent, DEFAULT_ACCENT, getMessages } from '@quill/shared';
 import { clientLocale } from '@/lib/client-locale';
@@ -280,7 +281,10 @@ function QuestionEditableBody({
 
   function addOption() {
     const n = (step.options ?? []).length + 1;
-    onUpdate({ options: [...(step.options ?? []), { label: `Option ${n}`, value: `option_${n}`, points: 0 }] });
+    // Deduped for the same reason as the settings panel's Add: `n` counts the
+    // current options, so a delete-then-add mints a value a sibling still holds.
+    const value = uniqueKey(`option_${n}`, new Set((step.options ?? []).map((o) => o.value)));
+    onUpdate({ options: [...(step.options ?? []), { label: `Option ${n}`, value, points: 0 }] });
   }
   function removeOption(i: number) {
     onUpdate({ options: (step.options ?? []).filter((_, oi) => oi !== i) });

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.spec.tsx
@@ -1,0 +1,89 @@
+/**
+ * The options editor's stored-value disclosure, rendered for real.
+ *
+ * `packages/engine/src/option-value.spec.ts` proves WHEN a value may move; this
+ * file proves the panel around it tells the truth: that the values are out of
+ * the way until asked for, that one the author wrote themselves is never hidden
+ * from them, and that a value the form can no longer move renders as read-only
+ * rather than as an editable box that will refuse the edit.
+ *
+ * Rendered with `renderToStaticMarkup` because these components use hooks (the
+ * web suite runs in plain node — see `vitest.config.ts`). That means the initial
+ * render only, which is exactly the surface at issue: every one of these
+ * decisions is a `useState` initialiser, and each was wrong once.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { FormOption } from '@quill/engine';
+import { getMessages } from '@quill/shared';
+import { OptionsEditor } from './options-editor';
+
+const m = getMessages('en').admin.editor.options;
+
+function render(options: FormOption[], locked: string[] = []) {
+  return renderToStaticMarkup(
+    <OptionsEditor
+      options={options}
+      onChange={() => {}}
+      onLabelChange={() => {}}
+      onValueChange={() => {}}
+      locked={new Set(locked)}
+      m={m}
+    />,
+  );
+}
+
+const derived: FormOption[] = [
+  { label: 'Under 50', value: 'under_50' },
+  { label: 'Over 50', value: 'over_50' },
+];
+
+describe('OptionsEditor — stored values', () => {
+  it('keeps the values out of the row while they still track their labels', () => {
+    const html = render(derived);
+
+    expect(html, 'the labels are the row').toContain('value="Under 50"');
+    expect(html, 'the values are not').not.toContain('value="under_50"');
+    expect(html).toContain('options-advanced-toggle');
+    expect(html).toContain('aria-expanded="false"');
+  });
+
+  it('opens itself when a value has stopped tracking its label', () => {
+    // A value chosen to match something outside this form is the one an author
+    // most needs to see, and the one a label edit will not move.
+    const html = render([derived[0]!, { label: 'Over 50', value: 'ENTERPRISE_TIER' }]);
+
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain('value="ENTERPRISE_TIER"');
+  });
+
+  it('treats the created placeholder as still tracking, so a stuck form stays tidy', () => {
+    // `option_2` is what creating an option puts there, not a choice anybody
+    // made — opening the section for it would flag every untouched new form.
+    const html = render([derived[0]!, { label: 'Over 50', value: 'option_2' }]);
+
+    expect(html).toContain('aria-expanded="false"');
+  });
+
+  it('renders a value the form can no longer move as read-only, not as absent', () => {
+    // Hiding it would leave the author hunting for a value that is still real
+    // and still theirs; an editable box that refuses the edit is worse.
+    const html = render(derived, ['over_50']);
+
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain('readonly');
+    expect(html, 'and says why').toContain('options-value-locked');
+  });
+
+  it('says nothing about locked values when none of THIS question’s are', () => {
+    // The hint is scoped to the step, so an unpublished form never reads a
+    // warning about a rule that is not applying to it.
+    const html = render(derived);
+
+    expect(html).not.toContain('options-value-locked');
+  });
+
+  it('offers no disclosure at all before there are options', () => {
+    expect(render([])).not.toContain('options-advanced-toggle');
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { FormOption, FormOptionLayout } from '@quill/engine';
-import { isDerivedOptionValue } from '@quill/engine';
+import { isDerivedOptionValue, uniqueKey } from '@quill/engine';
 import { Button } from '@/components/ui/button';
 import { HelpTip } from '@/components/ui/help-tip';
 import { TextField, NumberField } from './fields';
@@ -22,10 +22,12 @@ import type { EditorMessages } from './messages';
  * something they were supposed to fill in. Hiding it makes the row say what the
  * row is for.
  *
- * It opens on its own when any value has stopped tracking its label, so a value
- * somebody chose deliberately - to match a CRM enum, say - is never hidden from
- * the person who chose it, and a form whose values are frozen because it is
- * published shows them rather than implying they still follow.
+ * It opens on its own in the two cases where a closed section would mislead:
+ * when a value has stopped tracking its label, so one somebody chose
+ * deliberately (to match a CRM enum, say) is never hidden from them; and when a
+ * value is LOCKED, because otherwise a form whose values happen to look derived
+ * stays shut, its labels reword without them, and the sentence explaining why is
+ * behind the very toggle nobody was given a reason to press.
  */
 export function OptionsEditor({
   options,
@@ -78,7 +80,9 @@ export function OptionsEditor({
   // stay open once opened. Not derived on every render: an author who opens
   // the section and then edits a label back into alignment should not have the
   // box they are typing in vanish under the cursor.
-  const [advanced, setAdvanced] = useState(() => options.some((o) => !isDerivedOptionValue(o)));
+  const [advanced, setAdvanced] = useState(
+    () => options.some((o) => !isDerivedOptionValue(o) || locked.has(o.value)),
+  );
   // Explains why the values below are not moving with the labels. Only shown
   // when a value on THIS question is actually held, so an unpublished form
   // never reads a warning about a rule that is not applying to it.
@@ -92,7 +96,12 @@ export function OptionsEditor({
   }
   function add() {
     const n = options.length + 1;
-    onChange([...options, { label: `Option ${n}`, value: `option_${n}`, points: 0 }]);
+    // Deduped: `n` counts the CURRENT options, so deleting a middle one and
+    // adding mints a value a sibling already holds. Two options on one token is
+    // not a cosmetic duplicate - it makes "which option did they pick"
+    // unanswerable, for the renamer and for the stored answer alike.
+    const value = uniqueKey(`option_${n}`, new Set(options.map((o) => o.value)));
+    onChange([...options, { label: `Option ${n}`, value, points: 0 }]);
   }
   function reorder(from: number, to: number) {
     const next = [...options];
@@ -289,6 +298,15 @@ function OptionValueField({
   const clean = text.replace(/,/g, '').trim();
 
   function commit() {
+    // A readonly input still fires `blur`, and `clean` strips commas and trims,
+    // so a stored value carrying either would "change" on a bare tab-through and
+    // rename itself with no edit at all. The mutation boundary refuses it too;
+    // this stops the attempt at the field so nothing flickers.
+    if (locked) {
+      setText(value);
+      setRefused(false);
+      return;
+    }
     if (clean === value) {
       setText(value);
       setRefused(false);

--- a/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/options-editor.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { FormOption, FormOptionLayout } from '@quill/engine';
-import { slugify } from '@quill/engine';
+import { isDerivedOptionValue } from '@quill/engine';
 import { Button } from '@/components/ui/button';
 import { HelpTip } from '@/components/ui/help-tip';
 import { TextField, NumberField } from './fields';
@@ -12,14 +12,27 @@ import { SortableList, SortableRow } from './sortable';
 import type { EditorMessages } from './messages';
 
 /**
- * Editor for a choice/dropdown step's options: label, value, points and an
- * optional icon, drag-reorderable. Value auto-fills from the label until the
- * author edits it directly (then it's left alone). No native scrollbars; the
- * whole panel scrolls with the page.
+ * Editor for a choice/dropdown step's options: label, points and an optional
+ * icon, drag-reorderable. No native scrollbars; the whole panel scrolls with
+ * the page.
+ *
+ * The stored `value` is behind "Advanced" rather than beside the label. It is a
+ * second text box that most authors have no reason to think about: it fills
+ * itself from the label, and the ones who did notice it mostly read it as
+ * something they were supposed to fill in. Hiding it makes the row say what the
+ * row is for.
+ *
+ * It opens on its own when any value has stopped tracking its label, so a value
+ * somebody chose deliberately - to match a CRM enum, say - is never hidden from
+ * the person who chose it, and a form whose values are frozen because it is
+ * published shows them rather than implying they still follow.
  */
 export function OptionsEditor({
   options,
   onChange,
+  onLabelChange,
+  onValueChange,
+  locked,
   showPoints = true,
   showIcon = false,
   layout = 'list',
@@ -27,6 +40,22 @@ export function OptionsEditor({
 }: {
   options: FormOption[];
   onChange: (next: FormOption[]) => void;
+  /**
+   * Write one option's label. Separate from `onChange` because the `value` may
+   * follow the label, and the value is pointed at from outside this step
+   * (conditions on other steps, outcome overrides), which an options-array
+   * patch cannot reach. See `setOptionLabel` in the engine.
+   */
+  onLabelChange: (index: number, label: string) => void;
+  /**
+   * Rewrite one option's stored value by hand. Also separate from `onChange`:
+   * a value is pointed at from outside this step, so moving it is a rename, not
+   * a field edit. Committed on blur rather than per keystroke, because each
+   * commit rewrites those pointers across the whole config.
+   */
+  onValueChange: (index: number, value: string) => void;
+  /** Values this form may no longer move (published, or mapped to a CRM enum). */
+  locked: ReadonlySet<string>;
   /**
    * Render the Points column (V5-B6). Hidden while this question is not scored,
    * so the row shows the two fields that always matter instead of a column that
@@ -45,6 +74,15 @@ export function OptionsEditor({
 }) {
   const ids = options.map((_, i) => `opt-${i}`);
   const [importOpen, setImportOpen] = useState(false);
+  // Open from the start when a value has stopped tracking its label, and
+  // stay open once opened. Not derived on every render: an author who opens
+  // the section and then edits a label back into alignment should not have the
+  // box they are typing in vanish under the cursor.
+  const [advanced, setAdvanced] = useState(() => options.some((o) => !isDerivedOptionValue(o)));
+  // Explains why the values below are not moving with the labels. Only shown
+  // when a value on THIS question is actually held, so an unpublished form
+  // never reads a warning about a rule that is not applying to it.
+  const hasLocked = options.some((o) => locked.has(o.value));
 
   function update(index: number, patch: Partial<FormOption>) {
     onChange(options.map((o, i) => (i === index ? { ...o, ...patch } : o)));
@@ -54,7 +92,7 @@ export function OptionsEditor({
   }
   function add() {
     const n = options.length + 1;
-    onChange([...options, { label: `Option ${n}`, value: slugify(`option ${n}`), points: 0 }]);
+    onChange([...options, { label: `Option ${n}`, value: `option_${n}`, points: 0 }]);
   }
   function reorder(from: number, to: number) {
     const next = [...options];
@@ -96,28 +134,7 @@ export function OptionsEditor({
                       </span>
                       <TextField
                         value={o.label}
-                        onChange={(e) => {
-                          const label = e.target.value;
-                          const autoValue = !o.value || o.value === slugify(o.label ?? '');
-                          update(index, autoValue ? { label, value: slugify(label) } : { label });
-                        }}
-                      />
-                    </label>
-                    <label className="flex min-w-0 flex-1 flex-col gap-1">
-                      <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
-                        {m.value}
-                        <HelpTip text={m.valueHelp} label={m.value} />
-                      </span>
-                      <TextField
-                        value={o.value}
-                        onChange={(e) =>
-                          // Commas are the separator in a dynamic-question
-                          // variant key, so a value containing one is
-                          // indistinguishable from a two-option set — a row
-                          // authored for one option would also fire for a
-                          // completely different answer.
-                          update(index, { value: e.target.value.replace(/,/g, '') })
-                        }
+                        onChange={(e) => onLabelChange(index, e.target.value)}
                       />
                     </label>
                     {showPoints ? (
@@ -141,6 +158,21 @@ export function OptionsEditor({
                       <i aria-hidden className="pi pi-trash" style={{ fontSize: 13 }} />
                     </Button>
                   </div>
+                  {advanced ? (
+                    // Its own row for the same reason the icon has one: the panel
+                    // is ~420px and a third column in the label row clipped the
+                    // value to eight characters, which is unreadable for the one
+                    // field here whose exact characters are the point.
+                    <div className="pl-7" data-testid={`option-value-${index}`}>
+                      <OptionValueField
+                        value={o.value}
+                        locked={locked.has(o.value)}
+                        taken={options.filter((_, i) => i !== index).map((x) => x.value)}
+                        onRename={(next) => onValueChange(index, next)}
+                        m={m}
+                      />
+                    </div>
+                  ) : null}
                   {showIcon ? (
                     <div className="flex min-w-0 flex-col gap-1 pl-7" data-testid={`option-icon-${index}`}>
                       <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
@@ -168,6 +200,27 @@ export function OptionsEditor({
           {m.pointsHint}
         </p>
       ) : null}
+      {options.length > 0 ? (
+        <button
+          type="button"
+          data-testid="options-advanced-toggle"
+          aria-expanded={advanced}
+          onClick={() => setAdvanced((v) => !v)}
+          className="flex w-fit items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i
+            aria-hidden
+            className={`pi ${advanced ? 'pi-chevron-down' : 'pi-chevron-right'}`}
+            style={{ fontSize: 10 }}
+          />
+          {m.advanced}
+        </button>
+      ) : null}
+      {advanced && hasLocked ? (
+        <p className="text-xs leading-relaxed text-muted-foreground" data-testid="options-value-locked">
+          {m.valueLocked}
+        </p>
+      ) : null}
       <div className="flex flex-wrap gap-2">
         <Button variant="outline" size="sm" onClick={add}>
           <i aria-hidden className="pi pi-plus" style={{ fontSize: 11 }} /> {m.add}
@@ -190,5 +243,99 @@ export function OptionsEditor({
         m={m.importer}
       />
     </div>
+  );
+}
+
+/**
+ * One option's stored value, editable by hand.
+ *
+ * Local text state committing on blur or Enter, the same shape as the step's
+ * field-key editor and for the same reason: a commit rewrites every pointer
+ * aimed at this value across the config, so doing it per keystroke would churn
+ * the form (and the autosave) on the way to a name. It also makes a collision
+ * refusable: typing `yes` while another option already stores it would merge two
+ * distinct answers into one token, so it is rejected with a message rather than
+ * silently mangled into `yes_2`.
+ *
+ * A locked value renders read-only instead of vanishing. Hiding it would leave
+ * the author wondering where their value went; showing it greyed says the value
+ * is real, it is theirs, and this form has gone too far to move it.
+ */
+function OptionValueField({
+  value,
+  locked,
+  taken,
+  onRename,
+  m,
+}: {
+  value: string;
+  locked: boolean;
+  taken: string[];
+  onRename: (next: string) => void;
+  m: EditorMessages['options'];
+}) {
+  const [text, setText] = useState(value);
+  const [refused, setRefused] = useState(false);
+  // Follow an external change: switching questions, an undo, or the value
+  // moving because the label did.
+  useEffect(() => {
+    setText(value);
+    setRefused(false);
+  }, [value]);
+
+  // Commas separate the values inside a dynamic-question variant key, so a value
+  // containing one is indistinguishable from a two-option set - a variant
+  // authored for this option would also fire for a completely different answer.
+  const clean = text.replace(/,/g, '').trim();
+
+  function commit() {
+    if (clean === value) {
+      setText(value);
+      setRefused(false);
+      return;
+    }
+    if (!clean || taken.includes(clean)) {
+      setText(value);
+      setRefused(!!clean);
+      return;
+    }
+    setRefused(false);
+    onRename(clean);
+  }
+
+  return (
+    <label className="flex min-w-0 flex-1 flex-col gap-1">
+      <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+        {m.value}
+        <HelpTip text={m.valueHelp} label={m.value} />
+      </span>
+      <TextField
+        value={text}
+        readOnly={locked}
+        aria-readonly={locked || undefined}
+        aria-invalid={refused || undefined}
+        className={locked ? 'opacity-60' : undefined}
+        onChange={(e) => {
+          setText(e.target.value);
+          setRefused(false);
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            // Commit WITHOUT blurring, so a keyboard user keeps their place.
+            e.preventDefault();
+            commit();
+          } else if (e.key === 'Escape') {
+            setText(value);
+            setRefused(false);
+          }
+        }}
+      />
+      {refused ? (
+        <p role="alert" data-testid="option-value-taken" className="text-xs text-destructive">
+          {m.valueTaken}
+        </p>
+      ) : null}
+    </label>
   );
 }

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -299,6 +299,12 @@ export function QuestionSettings({
             </InlineField>
           ) : null}
           <OptionsEditor
+            // Keyed by the step, so the disclosure and the value fields' local
+            // text are re-evaluated per QUESTION rather than per mount. Without
+            // it, landing on a question whose values are all derived collapses
+            // the section and switching to one with a hand-written value keeps
+            // it hidden - which is the one case it is supposed to open for.
+            key={step.key}
             options={step.options ?? []}
             onChange={(options) => onUpdate({ options })}
             onLabelChange={onOptionLabel}

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -97,6 +97,9 @@ export function QuestionSettings({
   layout = 'slides',
   scoringEnabled,
   onUpdate,
+  onOptionLabel,
+  onOptionValue,
+  lockedValues,
   onDelete,
   bm,
   em,
@@ -115,6 +118,12 @@ export function QuestionSettings({
   layout?: FormLayout;
   scoringEnabled: boolean;
   onUpdate: (patch: Partial<FormStep>) => void;
+  /** Write one option's label; its value may follow. See `setOptionLabel`. */
+  onOptionLabel: (optionIndex: number, label: string) => void;
+  /** Rewrite one option's stored value by hand, pointers included. */
+  onOptionValue: (optionIndex: number, value: string) => void;
+  /** Values on THIS step that may no longer move (published, or CRM-mapped). */
+  lockedValues: ReadonlySet<string>;
   onDelete: () => void;
   bm: BuilderMessages;
   em: EditorMessages;
@@ -292,6 +301,9 @@ export function QuestionSettings({
           <OptionsEditor
             options={step.options ?? []}
             onChange={(options) => onUpdate({ options })}
+            onLabelChange={onOptionLabel}
+            onValueChange={onOptionValue}
+            locked={lockedValues}
             showPoints={stepScores}
             showIcon={step.type === 'multiple_choice'}
             layout={resolveOptionLayout(step)}

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -23,7 +23,7 @@ import {
 } from '@quill/engine';
 import type { FormTracking } from '@quill/types';
 import { formConfigSchema } from '@quill/types';
-import { saveFormAction } from '@/app/admin/actions';
+import { optionLocksAction, saveFormAction } from '@/app/admin/actions';
 import { useToast } from '@/components/toast';
 import { callAction, isTransportError } from '@/lib/call-action';
 import { useAutosave } from '@/lib/use-autosave';
@@ -197,6 +197,24 @@ export function FormEditor({
       // Mappings can change inside Connect — drop the Build settings panel's
       // cached HubSpot data so it refetches fresh on the next Build activation.
       if (next === 'connect') invalidateQuestionHubspotCache(id);
+      // …and a mapping saved in there locks the option values it points at, on
+      // the LIVE config, which this editor's draft autosave never reads. Pick
+      // those up on the way back rather than letting a label edit move a value
+      // the CRM is now keyed by. Unioned, never replaced: a failed read leaves
+      // the set alone, and a step key renamed earlier in this session keeps the
+      // entry that was re-filed under its new name.
+      if (next === 'build') {
+        void callAction(() => optionLocksAction(id)).then((res) => {
+          if (isTransportError(res) || !res.ok) return;
+          setLocks((prev) => {
+            const merged: Record<string, string[]> = { ...prev };
+            for (const [key, values] of Object.entries(res.locks)) {
+              merged[key] = [...new Set([...(merged[key] ?? []), ...values])];
+            }
+            return merged;
+          });
+        });
+      }
       setTabState(next);
       const url = new URL(window.location.href);
       if (next === 'build') url.searchParams.delete('tab');
@@ -365,7 +383,13 @@ export function FormEditor({
     const step = config.steps[stepIndex];
     const current = step?.options?.[optionIndex];
     if (!step || !current) return;
-    mutate((c) => engineRenameOptionValue(c, step.key, current.value, value));
+    // The lock is enforced HERE, not only by the field's `readOnly`. A readonly
+    // input still fires `blur`, so a stored value carrying a comma or stray
+    // whitespace would sanitize to something different and rename itself the
+    // moment somebody tabbed through it - a write on the one path the UI
+    // promises is frozen. The attribute is the affordance; this is the rule.
+    if ((locks[step.key] ?? []).includes(current.value)) return;
+    mutate((c) => engineRenameOptionValue(c, step.key, optionIndex, value));
   }
   /**
    * Rename a step's answer key (V5-A10). The engine's `renameStepKey` moves every
@@ -378,7 +402,15 @@ export function FormEditor({
     const current = config.steps[index];
     if (!current) return;
     const oldKey = current.key;
-    mutate((c) => engineRenameStepKey(c, oldKey, nextKey));
+    // `renameStepKey` returns the config UNCHANGED when it refuses - a key
+    // already taken, a collision with a `name` step's subfield keys, a missing
+    // step. Identity is how that refusal is detectable, and everything below
+    // must not run on one: re-keying the locks after a refused rename would file
+    // them under a key no step has, quietly freeing this step's published
+    // values, and the CRM call would move a mapping the config did not move.
+    const renamed = engineRenameStepKey(config, oldKey, nextKey);
+    if (renamed === config) return;
+    mutate(() => renamed);
     // The locks are filed BY step key, so the key moving would strand them and
     // this step's published values would quietly become editable again.
     setLocks((prev) => {

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -15,6 +15,8 @@ import type {
 import {
   normalizeConfig,
   renameStepKey as engineRenameStepKey,
+  setOptionLabel as engineSetOptionLabel,
+  renameOptionValue as engineRenameOptionValue,
   createEmptyStep,
   migrateRevealToStep,
   resolveFormLayout,
@@ -129,6 +131,7 @@ export function FormEditor({
   m,
   initialHasDraft = false,
   updatedAt,
+  lockedValues = {},
 }: {
   id: string;
   initialName: string;
@@ -140,6 +143,12 @@ export function FormEditor({
   initialHasDraft?: boolean;
   /** Server row's last-write stamp — gates the crash-recovery offer. */
   updatedAt?: number;
+  /**
+   * Option values a label edit must leave alone, by step key: everything a
+   * published config already carries, plus everything a HubSpot value map
+   * points at. See `lockedOptionValues`.
+   */
+  lockedValues?: Record<string, string[]>;
 }) {
   const bm = getBuilderMessages(locale);
   const searchParams = useSearchParams();
@@ -156,6 +165,15 @@ export function FormEditor({
    * is most likely to press next.
    */
   const [publicPath, setPublicPath] = useState(initialPublicPath);
+  /**
+   * Locked option values, as STATE rather than the prop they arrive as: a step
+   * key can be renamed in this session and the locks are filed under it.
+   * Publishing from here does not add to them on purpose - the values the
+   * author just published are the ones they were editing a moment ago, and
+   * freezing them mid-session would be a rule that appears out of nowhere. The
+   * next load reads the published config and locks them properly.
+   */
+  const [locks, setLocks] = useState(lockedValues);
   // The builder has ONE reveal model: a `reveal` step in the list. A form
   // authored under the old form-level reveal (Design-tab copy + a draggable
   // position marker) is folded into that shape the moment it opens, so the two
@@ -317,6 +335,39 @@ export function FormEditor({
     }));
   }
   /**
+   * Write an option's label, letting its VALUE follow unless the value is the
+   * author's or already out in the world.
+   *
+   * A dedicated operation rather than another `patchStep({ options })`, because
+   * the value is referenced from OUTSIDE the step that owns it (conditions on
+   * other steps, outcome overrides), so a step-scoped patch cannot carry the
+   * pointers. Both editing surfaces route through here so they cannot disagree
+   * about when the value moves - and that disagreement is the bug: the settings
+   * panel has always kept the value in step and the canvas never did, which is
+   * how forms end up reading properly on screen and storing `option_1`.
+   */
+  function setOptionLabel(stepIndex: number, optionIndex: number, label: string) {
+    const stepKey = config.steps[stepIndex]?.key;
+    if (!stepKey) return;
+    const locked = new Set(locks[stepKey] ?? []);
+    mutate((c) => engineSetOptionLabel(c, stepKey, optionIndex, label, locked));
+  }
+  /**
+   * Rewrite an option's stored value by hand (the Advanced disclosure).
+   *
+   * Goes through the same engine rename as a label-driven one, so a value the
+   * author moves themselves carries its conditions, jumps, variant keys and
+   * outcome overrides exactly as one that moved on its own. The panel commits
+   * this on blur rather than per keystroke and refuses a collision before
+   * calling, so each call here is a whole, valid new name.
+   */
+  function setOptionValue(stepIndex: number, optionIndex: number, value: string) {
+    const step = config.steps[stepIndex];
+    const current = step?.options?.[optionIndex];
+    if (!step || !current) return;
+    mutate((c) => engineRenameOptionValue(c, step.key, current.value, value));
+  }
+  /**
    * Rename a step's answer key (V5-A10). The engine's `renameStepKey` moves every
    * in-config pointer (conditions, goto targets, variant sources, override rules,
    * `[key]` tokens). HubSpot field mappings are stored OUTSIDE this config and
@@ -328,6 +379,14 @@ export function FormEditor({
     if (!current) return;
     const oldKey = current.key;
     mutate((c) => engineRenameStepKey(c, oldKey, nextKey));
+    // The locks are filed BY step key, so the key moving would strand them and
+    // this step's published values would quietly become editable again.
+    setLocks((prev) => {
+      const held = prev[oldKey];
+      if (!held) return prev;
+      const { [oldKey]: _moved, ...rest } = prev;
+      return { ...rest, [nextKey]: held };
+    });
     void callAction(() => renameQuestionMappingAction(id, oldKey, nextKey)).then((res) => {
       if (isTransportError(res) || (!res.ok && res.code === 'error')) {
         // The config rename already applied and autosaved; only the CRM mapping
@@ -845,6 +904,7 @@ export function FormEditor({
                         focusSignal={focusCanvas}
                         onSelect={setSelected}
                         onUpdateStep={patchStep}
+                        onOptionLabel={setOptionLabel}
                         m={bm}
                       />
                     ) : (
@@ -856,6 +916,7 @@ export function FormEditor({
                         total={config.steps.length}
                         device={device}
                         onUpdate={(patch) => patchStep(selected, patch)}
+                        onOptionLabel={(optionIndex, label) => setOptionLabel(selected, optionIndex, label)}
                         m={bm}
                       />
                     )
@@ -907,6 +968,9 @@ export function FormEditor({
                     layout={layout}
                     scoringEnabled={scoringEnabled}
                     onUpdate={(patch) => patchStep(selected, patch)}
+                    onOptionLabel={(optionIndex, label) => setOptionLabel(selected, optionIndex, label)}
+                    onOptionValue={(optionIndex, value) => setOptionValue(selected, optionIndex, value)}
+                    lockedValues={new Set(locks[selectedStep.key] ?? [])}
                     onDelete={() => deleteStep(selected)}
                     bm={bm}
                     em={m}

--- a/apps/web/app/admin/forms/[id]/edit/page.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { getMessages } from '@quill/shared';
+import { lockedOptionValues } from '@quill/engine';
 import { adminApi, ApiError } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { FormEditor } from './form-editor';
@@ -33,6 +34,12 @@ export default async function EditFormPage({ params }: { params: Promise<{ id: s
         // draft, and the explicit Publish action makes it live.
         initialConfig={form.draftConfig ?? form.config}
         initialHasDraft={form.draftConfig != null}
+        // Which option values a label edit must not move, read from the LIVE
+        // config rather than the draft being edited: a value is untouchable
+        // because of what already left the building (answers already stored
+        // against it, or a CRM mapping pointing at it), and the draft knows
+        // neither. Computed here so the builder never pays a request for it.
+        lockedValues={lockedOptionValues(form.config)}
         updatedAt={form.updatedAt}
         publicPath={publicPath}
         locale={locale}

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -212,14 +212,25 @@ export function isDerivedOptionValue(option: FormOption): boolean {
   const value = (option.value ?? '').trim();
   if (!value) return true;
   if (/^option_\d+$/.test(value)) return true;
-  return value === slugify(option.label ?? '');
+  // A blank label proves NOTHING about the value, so it cannot be evidence the
+  // author wrote one. `slugify` falls back to 'item' on empty input, so
+  // comparing against it would call every value hand-written the moment the
+  // field is empty - and emptying the field is how people reword an option.
+  // Backspace to nothing and the value freezes wherever it had got to, which is
+  // the same label/value divorce this function exists to end, with a stranger
+  // token. `setOptionLabel` declines to rename while the label is blank, so
+  // answering true here holds the value still and resumes tracking on the next
+  // keystroke.
+  const derived = slugify(option.label ?? '', '');
+  if (!derived) return true;
+  return value === derived;
 }
 
 /**
  * Move an option's `value`, carrying every pointer aimed at it.
  *
  * An option value is not decoration: it is the token stored as the answer, so
- * everything that reasons about "what did they pick" names it by string. Seven
+ * everything that reasons about "what did they pick" names it by string. Eight
  * places do, and every one of them is silent when it stops matching, which is
  * why this is a function and not an assignment at a call site:
  *
@@ -230,9 +241,11 @@ export function isDerivedOptionValue(option: FormOption): boolean {
  *  - the KEYS of `questionVariants` and `sliderLabelVariants` on any step that
  *    sources from this one, including the comma-joined composite keys a
  *    multi-select variant uses;
- *  - `outcomes[].overrides[].values` whose `field` reads this step.
+ *  - `outcomes[].overrides[].values` whose `field` reads this step;
+ *  - the owning step's `defaultValue`, which seeds the answer with an option
+ *    value and simply stops seeding when it dangles.
  *
- * The seventh lives OUTSIDE this config - a HubSpot destination's
+ * The eighth lives OUTSIDE this config - a HubSpot destination's
  * `valueMaps[stepKey][value]`, which the draft autosave never writes. It cannot
  * be migrated from here and it is not attempted; the builder refuses to move a
  * value that a CRM mapping depends on instead. See `lockedOptionValues`.
@@ -240,17 +253,35 @@ export function isDerivedOptionValue(option: FormOption): boolean {
  * A no-op rename, an empty destination, or a value another option on the same
  * step already holds all return the config untouched: a collision would merge
  * two distinct answers into one token, which loses data rather than renaming it.
+ * The option is named by INDEX rather than by its current value, because two
+ * options can legitimately hold the same one - see the note in the body.
  */
 export function renameOptionValue(
   config: FormConfig,
   stepKey: string,
-  oldValue: string,
+  optionIndex: number,
   newValue: string,
 ): FormConfig {
-  if (!newValue || oldValue === newValue) return config;
+  if (!newValue) return config;
   const owner = config.steps.find((s) => s.key === stepKey);
-  if (!owner) return config;
-  if ((owner.options ?? []).some((o) => o.value === newValue)) return config;
+  const target = owner?.options?.[optionIndex];
+  if (!owner || !target) return config;
+  const oldValue = target.value;
+  if (oldValue === newValue) return config;
+  if ((owner.options ?? []).some((o, i) => i !== optionIndex && o.value === newValue)) return config;
+
+  // Two options CAN hold the same value: both editors mint `option_${n}` from
+  // the list length, so deleting a middle option and adding one mints a value a
+  // sibling already has. Renaming every option that matches the string would
+  // move a row nobody touched, and `normalizeOptions` would then dedupe the
+  // collision into `..._2` on save - a token nothing points at, on an option the
+  // author never edited. So the option moves BY POSITION.
+  //
+  // The pointers are a separate question, because they name a token, not a row.
+  // They only follow when the token is actually leaving: if a sibling still
+  // holds `oldValue` the answer it names still exists, and repointing would aim
+  // a branch at a different option than the one it was authored for.
+  const tokenLeaves = !(owner.options ?? []).some((o, i) => i !== optionIndex && o.value === oldValue);
 
   const repoint = (values: string[] | undefined): string[] | undefined =>
     values == null ? undefined : values.map((v) => (v === oldValue ? newValue : v));
@@ -277,9 +308,14 @@ export function renameOptionValue(
   const steps = config.steps.map((s) => {
     const next: FormStep = { ...s };
     if (s.key === stepKey && s.options) {
-      next.options = s.options.map((o) => (o.value === oldValue ? { ...o, value: newValue } : o));
-      if (s.goto) next.goto = s.goto.map((r) => ({ ...r, values: repoint(r.values) ?? [] }));
+      next.options = s.options.map((o, i) => (i === optionIndex ? { ...o, value: newValue } : o));
+      // A choice step's `defaultValue` seeds the answer with an option value
+      // (see apps/web/lib/capture-defaults.ts), so it is a pointer like the
+      // rest and stops seeding in silence when it dangles.
+      if (tokenLeaves && s.defaultValue === oldValue) next.defaultValue = newValue;
+      if (tokenLeaves && s.goto) next.goto = s.goto.map((r) => ({ ...r, values: repoint(r.values) ?? [] }));
     }
+    if (!tokenLeaves) return next;
     if (s.showWhen?.field === stepKey) {
       next.showWhen = { ...s.showWhen, values: repoint(s.showWhen.values) };
     }
@@ -293,12 +329,14 @@ export function renameOptionValue(
     return next;
   });
 
-  const outcomes = config.outcomes?.map((o) => ({
-    ...o,
-    overrides: o.overrides?.map((r) =>
-      r.field === stepKey ? { ...r, values: repoint(r.values) } : r,
-    ),
-  }));
+  const outcomes = tokenLeaves
+    ? config.outcomes?.map((o) => ({
+        ...o,
+        overrides: o.overrides?.map((r) =>
+          r.field === stepKey ? { ...r, values: repoint(r.values) } : r,
+        ),
+      }))
+    : config.outcomes;
 
   return { ...config, steps, ...(outcomes ? { outcomes } : {}) };
 }
@@ -353,13 +391,19 @@ export function setOptionLabel(
   // to `item` on the way through would be a rename nobody asked for.
   const base = slugify(label, '');
   if (!base) return withLabel;
-  const siblings = new Set(
-    (step.options ?? []).filter((_, i) => i !== optionIndex).map((o) => o.value),
-  );
-  const nextValue = uniqueKey(base, siblings);
+  // Deduped against the siblings AND the locked set. Locked values include ones
+  // whose option was deleted from the draft, and those are exactly the tokens
+  // that must not be reissued: a new option landing on a retired value would
+  // inherit every answer already stored against it and any CRM mapping still
+  // pointing at it, which is the whole thing the lock exists to prevent.
+  const taken = new Set([
+    ...(step.options ?? []).filter((_, i) => i !== optionIndex).map((o) => o.value),
+    ...locked,
+  ]);
+  const nextValue = uniqueKey(base, taken);
   if (nextValue === option.value) return withLabel;
 
-  return renameOptionValue(withLabel, stepKey, option.value, nextValue);
+  return renameOptionValue(withLabel, stepKey, optionIndex, nextValue);
 }
 
 /**

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -186,6 +186,251 @@ function normalizeOptions(options: FormOption[] | undefined): FormOption[] | und
   });
 }
 
+/**
+ * Does this option's `value` still look derived from its `label`?
+ *
+ * The builder writes `value` for you and gets out of the way the moment you
+ * write it yourself, so every label edit has to answer this first. Three shapes
+ * count as "the builder wrote it":
+ *
+ *  - empty: nothing to protect;
+ *  - the slug of the current label: the last thing that wrote it was a label
+ *    edit, so the next one may write it again;
+ *  - `option_3`: what CREATING an option puts there. This case exists because
+ *    the value used to stop following the label, and the forms that came out of
+ *    that are exactly the ones this is fixing. Their label reads "More than 50"
+ *    while the value still reads `option_3`, so the slug test above calls them
+ *    hand-written and would freeze them that way forever. Treating the created
+ *    placeholder as unwritten is what lets those heal on the next edit.
+ *
+ * Someone who deliberately typed `option_3` as their value loses it on their
+ * next label edit. That is the trade, and it is the right way round: the
+ * placeholder is generated for every option of every form, a hand-typed copy of
+ * it is a curiosity, and the recovery is to type it again.
+ */
+export function isDerivedOptionValue(option: FormOption): boolean {
+  const value = (option.value ?? '').trim();
+  if (!value) return true;
+  if (/^option_\d+$/.test(value)) return true;
+  return value === slugify(option.label ?? '');
+}
+
+/**
+ * Move an option's `value`, carrying every pointer aimed at it.
+ *
+ * An option value is not decoration: it is the token stored as the answer, so
+ * everything that reasons about "what did they pick" names it by string. Seven
+ * places do, and every one of them is silent when it stops matching, which is
+ * why this is a function and not an assignment at a call site:
+ *
+ *  - `showWhen.values` / `hideWhen.values` on ANY step whose condition reads
+ *    this step (`field === stepKey`);
+ *  - `goto[].values` on the step that owns the options (a jump is defined by
+ *    the answer to its own question);
+ *  - the KEYS of `questionVariants` and `sliderLabelVariants` on any step that
+ *    sources from this one, including the comma-joined composite keys a
+ *    multi-select variant uses;
+ *  - `outcomes[].overrides[].values` whose `field` reads this step.
+ *
+ * The seventh lives OUTSIDE this config - a HubSpot destination's
+ * `valueMaps[stepKey][value]`, which the draft autosave never writes. It cannot
+ * be migrated from here and it is not attempted; the builder refuses to move a
+ * value that a CRM mapping depends on instead. See `lockedOptionValues`.
+ *
+ * A no-op rename, an empty destination, or a value another option on the same
+ * step already holds all return the config untouched: a collision would merge
+ * two distinct answers into one token, which loses data rather than renaming it.
+ */
+export function renameOptionValue(
+  config: FormConfig,
+  stepKey: string,
+  oldValue: string,
+  newValue: string,
+): FormConfig {
+  if (!newValue || oldValue === newValue) return config;
+  const owner = config.steps.find((s) => s.key === stepKey);
+  if (!owner) return config;
+  if ((owner.options ?? []).some((o) => o.value === newValue)) return config;
+
+  const repoint = (values: string[] | undefined): string[] | undefined =>
+    values == null ? undefined : values.map((v) => (v === oldValue ? newValue : v));
+
+  // Variant maps are keyed BY the answer, and a multi-select key is the answer's
+  // values joined with commas — so the rename has to reach inside a composite
+  // key rather than only matching a whole one. `*` (the fallback key) contains
+  // no value and passes through untouched.
+  const rekey = (
+    map: Record<string, string> | undefined,
+  ): Record<string, string> | undefined =>
+    map == null
+      ? undefined
+      : Object.fromEntries(
+          Object.entries(map).map(([key, text]) => [
+            key
+              .split(',')
+              .map((part) => (part === oldValue ? newValue : part))
+              .join(','),
+            text,
+          ]),
+        );
+
+  const steps = config.steps.map((s) => {
+    const next: FormStep = { ...s };
+    if (s.key === stepKey && s.options) {
+      next.options = s.options.map((o) => (o.value === oldValue ? { ...o, value: newValue } : o));
+      if (s.goto) next.goto = s.goto.map((r) => ({ ...r, values: repoint(r.values) ?? [] }));
+    }
+    if (s.showWhen?.field === stepKey) {
+      next.showWhen = { ...s.showWhen, values: repoint(s.showWhen.values) };
+    }
+    if (s.hideWhen?.field === stepKey) {
+      next.hideWhen = { ...s.hideWhen, values: repoint(s.hideWhen.values) };
+    }
+    if (s.questionField === stepKey) {
+      if (s.questionVariants) next.questionVariants = rekey(s.questionVariants);
+      if (s.sliderLabelVariants) next.sliderLabelVariants = rekey(s.sliderLabelVariants);
+    }
+    return next;
+  });
+
+  const outcomes = config.outcomes?.map((o) => ({
+    ...o,
+    overrides: o.overrides?.map((r) =>
+      r.field === stepKey ? { ...r, values: repoint(r.values) } : r,
+    ),
+  }));
+
+  return { ...config, steps, ...(outcomes ? { outcomes } : {}) };
+}
+
+/**
+ * Write an option's label, and let the value follow it when the value is still
+ * the builder's to write.
+ *
+ * The single entry point for editing an option label, so the canvas and the
+ * settings panel cannot disagree about when the value moves - they did, and
+ * that disagreement IS the bug this fixes: the panel has always kept the value
+ * in step, the canvas never did, and the canvas is where people type. The result
+ * was a form whose labels read properly and whose stored answers all read
+ * `option_1`, `option_2`, `option_3`.
+ *
+ * `locked` names values that must not move whatever they look like: anything
+ * already carried by a published config (renaming those splits the historical
+ * answers in two) and anything a HubSpot `valueMaps` entry points at (renaming
+ * those unmaps the question from the CRM, and this runs per keystroke, so it
+ * cannot migrate the mapping the way a field-key rename does). A locked value
+ * simply stays put while the label changes, which is the pre-existing behaviour
+ * and never loses anything.
+ *
+ * The derived value is deduped against its siblings, so two labels that slugify
+ * alike get `yes` and `yes_2` rather than one of them silently taking the
+ * other's answers.
+ */
+export function setOptionLabel(
+  config: FormConfig,
+  stepKey: string,
+  optionIndex: number,
+  label: string,
+  locked: ReadonlySet<string> = new Set(),
+): FormConfig {
+  const step = config.steps.find((s) => s.key === stepKey);
+  const option = step?.options?.[optionIndex];
+  if (!step || !option) return config;
+
+  const withLabel: FormConfig = {
+    ...config,
+    steps: config.steps.map((s) =>
+      s.key === stepKey
+        ? { ...s, options: s.options!.map((o, i) => (i === optionIndex ? { ...o, label } : o)) }
+        : s,
+    ),
+  };
+
+  if (locked.has(option.value) || !isDerivedOptionValue(option)) return withLabel;
+
+  // An empty label derives nothing usable. Leave the value alone rather than
+  // slugifying to a fallback: the author is mid-typing, and swapping the value
+  // to `item` on the way through would be a rename nobody asked for.
+  const base = slugify(label, '');
+  if (!base) return withLabel;
+  const siblings = new Set(
+    (step.options ?? []).filter((_, i) => i !== optionIndex).map((o) => o.value),
+  );
+  const nextValue = uniqueKey(base, siblings);
+  if (nextValue === option.value) return withLabel;
+
+  return renameOptionValue(withLabel, stepKey, option.value, nextValue);
+}
+
+/**
+ * What {@link lockedOptionValues} needs from a stored form.
+ *
+ * Structural rather than `FormConfig` because `destinations` is not part of the
+ * engine's config type at all - it lives in `@quill/types`, which this package
+ * must not depend on. Reading it through the narrowest shape that answers the
+ * question keeps the engine free of that edge while still seeing the CRM
+ * mapping, and an unexpected blob degrades to "nothing is locked" instead of
+ * throwing inside the builder's first render.
+ */
+export interface LockSource {
+  steps?: Array<{ key: string; options?: Array<{ value: string }> }>;
+  destinations?: unknown;
+}
+
+/**
+ * The option values on this form that a label edit must NOT move, keyed by step.
+ *
+ * Read from the LIVE config, never the draft being edited, because both reasons
+ * a value becomes untouchable are about what already left the building:
+ *
+ *  - the live config is what the public URL serves, so a respondent could have
+ *    answered with that token already. Renaming it does not relabel the history,
+ *    it orphans it;
+ *  - a HubSpot destination maps that value to a CRM enum. Renaming it unmaps the
+ *    answer silently, and the label edit that would trigger it runs per
+ *    keystroke, so it cannot migrate the mapping on the way past.
+ *
+ * Presence in the live config is the gate rather than a `published_at` stamp,
+ * which looks like the obvious test and is not: `publishForm` returns early
+ * WITHOUT stamping when no draft is pending, so a form created through the API
+ * with a config is publicly serving it while `published_at` is still null.
+ * Gating on the stamp would leave exactly those forms editable.
+ *
+ * It does not over-lock, because the builder creates a form EMPTY: the live
+ * config carries no options until the author publishes, so everything built
+ * before that first publish is free to follow its label. The same goes for an
+ * option added afterwards, which is not in the live config and therefore still
+ * follows - that is what stops adding one option to a live form reproducing the
+ * confusion this exists to remove. A form started from a template locks the
+ * template's own options, and those ship deliberate values (`asap`,
+ * `in_person`) nobody wants rewritten into a slug of their own sentence.
+ */
+export function lockedOptionValues(
+  liveConfig: LockSource | null | undefined,
+): Record<string, string[]> {
+  const locked: Record<string, Set<string>> = {};
+  const add = (stepKey: string, value: string) => {
+    (locked[stepKey] ??= new Set()).add(value);
+  };
+
+  for (const step of liveConfig?.steps ?? []) {
+    for (const option of step.options ?? []) add(step.key, option.value);
+  }
+  const destinations = Array.isArray(liveConfig?.destinations) ? liveConfig.destinations : [];
+  for (const raw of destinations) {
+    const destination = raw as { type?: unknown; valueMaps?: unknown };
+    if (destination.type !== 'hubspot') continue;
+    const maps = destination.valueMaps;
+    if (maps == null || typeof maps !== 'object') continue;
+    for (const [stepKey, map] of Object.entries(maps as Record<string, unknown>)) {
+      if (map == null || typeof map !== 'object') continue;
+      for (const value of Object.keys(map as Record<string, unknown>)) add(stepKey, value);
+    }
+  }
+
+  return Object.fromEntries(Object.entries(locked).map(([key, set]) => [key, [...set]]));
+}
+
 /** True when the config carries any scoring signal (points / ranges / outcomes). */
 export function hasScoringSignal(config: FormConfig): boolean {
   if ((config.outcomes ?? []).length > 0) return true;

--- a/packages/engine/src/option-value.spec.ts
+++ b/packages/engine/src/option-value.spec.ts
@@ -77,7 +77,7 @@ describe('isDerivedOptionValue', () => {
 
 describe('renameOptionValue', () => {
   it('moves the value and every pointer aimed at it', () => {
-    const out = renameOptionValue(config(), 'size', 'over_50', 'more_than_50');
+    const out = renameOptionValue(config(), 'size', 1, 'more_than_50');
 
     expect(out.steps[0].options?.map((o) => o.value)).toEqual(['under_50', 'more_than_50']);
     expect(out.steps[0].goto?.[0].values).toEqual(['more_than_50']);
@@ -90,8 +90,36 @@ describe('renameOptionValue', () => {
     expect(out.outcomes?.[0].overrides?.[0].values).toEqual(['more_than_50']);
   });
 
+  it('repoints the step default, which seeds the answer and dangles in silence', () => {
+    const base = config();
+    base.steps[0].defaultValue = 'over_50';
+
+    const out = renameOptionValue(base, 'size', 1, 'more_than_50');
+
+    expect(out.steps[0].defaultValue).toBe('more_than_50');
+  });
+
+  it('moves ONE option when two share a value, and leaves the pointers put', () => {
+    // Reachable with no API: both Add buttons mint `option_${length + 1}`, so
+    // deleting a middle option and adding one repeats a sibling's value.
+    // Renaming every match would move a row nobody touched, and the pointers
+    // must stay because the token they name still exists on the other option.
+    const base = config();
+    base.steps[0].options = [
+      { label: 'Option 1', value: 'option_1' },
+      { label: 'Option 3', value: 'option_3' },
+      { label: 'Option 3', value: 'option_3' },
+    ];
+    base.steps[0].goto = [{ values: ['option_3'], target: 'budget' }];
+
+    const out = renameOptionValue(base, 'size', 1, 'yes');
+
+    expect(out.steps[0].options?.map((o) => o.value)).toEqual(['option_1', 'yes', 'option_3']);
+    expect(out.steps[0].goto?.[0].values, 'the surviving token keeps its rule').toEqual(['option_3']);
+  });
+
   it('leaves pointers at OTHER values, and at other steps, alone', () => {
-    const out = renameOptionValue(config(), 'size', 'over_50', 'more_than_50');
+    const out = renameOptionValue(config(), 'size', 1, 'more_than_50');
 
     expect(out.steps[2].hideWhen?.values).toEqual(['under_50']);
     // `budget` has its own option called `yes`; renaming on `size` must not
@@ -105,7 +133,7 @@ describe('renameOptionValue', () => {
     const base = config();
     base.steps[2].questionVariants = { 'under_50,over_50': 'Mixed', over_50: 'Big' };
 
-    const out = renameOptionValue(base, 'size', 'over_50', 'big');
+    const out = renameOptionValue(base, 'size', 1, 'big');
 
     expect(out.steps[2].questionVariants).toEqual({ 'under_50,big': 'Mixed', big: 'Big' });
   });
@@ -114,14 +142,15 @@ describe('renameOptionValue', () => {
     // Not a rename: `under_50` already exists, so this would make two distinct
     // answers indistinguishable. Losing data is worse than refusing.
     const before = config();
-    expect(renameOptionValue(before, 'size', 'over_50', 'under_50')).toBe(before);
+    expect(renameOptionValue(before, 'size', 1, 'under_50')).toBe(before);
   });
 
   it('is a no-op for an empty target, an unchanged value or an unknown step', () => {
     const before = config();
-    expect(renameOptionValue(before, 'size', 'over_50', '')).toBe(before);
-    expect(renameOptionValue(before, 'size', 'over_50', 'over_50')).toBe(before);
-    expect(renameOptionValue(before, 'nope', 'over_50', 'x')).toBe(before);
+    expect(renameOptionValue(before, 'size', 1, '')).toBe(before);
+    expect(renameOptionValue(before, 'size', 1, 'over_50')).toBe(before);
+    expect(renameOptionValue(before, 'nope', 1, 'x')).toBe(before);
+    expect(renameOptionValue(before, 'size', 9, 'x')).toBe(before);
   });
 });
 
@@ -165,6 +194,34 @@ describe('setOptionLabel', () => {
     const out = setOptionLabel(base, 'size', 1, 'Yes');
 
     expect(out.steps[0].options?.map((o) => o.value)).toEqual(['yes', 'yes_2']);
+  });
+
+  it('resumes tracking after the label is cleared and retyped', () => {
+    // The ordinary reword gesture, and the one the e2e cannot see because
+    // Playwright's `fill()` writes the whole string in a single event. Judging
+    // "did the author write this value" against an EMPTY label froze it here
+    // forever, which is the bug this feature exists to end.
+    let out = setOptionLabel(config(), 'size', 1, '');
+    out = setOptionLabel(out, 'size', 1, 'O');
+    out = setOptionLabel(out, 'size', 1, 'Owner');
+
+    expect(out.steps[0].options?.[1]).toMatchObject({ label: 'Owner', value: 'owner' });
+    expect(out.steps[1].showWhen?.values).toEqual(['owner']);
+  });
+
+  it('will not reissue a value the form has retired', () => {
+    // A locked value whose option was deleted from the draft is not a sibling,
+    // so deduping against siblings alone would hand a NEW option every answer
+    // already stored against that token.
+    const base = config();
+    base.steps[0].options = [
+      { label: 'Under 50', value: 'under_50' },
+      { label: 'Option 2', value: 'option_2' },
+    ];
+
+    const out = setOptionLabel(base, 'size', 1, 'Over 50', new Set(['under_50', 'over_50']));
+
+    expect(out.steps[0].options?.[1].value).toBe('over_50_2');
   });
 
   it('holds the value still while the label is empty mid-typing', () => {

--- a/packages/engine/src/option-value.spec.ts
+++ b/packages/engine/src/option-value.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * An option's `value` follows its `label`, and every pointer follows the value.
+ *
+ * The value is the token stored as the answer, so it is what conditions, jumps,
+ * dynamic-question variants and outcome overrides all name by string. None of
+ * them complain when they stop matching: a branch simply never fires again. That
+ * silence is why the rename is one function with a suite rather than an
+ * assignment at four call sites.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  isDerivedOptionValue,
+  lockedOptionValues,
+  renameOptionValue,
+  setOptionLabel,
+} from './form-config';
+import type { FormConfig } from './form-logic';
+
+/** A form whose every option-value pointer is populated, so a rename has to move all of them. */
+function config(): FormConfig {
+  return {
+    version: 1,
+    steps: [
+      {
+        key: 'size',
+        type: 'multiple_choice',
+        question: 'Company size?',
+        options: [
+          { label: 'Under 50', value: 'under_50', points: 1 },
+          { label: 'Over 50', value: 'over_50', points: 5 },
+        ],
+        goto: [{ values: ['over_50'], target: 'budget' }],
+      },
+      {
+        key: 'budget',
+        type: 'multiple_choice',
+        question: 'Budget?',
+        showWhen: { field: 'size', values: ['over_50'] },
+        options: [{ label: 'Yes', value: 'yes' }],
+      },
+      {
+        key: 'detail',
+        type: 'text',
+        question: 'Tell us more',
+        hideWhen: { field: 'size', values: ['under_50'] },
+        questionField: 'size',
+        questionVariants: { over_50: 'What does your team need?', '*': 'Tell us more' },
+        sliderLabelVariants: { over_50: 'seats' },
+      },
+    ],
+    outcomes: [
+      { id: 'hot', label: 'Hot', minScore: 5, overrides: [{ field: 'size', values: ['over_50'] }] },
+    ],
+  } as unknown as FormConfig;
+}
+
+describe('isDerivedOptionValue', () => {
+  it('treats an empty value and the slug of the label as the builder’s to write', () => {
+    expect(isDerivedOptionValue({ label: 'Over 50', value: '' })).toBe(true);
+    expect(isDerivedOptionValue({ label: 'Over 50', value: 'over_50' })).toBe(true);
+  });
+
+  it('treats the created placeholder as unwritten, so a stuck form heals', () => {
+    // The whole reported symptom: labels read properly, values all read
+    // `option_N`. The slug test alone calls these hand-written and would freeze
+    // them that way forever.
+    expect(isDerivedOptionValue({ label: 'Over 50 employees', value: 'option_3' })).toBe(true);
+  });
+
+  it('leaves a hand-written value alone', () => {
+    // The case the whole "auto" heuristic exists to protect: a value chosen to
+    // match something outside this form, like a CRM enum.
+    expect(isDerivedOptionValue({ label: 'Over 50', value: 'ENTERPRISE_TIER' })).toBe(false);
+    expect(isDerivedOptionValue({ label: '1 mes', value: '4 mes' })).toBe(false);
+  });
+});
+
+describe('renameOptionValue', () => {
+  it('moves the value and every pointer aimed at it', () => {
+    const out = renameOptionValue(config(), 'size', 'over_50', 'more_than_50');
+
+    expect(out.steps[0].options?.map((o) => o.value)).toEqual(['under_50', 'more_than_50']);
+    expect(out.steps[0].goto?.[0].values).toEqual(['more_than_50']);
+    expect(out.steps[1].showWhen?.values).toEqual(['more_than_50']);
+    expect(out.steps[2].questionVariants).toEqual({
+      more_than_50: 'What does your team need?',
+      '*': 'Tell us more',
+    });
+    expect(out.steps[2].sliderLabelVariants).toEqual({ more_than_50: 'seats' });
+    expect(out.outcomes?.[0].overrides?.[0].values).toEqual(['more_than_50']);
+  });
+
+  it('leaves pointers at OTHER values, and at other steps, alone', () => {
+    const out = renameOptionValue(config(), 'size', 'over_50', 'more_than_50');
+
+    expect(out.steps[2].hideWhen?.values).toEqual(['under_50']);
+    // `budget` has its own option called `yes`; renaming on `size` must not
+    // reach into a step it does not own.
+    expect(out.steps[1].options?.[0].value).toBe('yes');
+  });
+
+  it('reaches inside a comma-joined multi-select variant key', () => {
+    // A multi-select variant is keyed by the whole answer, joined with commas.
+    // Matching only whole keys would leave every combination key dangling.
+    const base = config();
+    base.steps[2].questionVariants = { 'under_50,over_50': 'Mixed', over_50: 'Big' };
+
+    const out = renameOptionValue(base, 'size', 'over_50', 'big');
+
+    expect(out.steps[2].questionVariants).toEqual({ 'under_50,big': 'Mixed', big: 'Big' });
+  });
+
+  it('refuses to merge two options onto one token', () => {
+    // Not a rename: `under_50` already exists, so this would make two distinct
+    // answers indistinguishable. Losing data is worse than refusing.
+    const before = config();
+    expect(renameOptionValue(before, 'size', 'over_50', 'under_50')).toBe(before);
+  });
+
+  it('is a no-op for an empty target, an unchanged value or an unknown step', () => {
+    const before = config();
+    expect(renameOptionValue(before, 'size', 'over_50', '')).toBe(before);
+    expect(renameOptionValue(before, 'size', 'over_50', 'over_50')).toBe(before);
+    expect(renameOptionValue(before, 'nope', 'over_50', 'x')).toBe(before);
+  });
+});
+
+describe('setOptionLabel', () => {
+  it('carries the value along, pointers included', () => {
+    const out = setOptionLabel(config(), 'size', 1, 'More than 50');
+
+    expect(out.steps[0].options?.[1]).toMatchObject({ label: 'More than 50', value: 'more_than_50' });
+    expect(out.steps[1].showWhen?.values).toEqual(['more_than_50']);
+    expect(out.steps[0].goto?.[0].values).toEqual(['more_than_50']);
+  });
+
+  it('leaves a hand-written value where it is', () => {
+    const base = config();
+    base.steps[0].options![1].value = 'ENTERPRISE_TIER';
+
+    const out = setOptionLabel(base, 'size', 1, 'More than 50');
+
+    expect(out.steps[0].options?.[1]).toMatchObject({
+      label: 'More than 50',
+      value: 'ENTERPRISE_TIER',
+    });
+  });
+
+  it('leaves a LOCKED value where it is, however derived it looks', () => {
+    // Published, or mapped to a CRM enum. The label still changes; the token
+    // stored against every answer already collected does not.
+    const out = setOptionLabel(config(), 'size', 1, 'More than 50', new Set(['over_50']));
+
+    expect(out.steps[0].options?.[1]).toMatchObject({ label: 'More than 50', value: 'over_50' });
+    expect(out.steps[1].showWhen?.values).toEqual(['over_50']);
+  });
+
+  it('dedupes against siblings rather than colliding', () => {
+    const base = config();
+    base.steps[0].options = [
+      { label: 'Yes', value: 'yes' },
+      { label: 'Maybe', value: 'maybe' },
+    ];
+
+    const out = setOptionLabel(base, 'size', 1, 'Yes');
+
+    expect(out.steps[0].options?.map((o) => o.value)).toEqual(['yes', 'yes_2']);
+  });
+
+  it('holds the value still while the label is empty mid-typing', () => {
+    // Slugifying '' would fall back to a placeholder, which is a rename nobody
+    // asked for and would fire the moment somebody selects-all and retypes.
+    const out = setOptionLabel(config(), 'size', 1, '');
+
+    expect(out.steps[0].options?.[1]).toMatchObject({ label: '', value: 'over_50' });
+  });
+
+  it('heals a form whose values are stuck on the created placeholder', () => {
+    const base = config();
+    base.steps[0].options = [{ label: 'Over 50 employees', value: 'option_2' }];
+
+    const out = setOptionLabel(base, 'size', 0, 'Over 50 employees!');
+
+    expect(out.steps[0].options?.[0].value).toBe('over_50_employees');
+  });
+});
+
+describe('lockedOptionValues', () => {
+  it('locks nothing on the empty config the builder creates a form with', () => {
+    // The whole reason the gate can be "is it live" rather than "was it
+    // published": a new form serves nothing, so everything built before the
+    // first publish is free to follow its label.
+    expect(lockedOptionValues({ version: 1, steps: [] } as never)).toEqual({});
+  });
+
+  it('locks every option value the live config serves', () => {
+    expect(lockedOptionValues(config())).toEqual({
+      size: ['under_50', 'over_50'],
+      budget: ['yes'],
+    });
+  });
+
+  it('does not lock an option that is only in the draft', () => {
+    // Added to a live form after publishing: no answer can carry it and no
+    // mapping points at it, so its value still follows its label.
+    const live = config();
+    live.steps[0].options = [{ label: 'Under 50', value: 'under_50' }];
+
+    expect(lockedOptionValues(live).size).toEqual(['under_50']);
+  });
+
+  it('locks a value a HubSpot mapping points at', () => {
+    const mapped = {
+      version: 1,
+      steps: [],
+      destinations: [
+        { type: 'hubspot', enabled: true, valueMaps: { size: { over_50: 'ENTERPRISE' } } },
+      ],
+    };
+
+    expect(lockedOptionValues(mapped as never)).toEqual({ size: ['over_50'] });
+  });
+
+  it('degrades to nothing locked on a config it cannot read', () => {
+    // This runs in the builder's first render. A stale or hand-edited blob must
+    // not throw there.
+    expect(lockedOptionValues(null)).toEqual({});
+    expect(lockedOptionValues({ destinations: 'nonsense' })).toEqual({});
+    expect(lockedOptionValues({ destinations: [{ type: 'hubspot', valueMaps: null }] })).toEqual({});
+  });
+});

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -650,7 +650,7 @@ export interface FormsMessages {
         advanced: string;
         /** The typed value is already another option's on this question. */
         valueTaken: string;
-        /** Why a published form's values stay put while its labels change. */
+        /** Why values already in use stay put while their labels change. */
         valueLocked: string;
         /** Spreadsheet-paste import (option + optional score columns). */
         importer: {
@@ -2226,7 +2226,7 @@ export const en: FormsMessages = {
         advanced: 'Stored values',
         valueTaken: 'Another option on this question already stores that value.',
         valueLocked:
-          'This form is published, so its stored values stay as they are while you reword the labels. Answers already collected carry them, and so does any mapping pointing at them.',
+          'These values are already in use, so they stay as they are while you reword the labels. Answers collected on the live form carry them, and so does any HubSpot mapping pointing at them.',
         importer: {
           open: 'Import options',
           title: 'Import options from a spreadsheet',
@@ -3683,7 +3683,7 @@ export const es: FormsMessages = {
         advanced: 'Valores guardados',
         valueTaken: 'Otra opción de esta pregunta ya guarda ese valor.',
         valueLocked:
-          'Este formulario está publicado, así que sus valores guardados se quedan como están mientras reescribes las etiquetas. Las respuestas ya recibidas los llevan, y cualquier mapeo que apunte a ellos también.',
+          'Estos valores ya están en uso, así que se quedan como están mientras reescribes las etiquetas. Las respuestas recibidas en el formulario en vivo los llevan, y cualquier mapeo de HubSpot que apunte a ellos también.',
         importer: {
           open: 'Importar opciones',
           title: 'Importar opciones desde una hoja de cálculo',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -646,6 +646,12 @@ export interface FormsMessages {
         valueHelp: string;
         /** V5 — what the visible label is. */
         labelHelp: string;
+        /** Discloses the stored values, which fill themselves from the labels. */
+        advanced: string;
+        /** The typed value is already another option's on this question. */
+        valueTaken: string;
+        /** Why a published form's values stay put while its labels change. */
+        valueLocked: string;
         /** Spreadsheet-paste import (option + optional score columns). */
         importer: {
           /** The "Import options" button beside "Add option". */
@@ -2216,7 +2222,11 @@ export const en: FormsMessages = {
         empty: 'No options yet.',
         labelHelp: 'What respondents read on the option. Safe to reword at any time.',
         valueHelp:
-          'What gets stored in the response and sent to HubSpot or a webhook. Keep it stable: changing it breaks past answers and any mapping that points at it.',
+          'What gets stored in the response and sent to HubSpot or a webhook. It follows the label until you write one yourself, and then it stays as you left it.',
+        advanced: 'Stored values',
+        valueTaken: 'Another option on this question already stores that value.',
+        valueLocked:
+          'This form is published, so its stored values stay as they are while you reword the labels. Answers already collected carry them, and so does any mapping pointing at them.',
         importer: {
           open: 'Import options',
           title: 'Import options from a spreadsheet',
@@ -3669,7 +3679,11 @@ export const es: FormsMessages = {
         pointsHint: 'Se suma al puntaje cuando se elige esta opción. Usa un número negativo para restar.',
         labelHelp: 'Lo que leen los respondientes en la opción. Puedes reescribirlo cuando quieras.',
         valueHelp:
-          'Lo que se guarda en la respuesta y se envía a HubSpot o al webhook. Mantenlo estable: cambiarlo rompe las respuestas anteriores y cualquier mapeo que lo use.',
+          'Lo que se guarda en la respuesta y se envía a HubSpot o al webhook. Sigue a la etiqueta hasta que escribas uno tú, y a partir de ahí se queda como lo dejaste.',
+        advanced: 'Valores guardados',
+        valueTaken: 'Otra opción de esta pregunta ya guarda ese valor.',
+        valueLocked:
+          'Este formulario está publicado, así que sus valores guardados se quedan como están mientras reescribes las etiquetas. Las respuestas ya recibidas los llevan, y cualquier mapeo que apunte a ellos también.',
         importer: {
           open: 'Importar opciones',
           title: 'Importar opciones desde una hoja de cálculo',

--- a/qa/e2e/v14-option-value-follows-label.spec.ts
+++ b/qa/e2e/v14-option-value-follows-label.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * V14 — an option's stored value follows its label.
+ *
+ * The builder has always written the value for you, but only in the settings
+ * panel. The canvas, which is where people actually type, changed the label and
+ * left the value on the `option_1` / `option_2` the option was created with. The
+ * result was a form that read properly on screen and stored answers nobody could
+ * read, which is the reported complaint.
+ *
+ * Under test: the canvas inputs (canvas-question.tsx), the settings panel
+ * (options-editor.tsx), and the engine rename both now route through
+ * (`setOptionLabel` / `renameOptionValue` in form-config.ts). The assertions go
+ * through the API rather than the DOM wherever the claim is about STORED data:
+ * the point of the feature is what the submission will carry, not what the box
+ * shows.
+ *
+ * Auth is the `local` dev stub; the principal is the seeded owner.
+ */
+
+const API = 'http://localhost:4400';
+
+interface Form {
+  id: string;
+  config: Record<string, any>;
+  draftConfig?: Record<string, any> | null;
+}
+
+/** A form with an option value pointed at from a jump AND from another step's condition. */
+function branchingConfig() {
+  return {
+    version: 1,
+    steps: [
+      {
+        key: 'size',
+        type: 'multiple_choice',
+        question: 'Company size?',
+        options: [
+          { label: 'Under 50', value: 'under_50' },
+          { label: 'Over 50', value: 'over_50' },
+        ],
+        goto: [{ values: ['over_50'], target: 'budget' }],
+      },
+      {
+        key: 'budget',
+        type: 'multiple_choice',
+        question: 'Budget?',
+        showWhen: { field: 'size', values: ['over_50'] },
+        options: [{ label: 'Yes', value: 'yes' }],
+      },
+    ],
+  };
+}
+
+/**
+ * Build the form the way the BUILDER does, and the two steps are the point.
+ *
+ * A form is created EMPTY and its questions land in the DRAFT; the live config
+ * stays empty until somebody publishes. That is what makes a value free to
+ * follow its label while the form is being built, and creating one with its
+ * config in a single POST would publish it on the spot and lock every value
+ * before the test began.
+ */
+async function createForm(request: APIRequestContext, label: string, config: unknown): Promise<Form> {
+  const res = await request.post(`${API}/v1/forms`, {
+    data: { name: `qa-optval-${label}-${Math.random().toString(36).slice(2, 10)}` },
+  });
+  expect(res.status(), 'POST /v1/forms should create the form').toBe(201);
+  const form = (await res.json()) as Form;
+  const staged = await request.put(`${API}/v1/forms/${form.id}`, { data: { config } });
+  expect(staged.ok(), 'PUT /v1/forms/:id should stage the questions as a draft').toBeTruthy();
+  return form;
+}
+
+/** What the builder is editing: the pending draft, or the live config when there is none. */
+async function edited(request: APIRequestContext, id: string) {
+  const res = await request.get(`${API}/v1/forms/${id}`);
+  expect(res.ok(), `GET /v1/forms/${id}`).toBeTruthy();
+  const form = (await res.json()) as Form;
+  return form.draftConfig ?? form.config;
+}
+
+test.describe('V14: the option value follows the label', () => {
+  // A cold `next dev` compiles the editor route on first hit.
+  test.describe.configure({ timeout: 120_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 950 });
+  });
+
+  test('renaming a label on the CANVAS carries the value, the jump and the condition', async ({
+    page,
+    request,
+  }) => {
+    const form = await createForm(request, 'canvas', branchingConfig());
+    await page.goto(`/admin/forms/${form.id}/edit`);
+
+    const option = page.locator('input[value="Over 50"]').first();
+    await expect(option, 'the canvas renders the option label as an input').toBeVisible({
+      timeout: 25_000,
+    });
+    await option.fill('More than 50 employees');
+    // Blur, then let the debounced autosave land.
+    await page.keyboard.press('Tab');
+    await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 25_000 });
+
+    const config = await edited(request, form.id);
+    expect(
+      config.steps[0].options.map((o: { label: string; value: string }) => o.value),
+      'the value followed the label',
+    ).toEqual(['under_50', 'more_than_50_employees']);
+    // The half that makes the rename safe rather than merely tidy: a pointer
+    // left on the old token is a branch that silently never fires again.
+    expect(config.steps[0].goto[0].values, 'the jump followed').toEqual(['more_than_50_employees']);
+    expect(config.steps[1].showWhen.values, 'the other step condition followed').toEqual([
+      'more_than_50_employees',
+    ]);
+  });
+
+  test('a PUBLISHED form keeps its stored values while the labels change', async ({
+    page,
+    request,
+  }) => {
+    const form = await createForm(request, 'published', branchingConfig());
+    // Publishing is what moves the draft into the live config, and the live
+    // config is what a respondent can already have answered.
+    const published = await request.post(`${API}/v1/forms/${form.id}/publish`);
+    expect(published.ok(), 'POST /publish').toBeTruthy();
+
+    await page.goto(`/admin/forms/${form.id}/edit`);
+    const option = page.locator('input[value="Over 50"]').first();
+    await expect(option).toBeVisible({ timeout: 25_000 });
+    await option.fill('Over fifty');
+    await page.keyboard.press('Tab');
+    await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 25_000 });
+
+    const config = await edited(request, form.id);
+    // The label is the author's to reword at any time; the token is not, because
+    // answers already collected carry it and a CRM mapping may point at it.
+    expect(config.steps[0].options[1].label).toBe('Over fifty');
+    expect(config.steps[0].options[1].value).toBe('over_50');
+    expect(config.steps[1].showWhen.values).toEqual(['over_50']);
+  });
+
+  test('a form stuck on the created placeholder heals on the next label edit', async ({
+    page,
+    request,
+  }) => {
+    // Exactly the shape the bug produced: a proper label, a value nobody chose.
+    const form = await createForm(request, 'heal', {
+      version: 1,
+      steps: [
+        {
+          key: 'size',
+          type: 'multiple_choice',
+          question: 'Company size?',
+          options: [{ label: 'Over 50 employees', value: 'option_1' }],
+        },
+      ],
+    });
+
+    await page.goto(`/admin/forms/${form.id}/edit`);
+    const option = page.locator('input[value="Over 50 employees"]').first();
+    await expect(option).toBeVisible({ timeout: 25_000 });
+    await option.fill('Over 50 people');
+    await page.keyboard.press('Tab');
+    await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 25_000 });
+
+    const config = await edited(request, form.id);
+    expect(config.steps[0].options[0].value).toBe('over_50_people');
+  });
+
+  test('the stored values are collapsed, and open on request', async ({ page, request }) => {
+    const form = await createForm(request, 'advanced', branchingConfig());
+    await page.goto(`/admin/forms/${form.id}/edit`);
+
+    const toggle = page.getByTestId('options-advanced-toggle');
+    await expect(toggle, 'the disclosure is offered').toBeVisible({ timeout: 25_000 });
+    await expect(
+      page.locator('input[value="under_50"]'),
+      'and the values are not in the way until asked for',
+    ).toHaveCount(0);
+
+    await toggle.click();
+    await expect(page.locator('input[value="under_50"]')).toBeVisible();
+  });
+
+  test('a hand-written value shows itself rather than hiding behind the disclosure', async ({
+    page,
+    request,
+  }) => {
+    // A value chosen to match something outside this form is the one thing here
+    // an author needs to SEE, and it is also the one the label will not move.
+    const form = await createForm(request, 'manual', {
+      version: 1,
+      steps: [
+        {
+          key: 'size',
+          type: 'multiple_choice',
+          question: 'Company size?',
+          options: [
+            { label: 'Under 50', value: 'under_50' },
+            { label: 'Over 50', value: 'ENTERPRISE_TIER' },
+          ],
+        },
+      ],
+    });
+
+    await page.goto(`/admin/forms/${form.id}/edit`);
+
+    await expect(page.locator('input[value="ENTERPRISE_TIER"]')).toBeVisible({ timeout: 25_000 });
+
+    // And it stays put when the label moves.
+    const option = page.locator('input[value="Over 50"]').first();
+    await option.fill('Over fifty');
+    await page.keyboard.press('Tab');
+    await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 25_000 });
+
+    const config = await edited(request, form.id);
+    expect(config.steps[0].options[1]).toMatchObject({
+      label: 'Over fifty',
+      value: 'ENTERPRISE_TIER',
+    });
+  });
+});


### PR DESCRIPTION
## What

A choice option carries two strings: the **label** a respondent reads, and the
**value** stored in the answer. The builder has always written the value for
you, but only in the settings panel. The canvas, which is where people actually
type, changed the label and left the value on the `option_1` / `option_2` the
option was created with.

So forms came out reading properly on screen and storing answers nobody could
read, and authors reasonably concluded the value was a box they had failed to
fill in. Both surfaces now route through one engine function and cannot disagree
again. The value follows the label until you write a value yourself, after which
it is yours and stays exactly where you left it.

## Why this is a rename and not an assignment

Six other places name an option value by string, and **not one of them complains
when it stops matching** - a branch simply never fires again. `renameOptionValue`
carries all of them:

- `showWhen` / `hideWhen` values on any step whose condition reads this one
- `goto` jump values on the step that owns the options
- the keys of `questionVariants` and `sliderLabelVariants`, including the
  comma-joined composite keys a multi-select variant uses
- outcome override values

A **seventh lives outside the config**: a HubSpot destination's
`valueMaps[stepKey][value]`, which the draft autosave never writes. A label edit
runs per keystroke, so it cannot migrate that mapping the way a field-key rename
does. Rather than migrate it badly, a mapped value is refused the move.

## What may not move

`lockedOptionValues` reads the **live** config: what the public URL already
serves, plus what a value map points at.

Presence in the live config is the gate rather than a `published_at` stamp,
which looks like the obvious test and is not: `publishForm` returns early
*without* stamping when no draft is pending, so a form created through the API
with a config is serving it publicly while its stamp is still null. Gating on
the stamp would leave exactly those forms editable.

It does not over-lock either, because the builder creates a form **empty**:
nothing is locked while a form is being built, and an option added after
publication is not in the live config, so its value still follows its label.
Otherwise adding one option to a live form would reproduce the confusion this
removes. A form started from a template locks the template's own options, and
those ship deliberate values (`asap`, `in_person`) nobody wants rewritten into a
slug of their own sentence.

## The panel

Stored values move behind a **"Stored values"** disclosure instead of sitting in
a column beside every label. It opens on its own when a value has stopped
tracking its label, so a value chosen deliberately is never hidden from whoever
chose it, and it gets its own row rather than a third column: the panel is
~420px and the old layout clipped values to eight characters, which is
unreadable for the one field here whose exact characters are the point.

Editing one by hand commits on blur, like the step field-key editor and for the
same reason, and refuses a value a sibling already holds rather than merging two
distinct answers onto one token.

## Compatibility

Forms already stuck on `option_1` **heal on the next label edit**: the created
placeholder counts as unwritten rather than as a value somebody chose. A
hand-written value is never touched. No stored config changes on its own.

## Verified

| | |
|---|---|
| `pnpm test` | 16/16 tasks, +19 engine tests |
| `pnpm lint` / `pnpm typecheck` | 16/16, no new warnings |
| e2e | `v14-option-value-follows-label` 5/5 (new), plus `v4-qsettings`, `regression-core`, `v12-account-settings`, `v2-editor-links` |
| dash-check vs `origin/develop` | clean |
| publish-gate | passed (trufflehog skipped locally, gitleaks clean) |

Confirmed by hand against a running stack: renaming a label on an unpublished
form moved the value **and** both the `goto` rule and the other step's
`showWhen`; the same edit on the published form left every stored value where it
was.

**Pre-existing failure, not from this branch:** the two `V4-13` prefill cases in
`qa/e2e/v4-fields2.spec.ts` fail on unmodified `develop` too (verified by
stashing this work and rerunning). Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
