### PR TITLE
feat(web): sign-in parity with Orbit's auth contract (prompt=login + session refresh)

### DIFF
--- a/.changeset/login-orbit-parity.md
+++ b/.changeset/login-orbit-parity.md
@@ -1,0 +1,5 @@
+---
+'@quill/web': patch
+---
+
+Sign-in reaches parity with the Dapta platform's auth contract. The "Continue with Dapta" button on the signed-out and error landings now asks the hosted login to actually prompt (prompt=login patched onto the authorize URL, since the identity service does not forward the parameter yet), so signing out followed by signing in offers a real account choice instead of silently re-entering the same session. To make that viable, the web now refreshes its session in place: a 401 from the API first trades the stored refresh token for a new access token (retrying the request once in server actions, or through the new /api/auth/refresh route during a page render) and only bounces to the login page when the refresh token itself is dead. The bare /login auto-redirect keeps the silent single sign-on for people arriving from the Dapta platform.

--- a/apps/web/app/api/auth/login/route.spec.ts
+++ b/apps/web/app/api/auth/login/route.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const cookieJar = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => cookieJar) }));
+vi.mock('@/lib/auth-session', () => ({ authProvider: () => 'workos' }));
+
+import { GET } from './route';
+
+const AUTHORIZE =
+  'https://api.workos.com/user_management/authorize?client_id=client_1&provider=authkit&state=abc';
+
+const req = (path: string) => new NextRequest(`https://forms.example.com${path}`);
+
+describe('GET /api/auth/login prompt handling', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('PUBLIC_APP_URL', '');
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ loginUrl: AUTHORIZE }) });
+    cookieJar.get.mockReturnValue(undefined);
+  });
+
+  it('patches prompt=login onto the authorize URL when asked (the IAM drops the param)', async () => {
+    const res = await GET(req('/api/auth/login?prompt=login'));
+
+    const target = new URL(res.headers.get('location')!);
+    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/authorize');
+    expect(target.searchParams.get('prompt')).toBe('login');
+    // Forwarded to the IAM too, so nothing changes here the day it propagates it.
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('prompt=login');
+  });
+
+  it('sends no prompt on the bare auto-redirect (silent SSO stays)', async () => {
+    const res = await GET(req('/api/auth/login'));
+
+    expect(new URL(res.headers.get('location')!).searchParams.get('prompt')).toBeNull();
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('prompt');
+  });
+
+  it('ignores any prompt value that is not exactly login', async () => {
+    const res = await GET(req('/api/auth/login?prompt=evil%20login'));
+
+    expect(new URL(res.headers.get('location')!).searchParams.get('prompt')).toBeNull();
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('prompt');
+  });
+});

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -85,12 +85,35 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     });
   }
 
+  // `prompt=login` makes AuthKit show its sign-in screen even when the shared
+  // WorkOS session cookie is still alive, which is what turns the button on
+  // the signed-out landing into a real "sign in as someone" instead of a
+  // silent re-authentication (Orbit's promptLogin contract). Allowlisted to
+  // the one value we mean: this route is directly reachable and the value
+  // ends up on a WorkOS URL. The bare auto-redirect from /login sends no
+  // prompt, keeping the arriving-from-Dapta silent SSO.
+  const prompt = sp.get('prompt') === 'login' ? 'login' : null;
+
   const returnTo = `${origin}/api/auth/callback`;
   const res = await fetch(
-    `${iam}/auth/login-url?returnTo=${encodeURIComponent(returnTo)}&state=${encodeURIComponent(state)}`,
+    `${iam}/auth/login-url?returnTo=${encodeURIComponent(returnTo)}&state=${encodeURIComponent(state)}` +
+      (prompt ? `&prompt=${prompt}` : ''),
     { cache: 'no-store' },
   ).catch(() => null);
   const loginUrl = res && res.ok ? ((await res.json().catch(() => ({}))) as { loginUrl?: string }).loginUrl : undefined;
   if (!loginUrl) return NextResponse.redirect(new URL('/login?error=login', origin));
+  // The IAM currently drops the prompt param instead of forwarding it to the
+  // authorize URL, so patch it on ourselves, exactly like Orbit's
+  // enforcePromptOnLoginUrl ("if IAM forgets to propagate prompt to WorkOS,
+  // patch the returned loginUrl"). Harmless once the IAM learns to forward it.
+  if (prompt) {
+    try {
+      const patched = new URL(loginUrl);
+      patched.searchParams.set('prompt', prompt);
+      return NextResponse.redirect(patched.toString());
+    } catch {
+      return NextResponse.redirect(new URL('/login?error=login', origin));
+    }
+  }
   return NextResponse.redirect(loginUrl);
 }

--- a/apps/web/app/api/auth/refresh/route.spec.ts
+++ b/apps/web/app/api/auth/refresh/route.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const getSession = vi.fn();
+const setSession = vi.fn();
+const refreshUpstreamSession = vi.fn();
+vi.mock('@/lib/auth-session', () => ({
+  getSession: (...a: unknown[]) => getSession(...a),
+  setSession: (...a: unknown[]) => setSession(...a),
+  refreshUpstreamSession: (...a: unknown[]) => refreshUpstreamSession(...a),
+}));
+
+import { GET } from './route';
+
+const req = () => new NextRequest('https://forms.example.com/api/auth/refresh');
+const staleSession = { provider: 'workos', accessToken: 'old', refreshToken: 'refresh-1' };
+const freshSession = { provider: 'workos', accessToken: 'new', refreshToken: 'refresh-2' };
+
+describe('GET /api/auth/refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('PUBLIC_APP_URL', '');
+    getSession.mockResolvedValue(staleSession);
+  });
+
+  it('stores the refreshed session and returns to /admin', async () => {
+    refreshUpstreamSession.mockResolvedValue(freshSession);
+
+    const res = await GET(req());
+
+    expect(refreshUpstreamSession).toHaveBeenCalledWith(staleSession);
+    expect(setSession).toHaveBeenCalledWith(freshSession);
+    expect(res.headers.get('location')).toBe('https://forms.example.com/admin');
+  });
+
+  it('hands off to the logout route when the refresh fails, without touching the cookie', async () => {
+    refreshUpstreamSession.mockResolvedValue(null);
+
+    const res = await GET(req());
+
+    expect(setSession).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toBe(
+      'https://forms.example.com/api/auth/logout?reason=expired',
+    );
+  });
+
+  it('hands off to the logout route when there is no session at all', async () => {
+    getSession.mockResolvedValue(null);
+    refreshUpstreamSession.mockResolvedValue(null);
+
+    const res = await GET(req());
+
+    expect(res.headers.get('location')).toBe(
+      'https://forms.example.com/api/auth/logout?reason=expired',
+    );
+  });
+});

--- a/apps/web/app/api/auth/refresh/route.ts
+++ b/apps/web/app/api/auth/refresh/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSession, refreshUpstreamSession, setSession } from '@/lib/auth-session';
+import { requestOrigin } from '@/lib/request-origin';
+
+/**
+ * Session refresh for the one context that cannot write cookies itself: a 401
+ * during a Server Component render (`admin-api.ts`, where `cookies().set()`
+ * throws). The render redirects here; this handler trades the refresh token
+ * for a fresh access token, stores it, and sends the person back to /admin.
+ * When the refresh fails (refresh token expired or revoked, IAM down) it
+ * hands off to the logout route, which is exactly where the render-time 401
+ * used to go before refresh existed.
+ *
+ * No `next` parameter on purpose: a redirect target taken from the query is
+ * an open-redirect surface on the auth path, and landing on /admin matches
+ * what the pre-refresh flow already did. Server actions never come through
+ * here; `hostFetch` refreshes inline.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const origin = requestOrigin(req);
+  const refreshed = await refreshUpstreamSession(await getSession());
+  if (!refreshed) {
+    return NextResponse.redirect(new URL('/api/auth/logout?reason=expired', origin));
+  }
+  await setSession(refreshed);
+  return NextResponse.redirect(new URL('/admin', origin));
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -52,8 +52,13 @@ export default async function LoginPage({
           {workos ? (
             // WorkOS provider: hand off to IAM's hosted login (Google/Microsoft/
             // LinkedIn are rendered by WorkOS — nothing per-provider to build).
+            // prompt=login: this button only renders on the signed-out and
+            // error landings, where a silent re-authentication into the same
+            // account is exactly what the person is trying to escape; the
+            // hosted login must actually ask. The bare /login auto-redirect
+            // above stays promptless (silent SSO from the Dapta platform).
             <Link
-              href="/api/auth/login"
+              href="/api/auth/login?prompt=login"
               className="inline-flex min-h-[44px] w-full items-center justify-center rounded-md bg-primary px-4 py-2.5 font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
             >
               {m.workosCta}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -59,15 +59,14 @@ async function req<T>(method: string, path: string, body?: unknown, opts: ReqOpt
     cache: 'no-store',
   });
   if (res.status === 401) {
-    // Workos: leave the cookie alone. /api/auth/logout reads the session id off
-    // it to revoke upstream and then clears it itself — deleting it here first
-    // hands that route a null session and silently skips the single-logout (see
-    // `signOutAction`). This path only appeared to work because `delete()` throws
-    // during a Server Component render; from a Server Action it lands and breaks.
-    // ?reason=expired: this is a token expiring mid-render, not a person asking
-    // to leave, so the route must not bounce the browser through the WorkOS
-    // logout and end their whole Dapta platform session.
-    if (authProvider() === 'workos') redirect('/api/auth/logout?reason=expired');
+    // Workos: leave the cookie alone. A render cannot write cookies (`set()`
+    // and `delete()` both throw here), so the token exchange happens in the
+    // /api/auth/refresh route handler: it trades the refresh token for a new
+    // access token and returns to /admin, or hands off to the logout route
+    // when the refresh token itself is dead. Deleting the cookie first would
+    // hand both routes a null session (see `signOutAction`'s read-then-clear
+    // note).
+    if (authProvider() === 'workos') redirect('/api/auth/refresh');
     try {
       await clearSession();
     } catch {

--- a/apps/web/lib/auth-session-refresh.spec.ts
+++ b/apps/web/lib/auth-session-refresh.spec.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cookieJar = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => cookieJar) }));
+const redirect = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+vi.mock('next/navigation', () => ({ redirect: (url: string) => redirect(url) }));
+
+import { encodeSession, hostFetch, refreshUpstreamSession, type Session } from './auth-session';
+
+const b64u = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+const jwtWith = (claims: Record<string, unknown>) =>
+  `${b64u({ alg: 'HS256', typ: 'JWT' })}.${b64u(claims)}.sig`;
+
+const workosSession: Session = {
+  provider: 'workos',
+  accessToken: 'tok',
+  refreshToken: 'refresh-1',
+  sessionId: 'session_OLD',
+};
+
+describe('refreshUpstreamSession', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: jwtWith({ workos_session_id: 'session_NEW' }), refresh_token: 'refresh-2' }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('POSTs the refresh token with no Authorization header', async () => {
+    await refreshUpstreamSession(workosSession);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://iam.example.com/iam/auth/refresh',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ refresh_token: 'refresh-1' }) }),
+    );
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('authorization');
+  });
+
+  it('returns the rotated pair with the WorkOS id re-read from the new JWT', async () => {
+    await expect(refreshUpstreamSession(workosSession)).resolves.toEqual({
+      provider: 'workos',
+      accessToken: jwtWith({ workos_session_id: 'session_NEW' }),
+      refreshToken: 'refresh-2',
+      sessionId: 'session_NEW',
+    });
+  });
+
+  it('keeps the old session id when the new JWT carries no claim', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: jwtWith({ sub: 'u' }), refresh_token: 'refresh-2' }),
+    });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toMatchObject({ sessionId: 'session_OLD' });
+  });
+
+  it('keeps the old refresh token when the IAM omits a rotated one', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ access_token: jwtWith({}) }) });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toMatchObject({ refreshToken: 'refresh-1' });
+  });
+
+  it('resolves null on a 401 from the IAM: the refresh token is dead, sign in again', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves null on a rejected fetch instead of throwing', async () => {
+    fetchMock.mockRejectedValue(new Error('iam down'));
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+  });
+
+  it('resolves null on a body with no access token', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+  });
+
+  it('skips the IAM entirely for a local session, a missing refresh token, or no IAM', async () => {
+    await expect(refreshUpstreamSession({ provider: 'local', email: 'a@b.c' })).resolves.toBeNull();
+    await expect(refreshUpstreamSession({ provider: 'workos', accessToken: 'tok' })).resolves.toBeNull();
+    vi.stubEnv('IAM_BASE_URL', '');
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('hostFetch 401 refresh path', () => {
+  const fetchMock = vi.fn();
+  const freshJwt = jwtWith({ workos_session_id: 'session_NEW' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    vi.stubEnv('AUTH_PROVIDER', 'workos');
+    vi.stubEnv('WEB_SESSION_SECRET', 'spec-secret');
+    cookieJar.get.mockImplementation((name: string) =>
+      name === 'quill_session' ? { value: encodeSession(workosSession) } : undefined,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+
+  it('refreshes once and retries the request with the new bearer', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 401 }) // original API call
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: freshJwt, refresh_token: 'refresh-2' }),
+      }) // IAM refresh
+      .mockResolvedValueOnce({ status: 200, ok: true }); // retried API call
+
+    // After setSession the cookie jar must serve the refreshed session or the
+    // retry re-sends the dead token.
+    cookieJar.set.mockImplementation((name: string, value: string) => {
+      cookieJar.get.mockImplementation((n: string) => (n === 'quill_session' ? { value } : undefined));
+    });
+
+    const res = await hostFetch('/v1/forms');
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://iam.example.com/iam/auth/refresh');
+    const retryHeaders = (fetchMock.mock.calls[2]?.[1] as RequestInit).headers as Record<string, string>;
+    expect(retryHeaders['authorization']).toBe(`Bearer ${freshJwt}`);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the logout flow when the refresh itself fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 401 }) // original API call
+      .mockResolvedValueOnce({ ok: false, status: 401 }) // IAM refresh: dead
+      .mockResolvedValue({ ok: true, json: async () => ({}) }); // IAM revoke
+
+    await expect(hostFetch('/v1/forms')).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    expect(cookieJar.delete).toHaveBeenCalled();
+  });
+
+  it('never refreshes twice: a 401 on the retried request goes straight to logout', async () => {
+    cookieJar.set.mockImplementation((name: string, value: string) => {
+      cookieJar.get.mockImplementation((n: string) => (n === 'quill_session' ? { value } : undefined));
+    });
+    fetchMock
+      .mockResolvedValueOnce({ status: 401 }) // original API call
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: freshJwt, refresh_token: 'refresh-2' }),
+      }) // IAM refresh succeeds
+      .mockResolvedValueOnce({ status: 401 }) // retried API call STILL 401
+      .mockResolvedValue({ ok: true, json: async () => ({}) }); // IAM revoke
+
+    await expect(hostFetch('/v1/forms')).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    // original + one refresh + one retry + revoke; a second refresh would make 5 with two IAM refresh calls
+    const refreshCalls = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/auth/refresh'));
+    expect(refreshCalls).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -247,19 +247,80 @@ export async function setWorkspace(accountId: string | null): Promise<void> {
 }
 
 /**
+ * Trade the refresh token for a fresh access token (Orbit's refreshToken()
+ * flow): POST {IAM}/auth/refresh, a public route like login/logout, no Bearer.
+ * The IAM ROTATES the refresh token on every call, so the returned session
+ * must always be stored: keeping the old one guarantees the next refresh 401s.
+ * The workos_session_id claim is re-read from the new JWT (the IAM re-mints it
+ * with the claim intact); the old id is kept as fallback so a logout after a
+ * refresh still revokes.
+ *
+ * Concurrent server actions can race this (no single process to single-flight
+ * in, unlike Orbit's in-memory refreshPromise); the IAM's rotation grace
+ * window is what makes that safe, with both racers ending on valid tokens.
+ *
+ * Returns null and never throws on anything short of success: a 401 (refresh
+ * expired or revoked), a down IAM, a timeout, a local session, or a session
+ * that never carried a refresh token. Callers treat null as "sign in again".
+ */
+export async function refreshUpstreamSession(session: Session | null): Promise<Session | null> {
+  const iam = process.env.IAM_BASE_URL?.replace(/\/$/, '');
+  if (!iam || session?.provider !== 'workos' || !session.refreshToken) return null;
+  const res = await fetch(`${iam}/auth/refresh`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ refresh_token: session.refreshToken }),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(5000),
+  }).catch(() => null);
+  if (!res?.ok) return null;
+  const out = (await res.json().catch(() => null)) as {
+    access_token?: unknown;
+    refresh_token?: unknown;
+  } | null;
+  if (typeof out?.access_token !== 'string' || !out.access_token) return null;
+  return {
+    provider: 'workos',
+    accessToken: out.access_token,
+    refreshToken:
+      typeof out.refresh_token === 'string' && out.refresh_token
+        ? out.refresh_token
+        : session.refreshToken,
+    sessionId: workosSessionIdFromJwt(out.access_token) ?? session.sessionId,
+  };
+}
+
+/**
  * Authenticated host fetch for SERVER ACTIONS (AUTH-WEB-CONTRACT §1 + §4):
- * attaches identity, and on a `401` clears the (now-invalid) session and bounces
- * to /login — so a mid-session expiry logs the user out instead of a dead-end
- * "Failed" toast. The thrown redirect must be re-thrown past any action catch
- * (use `unstable_rethrow(e)` first in the catch). Only call from an action/route
- * handler (it may clear the cookie).
+ * attaches identity, and on a `401` first tries to refresh the session in
+ * place (Orbit's interceptor contract: 401 -> refresh -> retry once) before
+ * treating it as a logout. Only when the refresh fails, or the retried
+ * request 401s again, does it clear the session and bounce to /login. The
+ * thrown redirect must be re-thrown past any action catch (use
+ * `unstable_rethrow(e)` first in the catch). Only call from an action/route
+ * handler (it may write the cookie).
  */
 export async function hostFetch(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(`${API_URL}${path}`, {
+  let res = await fetch(`${API_URL}${path}`, {
     ...init,
     headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(await hostHeaders()) },
     cache: 'no-store',
   });
+  if (res.status === 401) {
+    // One refresh attempt, never a loop: a 401 on the RETRIED request means
+    // the token the IAM just minted is being rejected, and refreshing again
+    // cannot fix that.
+    const expired = await getSession();
+    const refreshed = await refreshUpstreamSession(expired);
+    if (refreshed) {
+      await setSession(refreshed);
+      res = await fetch(`${API_URL}${path}`, {
+        ...init,
+        headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(await hostHeaders()) },
+        cache: 'no-store',
+      });
+    }
+  }
   if (res.status === 401) {
     // Same shape as `signOutAction` (Orbit contract): read the session BEFORE
     // clearing (the revoke needs its id), clear unconditionally, revoke


### PR DESCRIPTION
## What

Completes the Orbit-parity work that #146 started on the logout side, now on sign-in. Two pieces that only work together:

**1. `prompt=login` on the explicit sign-in click.** The "Continue with Dapta" button (it only renders on the signed-out and error landings) now sends `prompt=login`, and the login route patches the value onto the WorkOS authorize URL itself, because the IAM drops the parameter instead of forwarding it (verified against the live IAM; Orbit patches it client-side in `enforcePromptOnLoginUrl` for exactly the same reason). AuthKit then shows its sign-in screen even while the shared WorkOS session cookie is alive: signing out and signing back in offers a real account choice instead of silently re-entering the same session. The bare `/login` auto-redirect stays promptless, so arriving from the Dapta platform keeps its silent SSO.

**2. Session refresh.** The IAM's access token lives 30 minutes, and Forms outlived it only through that silent re-authentication loop, which `prompt=login` would have turned into a credential prompt every half hour. `refreshUpstreamSession()` trades the stored refresh token at `POST /auth/refresh` (public route, no Bearer), always keeps the rotated refresh token, and re-reads the `workos_session_id` claim from the new JWT so a later logout still revokes. Server actions (`hostFetch`) refresh inline on a 401 and retry once, never twice. Server Component renders cannot write cookies, so `admin-api`'s 401 now routes through the new `/api/auth/refresh` handler, which stores the refreshed session and returns to `/admin`, handing off to the logout flow only when the refresh token itself is dead. Concurrent refreshes are safe under the IAM's rotation grace window (V1.54).

## Verification

Offline harness (stub IAM emulating the real contracts, including dropping the prompt param and rotating refresh tokens), web `next build` + `start`, API in workos mode with a shared secret:

- `/api/auth/login?prompt=login` redirects to an authorize URL carrying `prompt=login`; the bare route carries none.
- A login minted with an already-expired access token reaches `/admin` through exactly one stub refresh, with the session cookie carrying the rotated refresh token and a valid JWT.
- With the stub answering 401 to refreshes, the same flow lands on `/login?signedout=1` with the IAM revoke fired (the pre-refresh behavior).
- Sign-out still POSTs the WorkOS claim id and never visits the IdP (no #146 regression).
- `pnpm test` (web 574/574, api 454/454), `pnpm typecheck`, `pnpm lint`, `dash-check`, `PUBLISH_GATE_LOCAL=1 publish-gate` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)