### PR TITLE
feat(notifications): answers, submissions link and a real HTML body in the owner notice

### DIFF
--- a/.changeset/owner-email-answers.md
+++ b/.changeset/owner-email-answers.md
@@ -1,0 +1,43 @@
+---
+'@quill/engine': minor
+'@quill/notifications': minor
+'@quill/db': patch
+'@quill/shared': patch
+---
+
+The owner notice now carries the answers, a working submissions link and a real HTML body.
+
+Until now the "new submission" email told the owner that someone answered and
+nothing else: the answers were never passed to the template, the
+`{{formLink}}` token had no producer (so the "View submissions" line always
+dropped out and custom templates looked half rendered), and the HTML body was
+a bare `<p>` with `<br/>` separators, which most clients showed as plain text.
+
+- `summarizeAnswers(config, answers)` in the engine resolves a submission to
+  `{label, value}` rows in step order: the question the respondent actually
+  saw, option values mapped back to their labels, multi-selects joined with
+  commas, bookings as `YYYY-MM-DD HH:mm UTC`, values capped at 2000 characters.
+- New `{{answers}}` token, available in both submission emails and included
+  by default in the owner notice only (blank line, the answers, blank line,
+  then the link). In text it renders one `Label: value` line per answer; in
+  HTML a two-column table with every cell escaped.
+- `{{formLink}}` now points the owner at `PUBLIC_APP_URL/admin/forms/:id/submissions`
+  (absent in a bare fork without `PUBLIC_APP_URL`; never on the respondent receipt).
+- Every email is a complete responsive HTML document (doctype, viewport,
+  600px card, system font stack, real `</body></html>` so the transactional
+  service can splice its footer). Stock and custom bodies follow one rule: a
+  line is dropped only when it has tokens and all of them resolved empty, so
+  blank spacer lines and sign-offs survive. Runs of blank lines left behind by
+  dropped lines collapse to one, and leading or trailing blank lines are
+  trimmed.
+- Migration 0019 appends `{{answers}}` to every custom owner-notice body that
+  lacks it (account and per-form rows), so templates edited before the token
+  existed also get the answers. Idempotent.
+- An owner without an email no longer enqueues a row that fails five times;
+  rows already queued with no recipient are skipped once instead of retried.
+- Settings and the Connect tab show an "Answers" variable chip and a permanent
+  notice on the owner notice when its body lacks `{{answers}}`; the preview
+  sample shows the answers block. The respondent card no longer offers the
+  `{{formLink}}` chip, which that email never produces. The chip label reads
+  "Submissions link".
+- i18n: `admin.notifications.tokenAnswers`, `answersMissing` (EN + ES).

--- a/apps/api/src/email-effects.spec.ts
+++ b/apps/api/src/email-effects.spec.ts
@@ -22,7 +22,8 @@ import {
   type Db,
 } from '@quill/db';
 import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
-import { EmailEffects } from './email-effects';
+import type { ServerEnv } from '@quill/config/env';
+import { EmailEffects, OutboxSkipError } from './email-effects';
 
 let db: Db;
 let effects: EmailEffects;
@@ -214,5 +215,76 @@ describe('submission_received uses the same merge', () => {
       formId,
     );
     expect(await listOutbox(db, { kind: 'email' })).toHaveLength(1); // unchanged
+  });
+});
+
+describe('formLink (owner notice only)', () => {
+  it('points the owner at the submissions page when PUBLIC_APP_URL is set', async () => {
+    const withEnv = new EmailEffects(
+      new SubmissionNotifier(new LogOnlyEmailProvider()),
+      db,
+      undefined,
+      { PUBLIC_APP_URL: 'https://forms.example.com/' } as ServerEnv,
+    );
+    await withEnv.enqueueSubmissionReceived(
+      accountId,
+      { submissionId: 'sub-link', formName: 'Lead Qualifier', respondentEmail: null },
+      formId,
+    );
+    const rows = await listOutbox(db, { kind: 'email' });
+    const p = JSON.parse(rows[0]!.payload!) as { formLink: string | null };
+    expect(p.formLink).toBe(`https://forms.example.com/admin/forms/${formId}/submissions`);
+  });
+
+  it('carries no link in a bare fork without PUBLIC_APP_URL, and never on the respondent receipt', async () => {
+    await effects.enqueueSubmissionReceived(
+      accountId,
+      { submissionId: 'sub-nolink', formName: 'Lead Qualifier', respondentEmail: null },
+      formId,
+    );
+    await enqueueConfirmed();
+    const rows = await listOutbox(db, { kind: 'email' });
+    for (const row of rows) {
+      const p = JSON.parse(row.payload!) as { formLink?: string | null };
+      expect(p.formLink ?? null).toBeNull();
+    }
+  });
+});
+
+describe('no recipient', () => {
+  it('an account whose owner has no email enqueues nothing (instead of a row that fails 5 times)', async () => {
+    const lonely = 'acc-lonely';
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at) VALUES (${lonely}, 'lonely', 'Lonely', ${Date.now()})`,
+    );
+    await effects.enqueueSubmissionReceived(lonely, {
+      submissionId: 'sub-lonely',
+      formName: 'Orphan',
+      respondentEmail: null,
+    });
+    expect(await listOutbox(db, { kind: 'email' })).toHaveLength(0);
+  });
+
+  it('deliver() skips (never retries) an owner notice already enqueued with an empty `to`', async () => {
+    // The typical stuck row: the respondent left an email, the owner has none.
+    // The owner notice is addressed to `to` alone, so that email is no recipient.
+    const payload = JSON.stringify({
+      accountId,
+      submissionId: 'sub-empty',
+      formName: 'Orphan',
+      to: [],
+      respondentEmail: 'lead@acme.io',
+    });
+    await expect(effects.deliver('submission_received', payload)).rejects.toBeInstanceOf(OutboxSkipError);
+  });
+
+  it('deliver() skips a receipt with neither a respondent email nor a `to`, but sends one addressed by respondentEmail', async () => {
+    const base = { accountId, submissionId: 'sub-r', formName: 'Orphan', to: [] };
+    await expect(
+      effects.deliver('submission_confirmed', JSON.stringify(base)),
+    ).rejects.toBeInstanceOf(OutboxSkipError);
+    await expect(
+      effects.deliver('submission_confirmed', JSON.stringify({ ...base, respondentEmail: 'lead@acme.io' })),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -86,6 +86,12 @@ export class EmailEffects {
             ORDER BY created_at ASC LIMIT 1`,
       );
       const to = n.to ?? (owner?.email ? [owner.email] : []);
+      // Nobody to tell: every adapter throws on an empty recipient list, so a
+      // row enqueued here would burn its whole retry schedule for nothing.
+      if (to.length === 0) {
+        this.log.warn(`submission_received for account ${accountId} has no recipient: not enqueued`);
+        return;
+      }
       // Snapshot the toggle AND the custom copy, already merged form → account →
       // stock (absent rows = enabled with the stock template, the fork-friendly
       // default). Snapshotting here means the worker renders the copy the owner
@@ -95,6 +101,10 @@ export class EmailEffects {
       const payload: SubmissionNotification = {
         ...n,
         accountId,
+        // Where the owner reads the answers. Absent in a bare fork with no
+        // PUBLIC_APP_URL, or when the caller carries no form: the template
+        // drops the line rather than printing a broken link.
+        formLink: n.formLink ?? this.submissionsLink(formId),
         // Stamped into the payload, not merely used to resolve the template
         // above: `outbox` has no form column, so a row that does not NAME its
         // form cannot be attributed to one, and every email this queue has ever
@@ -158,6 +168,17 @@ export class EmailEffects {
     }
   }
 
+  /** An absolute app URL for `path`, or null in a bare fork with no PUBLIC_APP_URL. */
+  private appUrl(path: string): string | null {
+    const base = this.env?.PUBLIC_APP_URL;
+    return base ? `${base.replace(/\/$/, '')}${path}` : null;
+  }
+
+  /** Where the owner reads the answers; null without a form or an app URL. */
+  private submissionsLink(formId: string | null | undefined): string | null {
+    return formId ? this.appUrl(`/admin/forms/${formId}/submissions`) : null;
+  }
+
   /**
    * Tell an invited person they were invited.
    *
@@ -190,7 +211,7 @@ export class EmailEffects {
         invitedBy: input.invitedBy ?? null,
         // Empty in a bare fork with no PUBLIC_APP_URL — the template drops the
         // line rather than printing a broken link.
-        signInLink: this.env?.PUBLIC_APP_URL ? `${this.env!.PUBLIC_APP_URL.replace(/\/$/, '')}/login` : null,
+        signInLink: this.appUrl('/login'),
         locale: input.locale ?? null,
       };
       await enqueueOutbox(this.db, {
@@ -203,6 +224,19 @@ export class EmailEffects {
     } catch (err) {
       this.log.error(`failed to enqueue member_invited: ${String(err)}`);
     }
+  }
+
+  /**
+   * A row with nobody to address is a DECISION (skip once), not a transport
+   * failure to retry: rows enqueued before the producer guarded against an
+   * empty recipient list would otherwise fail five times each. Mirrors how
+   * the notifier addresses each email: the owner notice goes to `to` only,
+   * the receipt to `respondentEmail` with `to` as the fallback.
+   */
+  private assertRecipient(action: EmailKind, n: SubmissionNotification): void {
+    const to = Array.isArray(n.to) ? n.to.filter(Boolean) : [];
+    const addressed = action === 'submission_confirmed' ? Boolean(n.respondentEmail) || to.length > 0 : to.length > 0;
+    if (!addressed) throw new OutboxSkipError('no recipient');
   }
 
   /**
@@ -229,9 +263,11 @@ export class EmailEffects {
         );
         return;
       case 'submission_received':
+        this.assertRecipient(action, n);
         await this.notifier.sendSubmissionReceived(n);
         return;
       case 'submission_confirmed':
+        this.assertRecipient(action, n);
         await this.notifier.sendSubmissionConfirmed(n);
         return;
       default:

--- a/apps/api/src/notifications.controller.spec.ts
+++ b/apps/api/src/notifications.controller.spec.ts
@@ -73,6 +73,7 @@ describe('GET /v1/notifications', () => {
       'score',
       'outcomeLabel',
       'formLink',
+      'answers',
     ]);
   });
 });

--- a/apps/api/src/submission.service.spec.ts
+++ b/apps/api/src/submission.service.spec.ts
@@ -87,6 +87,30 @@ describe('submit', () => {
     expect(payload.respondentEmail).toBe('lead@acme.io');
   });
 
+  it('both emails carry the answers as resolved {label, value} rows in step order', async () => {
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-answers',
+      data: { role: 'founder', team_size: 20, company: 'Acme', email: 'lead@acme.io' },
+    });
+    await flushEffects();
+    const outbox = await listOutbox(db, { kind: 'email' });
+    expect(outbox).toHaveLength(2);
+    for (const row of outbox) {
+      const payload = JSON.parse(row.payload!) as { answers: Array<{ label: string; value: string }> };
+      expect(payload.answers.map((a) => a.label)).toEqual([
+        'What best describes you?',
+        'How big is your team?',
+        'What company do you work at?',
+        'Where should we send the results?',
+      ]);
+      // Option VALUE → option LABEL, numbers stringified.
+      expect(payload.answers[0]!.value).not.toBe('founder');
+      expect(payload.answers[1]!.value).toBe('20');
+      expect(payload.answers[2]!.value).toBe('Acme');
+      expect(payload.answers[3]!.value).toBe('lead@acme.io');
+    }
+  });
+
   it('a re-landed complete enqueues NO second round of effects', async () => {
     // `callActionWithRetry` cannot abort an in-flight request, so a complete
     // that landed slowly IS retried and this method runs twice for one real

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -13,7 +13,7 @@ import {
   getAccountOwner,
   type SubmissionRow,
 } from '@quill/db';
-import { computeScore, resolveOutcome, type FormConfig } from '@quill/engine';
+import { computeScore, resolveOutcome, summarizeAnswers, type FormConfig } from '@quill/engine';
 import {
   memberProfileSchema,
   submissionSchema,
@@ -149,6 +149,11 @@ export class SubmissionService {
 
     if (!input.partial && !reCompleted) {
       const respondentEmail = pickEmail(input.data);
+      // The answers as the owner reads them (labels, option labels, step
+      // order): resolved once here, printed by the `{{answers}}` token in
+      // either email. The respondent copy carries them too so a custom receipt
+      // can echo what was submitted.
+      const answers = summarizeAnswers(config, input.data);
       // form.id lets the effect apply any per-form template override
       // (precedence form → account → stock, resolved inside the effect).
       void this.email.enqueueSubmissionReceived(
@@ -159,6 +164,7 @@ export class SubmissionService {
           respondentEmail,
           score,
           outcomeLabel: outcome?.label ?? null,
+          answers,
         },
         form.id,
       );
@@ -172,6 +178,7 @@ export class SubmissionService {
             submissionId: row.id,
             formName: form.name,
             respondentEmail,
+            answers,
           },
           form.id,
         );

--- a/apps/web/app/admin/account/notifications/notification-settings.tsx
+++ b/apps/web/app/admin/account/notifications/notification-settings.tsx
@@ -12,6 +12,7 @@ import {
 import type { NotificationSettingView } from '@/lib/admin-api';
 import { saveNotificationAction, resetNotificationAction } from './actions';
 import { callAction } from '@/lib/call-action';
+import { hasToken } from '@/lib/notification-preview';
 
 export interface NotificationLabels {
   heading: string;
@@ -42,7 +43,14 @@ export interface NotificationLabels {
   tokenScore: string;
   tokenOutcomeLabel: string;
   tokenFormLink: string;
+  tokenAnswers: string;
+  answersMissing: string;
   formOverrideNote: string;
+}
+
+/** `{{formLink}}` is produced for the owner notice only; do not offer a dead chip on the receipt. */
+function visibleTokens(key: string, tokens: string[]): string[] {
+  return key === 'submission_confirmed' ? tokens.filter((t) => t !== 'formLink') : tokens;
 }
 
 /**
@@ -126,7 +134,11 @@ function NotificationEmailCard({
     score: labels.tokenScore,
     outcomeLabel: labels.tokenOutcomeLabel,
     formLink: labels.tokenFormLink,
+    answers: labels.tokenAnswers,
   };
+  // The owner notice exists to carry the answers; a body without the token
+  // silently sends an email with nothing useful in it, so say so permanently.
+  const answersMissing = setting.emailKey === 'submission_received' && !hasToken(value.body, 'answers');
 
   /** Reconcile local state with a freshly-persisted setting. */
   function applyPersisted(next: NotificationSettingView) {
@@ -199,7 +211,7 @@ function NotificationEmailCard({
       <NotificationEmailFields
         value={value}
         onChange={setValue}
-        tokens={setting.tokens}
+        tokens={visibleTokens(setting.emailKey, setting.tokens)}
         labels={{
           enabledLabel: labels.enabledLabel,
           enabledHint: labels.enabledHint,
@@ -211,6 +223,7 @@ function NotificationEmailCard({
           previewSubject: labels.previewSubject,
           tokenLabels,
         }}
+        notice={answersMissing ? labels.answersMissing : null}
       />
 
       {/* Actions */}

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
@@ -10,7 +10,7 @@ import {
   type NotificationEmailValue,
 } from '@/components/notification-email-fields';
 import type { DeliveryKind, FormNotificationView, NotificationEmailKey } from '@/lib/admin-api';
-import { interpolate, NOTIFICATION_SAMPLE as SAMPLE } from '@/lib/notification-preview';
+import { hasToken, interpolate, NOTIFICATION_SAMPLE as SAMPLE } from '@/lib/notification-preview';
 import { DeliveryHistory } from '../../integrations/delivery-history';
 import {
   loadFormNotificationsAction,
@@ -132,6 +132,11 @@ export function ConnectEmailsSection({
   );
 }
 
+/** `{{formLink}}` is produced for the owner notice only; do not offer a dead chip on the receipt. */
+function visibleTokens(key: NotificationEmailKey, tokens: string[]): string[] {
+  return key === 'submission_confirmed' ? tokens.filter((t) => t !== 'formLink') : tokens;
+}
+
 /** One email's per-form card: inherit state or the expanded override editor. */
 function FormEmailCard({
   formId,
@@ -186,7 +191,11 @@ function FormEmailCard({
     score: nm.tokenScore,
     outcomeLabel: nm.tokenOutcomeLabel,
     formLink: nm.tokenFormLink,
+    answers: nm.tokenAnswers,
   };
+  // The owner notice exists to carry the answers; a body without the token
+  // silently sends an email with nothing useful in it, so say so permanently.
+  const answersMissing = key === 'submission_received' && !hasToken(value.body, 'answers');
 
   function openEditor() {
     setValue({
@@ -292,7 +301,7 @@ function FormEmailCard({
           <NotificationEmailFields
             value={value}
             onChange={setValue}
-            tokens={setting.tokens}
+            tokens={visibleTokens(key, setting.tokens)}
             labels={{
               enabledLabel: nm.enabledLabel,
               enabledHint: nm.enabledHint,
@@ -305,6 +314,7 @@ function FormEmailCard({
               tokenLabels,
             }}
             testIdPrefix={`connect-email-${key}`}
+            notice={answersMissing ? nm.answersMissing : null}
           />
           <div className="mt-4 flex items-center justify-end gap-2">
             <Button

--- a/apps/web/components/notification-email-fields.spec.tsx
+++ b/apps/web/components/notification-email-fields.spec.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NotificationEmailFields } from "./notification-email-fields";
+
+const labels = {
+  enabledLabel: "Send",
+  enabledHint: "hint",
+  subjectLabel: "Subject",
+  bodyLabel: "Body",
+  tokensLabel: "Tokens",
+  tokensHint: "hint",
+  previewLabel: "Preview",
+  previewSubject: "Subject",
+  tokenLabels: { formName: "Form name", answers: "Answers" },
+};
+
+function render(notice?: string | null) {
+  return renderToStaticMarkup(
+    createElement(NotificationEmailFields, {
+      value: { enabled: true, subject: "S", body: "B" },
+      onChange: () => {},
+      tokens: ["formName", "answers"],
+      labels,
+      notice,
+    }),
+  );
+}
+
+describe("NotificationEmailFields notice", () => {
+  it("renders the notice as a status line above the token chips when given", () => {
+    const html = render("This email does not include the answers.");
+    expect(html).toContain('role="status"');
+    expect(html).toContain("This email does not include the answers.");
+    expect(html.indexOf('role="status"')).toBeLessThan(
+      html.indexOf("{{answers}}"),
+    );
+  });
+
+  it("renders nothing extra without a notice", () => {
+    expect(render(null)).not.toContain('role="status"');
+  });
+});

--- a/apps/web/components/notification-email-fields.tsx
+++ b/apps/web/components/notification-email-fields.tsx
@@ -39,6 +39,7 @@ export function NotificationEmailFields({
   tokens,
   labels,
   testIdPrefix,
+  notice,
 }: {
   value: NotificationEmailValue;
   onChange: (next: NotificationEmailValue) => void;
@@ -46,6 +47,11 @@ export function NotificationEmailFields({
   labels: NotificationFieldsLabels;
   /** Optional data-testid prefix for the subject/body controls. */
   testIdPrefix?: string;
+  /**
+   * A permanent, non-blocking warning about the current draft (e.g. the owner
+   * notice lacks `{{answers}}`), shown above the token chips. Null hides it.
+   */
+  notice?: string | null;
 }) {
   const subjectRef = useRef<HTMLInputElement>(null);
   const bodyRef = useRef<HTMLTextAreaElement>(null);
@@ -120,6 +126,17 @@ export function NotificationEmailFields({
           className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
         />
       </label>
+
+      {notice ? (
+        <p
+          role="status"
+          data-testid={testIdPrefix ? `${testIdPrefix}-notice` : undefined}
+          className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-foreground"
+        >
+          <i aria-hidden className="pi pi-exclamation-triangle mt-0.5 shrink-0" style={{ fontSize: 12 }} />
+          <span>{notice}</span>
+        </p>
+      ) : null}
 
       {/* Token chips */}
       <div className="mt-3">

--- a/apps/web/lib/notification-preview.spec.ts
+++ b/apps/web/lib/notification-preview.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { interpolate, NOTIFICATION_SAMPLE } from './notification-preview';
+import { hasToken, interpolate, NOTIFICATION_SAMPLE } from './notification-preview';
 
 describe('notification preview interpolate', () => {
   it('substitutes known {{tokens}} from the sample and tolerates whitespace', () => {
@@ -16,6 +16,11 @@ describe('notification preview interpolate', () => {
     expect(interpolate('{{formName}}', { formName: '{{score}}', score: '9' })).toBe('{{score}}');
   });
 
+  it('carries a multi-line answers sample so the preview shows the block as the email will', () => {
+    expect(NOTIFICATION_SAMPLE.answers).toContain('\n');
+    expect(NOTIFICATION_SAMPLE.answers!.split('\n').every((line) => /: /.test(line))).toBe(true);
+  });
+
   it('renders the default owner template with all five tokens filled', () => {
     const body = [
       'You have a new submission on "{{formName}}".',
@@ -30,8 +35,18 @@ describe('notification preview interpolate', () => {
         'From: lead@acme.io',
         'Score: 15',
         'Outcome: Qualified',
-        'View submissions: https://forms.example.com/acme/lead-qualifier',
+        'View submissions: https://forms.example.com/admin/forms/lead-qualifier/submissions',
       ].join('\n'),
     );
+  });
+});
+
+describe('hasToken', () => {
+  it('finds the token with or without inner whitespace, and not another token', () => {
+    expect(hasToken('A\n{{answers}}', 'answers')).toBe(true);
+    expect(hasToken('{{ answers }}', 'answers')).toBe(true);
+    expect(hasToken('{{answers }}', 'answers')).toBe(true);
+    expect(hasToken('{{formName}} answers', 'answers')).toBe(false);
+    expect(hasToken('', 'answers')).toBe(false);
   });
 });

--- a/apps/web/lib/notification-preview.ts
+++ b/apps/web/lib/notification-preview.ts
@@ -12,8 +12,16 @@ export const NOTIFICATION_SAMPLE: Record<string, string> = {
   respondentEmail: 'lead@acme.io',
   score: '15',
   outcomeLabel: 'Qualified',
-  formLink: 'https://forms.example.com/acme/lead-qualifier',
+  formLink: 'https://forms.example.com/admin/forms/lead-qualifier/submissions',
+  // Multi-line on purpose: the real token expands to one "Label: value" line
+  // per answered question, and the preview should show that shape.
+  answers: ['What best describes you?: Founder / Owner', 'How big is your team?: 20', 'Email: lead@acme.io'].join('\n'),
 };
+
+/** True when `template` references `{{name}}` (inner whitespace tolerated, like the server). */
+export function hasToken(template: string, name: string): boolean {
+  return new RegExp(`\\{\\{\\s*${name}\\s*\\}\\}`).test(template);
+}
 
 /** Substitute `{{token}}` markers in one pass; an unknown token stays literal. */
 export function interpolate(template: string, values: Record<string, string>): string {

--- a/packages/db/migrations/postgres/0019_owner_email_answers_token.sql
+++ b/packages/db/migrations/postgres/0019_owner_email_answers_token.sql
@@ -1,0 +1,14 @@
+-- The owner notice gained an `{{answers}}` token (the submission's answers as
+-- "Label: value" lines / a table), and the shipped default now carries it.
+-- An account or form that customized its owner-notice body BEFORE the token
+-- existed would otherwise keep receiving an email without the answers, which
+-- is the exact bug this release fixes. Append the token to every custom body
+-- that lacks it (with a blank spacer line, matching the default's layout).
+-- NULL bodies render the shipped default and need nothing. The respondent
+-- email is untouched: the answers there are opt-in. Reruns match nothing.
+UPDATE notification_setting
+SET body = body || chr(10) || chr(10) || '{{answers}}'
+WHERE email_key = 'submission_received'
+  AND body IS NOT NULL
+  AND body NOT LIKE '%{{answers}}%'
+  AND body NOT LIKE '%{{ answers }}%';

--- a/packages/db/migrations/sqlite/0019_owner_email_answers_token.sql
+++ b/packages/db/migrations/sqlite/0019_owner_email_answers_token.sql
@@ -1,0 +1,14 @@
+-- The owner notice gained an `{{answers}}` token (the submission's answers as
+-- "Label: value" lines / a table), and the shipped default now carries it.
+-- An account or form that customized its owner-notice body BEFORE the token
+-- existed would otherwise keep receiving an email without the answers, which
+-- is the exact bug this release fixes. Append the token to every custom body
+-- that lacks it (with a blank spacer line, matching the default's layout).
+-- NULL bodies render the shipped default and need nothing. The respondent
+-- email is untouched: the answers there are opt-in. Reruns match nothing.
+UPDATE notification_setting
+SET body = body || char(10) || char(10) || '{{answers}}'
+WHERE email_key = 'submission_received'
+  AND body IS NOT NULL
+  AND body NOT LIKE '%{{answers}}%'
+  AND body NOT LIKE '%{{ answers }}%';

--- a/packages/db/src/migration-0019.spec.ts
+++ b/packages/db/src/migration-0019.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Migration 0019 appends the `{{answers}}` token to every CUSTOM owner-notice
+ * body that lacks it, so accounts that edited their template before the token
+ * existed still get the answers in the email. Exercised by running the script
+ * directly against a migrated database (in-memory SQLite locally, the shared
+ * Postgres in parity mode), because the migrator has already applied it by the
+ * time the rows exist. Must be idempotent: a second run changes nothing.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { sql } from "drizzle-orm";
+import { createDb, type Db } from "./client";
+import { migrate } from "./migrate";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FILE = "0019_owner_email_answers_token.sql";
+
+let db: Db;
+/** One account per row: the account scope allows a single row per email key. */
+const accounts: string[] = [];
+
+async function insertAccount(): Promise<string> {
+  const id = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${id}, ${"t" + id.slice(0, 7)}, ${"Test"}, ${Date.now()})`,
+  );
+  accounts.push(id);
+  return id;
+}
+
+async function insertSetting(
+  emailKey: string,
+  body: string | null,
+  formId: string | null = null,
+): Promise<string> {
+  const id = randomUUID();
+  const accountId = await insertAccount();
+  await db.run(
+    sql`INSERT INTO notification_setting
+          (id, account_id, email_key, form_id, enabled, subject, body, created_at, updated_at)
+        VALUES (${id}, ${accountId}, ${emailKey}, ${formId}, 1, ${null}, ${body}, 1, 1)`,
+  );
+  return id;
+}
+
+async function bodyOf(id: string): Promise<string | null> {
+  const r = await db.get<{ body: string | null }>(
+    sql`SELECT body FROM notification_setting WHERE id = ${id}`,
+  );
+  return r?.body ?? null;
+}
+
+async function runScript(): Promise<void> {
+  await db.execRaw(
+    readFileSync(join(HERE, "..", "migrations", db.dialect, FILE), "utf8"),
+  );
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? "file::memory:");
+  await migrate(db);
+});
+
+afterEach(async () => {
+  // Postgres parity mode shares a database: leave no rows behind.
+  for (const accountId of accounts.splice(0)) {
+    await db.run(
+      sql`DELETE FROM notification_setting WHERE account_id = ${accountId}`,
+    );
+    await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  }
+  await db.close();
+});
+
+describe(FILE, () => {
+  it("appends {{answers}} to a custom owner body that lacks it, account and form rows alike", async () => {
+    const account = await insertSetting(
+      "submission_received",
+      "Lead on {{formName}}\nScore {{score}}",
+    );
+    const form = await insertSetting(
+      "submission_received",
+      "Form copy",
+      randomUUID(),
+    );
+    await runScript();
+    expect(await bodyOf(account)).toBe(
+      "Lead on {{formName}}\nScore {{score}}\n\n{{answers}}",
+    );
+    expect(await bodyOf(form)).toBe("Form copy\n\n{{answers}}");
+  });
+
+  it("leaves alone bodies that already carry the token (spaced or not), NULL bodies and the respondent email", async () => {
+    const has = await insertSetting("submission_received", "A\n{{answers}}");
+    const spaced = await insertSetting(
+      "submission_received",
+      "A\n{{ answers }}",
+    );
+    const stock = await insertSetting("submission_received", null);
+    const confirmed = await insertSetting(
+      "submission_confirmed",
+      "Thanks {{formName}}",
+    );
+    await runScript();
+    expect(await bodyOf(has)).toBe("A\n{{answers}}");
+    expect(await bodyOf(spaced)).toBe("A\n{{ answers }}");
+    expect(await bodyOf(stock)).toBeNull();
+    expect(await bodyOf(confirmed)).toBe("Thanks {{formName}}");
+  });
+
+  it("is idempotent: a second run changes nothing", async () => {
+    const id = await insertSetting("submission_received", "Custom");
+    await runScript();
+    const once = await bodyOf(id);
+    await runScript();
+    expect(await bodyOf(id)).toBe(once);
+    expect(once).toBe("Custom\n\n{{answers}}");
+  });
+});

--- a/packages/engine/src/answer-summary.spec.ts
+++ b/packages/engine/src/answer-summary.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { summarizeAnswers } from "./answer-summary";
+import type { FormConfig, FormStep } from "./form-logic";
+
+const step = (
+  partial: Partial<FormStep> & Pick<FormStep, "key" | "type">,
+): FormStep => partial;
+
+const config: FormConfig = {
+  version: 1,
+  steps: [
+    step({ key: "intro", type: "message", question: "Welcome" }),
+    step({ key: "name", type: "name", question: "Your name?" }),
+    step({
+      key: "role",
+      type: "multiple_choice",
+      question: "What is your role?",
+      options: [
+        { label: "Founder / CEO", value: "founder" },
+        { label: "Marketing", value: "marketing" },
+      ],
+    }),
+    step({
+      key: "tools",
+      type: "dropdown",
+      question: "Which tools do you use?",
+      options: [
+        { label: "HubSpot", value: "hubspot" },
+        { label: "Salesforce", value: "salesforce" },
+      ],
+    }),
+    step({ key: "team_size", type: "slider", question: "Team size" }),
+    step({ key: "email", type: "email", question: "Email" }),
+    step({ key: "processing", type: "reveal" }),
+    step({
+      key: "why",
+      type: "textarea",
+      question: "Why, [firstname]?",
+    }),
+    step({ key: "call", type: "scheduler", question: "Book a call" }),
+    step({ key: "nolabel", type: "text" }),
+  ],
+};
+
+describe("summarizeAnswers", () => {
+  it("walks the steps in order, skipping inputless steps and unanswered ones", () => {
+    const rows = summarizeAnswers(config, {
+      firstname: "Ana",
+      lastname: "Ruiz",
+      role: "founder",
+      team_size: 20,
+      email: "ana@acme.io",
+    });
+    expect(rows).toEqual([
+      { label: "Your name?", value: "Ana Ruiz" },
+      { label: "What is your role?", value: "Founder / CEO" },
+      { label: "Team size", value: "20" },
+      { label: "Email", value: "ana@acme.io" },
+    ]);
+  });
+
+  it("maps option values to their labels and joins multi-selects with a comma", () => {
+    const rows = summarizeAnswers(config, { tools: ["hubspot", "salesforce"] });
+    expect(rows).toEqual([
+      { label: "Which tools do you use?", value: "HubSpot, Salesforce" },
+    ]);
+  });
+
+  it('keeps a value that matches no option verbatim (an "other" answer is still an answer)', () => {
+    const rows = summarizeAnswers(config, { role: "student" });
+    expect(rows).toEqual([{ label: "What is your role?", value: "student" }]);
+  });
+
+  it("resolves the question the respondent actually saw ([field] interpolation)", () => {
+    const rows = summarizeAnswers(config, { firstname: "Ana", why: "Speed" });
+    expect(rows).toEqual([
+      { label: "Your name?", value: "Ana" },
+      { label: "Why, Ana?", value: "Speed" },
+    ]);
+  });
+
+  it("formats a scheduler booking as a readable UTC timestamp", () => {
+    expect(
+      summarizeAnswers(config, { call: "2026-09-03T14:30:00.000Z" }),
+    ).toEqual([{ label: "Book a call", value: "2026-09-03 14:30 UTC" }]);
+    // The renderer falls back to the literal "booked" when the provider sent no time.
+    expect(summarizeAnswers(config, { call: "booked" })).toEqual([
+      { label: "Book a call", value: "booked" },
+    ]);
+  });
+
+  it("falls back to the step key when a step has no question", () => {
+    expect(summarizeAnswers(config, { nolabel: "x" })).toEqual([
+      { label: "nolabel", value: "x" },
+    ]);
+  });
+
+  it("drops blank strings, empty arrays and nulls; keeps 0 and false", () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: "a", type: "text", question: "A" }),
+        step({ key: "b", type: "multiple_choice", question: "B", options: [] }),
+        step({ key: "c", type: "text", question: "C" }),
+        step({ key: "d", type: "slider", question: "D" }),
+        step({ key: "e", type: "text", question: "E" }),
+      ],
+    };
+    expect(
+      summarizeAnswers(cfg, { a: "   ", b: [], c: null, d: 0, e: false }),
+    ).toEqual([
+      { label: "D", value: "0" },
+      { label: "E", value: "false" },
+    ]);
+  });
+
+  it("caps a value at 2000 characters", () => {
+    const rows = summarizeAnswers(config, { why: "x".repeat(2500) });
+    expect(rows[0]!.value).toHaveLength(2000);
+  });
+
+  it("ignores answers with no matching step (hidden fields, UTM params)", () => {
+    expect(summarizeAnswers(config, { utm_source: "linkedin" })).toEqual([]);
+  });
+});

--- a/packages/engine/src/answer-summary.ts
+++ b/packages/engine/src/answer-summary.ts
@@ -1,0 +1,98 @@
+/**
+ * A submission's answers as the owner reads them: one `{label, value}` row per
+ * answered question, in step order, with option values mapped back to their
+ * labels and the question text resolved exactly as the respondent saw it.
+ *
+ * Pure and framework-free so the API can build it and hand plain rows to the
+ * notifications package (which stays independent of the engine). Nothing here
+ * escapes HTML: the email renderer owns that boundary.
+ */
+import {
+  isInputlessStep,
+  nameFields,
+  resolveQuestion,
+  type Answers,
+  type AnswerValue,
+  type FormConfig,
+  type FormStep,
+} from "./form-logic";
+
+/** One answered question, ready to print. */
+export interface AnswerSummaryRow {
+  label: string;
+  value: string;
+}
+
+/** Longest value an email row carries; a pasted essay must not become the email. */
+export const ANSWER_VALUE_MAX = 2000;
+
+function isBlank(value: AnswerValue): boolean {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
+/** Map one raw token to its option label (an unknown token stays as typed). */
+function optionLabel(step: FormStep, token: string): string {
+  const match = (step.options ?? []).find((o) => o.value === token);
+  return match ? match.label : token;
+}
+
+/** `2026-09-03T14:30:00.000Z` → `2026-09-03 14:30 UTC`; anything else verbatim. */
+function formatBooking(value: string): string {
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return value;
+  const iso = new Date(ms).toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}
+
+function formatValue(step: FormStep, value: AnswerValue): string {
+  if (Array.isArray(value))
+    return value.map((v) => optionLabel(step, v)).join(", ");
+  if (typeof value === "string") {
+    if (step.type === "scheduler") return formatBooking(value.trim());
+    if (step.type === "multiple_choice" || step.type === "dropdown")
+      return optionLabel(step, value.trim());
+    return value.trim();
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value)
+      .filter((v) => typeof v === "string" && v.trim())
+      .join(" ");
+  }
+  return String(value);
+}
+
+/** The answered rows of `answers`, in step order. Unanswered steps are omitted. */
+export function summarizeAnswers(
+  config: FormConfig,
+  answers: Answers,
+): AnswerSummaryRow[] {
+  const rows: AnswerSummaryRow[] = [];
+  for (const step of config.steps) {
+    if (isInputlessStep(step)) continue;
+    let value: string;
+    if (step.type === "name") {
+      value = nameFields(step)
+        .map((field) => answers[field])
+        .filter(
+          (v): v is string => typeof v === "string" && v.trim().length > 0,
+        )
+        .map((v) => v.trim())
+        .join(" ");
+      if (!value) continue;
+    } else {
+      const raw = answers[step.key];
+      if (isBlank(raw)) continue;
+      value = formatValue(step, raw);
+      if (!value) continue;
+    }
+    const question = resolveQuestion(step, answers).trim();
+    rows.push({
+      label: question || step.key,
+      value: value.slice(0, ANSWER_VALUE_MAX),
+    });
+  }
+  return rows;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,6 +3,7 @@
  * Fully unit-tested; portable across SQLite and Postgres deployments.
  */
 export * from './form-logic';
+export * from './answer-summary';
 export * from './form-config';
 export * from './form-design';
 export * from './short-links';

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -15,10 +15,15 @@ export {
   isSubmissionEmailKey,
   NOTIFICATION_TOKENS,
   notificationTokenValues,
+  htmlTokenValues,
   interpolateTokens,
+  renderBodyLines,
+  renderSubmissionEmail,
   applyCopyOverride,
   defaultSubmissionTemplate,
   type NotificationLocale,
+  type RenderedBodyLines,
+  type RenderedSubmissionEmail,
   type ReceivedCopyVars,
   type ConfirmedCopyVars,
   type MemberInvitedCopyVars,
@@ -26,6 +31,7 @@ export {
   type SubmissionEmailKey,
   type NotificationToken,
 } from './templates';
+export { answersTableHtml, emailDocument, type AnswerRow } from './render-html';
 export { LogOnlyEmailProvider } from './adapters/log-only';
 export { NoopEmailProvider } from './adapters/noop';
 export { SmtpEmailProvider, type SmtpOptions } from './adapters/smtp';

--- a/packages/notifications/src/render-html.spec.ts
+++ b/packages/notifications/src/render-html.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { answersTableHtml, emailDocument } from "./render-html";
+
+describe("answersTableHtml", () => {
+  it("renders one row per answer with the label and value HTML-escaped", () => {
+    const html = answersTableHtml([
+      { label: "Role", value: "Founder" },
+      { label: "<b>Why</b>", value: '<script>alert(1)</script> & "quotes"' },
+    ]);
+    expect(html).toContain("<table");
+    expect(html).toContain('role="presentation"');
+    expect(html).toContain("Role");
+    expect(html).toContain("Founder");
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<b>Why</b>");
+    expect(html).toContain("&lt;b&gt;Why&lt;/b&gt;");
+    expect(html).toContain(
+      "&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quotes&quot;",
+    );
+  });
+
+  it("renders an empty string when there are no rows", () => {
+    expect(answersTableHtml([])).toBe("");
+  });
+
+  it("breaks long values so a URL cannot stretch the email", () => {
+    expect(answersTableHtml([{ label: "Site", value: "https://x" }])).toContain(
+      "word-break",
+    );
+  });
+});
+
+describe("emailDocument", () => {
+  it("wraps the lines in a complete, responsive HTML document", () => {
+    const html = emailDocument({ lang: "es", lines: ["Hola", "Segunda"] });
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain('<html lang="es">');
+    expect(html).toContain('name="viewport"');
+    expect(html).toContain("max-width:600px");
+    expect(html).toContain("Hola<br/>Segunda");
+    // dapta-email splices its support footer before the closing body tag.
+    expect(html.trimEnd().endsWith("</body></html>")).toBe(true);
+  });
+
+  it("does NOT escape the lines (the caller escapes text and passes trusted markup)", () => {
+    const html = emailDocument({ lang: "en", lines: ["<table></table>"] });
+    expect(html).toContain("<table></table>");
+  });
+
+  it("puts the lines inside a div, never a paragraph (a table inside <p> is invalid HTML)", () => {
+    const html = emailDocument({ lang: "en", lines: ["x"] });
+    expect(html).not.toContain("<p>");
+  });
+
+  it("lets a long link line wrap so it cannot push the card past a phone screen", () => {
+    const html = emailDocument({ lang: "en", lines: ["View: https://x"] });
+    expect(html).toMatch(
+      /<div style="[^"]*overflow-wrap:anywhere[^"]*">View: https:\/\/x<\/div>/,
+    );
+  });
+});

--- a/packages/notifications/src/render-html.ts
+++ b/packages/notifications/src/render-html.ts
@@ -1,0 +1,70 @@
+/**
+ * The HTML side of a notification email. The text body is the source of truth
+ * (every line is plain text); this module turns those lines into a complete,
+ * responsive document and renders the answers block as a real table.
+ *
+ * Escaping contract: `answersTableHtml` escapes its inputs. `emailDocument`
+ * does NOT escape `lines`: the caller passes lines that are already escaped
+ * text or trusted markup (the answers table), never raw user input.
+ */
+import { escapeHtml } from "./util";
+
+/** One answered question, already resolved to plain text by the caller. */
+export interface AnswerRow {
+  label: string;
+  value: string;
+}
+
+const FONT_STACK =
+  "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif";
+
+/**
+ * The answers as a two-column table: muted label on the left, value on the
+ * right. `role="presentation"` because it is layout, not data, to a screen
+ * reader; `word-break` so a long URL or a pasted paragraph wraps instead of
+ * forcing the email wider than a phone.
+ */
+export function answersTableHtml(rows: AnswerRow[]): string {
+  if (rows.length === 0) return "";
+  const body = rows
+    .map(
+      (row) =>
+        `<tr>` +
+        `<td style="padding:8px 12px 8px 0;vertical-align:top;width:40%;color:#6b7280;font-size:13px;line-height:1.4;word-break:break-word;">${escapeHtml(row.label)}</td>` +
+        `<td style="padding:8px 0;vertical-align:top;color:#111827;font-size:14px;line-height:1.4;word-break:break-word;white-space:pre-wrap;">${escapeHtml(row.value)}</td>` +
+        `</tr>`,
+    )
+    .join("");
+  return (
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;margin:12px 0;">` +
+    `<tbody>${body}</tbody></table>`
+  );
+}
+
+/**
+ * A complete email document around the rendered lines: doctype, viewport meta,
+ * a full-width outer table and a 600px white card, system font stack. The
+ * lines are joined with `<br/>` inside a `<div>` (a `<p>` cannot legally
+ * contain the answers table). Emits a real `</body></html>` because the
+ * transactional service appends its footer right before `</body>`.
+ */
+export function emailDocument(input: {
+  lang: "en" | "es";
+  lines: string[];
+}): string {
+  const content = input.lines.join("<br/>");
+  return (
+    `<!DOCTYPE html>` +
+    `<html lang="${input.lang}">` +
+    `<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/></head>` +
+    `<body style="margin:0;padding:0;background:#f3f4f6;">` +
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;background:#f3f4f6;">` +
+    `<tr><td align="center" style="padding:24px 12px;">` +
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;max-width:600px;background:#ffffff;border-radius:8px;">` +
+    `<tr><td style="padding:24px;font-family:${FONT_STACK};font-size:15px;line-height:1.5;color:#111827;">` +
+    `<div style="word-break:break-word;overflow-wrap:anywhere;">${content}</div>` +
+    `</td></tr></table>` +
+    `</td></tr></table>` +
+    `</body></html>`
+  );
+}

--- a/packages/notifications/src/submission-notifier.spec.ts
+++ b/packages/notifications/src/submission-notifier.spec.ts
@@ -97,7 +97,104 @@ describe('SubmissionNotifier', () => {
     const m = provider.sent[0]!;
     expect(m.subject).toBe('New lead on Lead Qualifier (15)');
     expect(m.text).toBe('lead@acme.io scored 15\nForm: Lead Qualifier');
-    expect(m.html).toBe('<p>lead@acme.io scored 15<br/>Form: Lead Qualifier</p>');
+    expect(m.html).toContain('lead@acme.io scored 15<br/>Form: Lead Qualifier');
+  });
+
+  it('sends a complete HTML document (doctype, lang, viewport, closing body)', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-doc',
+      formName: 'Survey',
+      to: ['owner@example.com'],
+      locale: 'es',
+    });
+    const html = provider.sent[0]!.html!;
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('<html lang="es">');
+    expect(html).toContain('name="viewport"');
+    expect(html.trimEnd().endsWith('</body></html>')).toBe(true);
+  });
+
+  it('puts the answers in the owner notice: "Label: value" in text, a table in HTML, escaped', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-ans',
+      formName: 'Lead Qualifier',
+      to: ['owner@example.com'],
+      score: 15,
+      outcomeLabel: 'Qualified',
+      formLink: 'https://forms.example.com/admin/forms/f1/submissions',
+      answers: [
+        { label: 'Role', value: 'Founder' },
+        { label: 'Why', value: '<script>alert(1)</script>' },
+      ],
+    });
+    const m = provider.sent[0]!;
+    expect(m.text).toBe(
+      [
+        'You have a new submission on "Lead Qualifier".',
+        'Score: 15',
+        'Outcome: Qualified',
+        '',
+        'Role: Founder',
+        'Why: <script>alert(1)</script>',
+        '',
+        'View submissions: https://forms.example.com/admin/forms/f1/submissions',
+      ].join('\n'),
+    );
+    expect(m.html).toContain('<table');
+    expect(m.html).toContain('Founder');
+    expect(m.html).not.toContain('<script>');
+    expect(m.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(m.html).toContain('View submissions: https://forms.example.com/admin/forms/f1/submissions');
+  });
+
+  it('a custom body can place {{answers}} anywhere, in both emails', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    const answers = [{ label: 'Role', value: 'Founder' }];
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-c1',
+      formName: 'Survey',
+      to: ['owner@example.com'],
+      bodyTemplate: 'Top\n{{answers}}\nBottom',
+      answers,
+    });
+    await notifier.sendSubmissionConfirmed({
+      accountId: 'acc-1',
+      submissionId: 'sub-c2',
+      formName: 'Survey',
+      to: [],
+      respondentEmail: 'lead@acme.io',
+      bodyTemplate: 'Your answers:\n{{answers}}',
+      answers,
+    });
+    expect(provider.sent[0]!.text).toBe('Top\nRole: Founder\nBottom');
+    expect(provider.sent[0]!.html).toContain('Top<br/><table');
+    expect(provider.sent[1]!.text).toBe('Your answers:\nRole: Founder');
+    expect(provider.sent[1]!.html).toContain('<table');
+  });
+
+  it('the invitation email is a complete HTML document too', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendMemberInvited({
+      accountId: 'acc-1',
+      memberId: 'm-1',
+      to: 'new@example.com',
+      accountName: '<Acme>',
+      signInLink: 'https://forms.example.com/login',
+    });
+    const m = provider.sent[0]!;
+    expect(m.html!.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(m.html).toContain('&lt;Acme&gt;');
+    expect(m.html).not.toContain('<Acme>');
+    expect(m.text).toContain('Sign in: https://forms.example.com/login');
   });
 
   it('ESCAPES interpolated values in a custom body (E8 — the boundary holds)', async () => {

--- a/packages/notifications/src/submission-notifier.ts
+++ b/packages/notifications/src/submission-notifier.ts
@@ -1,18 +1,12 @@
 import type { EmailProvider, EmailResult } from './email.port';
 import { escapeHtml } from './util';
+import { emailDocument, type AnswerRow } from './render-html';
 import {
-  applyCopyOverride,
   normalizeLocale,
   renderMemberInvited,
-  renderSubmissionConfirmed,
-  renderSubmissionReceived,
+  renderSubmissionEmail,
   type NotificationLocale,
 } from './templates';
-
-/** Render plaintext lines to a safe HTML body — every line HTML-escaped (E8). */
-function htmlBody(lines: string[]): string {
-  return `<p>${lines.filter(Boolean).map(escapeHtml).join('<br/>')}</p>`;
-}
 
 /** Everything a submission notification needs to render, provider-agnostic. */
 /** Everything the invitation email needs, resolved before it is enqueued. */
@@ -46,8 +40,13 @@ export interface SubmissionNotification {
   respondentEmail?: string | null;
   score?: number | null;
   outcomeLabel?: string | null;
-  /** A public link back to the form (book-again style). */
+  /** Where the owner reads the answers (the admin submissions page). Never set on the receipt. */
   formLink?: string | null;
+  /**
+   * The answers, resolved to `{label, value}` rows in step order by the caller
+   * (the API, via the engine). Printed by the `{{answers}}` token.
+   */
+  answers?: AnswerRow[] | null;
   /**
    * Language for the rendered copy. Accepts a bare `en`/`es` or any locale-ish
    * value (e.g. `es-CO`, an Accept-Language fragment) — normalized to one of the
@@ -66,9 +65,10 @@ export interface SubmissionNotification {
 }
 
 /**
- * Renders and sends submission emails through the EmailProvider port — plain
- * text + escaped HTML, no attachments. The app only ever calls these methods;
- * the transport is whatever adapter is wired (log-only by default). Copy is
+ * Renders and sends submission emails through the EmailProvider port — a plain
+ * text body plus a complete HTML document (escaped line by line, the answers as
+ * a table), no attachments. The app only ever calls these methods; the
+ * transport is whatever adapter is wired (log-only by default). Copy is
  * bilingual (EN/ES) via the templates module; the caller supplies `locale`.
  */
 export class SubmissionNotifier {
@@ -76,19 +76,19 @@ export class SubmissionNotifier {
 
   /** Internal notice to the account: a new submission landed. */
   sendSubmissionReceived(n: SubmissionNotification): Promise<EmailResult> {
-    const base = renderSubmissionReceived(normalizeLocale(n.locale), n);
-    const { subject, lines } = applyCopyOverride(
-      base,
+    const locale = normalizeLocale(n.locale);
+    const { subject, text, html } = renderSubmissionEmail(
+      'submission_received',
+      locale,
       { subject: n.subjectTemplate, body: n.bodyTemplate },
       n,
     );
-    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.to,
       subject,
-      text: body.join('\n'),
-      html: htmlBody(body),
+      text: text.join('\n'),
+      html: emailDocument({ lang: locale, lines: html }),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:received`,
     });
@@ -99,14 +99,16 @@ export class SubmissionNotifier {
    * copy, not the per-account submission templates an owner can edit.
    */
   sendMemberInvited(n: MemberInvitedNotification): Promise<EmailResult> {
-    const { subject, lines } = renderMemberInvited(normalizeLocale(n.locale), n);
+    const locale = normalizeLocale(n.locale);
+    const { subject, lines } = renderMemberInvited(locale, n);
     const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: [n.to],
       subject,
       text: body.join('\n'),
-      html: htmlBody(body),
+      // Platform copy with interpolated names: escape every line (E8).
+      html: emailDocument({ lang: locale, lines: body.map(escapeHtml) }),
       // One invite per member row — a retried delivery must not read as a second
       // invitation to a managed service that de-duplicates on this key.
       idempotencyKey: `member:${n.memberId}:invited`,
@@ -115,19 +117,19 @@ export class SubmissionNotifier {
 
   /** Confirmation to the respondent that their answers were recorded. */
   sendSubmissionConfirmed(n: SubmissionNotification): Promise<EmailResult> {
-    const base = renderSubmissionConfirmed(normalizeLocale(n.locale), n);
-    const { subject, lines } = applyCopyOverride(
-      base,
+    const locale = normalizeLocale(n.locale);
+    const { subject, text, html } = renderSubmissionEmail(
+      'submission_confirmed',
+      locale,
       { subject: n.subjectTemplate, body: n.bodyTemplate },
       n,
     );
-    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.respondentEmail ? [n.respondentEmail] : n.to,
       subject,
-      text: body.join('\n'),
-      html: htmlBody(body),
+      text: text.join('\n'),
+      html: emailDocument({ lang: locale, lines: html }),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:confirmed`,
     });

--- a/packages/notifications/src/templates.spec.ts
+++ b/packages/notifications/src/templates.spec.ts
@@ -6,6 +6,8 @@ import {
   isSubmissionEmailKey,
   normalizeLocale,
   notificationTokenValues,
+  NOTIFICATION_TOKENS,
+  renderBodyLines,
   renderSubmissionConfirmed,
   renderSubmissionReceived,
   SUBMISSION_EMAIL_KEYS,
@@ -60,6 +62,29 @@ describe('renderSubmissionReceived', () => {
     const { lines } = renderSubmissionReceived('en', { formName: 'Survey' });
     expect(lines.filter(Boolean)).toHaveLength(1);
   });
+
+  it('prints the answers as "Label: value" lines between the outcome and the link', () => {
+    const { lines } = renderSubmissionReceived('en', {
+      formName: 'Survey',
+      outcomeLabel: 'Hot',
+      formLink: 'https://forms.example.com/admin/forms/f1/submissions',
+      answers: [
+        { label: 'Role', value: 'Founder' },
+        { label: 'Team size', value: '20' },
+      ],
+    });
+    expect(lines.join('\n')).toBe(
+      [
+        'You have a new submission on "Survey".',
+        'Outcome: Hot',
+        '',
+        'Role: Founder',
+        'Team size: 20',
+        '',
+        'View submissions: https://forms.example.com/admin/forms/f1/submissions',
+      ].join('\n'),
+    );
+  });
 });
 
 describe('renderSubmissionConfirmed', () => {
@@ -98,7 +123,62 @@ describe('notificationTokenValues', () => {
       score: '0',
       outcomeLabel: '',
       formLink: '',
+      answers: '',
     });
+  });
+
+  it('renders the answers as one "Label: value" line each', () => {
+    expect(
+      notificationTokenValues({
+        formName: 'F',
+        answers: [
+          { label: 'Role', value: 'Founder' },
+          { label: 'Why', value: 'Speed' },
+        ],
+      }).answers,
+    ).toBe('Role: Founder\nWhy: Speed');
+  });
+
+  it('offers {{answers}} as a token', () => {
+    expect(NOTIFICATION_TOKENS).toContain('answers');
+  });
+});
+
+describe('renderBodyLines', () => {
+  const text = { formName: 'Survey', score: '', outcomeLabel: '', answers: 'Role: Founder' };
+  const html = { formName: 'Survey', score: '', outcomeLabel: '', answers: '<table></table>' };
+
+  it('keeps a line with no tokens, even a blank one', () => {
+    const out = renderBodyLines('Hello', text, html);
+    expect(out.text).toEqual(['Hello']);
+    expect(out.html).toEqual(['Hello']);
+  });
+
+  it('drops a line only when it has tokens and every token resolved empty', () => {
+    const out = renderBodyLines('Score: {{score}}\nName: {{formName}}\n{{score}} / {{outcomeLabel}}', text, html);
+    expect(out.text).toEqual(['Name: Survey']);
+  });
+
+  it('keeps a line where at least one token resolved', () => {
+    const out = renderBodyLines('{{score}} on {{formName}}', text, html);
+    expect(out.text).toEqual([' on Survey']);
+  });
+
+  it('keeps an unknown token literal and does not count it as empty', () => {
+    const out = renderBodyLines('{{nope}}', text, html);
+    expect(out.text).toEqual(['{{nope}}']);
+  });
+
+  it('escapes the template text on the html side but substitutes html token values raw', () => {
+    const out = renderBodyLines('<b>{{formName}}</b>\n{{answers}}', { ...text, formName: 'A & B' }, { ...html, formName: 'A &amp; B' });
+    expect(out.text).toEqual(['<b>A & B</b>', 'Role: Founder']);
+    expect(out.html).toEqual(['&lt;b&gt;A &amp; B&lt;/b&gt;', '<table></table>']);
+  });
+
+  it('collapses runs of blank lines left behind and trims blank ends', () => {
+    const out = renderBodyLines('\nA\n\n{{score}}\n\nB\n', text, html);
+    expect(out.text).toEqual(['A', '', 'B']);
+    expect(out.html).toEqual(['A', '', 'B']);
   });
 });
 
@@ -140,7 +220,15 @@ describe('defaultSubmissionTemplate (stays in sync with the code templates)', ()
     score: 15,
     outcomeLabel: 'Qualified',
     formLink: 'https://forms.example.com/x',
+    answers: [{ label: 'Role', value: 'Founder' }],
   };
+
+  it('the owner default carries {{answers}}; the respondent default does not', () => {
+    for (const locale of ['en', 'es'] as const) {
+      expect(defaultSubmissionTemplate('submission_received', locale).body).toContain('{{answers}}');
+      expect(defaultSubmissionTemplate('submission_confirmed', locale).body).not.toContain('{{answers}}');
+    }
+  });
 
   it('SUBMISSION_EMAIL_KEYS are exactly the two customizable emails', () => {
     expect([...SUBMISSION_EMAIL_KEYS]).toEqual(['submission_received', 'submission_confirmed']);
@@ -153,9 +241,7 @@ describe('defaultSubmissionTemplate (stays in sync with the code templates)', ()
       const def = defaultSubmissionTemplate('submission_received', locale);
       const stock = renderSubmissionReceived(locale, full);
       expect(interpolateTokens(def.subject, notificationTokenValues(full))).toBe(stock.subject);
-      expect(interpolateTokens(def.body, notificationTokenValues(full)).split('\n')).toEqual(
-        stock.lines.filter(Boolean),
-      );
+      expect(interpolateTokens(def.body, notificationTokenValues(full))).toBe(stock.lines.join('\n'));
     }
   });
 
@@ -164,9 +250,7 @@ describe('defaultSubmissionTemplate (stays in sync with the code templates)', ()
       const def = defaultSubmissionTemplate('submission_confirmed', locale);
       const stock = renderSubmissionConfirmed(locale, full);
       expect(interpolateTokens(def.subject, notificationTokenValues(full))).toBe(stock.subject);
-      expect(interpolateTokens(def.body, notificationTokenValues(full)).split('\n')).toEqual(
-        stock.lines.filter(Boolean),
-      );
+      expect(interpolateTokens(def.body, notificationTokenValues(full))).toBe(stock.lines.join('\n'));
     }
   });
 });

--- a/packages/notifications/src/templates.ts
+++ b/packages/notifications/src/templates.ts
@@ -11,6 +11,9 @@
  * text bodies read naturally while the HTML path stays XSS-safe (E8).
  */
 
+import { answersTableHtml, type AnswerRow } from './render-html';
+import { escapeHtml } from './util';
+
 /** The two supported notification languages. Mirrors @quill/shared `Locale`. */
 export type NotificationLocale = 'en' | 'es';
 
@@ -30,15 +33,23 @@ export interface ReceivedCopyVars {
   respondentEmail?: string | null;
   score?: number | null;
   outcomeLabel?: string | null;
-  /** A link back to the submissions view (owner) — optional. */
+  /** A link to the admin submissions page (owner notice only). */
   formLink?: string | null;
+  /**
+   * The answers as the owner reads them (label + value, in step order), already
+   * resolved by the caller. Rendered by the `{{answers}}` token: one
+   * `Label: value` line each in text, a two-column table in HTML.
+   */
+  answers?: AnswerRow[] | null;
 }
 
 /** Everything the "we got your responses" (respondent) copy can interpolate. */
 export interface ConfirmedCopyVars {
   formName: string;
-  /** A public link back to the form (view/edit) — optional. */
+  /** Reserved: no producer sets it on the receipt today, so the stock line drops. */
   formLink?: string | null;
+  /** The respondent's own answers, for a custom template that wants to echo them. */
+  answers?: AnswerRow[] | null;
 }
 
 /** A rendered email: a plain subject + the body lines (blank entries dropped). */
@@ -51,33 +62,15 @@ export interface RenderedCopy {
  * The internal notice to the account owner: "a new submission landed on your
  * form." This is the primary Forms notification — the equivalent of the
  * host-notification email a Calendly/Bookings flow emits when someone books.
+ * Rendered from the same token-bearing default an owner sees in Settings, so
+ * the stock email and the editable default can never drift.
  */
 export function renderSubmissionReceived(
   locale: NotificationLocale,
   v: ReceivedCopyVars,
 ): RenderedCopy {
-  if (locale === 'es') {
-    return {
-      subject: `Nueva respuesta: ${v.formName}`,
-      lines: [
-        `Recibiste una nueva respuesta en "${v.formName}".`,
-        v.respondentEmail ? `De: ${v.respondentEmail}` : '',
-        v.score != null ? `Puntuación: ${v.score}` : '',
-        v.outcomeLabel ? `Resultado: ${v.outcomeLabel}` : '',
-        v.formLink ? `Ver las respuestas: ${v.formLink}` : '',
-      ],
-    };
-  }
-  return {
-    subject: `New submission: ${v.formName}`,
-    lines: [
-      `You have a new submission on "${v.formName}".`,
-      v.respondentEmail ? `From: ${v.respondentEmail}` : '',
-      v.score != null ? `Score: ${v.score}` : '',
-      v.outcomeLabel ? `Outcome: ${v.outcomeLabel}` : '',
-      v.formLink ? `View submissions: ${v.formLink}` : '',
-    ],
-  };
+  const { subject, text } = renderSubmissionEmail('submission_received', locale, {}, v);
+  return { subject, lines: text };
 }
 
 /**
@@ -89,22 +82,8 @@ export function renderSubmissionConfirmed(
   locale: NotificationLocale,
   v: ConfirmedCopyVars,
 ): RenderedCopy {
-  if (locale === 'es') {
-    return {
-      subject: `Recibimos tus respuestas: ${v.formName}`,
-      lines: [
-        `Gracias: registramos tus respuestas de "${v.formName}".`,
-        v.formLink ? `Ver o editar: ${v.formLink}` : '',
-      ],
-    };
-  }
-  return {
-    subject: `We got your responses: ${v.formName}`,
-    lines: [
-      `Thanks: we've recorded your responses to "${v.formName}".`,
-      v.formLink ? `View or edit: ${v.formLink}` : '',
-    ],
-  };
+  const { subject, text } = renderSubmissionEmail('submission_confirmed', locale, {}, v);
+  return { subject, lines: text };
 }
 
 /** What an invitation email needs to say. */
@@ -185,6 +164,7 @@ export const NOTIFICATION_TOKENS = [
   'score',
   'outcomeLabel',
   'formLink',
+  'answers',
 ] as const;
 export type NotificationToken = (typeof NOTIFICATION_TOKENS)[number];
 
@@ -196,8 +176,29 @@ export function notificationTokenValues(v: ReceivedCopyVars): Record<Notificatio
     score: v.score != null ? String(v.score) : '',
     outcomeLabel: v.outcomeLabel ?? '',
     formLink: v.formLink ?? '',
+    answers: (v.answers ?? []).map((row) => `${row.label}: ${row.value}`).join('\n'),
   };
 }
+
+/**
+ * The same map for the HTML body: every value escaped, except `answers`, which
+ * is the already-escaped table (see render-html.ts). This is the ONLY place a
+ * token value reaches HTML unescaped, and only because the table escaped its
+ * cells itself.
+ */
+export function htmlTokenValues(v: ReceivedCopyVars): Record<NotificationToken, string> {
+  const text = notificationTokenValues(v);
+  return {
+    formName: escapeHtml(text.formName),
+    respondentEmail: escapeHtml(text.respondentEmail),
+    score: escapeHtml(text.score),
+    outcomeLabel: escapeHtml(text.outcomeLabel),
+    formLink: escapeHtml(text.formLink),
+    answers: answersTableHtml(v.answers ?? []),
+  };
+}
+
+const TOKEN_RE = /\{\{\s*([a-zA-Z][A-Za-z0-9_]*)\s*\}\}/g;
 
 /**
  * Substitute `{{token}}` markers in ONE pass. Single-pass matters: a value that
@@ -207,10 +208,78 @@ export function notificationTokenValues(v: ReceivedCopyVars): Record<Notificatio
  * inside the braces is tolerated (`{{ formName }}`).
  */
 export function interpolateTokens(template: string, values: Record<string, string>): string {
-  return template.replace(/\{\{\s*([a-zA-Z][A-Za-z0-9_]*)\s*\}\}/g, (whole, name: string) => {
+  return template.replace(TOKEN_RE, (whole, name: string) => {
     const value = values[name];
     return value === undefined ? whole : value;
   });
+}
+
+/** A rendered body: the text lines and their HTML twins, index for index. */
+export interface RenderedBodyLines {
+  text: string[];
+  html: string[];
+}
+
+/**
+ * Render a body template line by line, for the text and the HTML body at once.
+ * ONE rule for stock and custom copy alike: a line is dropped only when it
+ * carries tokens and every one of them resolved to nothing (`Score: {{score}}`
+ * with no score), so an absent optional never leaves a dangling label, while a
+ * line with no tokens (a blank spacer, a sign-off) is always kept. Runs of
+ * blank lines left behind collapse to one and blank ends are trimmed.
+ *
+ * The HTML twin escapes the TEMPLATE text first (the owner's own copy is plain
+ * text) and then substitutes `htmlValues`, which the caller has escaped per
+ * token; `escapeHtml` never touches `{{`, so the markers survive the escape.
+ * An unknown token stays literal on both sides and counts as visible content.
+ */
+export function renderBodyLines(
+  template: string,
+  textValues: Record<string, string>,
+  htmlValues: Record<string, string>,
+): RenderedBodyLines {
+  const text: string[] = [];
+  const html: string[] = [];
+  for (const line of template.replace(/\r\n?/g, '\n').split('\n')) {
+    const names = [...line.matchAll(TOKEN_RE)].map((m) => m[1]!);
+    if (names.length > 0 && names.every((name) => textValues[name] === '')) continue;
+    const rendered = interpolateTokens(line, textValues);
+    // A blank spacer stays; a run of blanks (from dropped lines) collapses.
+    if (rendered.trim() === '' && (text.length === 0 || text[text.length - 1]!.trim() === '')) continue;
+    text.push(rendered);
+    html.push(interpolateTokens(escapeHtml(line), htmlValues));
+  }
+  while (text.length > 0 && text[text.length - 1]!.trim() === '') {
+    text.pop();
+    html.pop();
+  }
+  return { text, html };
+}
+
+/** A fully rendered submission email: the subject plus text and HTML lines. */
+export interface RenderedSubmissionEmail extends RenderedBodyLines {
+  subject: string;
+}
+
+/**
+ * Render one submission email from its effective template: the account/form
+ * override where set, the shipped default otherwise, each field independent.
+ * The subject collapses any newlines to spaces (a header is single-line; this
+ * closes off subject header-injection).
+ */
+export function renderSubmissionEmail(
+  key: SubmissionEmailKey,
+  locale: NotificationLocale,
+  override: { subject?: string | null; body?: string | null },
+  vars: ReceivedCopyVars,
+): RenderedSubmissionEmail {
+  const def = defaultSubmissionTemplate(key, locale);
+  const values = notificationTokenValues(vars);
+  const subject = interpolateTokens(override.subject ?? def.subject, values)
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
+  const body = renderBodyLines(override.body ?? def.body, values, htmlTokenValues(vars));
+  return { subject, ...body };
 }
 
 /**
@@ -218,8 +287,8 @@ export function interpolateTokens(template: string, values: Record<string, strin
  * is independent: a non-null override replaces it (interpolated), a null/absent
  * override keeps the stock text. The subject collapses any newlines to spaces
  * (a header is single-line — closes off subject header-injection). The returned
- * lines are RAW (unescaped) exactly like the stock render, so the notifier's
- * `htmlBody` remains the single escaping boundary.
+ * lines are the TEXT lines (unescaped), exactly like the stock render; the HTML
+ * twin comes from `renderSubmissionEmail`.
  */
 export function applyCopyOverride(
   base: RenderedCopy,
@@ -232,7 +301,9 @@ export function applyCopyOverride(
       ? interpolateTokens(override.subject, values).replace(/[\r\n]+/g, ' ').trim()
       : base.subject;
   const lines =
-    override.body != null ? interpolateTokens(override.body, values).split('\n') : base.lines;
+    override.body != null
+      ? renderBodyLines(override.body, values, htmlTokenValues(vars)).text
+      : base.lines;
   return { subject, lines };
 }
 
@@ -255,6 +326,9 @@ export function defaultSubmissionTemplate(
             'De: {{respondentEmail}}',
             'Puntuación: {{score}}',
             'Resultado: {{outcomeLabel}}',
+            '',
+            '{{answers}}',
+            '',
             'Ver las respuestas: {{formLink}}',
           ].join('\n'),
         }
@@ -265,6 +339,9 @@ export function defaultSubmissionTemplate(
             'From: {{respondentEmail}}',
             'Score: {{score}}',
             'Outcome: {{outcomeLabel}}',
+            '',
+            '{{answers}}',
+            '',
             'View submissions: {{formLink}}',
           ].join('\n'),
         };

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -464,6 +464,9 @@ export interface FormsMessages {
       tokenScore: string;
       tokenOutcomeLabel: string;
       tokenFormLink: string;
+      tokenAnswers: string;
+      /** Permanent warning when the owner notice body lacks `{{answers}}`. */
+      answersMissing: string;
       /** Muted pointer: forms can override these from their Connect tab. */
       formOverrideNote: string;
     };
@@ -2033,7 +2036,10 @@ export const en: FormsMessages = {
       tokenRespondentEmail: 'Respondent email',
       tokenScore: 'Score',
       tokenOutcomeLabel: 'Outcome',
-      tokenFormLink: 'Form link',
+      tokenFormLink: 'Submissions link',
+      tokenAnswers: 'Answers',
+      answersMissing:
+        'This email does not include {{answers}}, so the answers will not be in it. Insert the Answers variable to add them.',
       formOverrideNote: 'Each form can override these emails from its Connect tab in the editor.',
     },
     login: {
@@ -3514,7 +3520,10 @@ export const es: FormsMessages = {
       tokenRespondentEmail: 'Correo del encuestado',
       tokenScore: 'Puntuación',
       tokenOutcomeLabel: 'Resultado',
-      tokenFormLink: 'Enlace del formulario',
+      tokenFormLink: 'Enlace a las respuestas',
+      tokenAnswers: 'Respuestas',
+      answersMissing:
+        'Este correo no incluye {{answers}}, así que las respuestas no aparecerán en él. Inserta la variable Respuestas para agregarlas.',
       formOverrideNote:
         'Cada formulario puede personalizar estos correos desde su pestaña Conectar en el editor.',
     },


### PR DESCRIPTION
## Why

The "new submission" email told the owner that someone answered and nothing else. Three defects stacked up:

- the answers were never passed to the template (`submission.service.ts` enqueued only name, email, score and outcome);
- the `{{formLink}}` token had no producer, so the "View submissions" line always dropped and custom templates looked half rendered;
- the HTML body was a bare `<p>` with `<br/>` separators and no document, which most clients showed as plain text.

The transactional service (dapta-email) forwards the HTML as is and splices its footer before `</body>`, so the whole fix lives in Forms.

## What

- **engine**: `summarizeAnswers(config, answers)` resolves a submission to `{label, value}` rows in step order: the question the respondent saw, option values mapped to labels, multi-selects joined with commas, bookings as `YYYY-MM-DD HH:mm UTC`, values capped at 2000 characters.
- **notifications**: new `{{answers}}` token (text: one `Label: value` line each; HTML: an escaped two-column table). `renderBodyLines` applies one rule to stock and custom copy: a line is dropped only when it has tokens and every one resolved empty. `emailDocument` wraps every email (owner notice, receipt, invitation) in a complete responsive document with a real `</body></html>`. The owner default carries the token between Outcome and the link; the respondent default does not.
- **api**: `formLink` = `PUBLIC_APP_URL/admin/forms/:id/submissions` on the owner notice only. Both payloads carry the answers so a custom receipt can echo them. An owner with no email no longer enqueues a row that fails five times, and rows already queued with no recipient are skipped once (per action) instead of retried.
- **db**: migration 0019 appends `{{answers}}` to every custom owner-notice body that lacks it (account and per-form rows), idempotent on both dialects.
- **web**: "Answers" chip, permanent notice on the owner notice when its body lacks the token, preview sample with the answers block, the dead `{{formLink}}` chip hidden on the respondent card. i18n EN + ES.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (16/16 tasks) and `pnpm build` pass; `scripts/dash-check.sh origin/develop` clean.
- New specs: `answer-summary.spec.ts`, `render-html.spec.ts`, `migration-0019.spec.ts`, `notification-email-fields.spec.tsx`; extended `templates.spec.ts`, `submission-notifier.spec.ts`, `email-effects.spec.ts`, `submission.service.spec.ts`, `notifications.controller.spec.ts`, `notification-preview.spec.ts`.
- Rendered the owner email and checked it at 375px and 1000px: the table wraps, a long URL no longer stretches the card, `<script>` in an answer shows as text.
- `build + start` in a worktree with `PUBLIC_APP_URL` set: submitting the demo form enqueued both emails with the answers and the link, the outbox worker delivered both (`done`, 0 retries), and the log-only provider logged both subjects. Settings and Connect show the chip; the notice appears when `{{answers}}` is removed and disappears with `{{ answers }}`.

Real delivery through dapta-email gets validated in develop after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
