### PR TITLE
fix(web): logout matches Orbit's contract and sends WorkOS the id it can resolve

### DIFF
--- a/.changeset/workos-session-id-claim.md
+++ b/.changeset/workos-session-id-claim.md
@@ -2,4 +2,4 @@
 '@quill/web': patch
 ---
 
-Sign-out now reaches WorkOS with the session id it can actually resolve. The login callback reads the workos_session_id claim from the IAM access token (the callback blob only carries the IAM's own row id), so the logout revoke and the IdP logout URL stop being silent no-ops that stranded the browser on a blank WorkOS page and let the next sign-in silently re-authenticate the same person. Sessions stored before this change carry the old id; for those the sign-out skips the WorkOS hop and lands directly on the signed-out login page.
+Sign-out now matches Orbit's logout contract exactly. The login callback reads the workos_session_id claim from the IAM access token (the callback blob only carries the IAM's own row id), so the upstream revoke stops being a silent no-op. And no logout path sends the browser to WorkOS anymore: sign-out revokes at the IAM, clears the local session, and lands on the signed-out login page, which removes the blank WorkOS page some sign-outs stranded on and removes any dependency on the WorkOS logout-redirect allowlist. As on the Dapta platform, the shared identity session deliberately survives a Forms sign-out.

--- a/.changeset/workos-session-id-claim.md
+++ b/.changeset/workos-session-id-claim.md
@@ -1,0 +1,5 @@
+---
+'@quill/web': patch
+---
+
+Sign-out now reaches WorkOS with the session id it can actually resolve. The login callback reads the workos_session_id claim from the IAM access token (the callback blob only carries the IAM's own row id), so the logout revoke and the IdP logout URL stop being silent no-ops that stranded the browser on a blank WorkOS page and let the next sign-in silently re-authenticate the same person. Sessions stored before this change carry the old id; for those the sign-out skips the WorkOS hop and lands directly on the signed-out login page.

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import { serverApiUrl } from '@/lib/api-url';
-import { setSession } from '@/lib/auth-session';
+import { setSession, workosSessionIdFromJwt } from '@/lib/auth-session';
 import { asLocale, LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE } from '@/lib/locale';
 import { requestOrigin } from '@/lib/request-origin';
 
@@ -166,11 +166,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.redirect(new URL('/login?error=callback', origin));
   }
 
+  // The blob's session_id is the IAM's own row id, not WorkOS's. The claim
+  // inside the JWT is the id WorkOS actually resolves at logout, so prefer it;
+  // the blob id stays as a fallback for an IAM that stops minting the claim.
   await setSession({
     provider: 'workos',
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,
-    sessionId: tokens.session_id,
+    sessionId: workosSessionIdFromJwt(tokens.access_token) ?? tokens.session_id,
   });
   await recordAttribution(jar, tokens.access_token);
   await seedLocale(jar, tokens.access_token);

--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -28,22 +28,20 @@ describe('GET /api/auth/logout', () => {
     revokeUpstreamSession.mockResolvedValue(null);
   });
 
-  it('follows the IdP logout URL with return_to so WorkOS ends the browser session too', async () => {
+  it('never follows the IdP logout URL (Orbit contract, skipIdpRedirect = true)', async () => {
     getSession.mockResolvedValue(workosSession);
     revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     const res = await GET(req());
 
-    const target = new URL(res.headers.get('location')!);
-    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
-    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
     // Read-then-clear: the revoke needs the session id the cookie carried.
     expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
     expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
   });
 
-  it('reason=expired skips the WorkOS hop: an expiry must not end the whole Dapta session', async () => {
+  it('reason=expired behaves identically: revoke, clear, local landing', async () => {
     getSession.mockResolvedValue(workosSession);
     revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 

--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/auth-session', async () => {
 import { GET } from './route';
 
 const req = (path = '/api/auth/logout') => new NextRequest(`https://forms.example.com${path}`);
-const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'session_123' };
 
 describe('GET /api/auth/logout', () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('GET /api/auth/logout', () => {
 
   it('follows the IdP logout URL with return_to so WorkOS ends the browser session too', async () => {
     getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     const res = await GET(req());
 
@@ -45,7 +45,7 @@ describe('GET /api/auth/logout', () => {
 
   it('reason=expired skips the WorkOS hop: an expiry must not end the whole Dapta session', async () => {
     getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     const res = await GET(req('/api/auth/logout?reason=expired'));
 

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,34 +1,29 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { clearSession, getSession, idpLogoutTarget, revokeUpstreamSession } from '@/lib/auth-session';
+import { clearSession, getSession, revokeUpstreamSession } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
 /**
- * Logout: revoke upstream best-effort (see `revokeUpstreamSession`), ALWAYS
- * clear our cookie, then follow the IdP logout URL so WorkOS ends the browser
- * session too and returns the person to /login?signedout=1 (whose param
- * suppresses the login page's auto-redirect). Without the WorkOS hop the shared
- * Dapta session survives and the next "sign in" silently re-authenticates the
- * same person.
- *
- * `?reason=expired` skips the WorkOS hop (Orbit's skipIdpRedirect = true):
- * it marks a session-expiry logout, not a person asking to leave, and a Forms
- * token expiring must not end their whole Dapta platform session.
+ * Logout, Orbit's contract exactly: revoke upstream best-effort (see
+ * `revokeUpstreamSession`), ALWAYS clear our cookie, land on
+ * /login?signedout=1 (whose param suppresses the login page's auto-redirect).
+ * The browser never visits WorkOS (Orbit's skipIdpRedirect = true), so nothing
+ * here depends on the WorkOS logout-redirect allowlist. The accepted
+ * consequence, same as the Dapta platform app: the AuthKit cookie on WorkOS's domain
+ * stays alive and the next "sign in" re-authenticates the same person without
+ * prompting. `?reason=expired` marks the session-expiry arrival from
+ * `admin-api.ts` but no longer changes behavior; it stays for observability.
  *
  * The explicit sign-out button does NOT come through here: `signOutAction` and
  * `hostFetch` revoke + clear inline, because an action `redirect()` into a
  * route handler soft-navigates and strands the URL bar on /api/auth/logout.
  * This route serves the contexts that cannot touch the cookie themselves: the
  * 401 path inside a Server Component render (`admin-api.ts`, where
- * `cookies().delete()` throws, arriving with ?reason=expired) and direct
- * navigation (full logout).
+ * `cookies().delete()` throws) and direct navigation.
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const origin = requestOrigin(req);
   const session = await getSession();
   await clearSession();
-  const logoutUrl = await revokeUpstreamSession(session);
-  const expired = req.nextUrl.searchParams.get('reason') === 'expired';
-  const idp = expired ? null : idpLogoutTarget(logoutUrl, origin);
-  if (idp) return NextResponse.redirect(idp);
+  await revokeUpstreamSession(session);
   return NextResponse.redirect(new URL('/login?signedout=1', origin));
 }

--- a/apps/web/app/login/actions.spec.ts
+++ b/apps/web/app/login/actions.spec.ts
@@ -44,17 +44,15 @@ describe('signOutAction', () => {
     vi.unstubAllEnvs();
   });
 
-  it('workos: follows the IdP logout URL with return_to back to the local landing', async () => {
+  it('workos: never follows the IdP logout URL (Orbit contract, skipIdpRedirect = true)', async () => {
     authProvider.mockReturnValue('workos');
     getSession.mockResolvedValue(workosSession);
     revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
-    await expect(signOutAction()).rejects.toThrow(
-      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
-    );
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
 
     // Read-then-clear: clearing first hands the revoke a null session (the
-    // pre-#82 bug that left the upstream WorkOS session alive).
+    // pre-#82 bug that left the upstream session alive).
     expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
     expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
@@ -68,14 +66,6 @@ describe('signOutAction', () => {
     await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
 
     expect(clearSession).toHaveBeenCalled();
-  });
-
-  it('workos: lands locally on an unparseable logout URL instead of failing the sign-out', async () => {
-    authProvider.mockReturnValue('workos');
-    getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('/relative-not-a-url');
-
-    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
   });
 
   it('workos: still clears and lands locally when the session is already gone', async () => {

--- a/apps/web/app/login/actions.spec.ts
+++ b/apps/web/app/login/actions.spec.ts
@@ -31,7 +31,7 @@ vi.mock('next/headers', () => ({
 
 import { signOutAction } from './actions';
 
-const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'session_123' };
 
 describe('signOutAction', () => {
   beforeEach(() => {
@@ -47,10 +47,10 @@ describe('signOutAction', () => {
   it('workos: follows the IdP logout URL with return_to back to the local landing', async () => {
     authProvider.mockReturnValue('workos');
     getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     await expect(signOutAction()).rejects.toThrow(
-      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=sess_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
+      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
     );
 
     // Read-then-clear: clearing first hands the revoke a null session (the

--- a/apps/web/app/login/actions.ts
+++ b/apps/web/app/login/actions.ts
@@ -1,16 +1,13 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { headers } from 'next/headers';
 import {
   setSession,
   clearSession,
   getSession,
   authProvider,
   revokeUpstreamSession,
-  idpLogoutTarget,
 } from '@/lib/auth-session';
-import { originFrom } from '@/lib/request-origin';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -31,31 +28,26 @@ export async function signInAction(
 }
 
 /**
- * Logout (AUTH-WEB-CONTRACT §2/§3.5): read the session, clear the cookie, tell
- * the IAM to revoke upstream, then FOLLOW the returned IdP logout URL (Orbit's
- * skipIdpRedirect = false case, "logout completo"). The browser hop through
- * WorkOS is not optional for the sign-out button: the AuthKit session cookie
- * lives on WorkOS's domain, and with the shared Dapta session still alive the
- * next "sign in" silently re-authenticates the same person back into /admin,
- * with no way to switch accounts. WorkOS sends the browser back to
- * /login?signedout=1 via return_to (the URL must stay allowlisted under
- * "Logout redirect URIs" in the WorkOS dashboard).
+ * Logout (AUTH-WEB-CONTRACT §2/§3.5), Orbit's contract exactly: read the
+ * session, clear the cookie, tell the IAM to revoke upstream, land on our own
+ * /login. The browser never visits WorkOS (Orbit's skipIdpRedirect = true,
+ * `logout({ skipWorkOSRedirect: true })` in its auth.service) so nothing here
+ * depends on the WorkOS dashboard's logout-redirect allowlist. The accepted
+ * consequence, same as the Dapta platform app: the AuthKit cookie on WorkOS's domain
+ * stays alive, so the next "sign in" re-authenticates the same person without
+ * prompting. The IdP logout URL the IAM returns is used only by a future
+ * switch-account flow (`idpLogoutTarget`).
  *
  * The order matters: the session must be READ before `clearSession()` lands its
  * Set-Cookie, or the revoke has no session id. That gap once left the upstream
- * WorkOS session alive (the pre-#82 bug). Local cleanup always runs, whatever
- * the IAM call does; when no logout URL comes back (IAM down, unparseable URL,
- * no session id) the person still lands signed out on /login?signedout=1, whose
- * param suppresses the login page's auto-redirect.
+ * session alive (the pre-#82 bug). Local cleanup always runs, whatever the IAM
+ * call does; /login?signedout=1's param suppresses the login page's
+ * auto-redirect back into the IAM.
  */
 export async function signOutAction(): Promise<void> {
   const session = await getSession();
   await clearSession();
-  const logoutUrl = await revokeUpstreamSession(session);
-  const hdrs = await headers();
-  const origin = originFrom((n) => hdrs.get(n));
-  const idp = origin ? idpLogoutTarget(logoutUrl, origin) : null;
-  if (idp) redirect(idp);
+  await revokeUpstreamSession(session);
   // Keyed on the configured provider, not the (possibly already-null) session:
   // in workos mode a bare /login auto-redirects straight back into the IAM.
   redirect(authProvider() === 'workos' ? '/login?signedout=1' : '/login');

--- a/apps/web/lib/auth-session-revoke.spec.ts
+++ b/apps/web/lib/auth-session-revoke.spec.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('next/headers', () => ({ cookies: vi.fn() }));
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
 
-import { idpLogoutTarget, revokeUpstreamSession, type Session } from './auth-session';
+import {
+  idpLogoutTarget,
+  revokeUpstreamSession,
+  workosSessionIdFromJwt,
+  type Session,
+} from './auth-session';
 
 const workosSession: Session = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
 
@@ -89,14 +94,37 @@ describe('revokeUpstreamSession', () => {
 describe('idpLogoutTarget', () => {
   it('appends return_to pointing at the local signed-out landing', () => {
     const target = idpLogoutTarget(
-      'https://api.workos.com/user_management/sessions/logout?session_id=sess_123',
+      'https://api.workos.com/user_management/sessions/logout?session_id=session_01ABC',
       'https://forms.example.com',
     );
 
     const url = new URL(target!);
     expect(url.origin + url.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
-    expect(url.searchParams.get('session_id')).toBe('sess_123');
+    expect(url.searchParams.get('session_id')).toBe('session_01ABC');
     expect(url.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  // WorkOS answers an id it cannot resolve with a blank 200: no redirect, no
+  // revocation. A session_id that is not a WorkOS-shaped id (the IAM's own UUID,
+  // stored by sessions minted before the JWT claim was read) must land locally
+  // instead of on that blank page.
+  it('returns null when the session_id is not a WorkOS session id', () => {
+    expect(
+      idpLogoutTarget(
+        'https://api.workos.com/user_management/sessions/logout?session_id=22d19884-f7f1-4084-90bc-7088229c34b3',
+        'https://forms.example.com',
+      ),
+    ).toBeNull();
+  });
+
+  it('still allows a logout URL that carries no session_id at all', () => {
+    const target = idpLogoutTarget(
+      'https://example.authkit.app/logout',
+      'https://forms.example.com',
+    );
+    expect(new URL(target!).searchParams.get('return_to')).toBe(
+      'https://forms.example.com/login?signedout=1',
+    );
   });
 
   it('overwrites a preexisting return_to', () => {
@@ -131,5 +159,35 @@ describe('idpLogoutTarget', () => {
     expect(new URL(target!).searchParams.get('return_to')).toBe(
       'http://localhost:3400/login?signedout=1',
     );
+  });
+});
+
+describe('workosSessionIdFromJwt', () => {
+  const jwtWith = (claims: Record<string, unknown>) =>
+    `${Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url')}.${Buffer.from(
+      JSON.stringify(claims),
+    ).toString('base64url')}.signature`;
+
+  it('reads the workos_session_id claim', () => {
+    const token = jwtWith({
+      sub: 'a4d2b7a0-0000-0000-0000-000000000000',
+      session_id: '22d19884-f7f1-4084-90bc-7088229c34b3',
+      workos_session_id: 'session_01JQEXAMPLE',
+    });
+
+    expect(workosSessionIdFromJwt(token)).toBe('session_01JQEXAMPLE');
+  });
+
+  it('returns null when the claim is absent, empty, or not a string', () => {
+    expect(workosSessionIdFromJwt(jwtWith({ sub: 'u' }))).toBeNull();
+    expect(workosSessionIdFromJwt(jwtWith({ workos_session_id: '' }))).toBeNull();
+    expect(workosSessionIdFromJwt(jwtWith({ workos_session_id: 42 }))).toBeNull();
+  });
+
+  it('returns null for a malformed token instead of throwing', () => {
+    expect(workosSessionIdFromJwt('not-a-jwt')).toBeNull();
+    expect(workosSessionIdFromJwt('a.%%%not-base64%%%.c')).toBeNull();
+    expect(workosSessionIdFromJwt(`a.${Buffer.from('[1,2]').toString('base64url')}.c`)).toBeNull();
+    expect(workosSessionIdFromJwt('')).toBeNull();
   });
 });

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -114,6 +114,38 @@ export async function revokeUpstreamSession(session: Session | null): Promise<st
 }
 
 /**
+ * The WorkOS session id, read from the IAM access token's claims.
+ *
+ * The callback's `?session=` blob carries `session_id` = the IAM's OWN session
+ * row id (a UUID), and no `workos_session_id` field at all: the only place the
+ * IAM puts the real WorkOS id (`session_01...`) is inside the JWT it mints
+ * (`create-unified-session` adds the claim for the workos provider). Orbit
+ * reads it from exactly this claim. Sending the IAM's UUID to WorkOS's logout
+ * endpoint is a silent no-op: WorkOS answers 200 with an empty body for an id
+ * it cannot resolve, so the browser strands on a blank api.workos.com page and
+ * the AuthKit cookie survives, silently re-authenticating the next sign-in.
+ *
+ * Decoded WITHOUT verifying the signature, deliberately: this runs in the
+ * callback on a token the IAM just handed over a state-checked redirect, the
+ * API re-verifies the token (HS256) on every request that uses it, and the web
+ * holds no JWT secret to verify with. A malformed token yields null, never a
+ * throw.
+ */
+export function workosSessionIdFromJwt(accessToken: string): string | null {
+  const payload = accessToken.split('.')[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as {
+      workos_session_id?: unknown;
+    };
+    const id = claims?.workos_session_id;
+    return typeof id === 'string' && id ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The IdP logout redirect for the sign-out button: the IAM's logout URL with
  * return_to pointing back at our login landing, so WorkOS ends the browser
  * session and sends the person to /login?signedout=1 instead of stranding
@@ -121,12 +153,21 @@ export async function revokeUpstreamSession(session: Session | null): Promise<st
  * "Logout redirect URIs" in the WorkOS dashboard or WorkOS ignores it.
  * Null when the logout URL is absent or unparseable (NextResponse.redirect
  * and the action redirect would both throw on it): callers land locally.
+ *
+ * Also null when the URL's session_id does not look like a WorkOS session id
+ * (`session_...`). The IAM builds the logout URL by echoing whatever id it was
+ * sent, without resolving it, and WorkOS answers an unresolvable id with a
+ * blank 200: no redirect back, nothing revoked. That is precisely the sessions
+ * minted before `workosSessionIdFromJwt` existed (30-day cookies carrying the
+ * IAM's UUID), so those land locally instead of on the blank page.
  */
 export function idpLogoutTarget(logoutUrl: string | null, origin: string): string | null {
   if (!logoutUrl) return null;
   try {
     const target = new URL(logoutUrl);
     if (!isBrowserNavigable(target)) return null;
+    const sessionId = target.searchParams.get('session_id');
+    if (sessionId !== null && !sessionId.startsWith('session_')) return null;
     target.searchParams.set('return_to', new URL('/login?signedout=1', origin).toString());
     return target.toString();
   } catch {

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -86,11 +86,11 @@ export async function getSession(): Promise<Session | null> {
  * Returns the WorkOS logout URL (the IAM serializes it as logoutUrl or
  * logoutURL) or null. Server-side revocation alone is NOT a browser logout:
  * the AuthKit session cookie lives on WorkOS's domain and only dies when the
- * browser visits this URL. Callers choose per Orbit's skipIdpRedirect switch:
- * the explicit sign-out button follows it (a Forms logout must also end the
- * shared Dapta session, or the next "sign in" silently re-authenticates the
- * same person); the 401 expiry paths ignore it (a Forms token expiring must
- * not log the person out of the whole Dapta platform).
+ * browser visits this URL. Per Orbit's contract NO current caller follows it
+ * (skipIdpRedirect = true everywhere: sign-out stays inside Forms and the
+ * shared Dapta session deliberately survives, same as the Dapta platform app). The URL
+ * is returned for the one flow that would need Orbit's skipIdpRedirect =
+ * false mode, a future switch-account (`idpLogoutTarget` shapes it).
  *
  * Never throws and never hangs past its timeout: the caller's local cleanup
  * must not be hostage to the IAM being up.
@@ -146,13 +146,16 @@ export function workosSessionIdFromJwt(accessToken: string): string | null {
 }
 
 /**
- * The IdP logout redirect for the sign-out button: the IAM's logout URL with
- * return_to pointing back at our login landing, so WorkOS ends the browser
- * session and sends the person to /login?signedout=1 instead of stranding
- * them on a blank api.workos.com page. The URL must be allowlisted under
- * "Logout redirect URIs" in the WorkOS dashboard or WorkOS ignores it.
- * Null when the logout URL is absent or unparseable (NextResponse.redirect
- * and the action redirect would both throw on it): callers land locally.
+ * The IdP logout redirect for Orbit's skipIdpRedirect = false mode (a full
+ * logout that also ends the shared Dapta session, e.g. a future
+ * switch-account): the IAM's logout URL with return_to pointing back at our
+ * login landing. UNUSED by the sign-out button and the logout route on
+ * purpose: per Orbit's contract those never send the browser to WorkOS, which
+ * is also what keeps them independent of the WorkOS dashboard's
+ * "Logout redirect URIs" allowlist (return_to is only honored when
+ * allowlisted). Null when the logout URL is absent or unparseable
+ * (NextResponse.redirect and the action redirect would both throw on it):
+ * callers land locally.
  *
  * Also null when the URL's session_id does not look like a WorkOS session id
  * (`session_...`). The IAM builds the logout URL by echoing whatever id it was
@@ -263,10 +266,10 @@ export async function hostFetch(path: string, init?: RequestInit): Promise<Respo
     // best-effort. Inline rather than via /api/auth/logout, because an action
     // `redirect()` into a route handler strands the URL bar there. And per the
     // contract, a 401 anywhere never re-enters logout: one revoke, then /login.
-    // The returned IdP logout URL is deliberately ignored here (Orbit's
-    // skipIdpRedirect = true): a Forms token expiring must not bounce the
-    // browser through WorkOS and end the person's whole Dapta session. Only
-    // the explicit sign-out button does that.
+    // The returned IdP logout URL is deliberately ignored (Orbit's
+    // skipIdpRedirect = true, like every logout path): the browser never
+    // bounces through WorkOS, so a Forms logout can never end the person's
+    // whole Dapta session.
     const session = await getSession();
     await clearSession();
     await revokeUpstreamSession(session);


### PR DESCRIPTION
## What

Two fixes to sign-out, verified end-to-end against an offline stub of the IAM:

1. **The login callback now reads the `workos_session_id` claim from the IAM access token.** The callback blob's `session_id` is the IAM's own session row id (a UUID), and the blob carries no `workos_session_id` at all; the only place the real WorkOS id (`session_01...`) appears is the JWT claim, which is exactly what Orbit reads (`getWorkosSessionIdFromToken()`). We were sending the UUID, so the IAM's revoke never found the session (`sessionRevoked: false`) and the logout URL it echoed pointed WorkOS at an id it cannot resolve, which WorkOS answers with a blank 200: the blank api.workos.com page people got stranded on.

2. **Every logout path now follows Orbit's contract exactly** (`skipIdpRedirect = true`, per Karen's spec): POST the IAM revoke (`redirect=false`, no Bearer), always clear the local session, land on `/login?signedout=1`. The browser never visits WorkOS, which also removes any dependency on the WorkOS dashboard's logout-redirect allowlist (that allowlist only governs the `return_to` of a browser visit that no longer happens). This reverts the #132 behavior where the sign-out button followed the IdP logout URL.

The accepted consequence, identical to the Dapta platform app: the shared AuthKit session survives a Forms sign-out, so the next "sign in" re-authenticates the same person without prompting.

`idpLogoutTarget` stays exported (now also refusing non-WorkOS-shaped session ids) as the ready-made `skipIdpRedirect = false` half of the contract for a future switch-account flow; no current caller uses it.

## Verification

- Offline harness (stub IAM emulating the real contract: blob carries the IAM UUID, JWT carries the claim, logout echoes the id verbatim): sign-out POSTs `workos_session_id: session_01...` with no Authorization header, the browser goes straight to `/login?signedout=1`, and the stub records zero visits to its fake WorkOS logout endpoint.
- `pnpm test` (web 557/557, api 454/454), `pnpm typecheck`, `pnpm lint`, `bash scripts/dash-check.sh origin/develop`, `PUBLISH_GATE_LOCAL=1 pnpm run publish-gate` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)