### PR TITLE
fix(db): personal workspaces self-parked in the legacy rebind, locking owners out

### DIFF
--- a/.changeset/self-park-personal-workspace.md
+++ b/.changeset/self-park-personal-workspace.md
@@ -1,0 +1,5 @@
+---
+'@quill/db': patch
+---
+
+A personal workspace whose upstream id equals its account id no longer destroys itself. `rebindLegacyAccount`'s two lookups resolved to the same row for those workspaces, so on the owner's second session the account parked itself (or, with no forms, deleted itself through the absorb branch), and every later login crashed on the parked row's unique `external_id`: a permanent lockout behind the "Something went wrong" screen. The rebind now recognizes the row as already bound and returns it untouched, and migration 0018 moves the stranded forms of every self-parked pair into their live twin, suffixing colliding slugs and retiring the parked account's public codes into `account_alias` so shared URLs keep resolving.

--- a/packages/db/migrations/postgres/0018_absorb_self_parked.sql
+++ b/packages/db/migrations/postgres/0018_absorb_self_parked.sql
@@ -1,0 +1,94 @@
+-- Repair the accounts that parked THEMSELVES.
+--
+-- The IAM hands some personal workspaces an id equal to their account id, so
+-- `rebindLegacyAccount`'s two lookups (legacy row by upstream ACCOUNT id,
+-- projected row by upstream WORKSPACE id) resolved to the SAME row. On the
+-- owner's second session that row parked itself (`external_id` prefixed with
+-- `legacy:`, members disabled) and the projection then recreated the workspace
+-- as a fresh, empty account — stranding the person's forms in a row nothing
+-- can reach. The code guard shipped alongside this migration stops new
+-- self-parks; this script moves the stranded forms into the live twin.
+--
+-- The pair signature is exact, and it is what keeps the legitimate pre-0015
+-- parks out of scope: those live rows carry a WORKSPACE id different from
+-- `iam_account_id`, while a self-parked pair's live row has the two equal.
+--
+--   parked.external_id = 'legacy:' || live.external_id
+--   live.external_id   = live.iam_account_id
+--
+-- The parked account and its disabled member rows STAY (this repo never
+-- deletes them — `created_by` on the moved forms keeps resolving), and the
+-- parked row's public code is retired into `account_alias` so any URL shared
+-- while the forms lived there still finds them. Every statement stops
+-- matching after the first run, so a rerun is a no-op.
+
+-- 1. A moved form's slug may already exist in the live twin (the owner
+--    recreated it from the same template). Slugs are unique per account, so
+--    suffix the parked copy with a fragment of its id before the move.
+UPDATE form SET slug = slug || '-' || substr(form.id, 1, 8)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+    AND EXISTS (SELECT 1 FROM form lf WHERE lf.account_id = live.id AND lf.slug = form.slug)
+);
+
+-- 2. Retired slugs follow their forms — but only where the live twin has not
+--    retired the same alias itself ((account_id, alias) is the primary key).
+--    A row that would collide stays behind on the parked account, dead but
+--    harmless.
+UPDATE form_alias SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+    AND NOT EXISTS (SELECT 1 FROM form_alias fa WHERE fa.account_id = live.id AND fa.alias = form_alias.alias)
+);
+
+-- 3. The move itself. submission, form_event and the webhook ledger hang off
+--    form_id and follow on their own.
+UPDATE form SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+);
+
+-- 4. Retire the parked row's public codes onto the live twin, so
+--    /{parkedCode}/{handle}/{slug} keeps resolving (the resolver falls back to
+--    account_alias, and the handle segment never gates). The fixed timestamp
+--    is this migration's authoring date.
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.code, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+ON CONFLICT DO NOTHING;
+
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.vanity_slug, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+WHERE parked.vanity_slug IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/packages/db/migrations/sqlite/0018_absorb_self_parked.sql
+++ b/packages/db/migrations/sqlite/0018_absorb_self_parked.sql
@@ -1,0 +1,94 @@
+-- Repair the accounts that parked THEMSELVES.
+--
+-- The IAM hands some personal workspaces an id equal to their account id, so
+-- `rebindLegacyAccount`'s two lookups (legacy row by upstream ACCOUNT id,
+-- projected row by upstream WORKSPACE id) resolved to the SAME row. On the
+-- owner's second session that row parked itself (`external_id` prefixed with
+-- `legacy:`, members disabled) and the projection then recreated the workspace
+-- as a fresh, empty account — stranding the person's forms in a row nothing
+-- can reach. The code guard shipped alongside this migration stops new
+-- self-parks; this script moves the stranded forms into the live twin.
+--
+-- The pair signature is exact, and it is what keeps the legitimate pre-0015
+-- parks out of scope: those live rows carry a WORKSPACE id different from
+-- `iam_account_id`, while a self-parked pair's live row has the two equal.
+--
+--   parked.external_id = 'legacy:' || live.external_id
+--   live.external_id   = live.iam_account_id
+--
+-- The parked account and its disabled member rows STAY (this repo never
+-- deletes them — `created_by` on the moved forms keeps resolving), and the
+-- parked row's public code is retired into `account_alias` so any URL shared
+-- while the forms lived there still finds them. Every statement stops
+-- matching after the first run, so a rerun is a no-op.
+
+-- 1. A moved form's slug may already exist in the live twin (the owner
+--    recreated it from the same template). Slugs are unique per account, so
+--    suffix the parked copy with a fragment of its id before the move.
+UPDATE form SET slug = slug || '-' || substr(form.id, 1, 8)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+    AND EXISTS (SELECT 1 FROM form lf WHERE lf.account_id = live.id AND lf.slug = form.slug)
+);
+
+-- 2. Retired slugs follow their forms — but only where the live twin has not
+--    retired the same alias itself ((account_id, alias) is the primary key).
+--    A row that would collide stays behind on the parked account, dead but
+--    harmless.
+UPDATE form_alias SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+    AND NOT EXISTS (SELECT 1 FROM form_alias fa WHERE fa.account_id = live.id AND fa.alias = form_alias.alias)
+);
+
+-- 3. The move itself. submission, form_event and the webhook ledger hang off
+--    form_id and follow on their own.
+UPDATE form SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+);
+
+-- 4. Retire the parked row's public codes onto the live twin, so
+--    /{parkedCode}/{handle}/{slug} keeps resolving (the resolver falls back to
+--    account_alias, and the handle segment never gates). The fixed timestamp
+--    is this migration's authoring date.
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.code, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+ON CONFLICT DO NOTHING;
+
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.vanity_slug, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+WHERE parked.vanity_slug IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/packages/db/src/workspaces.spec.ts
+++ b/packages/db/src/workspaces.spec.ts
@@ -13,7 +13,10 @@
  *      (no upstream membership id) — the owner survives a roster read.
  *   4. `rebindLegacyAccount` keeps the legacy row's id when it can, absorbs an
  *      EMPTY projected row, and parks a legacy row (disabled, renamed) when the
- *      projected one already has forms.
+ *      projected one already has forms — but NEVER acts on itself: a personal
+ *      workspace whose upstream id equals its account id resolves both lookups
+ *      to one row, which used to self-park (forms and members stranded) and
+ *      then crash every later login on the parked row's UNIQUE external_id.
  *   5. `pickHomeAccount` prefers the requested workspace, else most recent.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -237,6 +240,33 @@ describe('rebindLegacyAccount', () => {
     // Parked = unreachable from the switcher.
     const list = await listWorkspacesForIdentity(db, { externalId: SUB, email: null });
     expect(list.some((w) => w.accountId === legacy3)).toBe(false);
+  });
+
+  it('never parks a row against itself when workspaceId === iamAccountId (personal workspace)', async () => {
+    // The IAM hands some personal workspaces an id equal to their account id,
+    // so the legacy and projected lookups resolve to the SAME row.
+    const acct = `acct-${randomUUID()}`;
+    const selfId = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, iam_account_id, created_at) VALUES (${selfId}, ${'s' + selfId.slice(0, 5)}, 'Mine', ${acct}, ${acct}, 1)`);
+    await db.run(sql`INSERT INTO member (id, account_id, external_id, email, handle, role, status, created_at) VALUES (${randomUUID()}, ${selfId}, ${SUB}, ${EMAIL}, 'me', 'owner', 'active', 1)`);
+    await db.run(sql`INSERT INTO form (id, account_id, slug, name, config, created_at, updated_at) VALUES (${randomUUID()}, ${selfId}, 'f', 'F', '{}', 1, 1)`);
+    created.push(selfId);
+    const r = await rebindLegacyAccount(db, { iamAccountId: acct, workspaceId: acct, workspaceName: 'Mine' });
+    expect(r).toEqual({ accountId: selfId, parkedLegacyId: null });
+    const row = await db.get<{ external_id: string; name: string }>(sql`SELECT external_id, name FROM account WHERE id = ${selfId}`);
+    expect(row).toEqual({ external_id: acct, name: 'Mine' });
+    const mem = await db.get<{ status: string }>(sql`SELECT status FROM member WHERE account_id = ${selfId}`);
+    expect(mem!.status).toBe('active');
+  });
+
+  it('does not delete a form-less row through the absorb branch when it is its own projection', async () => {
+    const acct = `acct-${randomUUID()}`;
+    const selfId = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, iam_account_id, created_at) VALUES (${selfId}, ${'t' + selfId.slice(0, 5)}, 'Empty', ${acct}, ${acct}, 1)`);
+    created.push(selfId);
+    const r = await rebindLegacyAccount(db, { iamAccountId: acct, workspaceId: acct, workspaceName: 'Empty' });
+    expect(r).toEqual({ accountId: selfId, parkedLegacyId: null });
+    expect(await db.get(sql`SELECT id FROM account WHERE id = ${selfId}`)).toBeDefined();
   });
 });
 

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -181,6 +181,14 @@ export async function rebindLegacyAccount(
   const projected = await db.get<{ id: string }>(
     sql`SELECT id FROM account WHERE external_id = ${args.workspaceId} LIMIT 1`,
   );
+  // A personal workspace can arrive with ws.id === ws.account_id, so both
+  // lookups match the SAME row: it is already bound to the right workspace and
+  // must never be treated as its own stale twin — parking itself (and locking
+  // the person out on the next login, when the parked external_id collides),
+  // or, with no forms, deleting itself in the absorb branch below.
+  if (projected && projected.id === legacy.id) {
+    return { accountId: legacy.id, parkedLegacyId: null };
+  }
   if (!projected) {
     await db.run(
       sql`UPDATE account SET external_id = ${args.workspaceId}, iam_account_id = ${args.iamAccountId}


### PR DESCRIPTION
## Problem

`admin@strategymark.com.co` and 8 other users hit the "Something went wrong" screen on every login. Root cause, reproduced against the real code:

Some personal workspaces arrive from the IAM with `ws.id === ws.account_id`. `rebindLegacyAccount` (from #117) looks up the *legacy* row by upstream **account** id and the *projected* row by upstream **workspace** id — for those workspaces both queries return the **same row**, and the account gets processed against itself:

- **Session 2** (first projection refresh after the 5-min TTL): with ≥1 form the account **parks itself** (`external_id → legacy:…`, name `+ " (legacy)"`, member disabled) and `projectMemberships` recreates the workspace as a fresh empty account — the owner "loses" their form and their account code changes. With 0 forms, the absorb branch **deletes the account**.
- **Session 3**: the park `UPDATE` collides with the already-parked row (`account_external_id_key` UNIQUE) → uncaught → `/v1/me` 500 → root error boundary. **Permanent lockout.**

State in prd (read-only, 2026-08-31): **9 users locked out**, **16 parked/live pairs** holding 21 stranded forms, **122 accounts** carrying the at-risk shape (~3 new per day).

## Fix

- **Guard in `rebindLegacyAccount`**: when both lookups resolve to one row, it is already bound to the right workspace — return it untouched. This alone unblocks the 9 locked-out users on their next login.
- **Migration 0018**: for every self-parked pair (`parked.external_id = 'legacy:' || live.external_id` **and** `live.external_id = live.iam_account_id` — a signature that excludes the legitimate pre-0015 parks), move the stranded forms into the live twin, suffix the one colliding slug, carry `form_alias` rows along, and retire the parked account's code + vanity slug into `account_alias` so previously shared URLs keep resolving. Parked accounts and their disabled members stay, per the repo's never-delete rule.

## Verification

- 2 new cases in `workspaces.spec.ts` (self-park with forms → untouched/active; form-less variant → not deleted). Full `@quill/db` suite: 273 passing on SQLite **and** against real Postgres 16 (`DATABASE_URL`), where the fresh scratch DB also exercised 0018 through the real migrator.
- Migration semantics verified by seeding both a self-parked pair (with slug collision, `form_alias`, vanity slug) and a synthetic legitimate pre-0015 pair on both dialects: forms moved, collision suffixed, aliases carried/retired, legit pair untouched, rerun is a no-op.
- api specs touching the projection (`workspace-projection`, `workspace-switch`, `workspace.service`, `onboarding.controller`): 88 passing.

After this reaches prd, the 16-pair query should return 0 rows and the locked-out users get their dashboard back with their original forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)