### PR TITLE
Release: auth parity with the Dapta platform (sign-in, sign-out, session refresh) + workspace rebind fix

### DIFF
--- a/.changeset/login-orbit-parity.md
+++ b/.changeset/login-orbit-parity.md
@@ -1,0 +1,5 @@
+---
+'@quill/web': patch
+---
+
+Sign-in reaches parity with the Dapta platform's auth contract. The "Continue with Dapta" button on the signed-out and error landings now asks the hosted login to actually prompt (prompt=login patched onto the authorize URL, since the identity service does not forward the parameter yet), so signing out followed by signing in offers a real account choice instead of silently re-entering the same session. To make that viable, the web now refreshes its session in place: a 401 from the API first trades the stored refresh token for a new access token (retrying the request once in server actions, or through the new /api/auth/refresh route during a page render) and only bounces to the login page when the refresh token itself is dead. The bare /login auto-redirect keeps the silent single sign-on for people arriving from the Dapta platform.

--- a/.changeset/self-park-personal-workspace.md
+++ b/.changeset/self-park-personal-workspace.md
@@ -1,0 +1,5 @@
+---
+'@quill/db': patch
+---
+
+A personal workspace whose upstream id equals its account id no longer destroys itself. `rebindLegacyAccount`'s two lookups resolved to the same row for those workspaces, so on the owner's second session the account parked itself (or, with no forms, deleted itself through the absorb branch), and every later login crashed on the parked row's unique `external_id`: a permanent lockout behind the "Something went wrong" screen. The rebind now recognizes the row as already bound and returns it untouched, and migration 0018 moves the stranded forms of every self-parked pair into their live twin, suffixing colliding slugs and retiring the parked account's public codes into `account_alias` so shared URLs keep resolving.

--- a/.changeset/workos-session-id-claim.md
+++ b/.changeset/workos-session-id-claim.md
@@ -2,4 +2,4 @@
 '@quill/web': patch
 ---
 
-Sign-out now reaches WorkOS with the session id it can actually resolve. The login callback reads the workos_session_id claim from the IAM access token (the callback blob only carries the IAM's own row id), so the logout revoke and the IdP logout URL stop being silent no-ops that stranded the browser on a blank WorkOS page and let the next sign-in silently re-authenticate the same person. Sessions stored before this change carry the old id; for those the sign-out skips the WorkOS hop and lands directly on the signed-out login page.
+Sign-out now matches Orbit's logout contract exactly. The login callback reads the workos_session_id claim from the IAM access token (the callback blob only carries the IAM's own row id), so the upstream revoke stops being a silent no-op. And no logout path sends the browser to WorkOS anymore: sign-out revokes at the IAM, clears the local session, and lands on the signed-out login page, which removes the blank WorkOS page some sign-outs stranded on and removes any dependency on the WorkOS logout-redirect allowlist. As on the Dapta platform, the shared identity session deliberately survives a Forms sign-out.

--- a/.changeset/workos-session-id-claim.md
+++ b/.changeset/workos-session-id-claim.md
@@ -1,0 +1,5 @@
+---
+'@quill/web': patch
+---
+
+Sign-out now reaches WorkOS with the session id it can actually resolve. The login callback reads the workos_session_id claim from the IAM access token (the callback blob only carries the IAM's own row id), so the logout revoke and the IdP logout URL stop being silent no-ops that stranded the browser on a blank WorkOS page and let the next sign-in silently re-authenticate the same person. Sessions stored before this change carry the old id; for those the sign-out skips the WorkOS hop and lands directly on the signed-out login page.

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import { serverApiUrl } from '@/lib/api-url';
-import { setSession } from '@/lib/auth-session';
+import { setSession, workosSessionIdFromJwt } from '@/lib/auth-session';
 import { asLocale, LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE } from '@/lib/locale';
 import { requestOrigin } from '@/lib/request-origin';
 
@@ -166,11 +166,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.redirect(new URL('/login?error=callback', origin));
   }
 
+  // The blob's session_id is the IAM's own row id, not WorkOS's. The claim
+  // inside the JWT is the id WorkOS actually resolves at logout, so prefer it;
+  // the blob id stays as a fallback for an IAM that stops minting the claim.
   await setSession({
     provider: 'workos',
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,
-    sessionId: tokens.session_id,
+    sessionId: workosSessionIdFromJwt(tokens.access_token) ?? tokens.session_id,
   });
   await recordAttribution(jar, tokens.access_token);
   await seedLocale(jar, tokens.access_token);

--- a/apps/web/app/api/auth/login/route.spec.ts
+++ b/apps/web/app/api/auth/login/route.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const cookieJar = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => cookieJar) }));
+vi.mock('@/lib/auth-session', () => ({ authProvider: () => 'workos' }));
+
+import { GET } from './route';
+
+const AUTHORIZE =
+  'https://api.workos.com/user_management/authorize?client_id=client_1&provider=authkit&state=abc';
+
+const req = (path: string) => new NextRequest(`https://forms.example.com${path}`);
+
+describe('GET /api/auth/login prompt handling', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('PUBLIC_APP_URL', '');
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ loginUrl: AUTHORIZE }) });
+    cookieJar.get.mockReturnValue(undefined);
+  });
+
+  it('patches prompt=login onto the authorize URL when asked (the IAM drops the param)', async () => {
+    const res = await GET(req('/api/auth/login?prompt=login'));
+
+    const target = new URL(res.headers.get('location')!);
+    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/authorize');
+    expect(target.searchParams.get('prompt')).toBe('login');
+    // Forwarded to the IAM too, so nothing changes here the day it propagates it.
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('prompt=login');
+  });
+
+  it('sends no prompt on the bare auto-redirect (silent SSO stays)', async () => {
+    const res = await GET(req('/api/auth/login'));
+
+    expect(new URL(res.headers.get('location')!).searchParams.get('prompt')).toBeNull();
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('prompt');
+  });
+
+  it('ignores any prompt value that is not exactly login', async () => {
+    const res = await GET(req('/api/auth/login?prompt=evil%20login'));
+
+    expect(new URL(res.headers.get('location')!).searchParams.get('prompt')).toBeNull();
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('prompt');
+  });
+});

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -85,12 +85,35 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     });
   }
 
+  // `prompt=login` makes AuthKit show its sign-in screen even when the shared
+  // WorkOS session cookie is still alive, which is what turns the button on
+  // the signed-out landing into a real "sign in as someone" instead of a
+  // silent re-authentication (Orbit's promptLogin contract). Allowlisted to
+  // the one value we mean: this route is directly reachable and the value
+  // ends up on a WorkOS URL. The bare auto-redirect from /login sends no
+  // prompt, keeping the arriving-from-Dapta silent SSO.
+  const prompt = sp.get('prompt') === 'login' ? 'login' : null;
+
   const returnTo = `${origin}/api/auth/callback`;
   const res = await fetch(
-    `${iam}/auth/login-url?returnTo=${encodeURIComponent(returnTo)}&state=${encodeURIComponent(state)}`,
+    `${iam}/auth/login-url?returnTo=${encodeURIComponent(returnTo)}&state=${encodeURIComponent(state)}` +
+      (prompt ? `&prompt=${prompt}` : ''),
     { cache: 'no-store' },
   ).catch(() => null);
   const loginUrl = res && res.ok ? ((await res.json().catch(() => ({}))) as { loginUrl?: string }).loginUrl : undefined;
   if (!loginUrl) return NextResponse.redirect(new URL('/login?error=login', origin));
+  // The IAM currently drops the prompt param instead of forwarding it to the
+  // authorize URL, so patch it on ourselves, exactly like Orbit's
+  // enforcePromptOnLoginUrl ("if IAM forgets to propagate prompt to WorkOS,
+  // patch the returned loginUrl"). Harmless once the IAM learns to forward it.
+  if (prompt) {
+    try {
+      const patched = new URL(loginUrl);
+      patched.searchParams.set('prompt', prompt);
+      return NextResponse.redirect(patched.toString());
+    } catch {
+      return NextResponse.redirect(new URL('/login?error=login', origin));
+    }
+  }
   return NextResponse.redirect(loginUrl);
 }

--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -28,22 +28,20 @@ describe('GET /api/auth/logout', () => {
     revokeUpstreamSession.mockResolvedValue(null);
   });
 
-  it('follows the IdP logout URL with return_to so WorkOS ends the browser session too', async () => {
+  it('never follows the IdP logout URL (Orbit contract, skipIdpRedirect = true)', async () => {
     getSession.mockResolvedValue(workosSession);
     revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     const res = await GET(req());
 
-    const target = new URL(res.headers.get('location')!);
-    expect(target.origin + target.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
-    expect(target.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+    expect(res.headers.get('location')).toBe('https://forms.example.com/login?signedout=1');
     // Read-then-clear: the revoke needs the session id the cookie carried.
     expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
     expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
   });
 
-  it('reason=expired skips the WorkOS hop: an expiry must not end the whole Dapta session', async () => {
+  it('reason=expired behaves identically: revoke, clear, local landing', async () => {
     getSession.mockResolvedValue(workosSession);
     revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 

--- a/apps/web/app/api/auth/logout/route.spec.ts
+++ b/apps/web/app/api/auth/logout/route.spec.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/auth-session', async () => {
 import { GET } from './route';
 
 const req = (path = '/api/auth/logout') => new NextRequest(`https://forms.example.com${path}`);
-const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'session_123' };
 
 describe('GET /api/auth/logout', () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('GET /api/auth/logout', () => {
 
   it('follows the IdP logout URL with return_to so WorkOS ends the browser session too', async () => {
     getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     const res = await GET(req());
 
@@ -45,7 +45,7 @@ describe('GET /api/auth/logout', () => {
 
   it('reason=expired skips the WorkOS hop: an expiry must not end the whole Dapta session', async () => {
     getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     const res = await GET(req('/api/auth/logout?reason=expired'));
 

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,34 +1,29 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { clearSession, getSession, idpLogoutTarget, revokeUpstreamSession } from '@/lib/auth-session';
+import { clearSession, getSession, revokeUpstreamSession } from '@/lib/auth-session';
 import { requestOrigin } from '@/lib/request-origin';
 
 /**
- * Logout: revoke upstream best-effort (see `revokeUpstreamSession`), ALWAYS
- * clear our cookie, then follow the IdP logout URL so WorkOS ends the browser
- * session too and returns the person to /login?signedout=1 (whose param
- * suppresses the login page's auto-redirect). Without the WorkOS hop the shared
- * Dapta session survives and the next "sign in" silently re-authenticates the
- * same person.
- *
- * `?reason=expired` skips the WorkOS hop (Orbit's skipIdpRedirect = true):
- * it marks a session-expiry logout, not a person asking to leave, and a Forms
- * token expiring must not end their whole Dapta platform session.
+ * Logout, Orbit's contract exactly: revoke upstream best-effort (see
+ * `revokeUpstreamSession`), ALWAYS clear our cookie, land on
+ * /login?signedout=1 (whose param suppresses the login page's auto-redirect).
+ * The browser never visits WorkOS (Orbit's skipIdpRedirect = true), so nothing
+ * here depends on the WorkOS logout-redirect allowlist. The accepted
+ * consequence, same as the Dapta platform app: the AuthKit cookie on WorkOS's domain
+ * stays alive and the next "sign in" re-authenticates the same person without
+ * prompting. `?reason=expired` marks the session-expiry arrival from
+ * `admin-api.ts` but no longer changes behavior; it stays for observability.
  *
  * The explicit sign-out button does NOT come through here: `signOutAction` and
  * `hostFetch` revoke + clear inline, because an action `redirect()` into a
  * route handler soft-navigates and strands the URL bar on /api/auth/logout.
  * This route serves the contexts that cannot touch the cookie themselves: the
  * 401 path inside a Server Component render (`admin-api.ts`, where
- * `cookies().delete()` throws, arriving with ?reason=expired) and direct
- * navigation (full logout).
+ * `cookies().delete()` throws) and direct navigation.
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const origin = requestOrigin(req);
   const session = await getSession();
   await clearSession();
-  const logoutUrl = await revokeUpstreamSession(session);
-  const expired = req.nextUrl.searchParams.get('reason') === 'expired';
-  const idp = expired ? null : idpLogoutTarget(logoutUrl, origin);
-  if (idp) return NextResponse.redirect(idp);
+  await revokeUpstreamSession(session);
   return NextResponse.redirect(new URL('/login?signedout=1', origin));
 }

--- a/apps/web/app/api/auth/refresh/route.spec.ts
+++ b/apps/web/app/api/auth/refresh/route.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const getSession = vi.fn();
+const setSession = vi.fn();
+const refreshUpstreamSession = vi.fn();
+vi.mock('@/lib/auth-session', () => ({
+  getSession: (...a: unknown[]) => getSession(...a),
+  setSession: (...a: unknown[]) => setSession(...a),
+  refreshUpstreamSession: (...a: unknown[]) => refreshUpstreamSession(...a),
+}));
+
+import { GET } from './route';
+
+const req = () => new NextRequest('https://forms.example.com/api/auth/refresh');
+const staleSession = { provider: 'workos', accessToken: 'old', refreshToken: 'refresh-1' };
+const freshSession = { provider: 'workos', accessToken: 'new', refreshToken: 'refresh-2' };
+
+describe('GET /api/auth/refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('PUBLIC_APP_URL', '');
+    getSession.mockResolvedValue(staleSession);
+  });
+
+  it('stores the refreshed session and returns to /admin', async () => {
+    refreshUpstreamSession.mockResolvedValue(freshSession);
+
+    const res = await GET(req());
+
+    expect(refreshUpstreamSession).toHaveBeenCalledWith(staleSession);
+    expect(setSession).toHaveBeenCalledWith(freshSession);
+    expect(res.headers.get('location')).toBe('https://forms.example.com/admin');
+  });
+
+  it('hands off to the logout route when the refresh fails, without touching the cookie', async () => {
+    refreshUpstreamSession.mockResolvedValue(null);
+
+    const res = await GET(req());
+
+    expect(setSession).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toBe(
+      'https://forms.example.com/api/auth/logout?reason=expired',
+    );
+  });
+
+  it('hands off to the logout route when there is no session at all', async () => {
+    getSession.mockResolvedValue(null);
+    refreshUpstreamSession.mockResolvedValue(null);
+
+    const res = await GET(req());
+
+    expect(res.headers.get('location')).toBe(
+      'https://forms.example.com/api/auth/logout?reason=expired',
+    );
+  });
+});

--- a/apps/web/app/api/auth/refresh/route.ts
+++ b/apps/web/app/api/auth/refresh/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSession, refreshUpstreamSession, setSession } from '@/lib/auth-session';
+import { requestOrigin } from '@/lib/request-origin';
+
+/**
+ * Session refresh for the one context that cannot write cookies itself: a 401
+ * during a Server Component render (`admin-api.ts`, where `cookies().set()`
+ * throws). The render redirects here; this handler trades the refresh token
+ * for a fresh access token, stores it, and sends the person back to /admin.
+ * When the refresh fails (refresh token expired or revoked, IAM down) it
+ * hands off to the logout route, which is exactly where the render-time 401
+ * used to go before refresh existed.
+ *
+ * No `next` parameter on purpose: a redirect target taken from the query is
+ * an open-redirect surface on the auth path, and landing on /admin matches
+ * what the pre-refresh flow already did. Server actions never come through
+ * here; `hostFetch` refreshes inline.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const origin = requestOrigin(req);
+  const refreshed = await refreshUpstreamSession(await getSession());
+  if (!refreshed) {
+    return NextResponse.redirect(new URL('/api/auth/logout?reason=expired', origin));
+  }
+  await setSession(refreshed);
+  return NextResponse.redirect(new URL('/admin', origin));
+}

--- a/apps/web/app/login/actions.spec.ts
+++ b/apps/web/app/login/actions.spec.ts
@@ -44,17 +44,15 @@ describe('signOutAction', () => {
     vi.unstubAllEnvs();
   });
 
-  it('workos: follows the IdP logout URL with return_to back to the local landing', async () => {
+  it('workos: never follows the IdP logout URL (Orbit contract, skipIdpRedirect = true)', async () => {
     authProvider.mockReturnValue('workos');
     getSession.mockResolvedValue(workosSession);
     revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
-    await expect(signOutAction()).rejects.toThrow(
-      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
-    );
+    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
 
     // Read-then-clear: clearing first hands the revoke a null session (the
-    // pre-#82 bug that left the upstream WorkOS session alive).
+    // pre-#82 bug that left the upstream session alive).
     expect(getSession.mock.invocationCallOrder[0]).toBeLessThan(clearSession.mock.invocationCallOrder[0]!);
     expect(revokeUpstreamSession).toHaveBeenCalledWith(workosSession);
     expect(clearSession).toHaveBeenCalled();
@@ -68,14 +66,6 @@ describe('signOutAction', () => {
     await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
 
     expect(clearSession).toHaveBeenCalled();
-  });
-
-  it('workos: lands locally on an unparseable logout URL instead of failing the sign-out', async () => {
-    authProvider.mockReturnValue('workos');
-    getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('/relative-not-a-url');
-
-    await expect(signOutAction()).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
   });
 
   it('workos: still clears and lands locally when the session is already gone', async () => {

--- a/apps/web/app/login/actions.spec.ts
+++ b/apps/web/app/login/actions.spec.ts
@@ -31,7 +31,7 @@ vi.mock('next/headers', () => ({
 
 import { signOutAction } from './actions';
 
-const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
+const workosSession = { provider: 'workos', accessToken: 'tok', sessionId: 'session_123' };
 
 describe('signOutAction', () => {
   beforeEach(() => {
@@ -47,10 +47,10 @@ describe('signOutAction', () => {
   it('workos: follows the IdP logout URL with return_to back to the local landing', async () => {
     authProvider.mockReturnValue('workos');
     getSession.mockResolvedValue(workosSession);
-    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=sess_123');
+    revokeUpstreamSession.mockResolvedValue('https://api.workos.com/user_management/sessions/logout?session_id=session_123');
 
     await expect(signOutAction()).rejects.toThrow(
-      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=sess_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
+      `NEXT_REDIRECT:https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=${encodeURIComponent('https://forms.example.com/login?signedout=1')}`,
     );
 
     // Read-then-clear: clearing first hands the revoke a null session (the

--- a/apps/web/app/login/actions.ts
+++ b/apps/web/app/login/actions.ts
@@ -1,16 +1,13 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { headers } from 'next/headers';
 import {
   setSession,
   clearSession,
   getSession,
   authProvider,
   revokeUpstreamSession,
-  idpLogoutTarget,
 } from '@/lib/auth-session';
-import { originFrom } from '@/lib/request-origin';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -31,31 +28,26 @@ export async function signInAction(
 }
 
 /**
- * Logout (AUTH-WEB-CONTRACT §2/§3.5): read the session, clear the cookie, tell
- * the IAM to revoke upstream, then FOLLOW the returned IdP logout URL (Orbit's
- * skipIdpRedirect = false case, "logout completo"). The browser hop through
- * WorkOS is not optional for the sign-out button: the AuthKit session cookie
- * lives on WorkOS's domain, and with the shared Dapta session still alive the
- * next "sign in" silently re-authenticates the same person back into /admin,
- * with no way to switch accounts. WorkOS sends the browser back to
- * /login?signedout=1 via return_to (the URL must stay allowlisted under
- * "Logout redirect URIs" in the WorkOS dashboard).
+ * Logout (AUTH-WEB-CONTRACT §2/§3.5), Orbit's contract exactly: read the
+ * session, clear the cookie, tell the IAM to revoke upstream, land on our own
+ * /login. The browser never visits WorkOS (Orbit's skipIdpRedirect = true,
+ * `logout({ skipWorkOSRedirect: true })` in its auth.service) so nothing here
+ * depends on the WorkOS dashboard's logout-redirect allowlist. The accepted
+ * consequence, same as the Dapta platform app: the AuthKit cookie on WorkOS's domain
+ * stays alive, so the next "sign in" re-authenticates the same person without
+ * prompting. The IdP logout URL the IAM returns is used only by a future
+ * switch-account flow (`idpLogoutTarget`).
  *
  * The order matters: the session must be READ before `clearSession()` lands its
  * Set-Cookie, or the revoke has no session id. That gap once left the upstream
- * WorkOS session alive (the pre-#82 bug). Local cleanup always runs, whatever
- * the IAM call does; when no logout URL comes back (IAM down, unparseable URL,
- * no session id) the person still lands signed out on /login?signedout=1, whose
- * param suppresses the login page's auto-redirect.
+ * session alive (the pre-#82 bug). Local cleanup always runs, whatever the IAM
+ * call does; /login?signedout=1's param suppresses the login page's
+ * auto-redirect back into the IAM.
  */
 export async function signOutAction(): Promise<void> {
   const session = await getSession();
   await clearSession();
-  const logoutUrl = await revokeUpstreamSession(session);
-  const hdrs = await headers();
-  const origin = originFrom((n) => hdrs.get(n));
-  const idp = origin ? idpLogoutTarget(logoutUrl, origin) : null;
-  if (idp) redirect(idp);
+  await revokeUpstreamSession(session);
   // Keyed on the configured provider, not the (possibly already-null) session:
   // in workos mode a bare /login auto-redirects straight back into the IAM.
   redirect(authProvider() === 'workos' ? '/login?signedout=1' : '/login');

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -52,8 +52,13 @@ export default async function LoginPage({
           {workos ? (
             // WorkOS provider: hand off to IAM's hosted login (Google/Microsoft/
             // LinkedIn are rendered by WorkOS — nothing per-provider to build).
+            // prompt=login: this button only renders on the signed-out and
+            // error landings, where a silent re-authentication into the same
+            // account is exactly what the person is trying to escape; the
+            // hosted login must actually ask. The bare /login auto-redirect
+            // above stays promptless (silent SSO from the Dapta platform).
             <Link
-              href="/api/auth/login"
+              href="/api/auth/login?prompt=login"
               className="inline-flex min-h-[44px] w-full items-center justify-center rounded-md bg-primary px-4 py-2.5 font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
             >
               {m.workosCta}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -59,15 +59,14 @@ async function req<T>(method: string, path: string, body?: unknown, opts: ReqOpt
     cache: 'no-store',
   });
   if (res.status === 401) {
-    // Workos: leave the cookie alone. /api/auth/logout reads the session id off
-    // it to revoke upstream and then clears it itself — deleting it here first
-    // hands that route a null session and silently skips the single-logout (see
-    // `signOutAction`). This path only appeared to work because `delete()` throws
-    // during a Server Component render; from a Server Action it lands and breaks.
-    // ?reason=expired: this is a token expiring mid-render, not a person asking
-    // to leave, so the route must not bounce the browser through the WorkOS
-    // logout and end their whole Dapta platform session.
-    if (authProvider() === 'workos') redirect('/api/auth/logout?reason=expired');
+    // Workos: leave the cookie alone. A render cannot write cookies (`set()`
+    // and `delete()` both throw here), so the token exchange happens in the
+    // /api/auth/refresh route handler: it trades the refresh token for a new
+    // access token and returns to /admin, or hands off to the logout route
+    // when the refresh token itself is dead. Deleting the cookie first would
+    // hand both routes a null session (see `signOutAction`'s read-then-clear
+    // note).
+    if (authProvider() === 'workos') redirect('/api/auth/refresh');
     try {
       await clearSession();
     } catch {

--- a/apps/web/lib/auth-session-refresh.spec.ts
+++ b/apps/web/lib/auth-session-refresh.spec.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cookieJar = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => cookieJar) }));
+const redirect = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+vi.mock('next/navigation', () => ({ redirect: (url: string) => redirect(url) }));
+
+import { encodeSession, hostFetch, refreshUpstreamSession, type Session } from './auth-session';
+
+const b64u = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+const jwtWith = (claims: Record<string, unknown>) =>
+  `${b64u({ alg: 'HS256', typ: 'JWT' })}.${b64u(claims)}.sig`;
+
+const workosSession: Session = {
+  provider: 'workos',
+  accessToken: 'tok',
+  refreshToken: 'refresh-1',
+  sessionId: 'session_OLD',
+};
+
+describe('refreshUpstreamSession', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: jwtWith({ workos_session_id: 'session_NEW' }), refresh_token: 'refresh-2' }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('POSTs the refresh token with no Authorization header', async () => {
+    await refreshUpstreamSession(workosSession);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://iam.example.com/iam/auth/refresh',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ refresh_token: 'refresh-1' }) }),
+    );
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('authorization');
+  });
+
+  it('returns the rotated pair with the WorkOS id re-read from the new JWT', async () => {
+    await expect(refreshUpstreamSession(workosSession)).resolves.toEqual({
+      provider: 'workos',
+      accessToken: jwtWith({ workos_session_id: 'session_NEW' }),
+      refreshToken: 'refresh-2',
+      sessionId: 'session_NEW',
+    });
+  });
+
+  it('keeps the old session id when the new JWT carries no claim', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: jwtWith({ sub: 'u' }), refresh_token: 'refresh-2' }),
+    });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toMatchObject({ sessionId: 'session_OLD' });
+  });
+
+  it('keeps the old refresh token when the IAM omits a rotated one', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ access_token: jwtWith({}) }) });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toMatchObject({ refreshToken: 'refresh-1' });
+  });
+
+  it('resolves null on a 401 from the IAM: the refresh token is dead, sign in again', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves null on a rejected fetch instead of throwing', async () => {
+    fetchMock.mockRejectedValue(new Error('iam down'));
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+  });
+
+  it('resolves null on a body with no access token', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+  });
+
+  it('skips the IAM entirely for a local session, a missing refresh token, or no IAM', async () => {
+    await expect(refreshUpstreamSession({ provider: 'local', email: 'a@b.c' })).resolves.toBeNull();
+    await expect(refreshUpstreamSession({ provider: 'workos', accessToken: 'tok' })).resolves.toBeNull();
+    vi.stubEnv('IAM_BASE_URL', '');
+    await expect(refreshUpstreamSession(workosSession)).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('hostFetch 401 refresh path', () => {
+  const fetchMock = vi.fn();
+  const freshJwt = jwtWith({ workos_session_id: 'session_NEW' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('IAM_BASE_URL', 'https://iam.example.com/iam');
+    vi.stubEnv('AUTH_PROVIDER', 'workos');
+    vi.stubEnv('WEB_SESSION_SECRET', 'spec-secret');
+    cookieJar.get.mockImplementation((name: string) =>
+      name === 'quill_session' ? { value: encodeSession(workosSession) } : undefined,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+
+  it('refreshes once and retries the request with the new bearer', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 401 }) // original API call
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: freshJwt, refresh_token: 'refresh-2' }),
+      }) // IAM refresh
+      .mockResolvedValueOnce({ status: 200, ok: true }); // retried API call
+
+    // After setSession the cookie jar must serve the refreshed session or the
+    // retry re-sends the dead token.
+    cookieJar.set.mockImplementation((name: string, value: string) => {
+      cookieJar.get.mockImplementation((n: string) => (n === 'quill_session' ? { value } : undefined));
+    });
+
+    const res = await hostFetch('/v1/forms');
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://iam.example.com/iam/auth/refresh');
+    const retryHeaders = (fetchMock.mock.calls[2]?.[1] as RequestInit).headers as Record<string, string>;
+    expect(retryHeaders['authorization']).toBe(`Bearer ${freshJwt}`);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the logout flow when the refresh itself fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 401 }) // original API call
+      .mockResolvedValueOnce({ ok: false, status: 401 }) // IAM refresh: dead
+      .mockResolvedValue({ ok: true, json: async () => ({}) }); // IAM revoke
+
+    await expect(hostFetch('/v1/forms')).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    expect(cookieJar.delete).toHaveBeenCalled();
+  });
+
+  it('never refreshes twice: a 401 on the retried request goes straight to logout', async () => {
+    cookieJar.set.mockImplementation((name: string, value: string) => {
+      cookieJar.get.mockImplementation((n: string) => (n === 'quill_session' ? { value } : undefined));
+    });
+    fetchMock
+      .mockResolvedValueOnce({ status: 401 }) // original API call
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: freshJwt, refresh_token: 'refresh-2' }),
+      }) // IAM refresh succeeds
+      .mockResolvedValueOnce({ status: 401 }) // retried API call STILL 401
+      .mockResolvedValue({ ok: true, json: async () => ({}) }); // IAM revoke
+
+    await expect(hostFetch('/v1/forms')).rejects.toThrow('NEXT_REDIRECT:/login?signedout=1');
+
+    // original + one refresh + one retry + revoke; a second refresh would make 5 with two IAM refresh calls
+    const refreshCalls = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/auth/refresh'));
+    expect(refreshCalls).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/auth-session-revoke.spec.ts
+++ b/apps/web/lib/auth-session-revoke.spec.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('next/headers', () => ({ cookies: vi.fn() }));
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
 
-import { idpLogoutTarget, revokeUpstreamSession, type Session } from './auth-session';
+import {
+  idpLogoutTarget,
+  revokeUpstreamSession,
+  workosSessionIdFromJwt,
+  type Session,
+} from './auth-session';
 
 const workosSession: Session = { provider: 'workos', accessToken: 'tok', sessionId: 'sess_123' };
 
@@ -89,14 +94,37 @@ describe('revokeUpstreamSession', () => {
 describe('idpLogoutTarget', () => {
   it('appends return_to pointing at the local signed-out landing', () => {
     const target = idpLogoutTarget(
-      'https://api.workos.com/user_management/sessions/logout?session_id=sess_123',
+      'https://api.workos.com/user_management/sessions/logout?session_id=session_01ABC',
       'https://forms.example.com',
     );
 
     const url = new URL(target!);
     expect(url.origin + url.pathname).toBe('https://api.workos.com/user_management/sessions/logout');
-    expect(url.searchParams.get('session_id')).toBe('sess_123');
+    expect(url.searchParams.get('session_id')).toBe('session_01ABC');
     expect(url.searchParams.get('return_to')).toBe('https://forms.example.com/login?signedout=1');
+  });
+
+  // WorkOS answers an id it cannot resolve with a blank 200: no redirect, no
+  // revocation. A session_id that is not a WorkOS-shaped id (the IAM's own UUID,
+  // stored by sessions minted before the JWT claim was read) must land locally
+  // instead of on that blank page.
+  it('returns null when the session_id is not a WorkOS session id', () => {
+    expect(
+      idpLogoutTarget(
+        'https://api.workos.com/user_management/sessions/logout?session_id=22d19884-f7f1-4084-90bc-7088229c34b3',
+        'https://forms.example.com',
+      ),
+    ).toBeNull();
+  });
+
+  it('still allows a logout URL that carries no session_id at all', () => {
+    const target = idpLogoutTarget(
+      'https://example.authkit.app/logout',
+      'https://forms.example.com',
+    );
+    expect(new URL(target!).searchParams.get('return_to')).toBe(
+      'https://forms.example.com/login?signedout=1',
+    );
   });
 
   it('overwrites a preexisting return_to', () => {
@@ -131,5 +159,35 @@ describe('idpLogoutTarget', () => {
     expect(new URL(target!).searchParams.get('return_to')).toBe(
       'http://localhost:3400/login?signedout=1',
     );
+  });
+});
+
+describe('workosSessionIdFromJwt', () => {
+  const jwtWith = (claims: Record<string, unknown>) =>
+    `${Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url')}.${Buffer.from(
+      JSON.stringify(claims),
+    ).toString('base64url')}.signature`;
+
+  it('reads the workos_session_id claim', () => {
+    const token = jwtWith({
+      sub: 'a4d2b7a0-0000-0000-0000-000000000000',
+      session_id: '22d19884-f7f1-4084-90bc-7088229c34b3',
+      workos_session_id: 'session_01JQEXAMPLE',
+    });
+
+    expect(workosSessionIdFromJwt(token)).toBe('session_01JQEXAMPLE');
+  });
+
+  it('returns null when the claim is absent, empty, or not a string', () => {
+    expect(workosSessionIdFromJwt(jwtWith({ sub: 'u' }))).toBeNull();
+    expect(workosSessionIdFromJwt(jwtWith({ workos_session_id: '' }))).toBeNull();
+    expect(workosSessionIdFromJwt(jwtWith({ workos_session_id: 42 }))).toBeNull();
+  });
+
+  it('returns null for a malformed token instead of throwing', () => {
+    expect(workosSessionIdFromJwt('not-a-jwt')).toBeNull();
+    expect(workosSessionIdFromJwt('a.%%%not-base64%%%.c')).toBeNull();
+    expect(workosSessionIdFromJwt(`a.${Buffer.from('[1,2]').toString('base64url')}.c`)).toBeNull();
+    expect(workosSessionIdFromJwt('')).toBeNull();
   });
 });

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -114,6 +114,38 @@ export async function revokeUpstreamSession(session: Session | null): Promise<st
 }
 
 /**
+ * The WorkOS session id, read from the IAM access token's claims.
+ *
+ * The callback's `?session=` blob carries `session_id` = the IAM's OWN session
+ * row id (a UUID), and no `workos_session_id` field at all: the only place the
+ * IAM puts the real WorkOS id (`session_01...`) is inside the JWT it mints
+ * (`create-unified-session` adds the claim for the workos provider). Orbit
+ * reads it from exactly this claim. Sending the IAM's UUID to WorkOS's logout
+ * endpoint is a silent no-op: WorkOS answers 200 with an empty body for an id
+ * it cannot resolve, so the browser strands on a blank api.workos.com page and
+ * the AuthKit cookie survives, silently re-authenticating the next sign-in.
+ *
+ * Decoded WITHOUT verifying the signature, deliberately: this runs in the
+ * callback on a token the IAM just handed over a state-checked redirect, the
+ * API re-verifies the token (HS256) on every request that uses it, and the web
+ * holds no JWT secret to verify with. A malformed token yields null, never a
+ * throw.
+ */
+export function workosSessionIdFromJwt(accessToken: string): string | null {
+  const payload = accessToken.split('.')[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as {
+      workos_session_id?: unknown;
+    };
+    const id = claims?.workos_session_id;
+    return typeof id === 'string' && id ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The IdP logout redirect for the sign-out button: the IAM's logout URL with
  * return_to pointing back at our login landing, so WorkOS ends the browser
  * session and sends the person to /login?signedout=1 instead of stranding
@@ -121,12 +153,21 @@ export async function revokeUpstreamSession(session: Session | null): Promise<st
  * "Logout redirect URIs" in the WorkOS dashboard or WorkOS ignores it.
  * Null when the logout URL is absent or unparseable (NextResponse.redirect
  * and the action redirect would both throw on it): callers land locally.
+ *
+ * Also null when the URL's session_id does not look like a WorkOS session id
+ * (`session_...`). The IAM builds the logout URL by echoing whatever id it was
+ * sent, without resolving it, and WorkOS answers an unresolvable id with a
+ * blank 200: no redirect back, nothing revoked. That is precisely the sessions
+ * minted before `workosSessionIdFromJwt` existed (30-day cookies carrying the
+ * IAM's UUID), so those land locally instead of on the blank page.
  */
 export function idpLogoutTarget(logoutUrl: string | null, origin: string): string | null {
   if (!logoutUrl) return null;
   try {
     const target = new URL(logoutUrl);
     if (!isBrowserNavigable(target)) return null;
+    const sessionId = target.searchParams.get('session_id');
+    if (sessionId !== null && !sessionId.startsWith('session_')) return null;
     target.searchParams.set('return_to', new URL('/login?signedout=1', origin).toString());
     return target.toString();
   } catch {

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -247,19 +247,80 @@ export async function setWorkspace(accountId: string | null): Promise<void> {
 }
 
 /**
+ * Trade the refresh token for a fresh access token (Orbit's refreshToken()
+ * flow): POST {IAM}/auth/refresh, a public route like login/logout, no Bearer.
+ * The IAM ROTATES the refresh token on every call, so the returned session
+ * must always be stored: keeping the old one guarantees the next refresh 401s.
+ * The workos_session_id claim is re-read from the new JWT (the IAM re-mints it
+ * with the claim intact); the old id is kept as fallback so a logout after a
+ * refresh still revokes.
+ *
+ * Concurrent server actions can race this (no single process to single-flight
+ * in, unlike Orbit's in-memory refreshPromise); the IAM's rotation grace
+ * window is what makes that safe, with both racers ending on valid tokens.
+ *
+ * Returns null and never throws on anything short of success: a 401 (refresh
+ * expired or revoked), a down IAM, a timeout, a local session, or a session
+ * that never carried a refresh token. Callers treat null as "sign in again".
+ */
+export async function refreshUpstreamSession(session: Session | null): Promise<Session | null> {
+  const iam = process.env.IAM_BASE_URL?.replace(/\/$/, '');
+  if (!iam || session?.provider !== 'workos' || !session.refreshToken) return null;
+  const res = await fetch(`${iam}/auth/refresh`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ refresh_token: session.refreshToken }),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(5000),
+  }).catch(() => null);
+  if (!res?.ok) return null;
+  const out = (await res.json().catch(() => null)) as {
+    access_token?: unknown;
+    refresh_token?: unknown;
+  } | null;
+  if (typeof out?.access_token !== 'string' || !out.access_token) return null;
+  return {
+    provider: 'workos',
+    accessToken: out.access_token,
+    refreshToken:
+      typeof out.refresh_token === 'string' && out.refresh_token
+        ? out.refresh_token
+        : session.refreshToken,
+    sessionId: workosSessionIdFromJwt(out.access_token) ?? session.sessionId,
+  };
+}
+
+/**
  * Authenticated host fetch for SERVER ACTIONS (AUTH-WEB-CONTRACT §1 + §4):
- * attaches identity, and on a `401` clears the (now-invalid) session and bounces
- * to /login — so a mid-session expiry logs the user out instead of a dead-end
- * "Failed" toast. The thrown redirect must be re-thrown past any action catch
- * (use `unstable_rethrow(e)` first in the catch). Only call from an action/route
- * handler (it may clear the cookie).
+ * attaches identity, and on a `401` first tries to refresh the session in
+ * place (Orbit's interceptor contract: 401 -> refresh -> retry once) before
+ * treating it as a logout. Only when the refresh fails, or the retried
+ * request 401s again, does it clear the session and bounce to /login. The
+ * thrown redirect must be re-thrown past any action catch (use
+ * `unstable_rethrow(e)` first in the catch). Only call from an action/route
+ * handler (it may write the cookie).
  */
 export async function hostFetch(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(`${API_URL}${path}`, {
+  let res = await fetch(`${API_URL}${path}`, {
     ...init,
     headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(await hostHeaders()) },
     cache: 'no-store',
   });
+  if (res.status === 401) {
+    // One refresh attempt, never a loop: a 401 on the RETRIED request means
+    // the token the IAM just minted is being rejected, and refreshing again
+    // cannot fix that.
+    const expired = await getSession();
+    const refreshed = await refreshUpstreamSession(expired);
+    if (refreshed) {
+      await setSession(refreshed);
+      res = await fetch(`${API_URL}${path}`, {
+        ...init,
+        headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(await hostHeaders()) },
+        cache: 'no-store',
+      });
+    }
+  }
   if (res.status === 401) {
     // Same shape as `signOutAction` (Orbit contract): read the session BEFORE
     // clearing (the revoke needs its id), clear unconditionally, revoke

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -86,11 +86,11 @@ export async function getSession(): Promise<Session | null> {
  * Returns the WorkOS logout URL (the IAM serializes it as logoutUrl or
  * logoutURL) or null. Server-side revocation alone is NOT a browser logout:
  * the AuthKit session cookie lives on WorkOS's domain and only dies when the
- * browser visits this URL. Callers choose per Orbit's skipIdpRedirect switch:
- * the explicit sign-out button follows it (a Forms logout must also end the
- * shared Dapta session, or the next "sign in" silently re-authenticates the
- * same person); the 401 expiry paths ignore it (a Forms token expiring must
- * not log the person out of the whole Dapta platform).
+ * browser visits this URL. Per Orbit's contract NO current caller follows it
+ * (skipIdpRedirect = true everywhere: sign-out stays inside Forms and the
+ * shared Dapta session deliberately survives, same as the Dapta platform app). The URL
+ * is returned for the one flow that would need Orbit's skipIdpRedirect =
+ * false mode, a future switch-account (`idpLogoutTarget` shapes it).
  *
  * Never throws and never hangs past its timeout: the caller's local cleanup
  * must not be hostage to the IAM being up.
@@ -146,13 +146,16 @@ export function workosSessionIdFromJwt(accessToken: string): string | null {
 }
 
 /**
- * The IdP logout redirect for the sign-out button: the IAM's logout URL with
- * return_to pointing back at our login landing, so WorkOS ends the browser
- * session and sends the person to /login?signedout=1 instead of stranding
- * them on a blank api.workos.com page. The URL must be allowlisted under
- * "Logout redirect URIs" in the WorkOS dashboard or WorkOS ignores it.
- * Null when the logout URL is absent or unparseable (NextResponse.redirect
- * and the action redirect would both throw on it): callers land locally.
+ * The IdP logout redirect for Orbit's skipIdpRedirect = false mode (a full
+ * logout that also ends the shared Dapta session, e.g. a future
+ * switch-account): the IAM's logout URL with return_to pointing back at our
+ * login landing. UNUSED by the sign-out button and the logout route on
+ * purpose: per Orbit's contract those never send the browser to WorkOS, which
+ * is also what keeps them independent of the WorkOS dashboard's
+ * "Logout redirect URIs" allowlist (return_to is only honored when
+ * allowlisted). Null when the logout URL is absent or unparseable
+ * (NextResponse.redirect and the action redirect would both throw on it):
+ * callers land locally.
  *
  * Also null when the URL's session_id does not look like a WorkOS session id
  * (`session_...`). The IAM builds the logout URL by echoing whatever id it was
@@ -263,10 +266,10 @@ export async function hostFetch(path: string, init?: RequestInit): Promise<Respo
     // best-effort. Inline rather than via /api/auth/logout, because an action
     // `redirect()` into a route handler strands the URL bar there. And per the
     // contract, a 401 anywhere never re-enters logout: one revoke, then /login.
-    // The returned IdP logout URL is deliberately ignored here (Orbit's
-    // skipIdpRedirect = true): a Forms token expiring must not bounce the
-    // browser through WorkOS and end the person's whole Dapta session. Only
-    // the explicit sign-out button does that.
+    // The returned IdP logout URL is deliberately ignored (Orbit's
+    // skipIdpRedirect = true, like every logout path): the browser never
+    // bounces through WorkOS, so a Forms logout can never end the person's
+    // whole Dapta session.
     const session = await getSession();
     await clearSession();
     await revokeUpstreamSession(session);

--- a/packages/db/migrations/postgres/0018_absorb_self_parked.sql
+++ b/packages/db/migrations/postgres/0018_absorb_self_parked.sql
@@ -1,0 +1,94 @@
+-- Repair the accounts that parked THEMSELVES.
+--
+-- The IAM hands some personal workspaces an id equal to their account id, so
+-- `rebindLegacyAccount`'s two lookups (legacy row by upstream ACCOUNT id,
+-- projected row by upstream WORKSPACE id) resolved to the SAME row. On the
+-- owner's second session that row parked itself (`external_id` prefixed with
+-- `legacy:`, members disabled) and the projection then recreated the workspace
+-- as a fresh, empty account — stranding the person's forms in a row nothing
+-- can reach. The code guard shipped alongside this migration stops new
+-- self-parks; this script moves the stranded forms into the live twin.
+--
+-- The pair signature is exact, and it is what keeps the legitimate pre-0015
+-- parks out of scope: those live rows carry a WORKSPACE id different from
+-- `iam_account_id`, while a self-parked pair's live row has the two equal.
+--
+--   parked.external_id = 'legacy:' || live.external_id
+--   live.external_id   = live.iam_account_id
+--
+-- The parked account and its disabled member rows STAY (this repo never
+-- deletes them — `created_by` on the moved forms keeps resolving), and the
+-- parked row's public code is retired into `account_alias` so any URL shared
+-- while the forms lived there still finds them. Every statement stops
+-- matching after the first run, so a rerun is a no-op.
+
+-- 1. A moved form's slug may already exist in the live twin (the owner
+--    recreated it from the same template). Slugs are unique per account, so
+--    suffix the parked copy with a fragment of its id before the move.
+UPDATE form SET slug = slug || '-' || substr(form.id, 1, 8)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+    AND EXISTS (SELECT 1 FROM form lf WHERE lf.account_id = live.id AND lf.slug = form.slug)
+);
+
+-- 2. Retired slugs follow their forms — but only where the live twin has not
+--    retired the same alias itself ((account_id, alias) is the primary key).
+--    A row that would collide stays behind on the parked account, dead but
+--    harmless.
+UPDATE form_alias SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+    AND NOT EXISTS (SELECT 1 FROM form_alias fa WHERE fa.account_id = live.id AND fa.alias = form_alias.alias)
+);
+
+-- 3. The move itself. submission, form_event and the webhook ledger hang off
+--    form_id and follow on their own.
+UPDATE form SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+);
+
+-- 4. Retire the parked row's public codes onto the live twin, so
+--    /{parkedCode}/{handle}/{slug} keeps resolving (the resolver falls back to
+--    account_alias, and the handle segment never gates). The fixed timestamp
+--    is this migration's authoring date.
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.code, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+ON CONFLICT DO NOTHING;
+
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.vanity_slug, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+WHERE parked.vanity_slug IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/packages/db/migrations/sqlite/0018_absorb_self_parked.sql
+++ b/packages/db/migrations/sqlite/0018_absorb_self_parked.sql
@@ -1,0 +1,94 @@
+-- Repair the accounts that parked THEMSELVES.
+--
+-- The IAM hands some personal workspaces an id equal to their account id, so
+-- `rebindLegacyAccount`'s two lookups (legacy row by upstream ACCOUNT id,
+-- projected row by upstream WORKSPACE id) resolved to the SAME row. On the
+-- owner's second session that row parked itself (`external_id` prefixed with
+-- `legacy:`, members disabled) and the projection then recreated the workspace
+-- as a fresh, empty account — stranding the person's forms in a row nothing
+-- can reach. The code guard shipped alongside this migration stops new
+-- self-parks; this script moves the stranded forms into the live twin.
+--
+-- The pair signature is exact, and it is what keeps the legitimate pre-0015
+-- parks out of scope: those live rows carry a WORKSPACE id different from
+-- `iam_account_id`, while a self-parked pair's live row has the two equal.
+--
+--   parked.external_id = 'legacy:' || live.external_id
+--   live.external_id   = live.iam_account_id
+--
+-- The parked account and its disabled member rows STAY (this repo never
+-- deletes them — `created_by` on the moved forms keeps resolving), and the
+-- parked row's public code is retired into `account_alias` so any URL shared
+-- while the forms lived there still finds them. Every statement stops
+-- matching after the first run, so a rerun is a no-op.
+
+-- 1. A moved form's slug may already exist in the live twin (the owner
+--    recreated it from the same template). Slugs are unique per account, so
+--    suffix the parked copy with a fragment of its id before the move.
+UPDATE form SET slug = slug || '-' || substr(form.id, 1, 8)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+    AND EXISTS (SELECT 1 FROM form lf WHERE lf.account_id = live.id AND lf.slug = form.slug)
+);
+
+-- 2. Retired slugs follow their forms — but only where the live twin has not
+--    retired the same alias itself ((account_id, alias) is the primary key).
+--    A row that would collide stays behind on the parked account, dead but
+--    harmless.
+UPDATE form_alias SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form_alias.account_id
+    AND NOT EXISTS (SELECT 1 FROM form_alias fa WHERE fa.account_id = live.id AND fa.alias = form_alias.alias)
+);
+
+-- 3. The move itself. submission, form_event and the webhook ledger hang off
+--    form_id and follow on their own.
+UPDATE form SET account_id = (
+  SELECT live.id FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+)
+WHERE EXISTS (
+  SELECT 1 FROM account parked
+  JOIN account live
+    ON parked.external_id = 'legacy:' || live.external_id
+   AND live.external_id = live.iam_account_id
+  WHERE parked.id = form.account_id
+);
+
+-- 4. Retire the parked row's public codes onto the live twin, so
+--    /{parkedCode}/{handle}/{slug} keeps resolving (the resolver falls back to
+--    account_alias, and the handle segment never gates). The fixed timestamp
+--    is this migration's authoring date.
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.code, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+ON CONFLICT DO NOTHING;
+
+INSERT INTO account_alias (alias, account_id, created_at)
+SELECT parked.vanity_slug, live.id, 1756684800000
+FROM account parked
+JOIN account live
+  ON parked.external_id = 'legacy:' || live.external_id
+ AND live.external_id = live.iam_account_id
+WHERE parked.vanity_slug IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/packages/db/src/workspaces.spec.ts
+++ b/packages/db/src/workspaces.spec.ts
@@ -13,7 +13,10 @@
  *      (no upstream membership id) — the owner survives a roster read.
  *   4. `rebindLegacyAccount` keeps the legacy row's id when it can, absorbs an
  *      EMPTY projected row, and parks a legacy row (disabled, renamed) when the
- *      projected one already has forms.
+ *      projected one already has forms — but NEVER acts on itself: a personal
+ *      workspace whose upstream id equals its account id resolves both lookups
+ *      to one row, which used to self-park (forms and members stranded) and
+ *      then crash every later login on the parked row's UNIQUE external_id.
  *   5. `pickHomeAccount` prefers the requested workspace, else most recent.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -237,6 +240,33 @@ describe('rebindLegacyAccount', () => {
     // Parked = unreachable from the switcher.
     const list = await listWorkspacesForIdentity(db, { externalId: SUB, email: null });
     expect(list.some((w) => w.accountId === legacy3)).toBe(false);
+  });
+
+  it('never parks a row against itself when workspaceId === iamAccountId (personal workspace)', async () => {
+    // The IAM hands some personal workspaces an id equal to their account id,
+    // so the legacy and projected lookups resolve to the SAME row.
+    const acct = `acct-${randomUUID()}`;
+    const selfId = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, iam_account_id, created_at) VALUES (${selfId}, ${'s' + selfId.slice(0, 5)}, 'Mine', ${acct}, ${acct}, 1)`);
+    await db.run(sql`INSERT INTO member (id, account_id, external_id, email, handle, role, status, created_at) VALUES (${randomUUID()}, ${selfId}, ${SUB}, ${EMAIL}, 'me', 'owner', 'active', 1)`);
+    await db.run(sql`INSERT INTO form (id, account_id, slug, name, config, created_at, updated_at) VALUES (${randomUUID()}, ${selfId}, 'f', 'F', '{}', 1, 1)`);
+    created.push(selfId);
+    const r = await rebindLegacyAccount(db, { iamAccountId: acct, workspaceId: acct, workspaceName: 'Mine' });
+    expect(r).toEqual({ accountId: selfId, parkedLegacyId: null });
+    const row = await db.get<{ external_id: string; name: string }>(sql`SELECT external_id, name FROM account WHERE id = ${selfId}`);
+    expect(row).toEqual({ external_id: acct, name: 'Mine' });
+    const mem = await db.get<{ status: string }>(sql`SELECT status FROM member WHERE account_id = ${selfId}`);
+    expect(mem!.status).toBe('active');
+  });
+
+  it('does not delete a form-less row through the absorb branch when it is its own projection', async () => {
+    const acct = `acct-${randomUUID()}`;
+    const selfId = randomUUID();
+    await db.run(sql`INSERT INTO account (id, code, name, external_id, iam_account_id, created_at) VALUES (${selfId}, ${'t' + selfId.slice(0, 5)}, 'Empty', ${acct}, ${acct}, 1)`);
+    created.push(selfId);
+    const r = await rebindLegacyAccount(db, { iamAccountId: acct, workspaceId: acct, workspaceName: 'Empty' });
+    expect(r).toEqual({ accountId: selfId, parkedLegacyId: null });
+    expect(await db.get(sql`SELECT id FROM account WHERE id = ${selfId}`)).toBeDefined();
   });
 });
 

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -181,6 +181,14 @@ export async function rebindLegacyAccount(
   const projected = await db.get<{ id: string }>(
     sql`SELECT id FROM account WHERE external_id = ${args.workspaceId} LIMIT 1`,
   );
+  // A personal workspace can arrive with ws.id === ws.account_id, so both
+  // lookups match the SAME row: it is already bound to the right workspace and
+  // must never be treated as its own stale twin — parking itself (and locking
+  // the person out on the next login, when the parked external_id collides),
+  // or, with no forms, deleting itself in the absorb branch below.
+  if (projected && projected.id === legacy.id) {
+    return { accountId: legacy.id, parkedLegacyId: null };
+  }
   if (!projected) {
     await db.run(
       sql`UPDATE account SET external_id = ${args.workspaceId}, iam_account_id = ${args.iamAccountId}


### PR DESCRIPTION
## What ships

Three PRs, all verified in dev.

### #146: sign-out fixed at the root

The login callback stored the IAM's own session row id (a UUID) instead of the WorkOS session id, so the logout revoke never found the session and the WorkOS logout URL pointed at an id WorkOS answers with a blank page. The callback now reads the `workos_session_id` claim from the IAM access token (the same claim Orbit reads), and sign-out follows Orbit's contract on every path: revoke at the IAM, clear the local session, land on `/login?signedout=1`. The browser never visits WorkOS, which also removes any dependency on the WorkOS logout-redirect allowlist. Sessions stored before the deploy carry the old id; their first sign-out lands directly on the signed-out page and everything is normal from the next login on.

### #147: sign-in parity (prompt=login + session refresh)

- The "Continue with Dapta" button now sends `prompt=login`, patched onto the WorkOS authorize URL by the login route because the IAM does not forward the parameter. Signing out and signing back in now shows the hosted sign-in screen (a real account choice) instead of silently re-entering the same session. The bare `/login` auto-redirect keeps the silent SSO for people arriving from the Dapta platform.
- The web now refreshes its session in place: a 401 from the API trades the stored refresh token at the IAM's `/auth/refresh` (rotating it), retrying once in server actions or through the new `/api/auth/refresh` route during a page render. Only a dead refresh token (30 days) sends the person back to the login page. Without this, `prompt=login` would have meant typing credentials every 30 minutes, since the access token lives that long and Forms previously survived expiry through the silent re-authentication loop.

### #148: personal workspace rebind fix

A personal workspace whose id equals its account id no longer parks or deletes itself during the legacy rebind; migration 0018 repairs the affected rows.

## Deploy notes

- prd remains a manual gate: merging this PR ships nothing by itself.
- No new env vars. The WorkOS dashboard needs no changes (the logout allowlist is no longer used).
- After the prd deploy, existing sessions keep working; the refresh flow applies to them immediately (the refresh token was already stored in the cookie).

⚠️ Merge with a merge commit, never squash (release history rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)