### PR TITLE
feat(forms): form language and button copy, resolved everywhere the form renders

### DIFF
--- a/.changeset/form-language-and-labels.md
+++ b/.changeset/form-language-and-labels.md
@@ -1,0 +1,31 @@
+---
+'@quill/types': minor
+'@quill/engine': patch
+'@quill/shared': minor
+---
+
+A form can name its language and its button copy.
+
+Until now the public form's chrome (Start, Back, Next, Submit, the progress
+counter, the thank-you copy, the confirmation email) followed each visitor's
+browser, with no way for the author to decide. Two additive config fields fix
+that; a form saved before they existed renders exactly as it did.
+
+- `config.language` (`en` | `es`, absent = Auto). Precedence on the public
+  page: `?lang=` on the URL, then the form's language, then the browser,
+  then English. The page description, the social card, the `lang` attribute
+  on the form's subtree and the respondent's confirmation email follow the
+  same resolution (the submission now carries the locale the respondent saw).
+- `config.labels` (`back`, `next`, `submit`, up to 80 characters each) at the
+  form level. A step's own `buttonText` still wins for that step; the cover
+  keeps `cover.ctaText`. `resolveFormLabels(config, locale)` in `@quill/shared`
+  is the single resolver both renderers and the builder preview use.
+- Design tab: a Language selector (Auto / English / Spanish) and Button text
+  fields (Submit only on the one-page layout) at the top of the panel, with
+  the stock copy of the chosen language as placeholders. The live preview and
+  the Preview modal render in the FORM's language, not the editor's.
+- New forms are stamped with their author's language (dashboard "New form"
+  and the onboarding wizard alike). Existing forms stay on Auto.
+- The public error boundary and the 404 speak the visitor's language.
+- i18n: `admin.editor.design.language*` / `labels*` / `label*`, and
+  `renderer.error*` / `notFound*` (EN + ES).

--- a/apps/api/src/admin.service.ts
+++ b/apps/api/src/admin.service.ts
@@ -214,7 +214,11 @@ export class AdminService {
       p.accountId,
       {
         name: this.templateFormName(templateId, template.name, input.locale),
-        ...(template.config ? { config: template.config } : {}),
+        // The wizard's language becomes the form's (Auto only for forms that
+        // predate the field), the same rule as "New form" in the dashboard.
+        ...(template.config || input.locale
+          ? { config: { ...(template.config ?? { version: 1 as const, steps: [] }), ...(input.locale ? { language: input.locale } : {}) } }
+          : {}),
       },
       p.memberId,
     );

--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -122,8 +122,8 @@ export class EmailEffects {
    * notification_setting mechanism (`submission_confirmed`; absent rows =
    * enabled, the fork-friendly default), merged form → account → stock. No
    * respondent email in the answers → nothing to address, so it no-ops. Locale:
-   * the public surface does not persist the respondent's language yet, so the
-   * caller's value is used as-is (unset normalizes to English in the notifier).
+   * the caller resolves it (the language the respondent saw, else the form's
+   * own); unset normalizes to English in the notifier.
    * Never rejects — the caller fire-and-forgets with `void`.
    */
   async enqueueSubmissionConfirmed(

--- a/apps/api/src/submission.service.spec.ts
+++ b/apps/api/src/submission.service.spec.ts
@@ -87,6 +87,34 @@ describe('submit', () => {
     expect(payload.respondentEmail).toBe('lead@acme.io');
   });
 
+  it('the respondent receipt renders in the language the respondent saw, then the form language, then none', async () => {
+    const localeOf = async (sessionId: string, extra: Record<string, unknown>, language?: 'en' | 'es') => {
+      if (language) {
+        const form = await db.get<{ id: string; config: string }>(
+          sql`SELECT id, config FROM form WHERE slug = 'lead-qualifier' LIMIT 1`,
+        );
+        const config = JSON.parse(form!.config) as Record<string, unknown>;
+        await db.run(
+          sql`UPDATE form SET config = ${JSON.stringify({ ...config, language })} WHERE id = ${form!.id}`,
+        );
+      }
+      await svc.submit('acme', 'lead-qualifier', {
+        sessionId,
+        data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+        ...extra,
+      });
+      await flushEffects();
+      const rows = await listOutbox(db, { kind: 'email' });
+      const confirmed = rows.filter((r) => r.action === 'submission_confirmed').pop()!;
+      return (JSON.parse(confirmed.payload!) as { locale: string | null }).locale;
+    };
+    expect(await localeOf('sess-loc-none', {})).toBeNull();
+    expect(await localeOf('sess-loc-seen', { locale: 'es' })).toBe('es');
+    expect(await localeOf('sess-loc-form', {}, 'es')).toBe('es');
+    // What the respondent SAW wins over the form default (a ?lang=en link on a Spanish form).
+    expect(await localeOf('sess-loc-both', { locale: 'en' }, 'es')).toBe('en');
+  });
+
   it('a re-landed complete enqueues NO second round of effects', async () => {
     // `callActionWithRetry` cannot abort an in-flight request, so a complete
     // that landed slowly IS retried and this method runs twice for one real

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -172,6 +172,9 @@ export class SubmissionService {
             submissionId: row.id,
             formName: form.name,
             respondentEmail,
+            // The language the respondent saw (the page resolved ?lang and the
+            // browser), else the form's own language; null = English.
+            locale: input.locale ?? config.language ?? null,
           },
           form.id,
         );

--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -12,7 +12,7 @@ import type { BookingCallbackInput } from '@quill/types';
 export async function submitFormAction(
   accountCode: string,
   slug: string,
-  payload: { sessionId: string; data: Record<string, unknown>; partial?: boolean },
+  payload: { sessionId: string; data: Record<string, unknown>; partial?: boolean; locale?: 'en' | 'es' },
 ): Promise<{ ok: boolean; score?: number; outcome?: string | null; message?: string }> {
   const res = await postSubmission(accountCode, slug, payload);
   return { ok: res.ok, score: res.score, outcome: res.outcome, message: res.message };

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-labels.spec.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-labels.spec.tsx
@@ -1,0 +1,108 @@
+/**
+ * The renderers print the form's OWN button copy: the author's overrides,
+ * else the stock copy of the language the page resolved. Pinned through
+ * static markup so the public form and the builder preview (same component)
+ * cannot drift from `resolveFormLabels`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// `next/font/google` resolves at build time and has no runtime in vitest; the
+// renderers only need a className from it.
+vi.mock("next/font/google", () => {
+  const font = () => ({
+    className: "font",
+    variable: "--font",
+    style: { fontFamily: "font" },
+  });
+  return {
+    DM_Sans: font,
+    Figtree: font,
+    Fraunces: font,
+    IBM_Plex_Mono: font,
+    Inter: font,
+    Manrope: font,
+    Playfair_Display: font,
+    Poppins: font,
+    Space_Grotesk: font,
+    Work_Sans: font,
+  };
+});
+
+import { FormRenderer } from "./form-renderer";
+import { VerticalFormRenderer } from "./vertical-form-renderer";
+
+const step = { key: "q1", type: "text" as const, question: "Your name?" };
+
+function slides(
+  config: Record<string, unknown>,
+  locale: string,
+  startAt?: number | "cover",
+) {
+  return renderToStaticMarkup(
+    <FormRenderer
+      accountCode="acme"
+      slug="f"
+      name="F"
+      config={{ version: 1, steps: [step], ...config } as never}
+      locale={locale}
+      startAt={startAt}
+    />,
+  );
+}
+
+describe("button copy on the public form", () => {
+  it("the cover CTA is the author text, else the stock Start of the locale", () => {
+    expect(
+      slides(
+        { cover: { enabled: true, headline: "Hi", ctaText: "Vamos" } },
+        "en",
+        "cover",
+      ),
+    ).toContain("Vamos");
+    expect(
+      slides({ cover: { enabled: true, headline: "Hi" } }, "es", "cover"),
+    ).toContain("Comenzar");
+  });
+
+  it("the last step submits with the form-level label, else the stock Submit of the locale", () => {
+    expect(slides({ labels: { submit: "Send it" } }, "es", 0)).toContain(
+      "Send it",
+    );
+    expect(slides({}, "es", 0)).toContain("Enviar");
+    expect(slides({}, "en", 0)).toContain("Submit");
+  });
+
+  it("a step’s own buttonText still wins over the form-level label", () => {
+    const html = slides(
+      {
+        labels: { submit: "Send it" },
+        steps: [{ ...step, buttonText: "Go go" }],
+      },
+      "en",
+      0,
+    );
+    expect(html).toContain("Go go");
+    expect(html).not.toContain("Send it");
+  });
+
+  it("the one-page layout submits with the same resolver", () => {
+    const html = renderToStaticMarkup(
+      <VerticalFormRenderer
+        accountCode="acme"
+        slug="f"
+        name="F"
+        config={
+          {
+            version: 1,
+            steps: [step],
+            layout: "vertical",
+            labels: { submit: "Listo" },
+          } as never
+        }
+        locale="en"
+      />,
+    );
+    expect(html).toContain("Listo");
+  });
+});

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -31,7 +31,7 @@ import {
   type FormStep,
   type FormOutcome,
 } from '@quill/engine';
-import { getMessages } from '@quill/shared';
+import { getMessages, resolveFormLabels } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
 import { formDesignProps } from '@/lib/form-design';
 import { FormLogo } from '@/components/public/form-logo';
@@ -80,6 +80,9 @@ export function FormRenderer({
   startAt?: number | 'cover';
 }) {
   const m = getMessages(locale).renderer;
+  // The form's button copy: author overrides, else the stock copy of `locale`.
+  const formLocale = locale === 'es' ? 'es' : 'en';
+  const labels = resolveFormLabels(config, formLocale);
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
   // The cover SCREEN: null when switched off, which is what gates the `cover`
   // phase, the Start CTA and the back-to-cover step.
@@ -253,6 +256,8 @@ export function FormRenderer({
           submitFormAction(accountCode, slug, {
             sessionId,
             data: withData(finalAnswers),
+            // What the respondent SAW, so the confirmation email matches.
+            locale: formLocale,
           }),
         { timeoutMs: 8_000 },
       );
@@ -664,7 +669,7 @@ export function FormRenderer({
         </div>
         <div className="pf__cover-footer">
           <button type="button" className="pf__btn" onClick={start}>
-            {coverScreen.ctaText ?? m.start}
+            {labels.start}
           </button>
           {/* Under the CTA: every respondent sees the cover, so this is the
               highest-value slot for the attribution and it displaces nothing. */}
@@ -743,7 +748,7 @@ export function FormRenderer({
         <header className="pf__topbar">
           <div className="pf__topbar-inner">
             {index > 0 || coverScreen ? (
-              <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+              <button type="button" className="pf__back" onClick={back} aria-label={labels.back}>
                 ←
               </button>
             ) : (
@@ -812,7 +817,7 @@ export function FormRenderer({
       <header className="pf__topbar">
         <div className="pf__topbar-inner">
           {index > 0 || coverScreen ? (
-            <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+            <button type="button" className="pf__back" onClick={back} aria-label={labels.back}>
               ←
             </button>
           ) : (
@@ -861,7 +866,7 @@ export function FormRenderer({
 
               {showContinue ? (
                 <button type="button" className="pf__btn pf__btn--inline" onClick={submitCurrent}>
-                  {step.buttonText ?? (index + 1 === steps.length ? m.submit : m.next)}
+                  {step.buttonText ?? (index + 1 === steps.length ? labels.submit : labels.next)}
                 </button>
               ) : null}
             </div>

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -376,6 +376,7 @@ export function FormRenderer({
               sessionId,
               data: withData(nextAnswers),
               partial: true,
+              locale: formLocale,
             }),
           );
         }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/opengraph-image.tsx
@@ -105,15 +105,12 @@ export default async function OgImage({
   const config = form?.config;
   const cover = config?.cover;
   const style = resolveCardStyle(config?.branding);
-  // The same locale rule the page uses, which for a social crawler means English:
-  // they send no `Accept-Language`, and neither does a respondent with no
-  // preference — who would land on the English page too. So the card agrees with
-  // the page it opens, which is the property worth holding. It is NOT the same as
-  // being right: a Spanish form shared into a Spanish channel still says "Start".
-  // Fixing that needs a language ON THE FORM. The account has none, and the
-  // owner's `member.locale` is their dashboard language rather than their
-  // audience's, so guessing from it would trade one wrong answer for another.
-  const messages = getMessages(await publicLocale());
+  // The same locale rule the page uses: the form's own language when the author
+  // set one, else the browser, which for a social crawler means English (they
+  // send no `Accept-Language`). So the card agrees with the page it opens. A
+  // form left on Auto and shared into a Spanish channel still says "Start";
+  // setting the language in Design is the fix, not guessing from the owner.
+  const messages = getMessages(await publicLocale(undefined, config?.language ?? null));
 
   const headline =
     cover?.headline?.trim() ||

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -17,12 +17,16 @@ import { VerticalFormRenderer } from './vertical-form-renderer';
  */
 export async function generateMetadata({
   params,
+  searchParams,
 }: {
-  params: Promise<{ accountCode: string; handle: string; slug: string; lang?: string }>;
+  params: Promise<{ accountCode: string; handle: string; slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }): Promise<Metadata> {
   const { accountCode, handle, slug } = await params;
   const form = await getPublicForm(accountCode, slug);
   if (!form) return {};
+  const query = await searchParams;
+  const lang = typeof query.lang === 'string' ? query.lang : undefined;
   // NOTE: this function deliberately does NOT redirect, even though it runs
   // before the page and looks like the earlier, better place to do it. Next 16
   // has already begun streaming by the time either one resolves, so a redirect
@@ -32,7 +36,9 @@ export async function generateMetadata({
   // returning metadata at all. So the redirect stays in the page (for people,
   // whose browsers follow it) and this function keeps naming the canonical URL
   // (for everything that does not run scripts).
-  const locale = await publicLocale();
+  // The same rule as the page body: ?lang, then the form's language, then
+  // the browser. The description must agree with the page it describes.
+  const locale = await publicLocale(lang, form.config.language ?? null);
   // The author-set public title wins over the private dashboard name.
   const title = publicTitle(form.config, form.name);
   const description =
@@ -152,13 +158,14 @@ export default async function PublicFormPage({
   const { accountCode, handle, slug } = await params;
   const query = await searchParams;
   const lang = typeof query.lang === 'string' ? query.lang : undefined;
-  const locale = await publicLocale(lang);
   // Embedded render (?embed=1): same form, sized by its content instead of the
   // viewport, reporting its height to the host page's embed.js (iframe embeds).
   const embedded = query.embed === '1';
 
   const form = await getPublicForm(accountCode, slug);
   if (!form) notFound();
+  // ?lang, then the form's own language (Auto = absent), then the browser.
+  const locale = await publicLocale(lang, form.config.language ?? null);
 
   // Reached through a slug this form USED to answer to: the author renamed the
   // link and the alias ledger resolved the old one (see migration 0017). Move

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -46,7 +46,7 @@ import {
   type FormOutcome,
   type FormReveal,
 } from '@quill/engine';
-import { getMessages, t } from '@quill/shared';
+import { getMessages, resolveFormLabels, t } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
 import { FormLogo } from '@/components/public/form-logo';
 import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
@@ -165,6 +165,9 @@ export function VerticalFormRenderer({
   locale?: string;
 }) {
   const m = getMessages(locale).renderer;
+  // The form's button copy: author overrides, else the stock copy of `locale`.
+  const formLocale = locale === 'es' ? 'es' : 'en';
+  const labels = resolveFormLabels(config, formLocale);
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
   // The cover HERO: null when switched off, which is what gates the hero block.
   const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
@@ -312,6 +315,8 @@ export function VerticalFormRenderer({
           submitFormAction(accountCode, slug, {
             sessionId,
             data: withData(finalAnswers),
+            // What the respondent SAW, so the confirmation email matches.
+            locale: formLocale,
           }),
         { timeoutMs: 8_000 },
       );
@@ -774,7 +779,7 @@ export function VerticalFormRenderer({
                 </p>
               ) : null}
               <button type="button" className="pf__btn" onClick={() => void submitAll()}>
-                {m.submit}
+                {labels.submit}
               </button>
             </div>
           ) : null}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -416,6 +416,7 @@ export function VerticalFormRenderer({
             sessionId,
             data: withData(nextAnswers),
             partial: true,
+            locale: formLocale,
           }),
         );
       }

--- a/apps/web/app/[accountCode]/error.tsx
+++ b/apps/web/app/[accountCode]/error.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-/** R22 error boundary for the public form subtree — a real Retry, no dead end. */
+import { getMessages } from '@quill/shared';
+import { publicClientLocale } from '@/lib/client-locale';
+
+/** R22 error boundary for the public form subtree: a real Retry, no dead end. */
 export default function PublicError({ reset }: { error: Error; reset: () => void }) {
+  // A client boundary has no request to read: ?lang, then the browser.
+  const m = getMessages(publicClientLocale()).renderer;
   return (
     <main className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center gap-4 px-6 text-center">
-      <h1 className="text-2xl font-semibold">This page didn’t load</h1>
-      <p className="text-muted-foreground">Something went wrong reaching the forms service.</p>
+      <h1 className="text-2xl font-semibold">{m.errorTitle}</h1>
+      <p className="text-muted-foreground">{m.errorBody}</p>
       <button
         type="button"
         onClick={reset}
         className="rounded-md bg-primary px-5 py-2 font-semibold text-primary-foreground transition-transform active:scale-[0.98]"
       >
-        Try again
+        {m.errorRetry}
       </button>
     </main>
   );

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect, unstable_rethrow } from 'next/navigation';
 import { lockedOptionValues } from '@quill/engine';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 
 /** Create a form and jump straight into its editor. */
 export async function createFormAction(formData: FormData): Promise<void> {
@@ -12,9 +13,13 @@ export async function createFormAction(formData: FormData): Promise<void> {
   // `layout` already means slides (the engine's back-compat default), so a
   // slides form keeps the exact config shape every existing form has.
   const layout = String(formData.get('layout') ?? '');
+  // A new form speaks its author's language explicitly (Auto stays for forms
+  // that predate the field): the person building it in Spanish expects Spanish
+  // buttons, not whatever each visitor's browser asks for.
+  const language = await getLocale();
   const created = await adminApi.createForm({
     name,
-    ...(layout === 'vertical' ? { config: { version: 1, steps: [], layout: 'vertical' } } : {}),
+    config: { version: 1, steps: [], language, ...(layout === 'vertical' ? { layout: 'vertical' } : {}) },
   });
   revalidatePath('/admin');
   revalidatePath('/admin/forms');

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -14,6 +14,7 @@ import {
   uniqueKey,
 } from '@quill/engine';
 import { onAccent, DEFAULT_ACCENT, getMessages } from '@quill/shared';
+import { resolveFormLabels } from '@quill/shared';
 import { clientLocale } from '@/lib/client-locale';
 import { cn } from '@/lib/cn';
 import { iconForStep, hasOptions } from './question-types';
@@ -165,6 +166,9 @@ export function CanvasQuestion({
         : { background: accent, color: accentText };
   const progress = total > 0 ? Math.round(((index + 1) / total) * 100) : 0;
   const isLast = index + 1 >= total;
+  // The same resolver the public form and the preview use: the author's
+  // overrides, else the stock copy of the FORM's language (not the editor's).
+  const formLabels = resolveFormLabels(config, config.language ?? (clientLocale() === 'es' ? 'es' : 'en'));
 
   // A reveal is not a question — it asks nothing, has no title, no description
   // and no Next button, and the respondent sees a spinner over the configured
@@ -234,7 +238,7 @@ export function CanvasQuestion({
               )}
               style={btnStyle}
             >
-              {step.buttonText || (isLast ? m.canvas.submit : m.canvas.next)}
+              {step.buttonText || (isLast ? formLabels.submit : formLabels.next)}
               <i aria-hidden className="pi pi-arrow-right" style={{ fontSize: 12 }} />
             </button>
           </div>

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { FormBranding, FormConfig, FormCover, FormLayout } from '@quill/engine';
+import type { FormBranding, FormConfig, FormCover, FormLabels, FormLanguage, FormLayout } from '@quill/engine';
+import { getMessages } from '@quill/shared';
 import {
   DEFAULT_FORM_FONT,
   FORM_BACKGROUND_STYLES,
@@ -24,7 +25,7 @@ import {
   t,
 } from '@quill/shared';
 import { Switch } from '@/components/ui/switch';
-import { Field, InlineField, NumberField, PanelSection, SegmentedToggle, TextField } from './fields';
+import { Field, InlineField, NumberField, PanelSection, SegmentedToggle, SelectField, TextField } from './fields';
 import { ColorPicker } from './color-picker';
 import { FontPicker } from './font-picker';
 import { ThemePresets } from './theme-presets';
@@ -53,6 +54,8 @@ export function DesignPanel({
   locale,
   layout,
   onTitleChange,
+  onLanguageChange,
+  onLabelsChange,
   onLayoutChange,
   hasReveal,
   onEndRevealChange,
@@ -70,6 +73,10 @@ export function DesignPanel({
   layout: FormLayout;
   /** Set/clear the PUBLIC title (empty = fall back to the dashboard name). */
   onTitleChange: (title: string) => void;
+  /** The form's language; null = Auto (the visitor's browser). */
+  onLanguageChange: (language: FormLanguage | null) => void;
+  /** Patch the form-level button copy (null clears a field back to stock). */
+  onLabelsChange: (patch: Partial<FormLabels>) => void;
   onLayoutChange: (next: FormLayout) => void;
   /** Vertical's single end-of-form reveal (a form-level fact, not a question). */
   hasReveal: boolean;
@@ -90,6 +97,11 @@ export function DesignPanel({
   const vertical = layout === 'vertical';
 
   const d = m.design;
+  // The stock button copy of the language the form will render in, shown as
+  // placeholders so an author sees exactly what an empty field falls back to.
+  const stockLabels = getMessages(config.language ?? (locale === 'es' ? 'es' : 'en')).renderer;
+  // One page has no Back/Next: only Submit is offered there.
+  const labelKeys: Array<'back' | 'next' | 'submit'> = vertical ? ['submit'] : ['back', 'next', 'submit'];
   const branding = config.branding ?? {};
   const design = resolveDesign(branding);
   const cover = config.cover ?? {};
@@ -115,6 +127,43 @@ export function DesignPanel({
     <div className="grid h-full min-h-0 gap-4 px-4 py-6 sm:px-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,46%)] lg:overflow-hidden">
       {/* ── Controls ───────────────────────────────────────────────────── */}
       <div className="flex min-w-0 flex-col gap-4 lg:overflow-y-auto lg:pr-1">
+        <PanelSection title={d.languageTitle} subtitle={d.languageHint}>
+          <div className="max-w-[520px]">
+            <SelectField
+              aria-label={d.languageTitle}
+              value={config.language ?? ''}
+              onChange={(e) => {
+                const v = e.target.value;
+                onLanguageChange(v === 'en' || v === 'es' ? v : null);
+              }}
+            >
+              <option value="">{d.languageAuto}</option>
+              <option value="en">{d.languageEn}</option>
+              <option value="es">{d.languageEs}</option>
+            </SelectField>
+          </div>
+        </PanelSection>
+
+        <PanelSection title={d.labelsTitle} subtitle={d.labelsHint}>
+          <div className={cn('grid max-w-[520px] gap-3', !vertical && 'sm:grid-cols-3')}>
+            {labelKeys.map((key) => (
+              <Field
+                key={key}
+                htmlFor={`form-label-${key}`}
+                label={key === 'back' ? d.labelBack : key === 'next' ? d.labelNext : d.labelSubmit}
+              >
+                <TextField
+                  id={`form-label-${key}`}
+                  value={config.labels?.[key] ?? ''}
+                  placeholder={stockLabels[key]}
+                  maxLength={80}
+                  onChange={(e) => onLabelsChange({ [key]: e.target.value.trim() ? e.target.value : null })}
+                />
+              </Field>
+            ))}
+          </div>
+        </PanelSection>
+
         <PanelSection title={d.publicTitle} subtitle={d.publicTitleHint}>
           <div className="max-w-[520px]">
             <TextField
@@ -531,6 +580,7 @@ export function DesignPanel({
           config={config}
           name={name}
           locale={locale}
+          formLocale={config.language ?? locale}
           layout={layout}
           m={m.preview}
         />

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -157,7 +157,7 @@ export function DesignPanel({
                   value={config.labels?.[key] ?? ''}
                   placeholder={stockLabels[key]}
                   maxLength={80}
-                  onChange={(e) => onLabelsChange({ [key]: e.target.value.trim() ? e.target.value : null })}
+                  onChange={(e) => onLabelsChange({ [key]: e.target.value === '' ? null : e.target.value })}
                 />
               </Field>
             ))}

--- a/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
@@ -87,6 +87,7 @@ export function DevicePreviewModal({
             config={config}
             name={name}
             locale={locale}
+            formLocale={config.language ?? locale}
             layout={layout}
             m={m}
             hideAddressBar

--- a/apps/web/app/admin/forms/[id]/edit/_components/preview-frame.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/preview-frame.tsx
@@ -78,6 +78,7 @@ export function PreviewFrame({
   config,
   name,
   locale,
+  formLocale,
   layout,
   hideAddressBar = false,
   endSlot,
@@ -90,8 +91,14 @@ export function PreviewFrame({
   config: FormConfig;
   /** The form's dashboard name; the public title is resolved here. */
   name: string;
-  /** Drives both the renderer's chrome copy and this frame's own strings. */
+  /** This frame's own strings (the editor's language). */
   locale: string;
+  /**
+   * The language the FORM renders in (its `language`, else the editor's), so
+   * the preview shows what a visitor will see rather than the author's own
+   * dashboard preference. Absent = `locale`.
+   */
+  formLocale?: string;
   layout: FormLayout;
   /**
    * Drop the address bar. The Preview modal already sits above the editor
@@ -151,9 +158,17 @@ export function PreviewFrame({
             : 0
         : screen;
 
+  const rendererLocale = (formLocale ?? locale) === 'es' ? 'es' : 'en';
   const payload = useMemo<Omit<PreviewConfigMessage, 'channel' | 'type'>>(
-    () => ({ revision, config, name: publicTitle(config, name), locale, layout, screen: effectiveScreen }),
-    [revision, config, name, locale, layout, effectiveScreen],
+    () => ({
+      revision,
+      config,
+      name: publicTitle(config, name),
+      locale: rendererLocale,
+      layout,
+      screen: effectiveScreen,
+    }),
+    [revision, config, name, rendererLocale, layout, effectiveScreen],
   );
 
   useEffect(() => {

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -3,15 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import type {
-  FormConfig,
-  FormStep,
-  FormCover,
-  FormBranding,
-  FormOutcome,
-  FormEnding,
-  FormLayout,
-} from '@quill/engine';
+import type { FormBranding, FormConfig, FormCover, FormEnding, FormLabels, FormLanguage, FormLayout, FormOutcome, FormStep } from '@quill/engine';
 import {
   normalizeConfig,
   renameStepKey as engineRenameStepKey,
@@ -502,6 +494,10 @@ export function FormEditor({
 
   // Public title (V7): what the tab/OG/cover show. Empty clears back to `name`.
   const setTitle = (title: string) => mutate((c) => ({ ...c, title: title.trim() ? title : null }));
+  // Form language (null = Auto) and the form-level button copy.
+  const setLanguage = (language: FormLanguage | null) => mutate((c) => ({ ...c, language }));
+  const patchLabels = (patch: Partial<FormLabels>) =>
+    mutate((c) => ({ ...c, labels: { ...c.labels, ...patch } }));
   const patchCover = (patch: Partial<FormCover>) =>
     mutate((c) => ({ ...c, cover: { ...c.cover, ...patch } }));
   const patchBranding = (patch: Partial<FormBranding>) =>
@@ -1063,6 +1059,8 @@ export function FormEditor({
             locale={locale}
             layout={layout}
             onTitleChange={setTitle}
+            onLanguageChange={setLanguage}
+            onLabelsChange={patchLabels}
             onLayoutChange={setLayout}
             hasReveal={hasReveal}
             onEndRevealChange={setEndReveal}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,16 +1,21 @@
 import Link from 'next/link';
+import { getMessages } from '@quill/shared';
 import { BrandMark } from '@/components/brand/brand';
+import { preferredLocale } from '@/lib/locale';
 
-export default function NotFound() {
+export default async function NotFound() {
+  // The persisted admin choice when there is one, else the browser: a dead
+  // public URL is usually reached by a visitor who never saw the switcher.
+  const m = getMessages(await preferredLocale()).renderer;
   return (
     <main className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center gap-4 px-6 text-center">
       {/* A dead URL is often someone's first impression of the product, so it
-          gets the mark too — decorative here, the heading carries the meaning. */}
+          gets the mark too: decorative here, the heading carries the meaning. */}
       <BrandMark className="h-8 w-auto text-muted-foreground" />
-      <h1 className="text-3xl font-semibold">Not found</h1>
-      <p className="text-muted-foreground">This page doesn’t exist.</p>
+      <h1 className="text-3xl font-semibold">{m.notFoundTitle}</h1>
+      <p className="text-muted-foreground">{m.notFoundBody}</p>
       <Link href="/" className="text-primary underline underline-offset-4">
-        Go home
+        {m.notFoundHome}
       </Link>
     </main>
   );

--- a/apps/web/app/preview/preview-document.tsx
+++ b/apps/web/app/preview/preview-document.tsx
@@ -64,7 +64,9 @@ export function PreviewDocument() {
       <style>{SCROLLBAR_RESET}</style>
       {/* Same wrapper depth as the public page (`page.tsx` renders the renderer
           inside one plain div), so nothing about the box tree differs. */}
-      <div data-testid="live-preview" data-preview-state={input ? 'ready' : 'waiting'}>
+      {/* `lang` mirrors the public page's wrapper: the FORM's language, not the
+          editor's, so the preview is announced the way the real page will be. */}
+      <div data-testid="live-preview" data-preview-state={input ? 'ready' : 'waiting'} lang={input?.locale}>
         {input ? (
           input.layout === 'vertical' ? (
             // One page scrolls — there is no screen to start at, so no `startAt`.

--- a/apps/web/app/preview/protocol.spec.ts
+++ b/apps/web/app/preview/protocol.spec.ts
@@ -171,3 +171,23 @@ describe('isBlockedPreviewRequest — the inertness matrix', () => {
     expect(isBlockedPreviewRequest('/v1/x', { method: 'get' }, BASE)).toBe(false);
   });
 });
+
+describe('config message: locale is narrowed to a shipped language', () => {
+  const post = (locale: unknown) =>
+    readPreviewMessage(
+      {
+        origin: ORIGIN,
+        source: parentWindow,
+        data: { channel: PREVIEW_CHANNEL, type: 'config', config: validConfig, locale },
+      } as unknown as MessageEvent,
+      parentWindow,
+      ORIGIN,
+    );
+
+  it('keeps en and es, and folds anything else to en', () => {
+    expect(post('es')).toMatchObject({ type: 'config', locale: 'es' });
+    expect(post('en')).toMatchObject({ type: 'config', locale: 'en' });
+    expect(post('fr')).toMatchObject({ type: 'config', locale: 'en' });
+    expect(post(undefined)).toMatchObject({ type: 'config', locale: 'en' });
+  });
+});

--- a/apps/web/app/preview/protocol.ts
+++ b/apps/web/app/preview/protocol.ts
@@ -55,7 +55,8 @@ export interface PreviewConfigMessage {
   config: FormConfig;
   /** Already resolved through `publicTitle` by the sender. */
   name: string;
-  locale: string;
+  /** The FORM's language (its `language`, else the editor's), never free text. */
+  locale: 'en' | 'es';
   layout: FormLayout;
   /**
    * Where the renderer should START: a runtime step index, or `'cover'` for the
@@ -120,7 +121,7 @@ export function readPreviewMessage(
       revision: typeof body.revision === 'number' ? body.revision : 0,
       config: config as FormConfig,
       name: typeof body.name === 'string' ? body.name : '',
-      locale: typeof body.locale === 'string' ? body.locale : 'en',
+      locale: body.locale === 'es' ? 'es' : 'en',
       layout: body.layout === 'vertical' ? 'vertical' : 'slides',
       screen,
     };

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -53,7 +53,7 @@ export interface SubmitResult {
 export async function postSubmission(
   accountCode: string,
   slug: string,
-  body: { sessionId: string; data: Record<string, unknown>; partial?: boolean },
+  body: { sessionId: string; data: Record<string, unknown>; partial?: boolean; locale?: 'en' | 'es' },
 ): Promise<SubmitResult> {
   const res = await fetch(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/submissions`,

--- a/apps/web/lib/client-locale.spec.ts
+++ b/apps/web/lib/client-locale.spec.ts
@@ -17,6 +17,10 @@ describe("publicClientLocale (the public error boundary has no request to read)"
 
     vi.stubGlobal("navigator", { language: "de-DE" });
     expect(publicClientLocale()).toBe("en");
+    // An unshipped ?lang is ignored, the browser still decides.
+    vi.stubGlobal("location", { search: "?lang=fr" });
+    vi.stubGlobal("navigator", { language: "es-CO" });
+    expect(publicClientLocale()).toBe("es");
   });
 
   it("is safe without a window (server render of the boundary shell)", () => {

--- a/apps/web/lib/client-locale.spec.ts
+++ b/apps/web/lib/client-locale.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { publicClientLocale } from "./client-locale";
+
+describe("publicClientLocale (the public error boundary has no request to read)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads ?lang first, then the browser language, then English", () => {
+    vi.stubGlobal("location", { search: "?lang=es" });
+    vi.stubGlobal("navigator", { language: "en-US" });
+    expect(publicClientLocale()).toBe("es");
+
+    vi.stubGlobal("location", { search: "" });
+    vi.stubGlobal("navigator", { language: "es-CO" });
+    expect(publicClientLocale()).toBe("es");
+
+    vi.stubGlobal("navigator", { language: "de-DE" });
+    expect(publicClientLocale()).toBe("en");
+  });
+
+  it("is safe without a window (server render of the boundary shell)", () => {
+    vi.stubGlobal("location", undefined);
+    vi.stubGlobal("navigator", undefined);
+    expect(publicClientLocale()).toBe("en");
+  });
+});

--- a/apps/web/lib/client-locale.ts
+++ b/apps/web/lib/client-locale.ts
@@ -5,6 +5,22 @@ import type { Locale } from '@quill/shared';
  * is server-only): the persisted admin locale from the document cookie.
  * Defaults to English so a bare fork renders with no cookie.
  */
+/**
+ * The locale of a PUBLIC surface that has no request to read (the error
+ * boundary is a client component): an explicit `?lang`, else the browser's
+ * language, else English. Same order as `resolveFormLocale`, minus the form
+ * language, which the boundary cannot know.
+ */
+export function publicClientLocale(): Locale {
+  const pick = (v: string): Locale => (v.trim().toLowerCase().startsWith('es') ? 'es' : 'en');
+  if (typeof location !== 'undefined' && location?.search) {
+    const lang = new URLSearchParams(location.search).get('lang');
+    if (lang) return pick(lang);
+  }
+  if (typeof navigator !== 'undefined' && navigator?.language) return pick(navigator.language);
+  return 'en';
+}
+
 export function clientLocale(): Locale {
   if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
   return 'en';

--- a/apps/web/lib/client-locale.ts
+++ b/apps/web/lib/client-locale.ts
@@ -1,4 +1,5 @@
 import type { Locale } from '@quill/shared';
+import { shippedLocale } from './form-locale';
 
 /**
  * Client-side twin of lib/locale.ts#getLocale (that one reads next/headers and
@@ -14,8 +15,8 @@ import type { Locale } from '@quill/shared';
 export function publicClientLocale(): Locale {
   const pick = (v: string): Locale => (v.trim().toLowerCase().startsWith('es') ? 'es' : 'en');
   if (typeof location !== 'undefined' && location?.search) {
-    const lang = new URLSearchParams(location.search).get('lang');
-    if (lang) return pick(lang);
+    const asked = shippedLocale(new URLSearchParams(location.search).get('lang'));
+    if (asked) return asked;
   }
   if (typeof navigator !== 'undefined' && navigator?.language) return pick(navigator.language);
   return 'en';

--- a/apps/web/lib/form-locale.spec.ts
+++ b/apps/web/lib/form-locale.spec.ts
@@ -18,7 +18,9 @@ describe("resolveFormLocale: ?lang, then the form language, then the browser", (
       }),
     ).toBe("en");
     expect(resolveFormLocale({ lang: "ES-mx" })).toBe("es");
-    expect(resolveFormLocale({ lang: "fr", configLanguage: "es" })).toBe("en");
+    // A ?lang we do not ship is noise, not an ask: the author's language still wins.
+    expect(resolveFormLocale({ lang: "fr", configLanguage: "es" })).toBe("es");
+    expect(resolveFormLocale({ lang: "fr", acceptLanguage: "en-US" })).toBe("en");
   });
 
   it("the form language beats the browser", () => {

--- a/apps/web/lib/form-locale.spec.ts
+++ b/apps/web/lib/form-locale.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveFormLocale } from "./form-locale";
+
+describe("resolveFormLocale: ?lang, then the form language, then the browser", () => {
+  it("an explicit ?lang wins over everything, and only Spanish-ish values mean Spanish", () => {
+    expect(
+      resolveFormLocale({
+        lang: "es",
+        configLanguage: "en",
+        acceptLanguage: "en-US",
+      }),
+    ).toBe("es");
+    expect(
+      resolveFormLocale({
+        lang: "en",
+        configLanguage: "es",
+        acceptLanguage: "es-CO",
+      }),
+    ).toBe("en");
+    expect(resolveFormLocale({ lang: "ES-mx" })).toBe("es");
+    expect(resolveFormLocale({ lang: "fr", configLanguage: "es" })).toBe("en");
+  });
+
+  it("the form language beats the browser", () => {
+    expect(
+      resolveFormLocale({
+        configLanguage: "es",
+        acceptLanguage: "en-US,en;q=0.9",
+      }),
+    ).toBe("es");
+    expect(
+      resolveFormLocale({ configLanguage: "en", acceptLanguage: "es-CO" }),
+    ).toBe("en");
+  });
+
+  it("Auto (no form language) reads the browser, like before this field existed", () => {
+    expect(resolveFormLocale({ acceptLanguage: "es-CO,es;q=0.9" })).toBe("es");
+    expect(resolveFormLocale({ acceptLanguage: "en-GB" })).toBe("en");
+    expect(
+      resolveFormLocale({ configLanguage: null, acceptLanguage: "es" }),
+    ).toBe("es");
+  });
+
+  it("defaults to English with nothing at all", () => {
+    expect(resolveFormLocale({})).toBe("en");
+    expect(
+      resolveFormLocale({ lang: "", configLanguage: null, acceptLanguage: "" }),
+    ).toBe("en");
+  });
+});

--- a/apps/web/lib/form-locale.ts
+++ b/apps/web/lib/form-locale.ts
@@ -1,0 +1,27 @@
+import type { Locale } from "@quill/shared";
+
+/** Spanish-ish → es, anything else → en (the only two languages we ship). */
+function pick(value: string): Locale {
+  return value.trim().toLowerCase().startsWith("es") ? "es" : "en";
+}
+
+/**
+ * The language a public form renders in. Precedence, highest first:
+ *
+ *  1. `?lang=` on the URL, an explicit ask (a share link, an embed);
+ *  2. the form's own `language` (absent/null = Auto);
+ *  3. the visitor's `Accept-Language`;
+ *  4. English.
+ *
+ * Pure (no `next/headers`) so the matrix is testable in node; `publicLocale`
+ * in lib/locale.ts feeds it the request headers.
+ */
+export function resolveFormLocale(input: {
+  lang?: string | null;
+  configLanguage?: Locale | null;
+  acceptLanguage?: string | null;
+}): Locale {
+  if (input.lang) return pick(input.lang);
+  if (input.configLanguage) return input.configLanguage;
+  return pick(input.acceptLanguage ?? "");
+}

--- a/apps/web/lib/form-locale.ts
+++ b/apps/web/lib/form-locale.ts
@@ -8,7 +8,9 @@ function pick(value: string): Locale {
 /**
  * The language a public form renders in. Precedence, highest first:
  *
- *  1. `?lang=` on the URL, an explicit ask (a share link, an embed);
+ *  1. `?lang=` on the URL, an explicit ask (a share link, an embed), when it
+ *     names a language we ship: `?lang=fr` from a tracking tool is noise and
+ *     must not override the author's choice;
  *  2. the form's own `language` (absent/null = Auto);
  *  3. the visitor's `Accept-Language`;
  *  4. English.
@@ -16,12 +18,21 @@ function pick(value: string): Locale {
  * Pure (no `next/headers`) so the matrix is testable in node; `publicLocale`
  * in lib/locale.ts feeds it the request headers.
  */
+/** A `?lang` that names a language we ship, else null (a stray value must not beat the author). */
+export function shippedLocale(value: string | null | undefined): Locale | null {
+  const v = value?.trim().toLowerCase() ?? '';
+  if (v.startsWith('es')) return 'es';
+  if (v.startsWith('en')) return 'en';
+  return null;
+}
+
 export function resolveFormLocale(input: {
   lang?: string | null;
   configLanguage?: Locale | null;
   acceptLanguage?: string | null;
 }): Locale {
-  if (input.lang) return pick(input.lang);
+  const asked = shippedLocale(input.lang);
+  if (asked) return asked;
   if (input.configLanguage) return input.configLanguage;
   return pick(input.acceptLanguage ?? "");
 }

--- a/apps/web/lib/locale.ts
+++ b/apps/web/lib/locale.ts
@@ -1,5 +1,6 @@
 import { cookies, headers } from 'next/headers';
 import type { Locale } from '@quill/shared';
+import { resolveFormLocale } from './form-locale';
 
 /** Persisted admin-UI language choice (F8 parity with the old app's toggle). */
 export const LOCALE_COOKIE = 'quill_locale';
@@ -43,11 +44,14 @@ export async function preferredLocale(): Promise<Locale> {
 }
 
 /**
- * Public-surface locale (no admin cookie there): an explicit ?lang= wins,
- * otherwise the browser's Accept-Language decides. Defaults to English.
+ * Public-surface locale (no admin cookie there): an explicit ?lang= wins, then
+ * the form's own language, then the browser's Accept-Language. Defaults to
+ * English. See `resolveFormLocale` for the matrix.
  */
-export async function publicLocale(lang?: string): Promise<Locale> {
-  const pick = (v: string) => (v.trim().toLowerCase().startsWith('es') ? 'es' : 'en') as Locale;
-  if (lang) return pick(lang);
-  return pick((await headers()).get('accept-language') ?? '');
+export async function publicLocale(lang?: string, configLanguage?: Locale | null): Promise<Locale> {
+  return resolveFormLocale({
+    lang,
+    configLanguage,
+    acceptLanguage: (await headers()).get('accept-language'),
+  });
 }

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -570,6 +570,16 @@ export function publicTitle(config: { title?: string | null } | null | undefined
   return t ? t : name;
 }
 
+/** The languages the public form ships. Mirrors @quill/shared `Locale`. */
+export type FormLanguage = 'en' | 'es';
+
+/** Form-level overrides for the renderer's navigation buttons. */
+export interface FormLabels {
+  back?: string | null;
+  next?: string | null;
+  submit?: string | null;
+}
+
 export interface FormConfig {
   version: 1;
   /**
@@ -584,6 +594,10 @@ export interface FormConfig {
   cover?: FormCover | null;
   /** Presentation layout for the public form. Absent = `'slides'` (back-compat). */
   layout?: FormLayout;
+  /** Public chrome language. Absent/null = Auto (the visitor's browser). */
+  language?: FormLanguage | null;
+  /** Form-level button copy; a step's `buttonText` still wins for that step. */
+  labels?: FormLabels | null;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];

--- a/packages/shared/src/form-labels.spec.ts
+++ b/packages/shared/src/form-labels.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { resolveFormLabels } from "./form-labels";
+
+describe("resolveFormLabels", () => {
+  it("falls back to the stock renderer copy of the locale", () => {
+    expect(resolveFormLabels({}, "en")).toEqual({
+      back: "Back",
+      next: "Next",
+      submit: "Submit",
+      start: "Start",
+    });
+    expect(resolveFormLabels({}, "es")).toEqual({
+      back: "Atrás",
+      next: "Siguiente",
+      submit: "Enviar",
+      start: "Comenzar",
+    });
+  });
+
+  it("a form-level override wins over the stock copy, trimmed", () => {
+    const labels = resolveFormLabels(
+      { labels: { next: "  Continue  ", submit: "Send it" } },
+      "es",
+    );
+    expect(labels.next).toBe("Continue");
+    expect(labels.submit).toBe("Send it");
+    expect(labels.back).toBe("Atrás");
+  });
+
+  it("a blank or null override is no override", () => {
+    expect(
+      resolveFormLabels({ labels: { next: "   ", back: null } }, "en").next,
+    ).toBe("Next");
+    expect(resolveFormLabels({ labels: null }, "en").back).toBe("Back");
+  });
+
+  it("the cover CTA keeps its own field", () => {
+    expect(resolveFormLabels({ cover: { ctaText: "Go" } }, "en").start).toBe(
+      "Go",
+    );
+    expect(resolveFormLabels({ cover: { ctaText: "  " } }, "es").start).toBe(
+      "Comenzar",
+    );
+  });
+});

--- a/packages/shared/src/form-labels.ts
+++ b/packages/shared/src/form-labels.ts
@@ -1,0 +1,43 @@
+import { getMessages, type Locale } from "./i18n";
+
+/** What the renderer prints on its navigation buttons. */
+export interface ResolvedFormLabels {
+  back: string;
+  next: string;
+  submit: string;
+  /** The cover CTA: `cover.ctaText`, else the stock "Start". */
+  start: string;
+}
+
+/** The slice of a form config this resolver reads (engine and types both fit). */
+export interface FormLabelSource {
+  labels?: {
+    back?: string | null;
+    next?: string | null;
+    submit?: string | null;
+  } | null;
+  cover?: { ctaText?: string | null } | null;
+}
+
+function pick(override: string | null | undefined, fallback: string): string {
+  const trimmed = override?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+/**
+ * The button copy for a form in a locale: the author's form-level override
+ * where set (trimmed), the stock renderer copy otherwise. One resolver for
+ * both renderers and the builder preview, so they can never disagree.
+ */
+export function resolveFormLabels(
+  config: FormLabelSource,
+  locale: Locale,
+): ResolvedFormLabels {
+  const m = getMessages(locale).renderer;
+  return {
+    back: pick(config.labels?.back, m.back),
+    next: pick(config.labels?.next, m.next),
+    submit: pick(config.labels?.submit, m.submit),
+    start: pick(config.cover?.ctaText, m.start),
+  };
+}

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -58,6 +58,13 @@ export interface FormsMessages {
     dropdownEmpty: string;
     trustedBy: string;
     newTab: string;
+    /** The public error boundary and the 404, in the visitor's language. */
+    errorTitle: string;
+    errorBody: string;
+    errorRetry: string;
+    notFoundTitle: string;
+    notFoundBody: string;
+    notFoundHome: string;
     /** Scheduler step (V6): copy for an unconfigured embed + the optional skip. */
     schedulerUnconfigured: string;
     schedulerSkip: string;
@@ -937,6 +944,17 @@ export interface FormsMessages {
       };
       /** The Design tab: everything about how the form looks. */
       design: {
+        /** Form language (Auto / English / Spanish) and the button copy overrides. */
+        languageTitle: string;
+        languageHint: string;
+        languageAuto: string;
+        languageEn: string;
+        languageEs: string;
+        labelsTitle: string;
+        labelsHint: string;
+        labelBack: string;
+        labelNext: string;
+        labelSubmit: string;
         publicTitle: string;
         publicTitleHint: string;
         presetsTitle: string;
@@ -1693,6 +1711,12 @@ export const en: FormsMessages = {
     dropdownEmpty: 'No results found',
     trustedBy: 'Trusted by',
     newTab: '(opens in a new tab)',
+    errorTitle: 'This page didn\u2019t load',
+    errorBody: 'Something went wrong reaching the forms service.',
+    errorRetry: 'Try again',
+    notFoundTitle: 'Not found',
+    notFoundBody: 'This page doesn\u2019t exist.',
+    notFoundHome: 'Go home',
     schedulerUnconfigured: 'This scheduler has not been set up yet.',
     schedulerSkip: 'Skip for now',
     booking: {
@@ -2461,6 +2485,17 @@ export const en: FormsMessages = {
         next: 'Next screen',
       },
       design: {
+        languageTitle: 'Language',
+        languageHint:
+          'The language of the buttons, progress and thank-you copy visitors see. Auto follows each visitor\u2019s browser. A ?lang= link still wins.',
+        languageAuto: 'Auto (visitor\u2019s browser)',
+        languageEn: 'English',
+        languageEs: 'Spanish',
+        labelsTitle: 'Button text',
+        labelsHint: 'Replace the default button copy for this form. Leave empty to keep the default for the language. A question\u2019s own button text still wins on that question.',
+        labelBack: 'Back',
+        labelNext: 'Next',
+        labelSubmit: 'Submit',
         publicTitle: 'Form title',
         publicTitleHint:
           'What visitors see. The browser tab, share previews, and the cover heading. Leave empty to use the form\u2019s internal name.',
@@ -3173,6 +3208,12 @@ export const es: FormsMessages = {
     dropdownEmpty: 'No se encontraron resultados',
     trustedBy: 'Confían en nosotros',
     newTab: '(se abre en una pestaña nueva)',
+    errorTitle: 'Esta página no cargó',
+    errorBody: 'Algo falló al conectar con el servicio de formularios.',
+    errorRetry: 'Intentar de nuevo',
+    notFoundTitle: 'No encontrado',
+    notFoundBody: 'Esta página no existe.',
+    notFoundHome: 'Ir al inicio',
     schedulerUnconfigured: 'Este agendador aún no está configurado.',
     schedulerSkip: 'Omitir por ahora',
     booking: {
@@ -3943,6 +3984,17 @@ export const es: FormsMessages = {
         next: 'Pantalla siguiente',
       },
       design: {
+        languageTitle: 'Idioma',
+        languageHint:
+          'El idioma de los botones, el progreso y el mensaje de gracias que ven los visitantes. Auto sigue el navegador de cada visitante. Un enlace con ?lang= sigue ganando.',
+        languageAuto: 'Auto (navegador del visitante)',
+        languageEn: 'Inglés',
+        languageEs: 'Español',
+        labelsTitle: 'Texto de los botones',
+        labelsHint: 'Reemplaza el texto predeterminado de los botones de este formulario. Déjalo vacío para usar el predeterminado del idioma. El texto propio de una pregunta sigue ganando en esa pregunta.',
+        labelBack: 'Atrás',
+        labelNext: 'Siguiente',
+        labelSubmit: 'Enviar',
         publicTitle: 'Título del formulario',
         publicTitleHint:
           'Lo que ven los visitantes: la pestaña del navegador, las vistas previas al compartir y el encabezado de portada. Déjalo vacío para usar el nombre interno del formulario.',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './growth';
 export * from './nav';
 export * from './countries';
 export * from './i18n';
+export * from './form-labels';

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -198,7 +198,7 @@ describe('hasExtraHubspotDestination', () => {
   });
 });
 
-describe('formConfigSchema — form language and button labels (additive)', () => {
+describe('formConfigSchema: form language and button labels (additive)', () => {
   it('a legacy config parses with neither field set (Auto language, stock labels)', () => {
     const parsed = formConfigSchema.parse(baseConfig());
     expect(parsed.language).toBeUndefined();
@@ -227,7 +227,7 @@ describe('formConfigSchema — form language and button labels (additive)', () =
   });
 });
 
-describe('submissionSchema — the locale the respondent saw (additive)', () => {
+describe('submissionSchema: the locale the respondent saw (additive)', () => {
   it('carries an optional locale and rejects an unknown one', () => {
     expect(submissionSchema.parse({ sessionId: 's', data: {} }).locale).toBeUndefined();
     expect(submissionSchema.parse({ sessionId: 's', data: {}, locale: 'es' }).locale).toBe('es');

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -9,7 +9,7 @@
  * has somewhere obvious to prove the same thing.
  */
 import { describe, expect, it } from 'vitest';
-import { formConfigSchema, hasExtraHubspotDestination } from './index';
+import { formConfigSchema, hasExtraHubspotDestination, submissionSchema } from './index';
 
 /** The smallest config the schema accepts — one step, nothing configured. */
 function baseConfig() {
@@ -195,5 +195,42 @@ describe('hasExtraHubspotDestination', () => {
     it('still ignores webhooks on both sides', () => {
       expect(hasExtraHubspotDestination([webhook, webhook, hubspot], [hubspot])).toBe(false);
     });
+  });
+});
+
+describe('formConfigSchema — form language and button labels (additive)', () => {
+  it('a legacy config parses with neither field set (Auto language, stock labels)', () => {
+    const parsed = formConfigSchema.parse(baseConfig());
+    expect(parsed.language).toBeUndefined();
+    expect(parsed.labels).toBeUndefined();
+  });
+
+  it('keeps an explicit language and partial labels', () => {
+    const parsed = formConfigSchema.parse({
+      ...baseConfig(),
+      language: 'es',
+      labels: { next: 'Siguiente' },
+    });
+    expect(parsed.language).toBe('es');
+    expect(parsed.labels).toEqual({ next: 'Siguiente' });
+  });
+
+  it('accepts null for both (the editor clears back to Auto / stock this way)', () => {
+    const parsed = formConfigSchema.parse({ ...baseConfig(), language: null, labels: null });
+    expect(parsed.language).toBeNull();
+    expect(parsed.labels).toBeNull();
+  });
+
+  it('rejects a language the product does not ship and a label over 80 characters', () => {
+    expect(() => formConfigSchema.parse({ ...baseConfig(), language: 'fr' })).toThrow();
+    expect(() => formConfigSchema.parse({ ...baseConfig(), labels: { submit: 'x'.repeat(81) } })).toThrow();
+  });
+});
+
+describe('submissionSchema — the locale the respondent saw (additive)', () => {
+  it('carries an optional locale and rejects an unknown one', () => {
+    expect(submissionSchema.parse({ sessionId: 's', data: {} }).locale).toBeUndefined();
+    expect(submissionSchema.parse({ sessionId: 's', data: {}, locale: 'es' }).locale).toBe('es');
+    expect(() => submissionSchema.parse({ sessionId: 's', data: {}, locale: 'fr' })).toThrow();
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1089,6 +1089,26 @@ export const formConfigSchema = z.object({
    * config, which then renders as `'slides'`, exactly as it always has).
    */
   layout: z.enum(FORM_LAYOUTS).optional(),
+  /**
+   * The language the public form renders its chrome in: buttons, progress,
+   * thank-you copy, the confirmation email. ADDITIVE: absent or null = Auto,
+   * the visitor's browser decides, exactly as before this field existed. An
+   * explicit `?lang` on the URL still wins over both.
+   */
+  language: localeSchema.nullable().optional(),
+  /**
+   * Form-level button copy overriding the localized defaults (ADDITIVE).
+   * A step's own `buttonText` still wins for that step; the cover CTA keeps
+   * `cover.ctaText`. Blank or null = the stock label for the language.
+   */
+  labels: z
+    .object({
+      back: z.string().max(80).nullable().optional(),
+      next: z.string().max(80).nullable().optional(),
+      submit: z.string().max(80).nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),
@@ -1203,6 +1223,12 @@ export const submissionSchema = z.object({
   data: submissionAnswersSchema,
   /** True for an intermediate (partial) save; false/absent = final submit. */
   partial: z.boolean().optional(),
+  /**
+   * The language the respondent actually saw (the page resolved `?lang`, the
+   * form language and the browser; the API knows none of those). Drives the
+   * confirmation email. Absent = the form language, then English.
+   */
+  locale: localeSchema.optional(),
 });
 export type SubmissionInput = z.infer<typeof submissionSchema>;
 


### PR DESCRIPTION
## Why

The public form's chrome (Start, Back, Next, Submit, the progress counter, the thank-you copy, the confirmation email) followed each visitor's browser, and the author had no way to decide. Small things like the button text came out in a language the owner never chose.

## What

Two additive config fields. A form saved before they existed renders exactly as it did.

- **`config.language`** (`en` | `es`, absent = Auto). Precedence on the public page: `?lang=` on the URL, then the form's language, then the browser, then English. The page description, the social card, the `lang` attribute on the form's subtree and the respondent's confirmation email follow the same resolution: the submission now carries the locale the respondent saw, and the API uses it (else the form language) for the receipt.
- **`config.labels`** (`back`, `next`, `submit`, up to 80 characters each). A step's own `buttonText` still wins for that step; the cover keeps `cover.ctaText`. `resolveFormLabels(config, locale)` in `@quill/shared` is the single resolver both renderers and the builder preview use.
- **Design tab**: a Language selector (Auto / English / Spanish) and Button text fields (Submit only on the one-page layout) at the top of the panel, with the stock copy of the chosen language as placeholders. The live preview and the Preview modal render in the FORM's language, not the editor's.
- **New forms** are stamped with their author's language (dashboard "New form" and the onboarding wizard alike). Existing forms stay on Auto.
- The public **error boundary and the 404** speak the visitor's language.
- i18n: `admin.editor.design.language*` / `labels*` / `label*`, `renderer.error*` / `notFound*` (EN + ES).

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (16/16) and `pnpm build` pass; dash-check clean.
- New specs: `form-config.spec.ts` (schema), `form-labels.spec.ts`, `form-locale.spec.ts`, `client-locale.spec.ts`, `form-labels.spec.tsx` (both renderers through static markup), `protocol.spec.ts` (locale narrowing), `submission.service.spec.ts` (receipt locale precedence).
- `build + start`: with `Accept-Language: es-CO` the page wraps the form in `lang="es"`; `?lang=en` overrides it; a form set to Spanish renders `lang="es"` and its custom Submit label for an English browser; the 404 answers in Spanish; a submission sent with `locale: 'es'` enqueues the receipt with `locale: 'es'`. The Design tab shows Language = Español, the three label fields with Spanish placeholders and the custom value, and the preview iframe carries `lang="es"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
