### PR TITLE
feat(chrome): Docs item in the rail, localized to the reader's language

### DIFF
--- a/.changeset/docs-nav-link.md
+++ b/.changeset/docs-nav-link.md
@@ -1,0 +1,14 @@
+---
+'@quill/shared': patch
+---
+
+A "Docs" item in the rail, in the reader's language.
+
+The left nav gains a permanent "Docs" entry (book icon) right above "Dapta
+Agents". It opens the Forms documentation in a new tab: the English site for
+an English interface, the Spanish site for a Spanish one. The URL lives in the
+message catalog (`admin.chrome.docsHref`) because the shell only receives the
+localized messages, and it carries the same in-app UTM tags as the other suite
+doors (`utm_source=forms`, `utm_medium=sidebar`).
+
+- i18n: `admin.chrome.docsHref` and `admin.chrome.nav.docs` (EN + ES).

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -21,7 +21,7 @@ type ChromeMessages = FormsMessages['admin']['chrome'];
  *  a desktop collapse rail (cookie-persisted, no FOUC), and a <768px off-canvas
  *  drawer with a hamburger top bar. Tokens only; R22 press/hover; R27/R28. */
 
-type IconName = 'home' | 'forms' | 'submissions' | 'analytics' | 'integrations' | 'agents';
+type IconName = 'home' | 'forms' | 'submissions' | 'analytics' | 'integrations' | 'docs' | 'agents';
 
 interface NavItem {
   key: keyof ChromeMessages['nav'];
@@ -31,6 +31,11 @@ interface NavItem {
   match?: string[];
   /** Leaves the app: plain anchor in a new tab, never `aria-current`. */
   external?: true;
+  /**
+   * The href comes from the localized catalog instead of `href` (the docs
+   * site has one page per language). `NavLinks` resolves it from `docsHref`.
+   */
+  localizedHref?: 'docsHref';
 }
 
 // Forms information architecture: Home, Forms, Submissions, Analytics,
@@ -39,6 +44,10 @@ interface NavItem {
 // ACCOUNT (workspaces, brand kit, notifications, public page) lives behind the
 // profile button at the bottom of the rail, under /admin/account, the same
 // place Dapta's admin panel keeps it, so no rail item is active on those pages.
+//
+// Then "Docs": the product documentation, always present, in the reader's
+// language (the URL lives in the message catalog, see `docsHref`). External
+// like the platform door below, and tagged the same way.
 //
 // Last, and only on a deployment that has a platform: "Dapta Agents", the door
 // to the wider platform. It sits IN the nav rather than in a separate block so
@@ -53,6 +62,7 @@ const NAV: NavItem[] = [
   { key: 'submissions', href: '/admin/submissions', icon: 'submissions' },
   { key: 'analytics', href: '/admin/analytics', icon: 'analytics' },
   { key: 'integrations', href: '/admin/integrations', icon: 'integrations' },
+  { key: 'docs', href: '', icon: 'docs', external: true, localizedHref: 'docsHref' },
   ...(PLATFORM_URL
     ? [{ key: 'agents', href: suiteHref(PLATFORM_URL, 'sidebar'), icon: 'agents', external: true } as const]
     : []),
@@ -68,6 +78,7 @@ const PI_BY_NAME: Record<IconName, string> = {
   submissions: 'pi-inbox',
   analytics: 'pi-chart-bar',
   integrations: 'pi-link',
+  docs: 'pi-book',
   agents: 'pi-microchip-ai',
 };
 
@@ -84,11 +95,14 @@ function Icon({ name, className }: { name: IconName; className?: string }) {
 function NavLinks({
   collapsed,
   nav,
+  docsHref,
   newTab,
   onNavigate,
 }: {
   collapsed: boolean;
   nav: ChromeMessages['nav'];
+  /** The localized documentation URL, already UTM-tagged by the caller. */
+  docsHref: string;
   /** "(opens in a new tab)" — read out after an external item's label. */
   newTab: string;
   onNavigate?: () => void;
@@ -97,10 +111,11 @@ function NavLinks({
   return (
     <ul className="flex flex-col gap-1">
       {NAV.map((item) => {
+        const href = item.localizedHref ? docsHref : item.href;
         // An external item is never "here": its href is another origin, so the
         // prefix rule could not match anyway, but the intent should not depend
         // on that accident.
-        const active = !item.external && isNavItemActive(pathname, item.href, item.match);
+        const active = !item.external && isNavItemActive(pathname, href, item.match);
         const label = nav[item.key];
         const className = [
           'relative flex items-center gap-3 rounded-md text-sm transition-colors active:scale-[0.99]',
@@ -128,10 +143,10 @@ function NavLinks({
           </>
         );
         return (
-          <li key={item.href}>
+          <li key={item.key}>
             {item.external ? (
               <a
-                href={item.href}
+                href={href}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={onNavigate}
@@ -154,7 +169,7 @@ function NavLinks({
               </a>
             ) : (
               <Link
-                href={item.href}
+                href={href}
                 onClick={onNavigate}
                 title={collapsed ? label : undefined}
                 aria-current={active ? 'page' : undefined}
@@ -354,7 +369,12 @@ export function AdminShell({
           />
         ) : null}
         <nav aria-label="Primary">
-          <NavLinks collapsed={railCollapsed} nav={messages.nav} newTab={messages.switcher.opensNewTab} />
+          <NavLinks
+            collapsed={railCollapsed}
+            nav={messages.nav}
+            docsHref={suiteHref(messages.docsHref, 'sidebar')}
+            newTab={messages.switcher.opensNewTab}
+          />
         </nav>
         {renderFooter(railCollapsed)}
       </aside>
@@ -404,6 +424,7 @@ export function AdminShell({
           <NavLinks
             collapsed={false}
             nav={messages.nav}
+            docsHref={suiteHref(messages.docsHref, 'sidebar')}
             newTab={messages.switcher.opensNewTab}
             onNavigate={() => setDrawerOpen(false)}
           />

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -218,6 +218,8 @@ export function AdminShell({
   staff?: boolean;
   children: ReactNode;
 }) {
+  // Tagged once for both rails (desktop and drawer), like the other suite doors.
+  const docsHref = suiteHref(messages.docsHref, 'sidebar');
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -372,7 +374,7 @@ export function AdminShell({
           <NavLinks
             collapsed={railCollapsed}
             nav={messages.nav}
-            docsHref={suiteHref(messages.docsHref, 'sidebar')}
+            docsHref={docsHref}
             newTab={messages.switcher.opensNewTab}
           />
         </nav>
@@ -424,7 +426,7 @@ export function AdminShell({
           <NavLinks
             collapsed={false}
             nav={messages.nav}
-            docsHref={suiteHref(messages.docsHref, 'sidebar')}
+            docsHref={docsHref}
             newTab={messages.switcher.opensNewTab}
             onNavigate={() => setDrawerOpen(false)}
           />

--- a/apps/web/lib/suite.spec.ts
+++ b/apps/web/lib/suite.spec.ts
@@ -21,6 +21,13 @@ describe('suiteHref — the in-app doors to the suite', () => {
     expect(url.searchParams.get('utm_source')).toBe('forms');
   });
 
+  it('tags the documentation link without disturbing its path (the docs site routes on it)', () => {
+    const url = new URL(suiteHref('https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms', 'sidebar'));
+    expect(url.pathname).toBe('/dapta-docs-es/dapta-forms/forms');
+    expect(url.searchParams.get('utm_source')).toBe('forms');
+    expect(url.searchParams.get('utm_medium')).toBe('sidebar');
+  });
+
   it('returns an unparseable base verbatim rather than hiding it', () => {
     // A suite link that looks broken is a bug worth seeing; only the public
     // badge hides, because a fork may legitimately have no destination.

--- a/packages/shared/src/i18n/chrome.spec.ts
+++ b/packages/shared/src/i18n/chrome.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getMessages } from './index';
+
+describe('admin.chrome docs link', () => {
+  it('points each language at its own documentation site', () => {
+    expect(getMessages('en').admin.chrome.docsHref).toBe('https://docs.dapta.ai/dapta-forms/forms');
+    expect(getMessages('es').admin.chrome.docsHref).toBe('https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms');
+  });
+
+  it('carries absolute URLs (the rail opens them in a new tab, so a relative path would 404 in the app)', () => {
+    for (const locale of ['en', 'es'] as const) {
+      const url = new URL(getMessages(locale).admin.chrome.docsHref);
+      expect(url.protocol).toBe('https:');
+      expect(url.hostname).toBe('docs.dapta.ai');
+    }
+  });
+
+  it('labels the nav item in both languages', () => {
+    expect(getMessages('en').admin.chrome.nav.docs).toBe('Docs');
+    expect(getMessages('es').admin.chrome.nav.docs).toBe('Documentación');
+  });
+});

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -134,6 +134,12 @@ export interface FormsMessages {
         light: string;
         next: string;
       };
+      /**
+       * Where the "Docs" nav item goes: the Forms documentation in THIS
+       * language. Lives in the catalog because the shell only receives the
+       * localized messages, never the locale itself. Always an absolute URL.
+       */
+      docsHref: string;
       /** Left-nav item labels (icon + label). */
       nav: {
         home: string;
@@ -141,6 +147,8 @@ export interface FormsMessages {
         submissions: string;
         analytics: string;
         integrations: string;
+        /** The product documentation, an EXTERNAL link (see `docsHref`). */
+        docs: string;
         /**
          * The door to the wider platform (agents), an EXTERNAL link. Rendered
          * only when the deployment configures a platform URL, so a fork's rail
@@ -1752,12 +1760,14 @@ export const en: FormsMessages = {
         light: 'Light',
         next: 'Switch to',
       },
+      docsHref: 'https://docs.dapta.ai/dapta-forms/forms',
       nav: {
         home: 'Home',
         forms: 'Forms',
         submissions: 'Submissions',
         analytics: 'Analytics',
         integrations: 'Integrations',
+        docs: 'Docs',
         agents: 'Dapta Agents',
       },
       profileMenu: {
@@ -3232,12 +3242,14 @@ export const es: FormsMessages = {
         light: 'Claro',
         next: 'Cambiar a',
       },
+      docsHref: 'https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms',
       nav: {
         home: 'Inicio',
         forms: 'Formularios',
         submissions: 'Respuestas',
         analytics: 'Analíticas',
         integrations: 'Integraciones',
+        docs: 'Documentación',
         agents: 'Dapta Agents',
       },
       profileMenu: {


### PR DESCRIPTION
## What

A permanent "Docs" item in the left nav (book icon), right above "Dapta Agents", opening the Forms documentation in a new tab in the reader's language:

- English interface: `https://docs.dapta.ai/dapta-forms/forms`
- Spanish interface: `https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms`

The URL lives in the message catalog (`admin.chrome.docsHref`) because the shell only receives the localized messages, never the locale. It is tagged like the other suite doors (`utm_source=forms`, `utm_medium=sidebar`) and takes the existing external-link affordance (`target=_blank`, `rel`, trailing arrow, "(opens in a new tab)" for screen readers).

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (16/16) and `pnpm build` pass; dash-check clean.
- New `packages/shared/src/i18n/chrome.spec.ts` pins both URLs and labels; `apps/web/lib/suite.spec.ts` covers the docs URL keeping its path.
- `build + start`: the rail shows Docs with the EN href; with the `quill_locale=es` cookie it shows "Documentación" with the ES href, both `target=_blank` with `rel="noopener noreferrer"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
