### PR TITLE
feat(workspace): one shared timezone for dates, analytics day cuts and the CSV local columns

### DIFF
--- a/.changeset/workspace-timezone.md
+++ b/.changeset/workspace-timezone.md
@@ -1,0 +1,43 @@
+---
+'@quill/db': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+A workspace timezone: every date in the admin, the analytics day cuts and the CSV local columns read in one shared zone.
+
+Until now every timestamp in the dashboard was rendered on the server's clock
+(UTC) and the analytics buckets were UTC days, so a team in Bogota read its
+evening submissions as tomorrow's. The workspace now carries one IANA zone
+(`account.timezone`, migration 0020) that everyone in it shares.
+
+- **Default**: the first owner or admin to open the dashboard while the zone
+  is unset seeds it from their browser (a write-once claim, so two admins in
+  different zones cannot flip it), with a toast saying where to change it.
+  Staff entering an estate workspace never seed it. Until then dates read in
+  UTC, exactly as before.
+- **Two places to change it**, both writing the same column through
+  `PATCH /v1/workspaces/current/timezone` (admin/owner): Account settings,
+  under the workspace name, and a dropdown beside the submissions filter.
+  A member sees the zone with a lock and the note that only an admin can
+  change it.
+- **Dates**: the forms list, the submissions table, the delivery history,
+  the webhook health line and the brand kit stamp all go through
+  `formatDateTime` / `formatDate` in `@quill/shared` (Intl only; an unknown
+  zone renders as UTC with a warning, never a 500).
+- **Analytics**: day buckets are named in the workspace zone inside SQL
+  (`(col + offset) / 86400000` with the offset picked by a CASE over the DST
+  boundaries of the queried window), the range presets and custom dates cut
+  at local midnight, the picker's "today" is the zone's today, `?tz=` can
+  override per request, the response echoes `range.timeZone`, and a caption
+  under the trends chart names the zone.
+- **CSV export** keeps `started_at` / `completed_at` in UTC (`Z`) and adds
+  `started_at_local` / `completed_at_local` as ISO with the zone offset
+  (`2026-09-03T18:30:15-05:00`).
+- `@quill/shared`: `datetime.ts` (`isValidTimeZone`, `resolveTimeZone`,
+  `tzOffsetMs`, `localDayIndex`, `zonedMidnightMs`, `dayBoundsInZone`,
+  `isoDateInZone`, `utcOffsetSegments`, `formatDateTime`, `formatDate`,
+  `formatIsoWithOffset`). `@quill/types`: `timeZoneSchema`,
+  `workspaceTimezoneSchema`, `analyticsResponseSchema.range.timeZone`.
+- i18n: `admin.settings.workspaceTimezone*`, `admin.submissions.timezone*`,
+  `admin.analytics.timezoneNote`, `admin.chrome.timezoneAutoSet` (EN + ES).

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -73,6 +73,7 @@ import {
   onboardingProgressSchema,
   workspaceCreateSchema,
   workspaceRenameSchema,
+  workspaceTimezoneSchema,
 } from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
@@ -336,6 +337,17 @@ export class AdminCrudController {
   async renameWorkspace(@Req() req: ReqLike, @Body() body: unknown) {
     const input = parse(workspaceRenameSchema, body);
     return this.ws().rename(req, input);
+  }
+
+  /**
+   * Set the workspace's timezone (admin/owner). Its own route rather than a
+   * field on `PATCH workspaces/current`: that one goes upstream to the identity
+   * service, which has no zone, and this one never leaves this database.
+   */
+  @Patch('workspaces/current/timezone')
+  async setWorkspaceTimezone(@Req() req: ReqLike, @Body() body: unknown) {
+    const input = parse(workspaceTimezoneSchema, body);
+    return this.ws().setTimezone(req, input);
   }
 
   /**

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   Inject,
+  Logger,
   NotFoundException,
   Param,
   Query,
@@ -39,6 +40,8 @@ function iso(ms: number | null): string {
  */
 @Controller('v1')
 export class AnalyticsController {
+  private readonly log = new Logger('AnalyticsController');
+
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(AuthService) private readonly auth: AuthService,
@@ -59,7 +62,9 @@ export class AnalyticsController {
     @Query('tz') tz?: string,
   ) {
     const p = await this.auth.resolveHost(req);
-    const zone = resolveTimeZone(parseTimeZone(tz) ?? (await getAccountTimezone(this.db, p.accountId)));
+    const zone = resolveTimeZone(parseTimeZone(tz) ?? (await getAccountTimezone(this.db, p.accountId)), (m) =>
+      this.log.warn(m),
+    );
     const result = await this.analytics.funnel(
       p.accountId,
       id,
@@ -97,7 +102,7 @@ export class AnalyticsController {
     const stepKeys = (config.steps ?? []).map((s) => s.key);
     const filename = `${form.slug || 'submissions'}-submissions.csv`;
     // An unknown stored zone exports as UTC (+00:00) rather than failing the download.
-    const zone = resolveTimeZone(await getAccountTimezone(this.db, p.accountId));
+    const zone = resolveTimeZone(await getAccountTimezone(this.db, p.accountId), (m) => this.log.warn(m));
     const local = (ms: number | null) => (ms == null ? '' : formatIsoWithOffset(ms, zone));
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -11,13 +11,14 @@ import {
   Res,
 } from '@nestjs/common';
 import type { Db } from '@quill/db';
-import { getFormById } from '@quill/db';
+import { getAccountTimezone, getFormById } from '@quill/db';
+import { formatIsoWithOffset, resolveTimeZone } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
 import { AuthService, type ReqLike } from './auth.service';
 import { AnalyticsService } from './analytics.service';
 import { DB } from './tokens';
 import { csvRow } from './csv';
-import { parseBound, parseStatus } from './query-params';
+import { parseBound, parseStatus, parseTimeZone } from './query-params';
 
 /** A minimal response shape (structurally satisfied by the express Response). */
 interface StreamRes {
@@ -44,19 +45,27 @@ export class AnalyticsController {
     @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
   ) {}
 
-  /** Funnel metrics + per-step drop-off for a form over an optional date range. */
+  /**
+   * Funnel metrics + per-step drop-off for a form over an optional date range.
+   * Days are named in `?tz=`, else the workspace's zone, else UTC; a bare
+   * `YYYY-MM-DD` bound is a whole day in that zone.
+   */
   @Get('forms/:id/analytics')
   async formAnalytics(
     @Req() req: ReqLike,
     @Param('id') id: string,
     @Query('from') from?: string,
     @Query('to') to?: string,
+    @Query('tz') tz?: string,
   ) {
     const p = await this.auth.resolveHost(req);
-    const result = await this.analytics.funnel(p.accountId, id, {
-      from: parseBound(from, false),
-      to: parseBound(to, true),
-    });
+    const zone = resolveTimeZone(parseTimeZone(tz) ?? (await getAccountTimezone(this.db, p.accountId)));
+    const result = await this.analytics.funnel(
+      p.accountId,
+      id,
+      { from: parseBound(from, false, zone), to: parseBound(to, true, zone) },
+      zone,
+    );
     if (!result) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
     return result;
   }
@@ -64,6 +73,9 @@ export class AnalyticsController {
   /**
    * Stream the form's submissions as CSV. Answers flatten to one column per
    * configured step key (form config order), after the fixed metadata columns.
+   * `started_at` / `completed_at` stay UTC ISO (`Z`), and `*_local` twins carry
+   * the same instants read in the workspace's zone with their offset, so a
+   * spreadsheet shows the team's clock without losing the machine one.
    * Uses the un-paginated export query (`allSubmissionsForExport`) — the table
    * query caps `limit` at 200, so paging through it would silently truncate and
    * skip rows on large exports. Rows are still written incrementally.
@@ -84,17 +96,32 @@ export class AnalyticsController {
     const config = form.config as FormConfig;
     const stepKeys = (config.steps ?? []).map((s) => s.key);
     const filename = `${form.slug || 'submissions'}-submissions.csv`;
+    // An unknown stored zone exports as UTC (+00:00) rather than failing the download.
+    const zone = resolveTimeZone(await getAccountTimezone(this.db, p.accountId));
+    const local = (ms: number | null) => (ms == null ? '' : formatIsoWithOffset(ms, zone));
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.setHeader('Cache-Control', 'no-store');
 
-    res.write(csvRow(['id', 'session_id', 'status', 'score', 'started_at', 'completed_at', ...stepKeys]));
+    res.write(
+      csvRow([
+        'id',
+        'session_id',
+        'status',
+        'score',
+        'started_at',
+        'completed_at',
+        'started_at_local',
+        'completed_at_local',
+        ...stepKeys,
+      ]),
+    );
 
     const rows = await this.analytics.exportSubmissions(id, {
       status: parseStatus(status),
-      from: parseBound(from, false),
-      to: parseBound(to, true),
+      from: parseBound(from, false, zone),
+      to: parseBound(to, true, zone),
     });
     for (const s of rows) {
       const data = (s.data ?? {}) as Record<string, unknown>;
@@ -107,6 +134,8 @@ export class AnalyticsController {
           s.score,
           iso(s.startedAt),
           iso(s.completedAt),
+          local(s.startedAt),
+          local(s.completedAt),
           ...stepKeys.map((k) => data[k]),
         ]),
       );

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -594,3 +594,77 @@ describe('parseIntParam (NaN guard for limit/offset)', () => {
     expect(page.items.length).toBeGreaterThan(0);
   });
 });
+
+describe('workspace timezone: day cuts and the CSV local columns', () => {
+  const HOUR = 3_600_000;
+  // D1 = a UTC midnight; a submission at D1 + 2h is the PREVIOUS day in Bogota.
+  const D1 = Math.floor(NOW / DAY) * DAY + 10 * DAY;
+
+  it('buckets a submission at D1+2h into the previous day in Bogota, and names the zone', async () => {
+    await insertSubmission({
+      session: 'tz-1',
+      data: { role: 'founder' },
+      score: 10,
+      startedAt: D1 + HOUR,
+      completedAt: D1 + 2 * HOUR,
+    });
+    const utc = await svc.funnel(accountId, formId, { from: D1 - DAY, to: D1 + DAY - 1 });
+    const bogota = await svc.funnel(accountId, formId, { from: D1 - DAY, to: D1 + DAY - 1 }, 'America/Bogota');
+    const dayOf = (r: typeof utc, t: number) => r!.trends.find((p) => p.t === t)?.submissions ?? 0;
+    expect(dayOf(utc, D1)).toBe(1);
+    expect(dayOf(utc, D1 - DAY)).toBe(0);
+    expect(dayOf(bogota, D1 - DAY)).toBe(1);
+    expect(dayOf(bogota, D1)).toBe(0);
+    expect(bogota!.range.timeZone).toBe('America/Bogota');
+    expect(utc!.range.timeZone).toBe('UTC');
+  });
+
+  it('an unknown zone resolves as UTC rather than failing the request', async () => {
+    const r = await svc.funnel(accountId, formId, {}, 'Mars/Olympus');
+    expect(r!.range.timeZone).toBe('UTC');
+  });
+
+  it('the CSV keeps the UTC columns and adds started_at_local / completed_at_local in the zone', async () => {
+    await db.run(sql`UPDATE account SET timezone = 'America/Bogota' WHERE id = ${accountId}`);
+    await insertSubmission({
+      session: 'tz-csv',
+      data: { role: 'founder' },
+      score: 10,
+      startedAt: Date.UTC(2026, 8, 3, 23, 30),
+      completedAt: Date.UTC(2026, 8, 4, 0, 15),
+    });
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: 'test-member', role: 'owner' as const }),
+    } as unknown as AuthService;
+    const ctrl = new AnalyticsController(db, auth, svc);
+    const chunks: string[] = [];
+    const res = { setHeader: () => {}, write: (c: string) => void chunks.push(c), end: () => {} };
+    await ctrl.exportCsv({ headers: {} }, res, formId, undefined, undefined, undefined);
+    const lines = chunks.join('').trimEnd().split('\r\n');
+    expect(lines[0]).toMatch(/^id,session_id,status,score,started_at,completed_at,started_at_local,completed_at_local,/);
+    const row = lines.find((l) => l.includes('tz-csv'))!;
+    expect(row).toContain('2026-09-03T23:30:00.000Z');
+    expect(row).toContain('2026-09-03T18:30:00-05:00');
+    expect(row).toContain('2026-09-03T19:15:00-05:00');
+  });
+
+  it('an invalid workspace zone exports local columns as +00:00', async () => {
+    await db.run(sql`UPDATE account SET timezone = 'Mars/Olympus' WHERE id = ${accountId}`);
+    await insertSubmission({
+      session: 'tz-bad',
+      data: { role: 'founder' },
+      score: 10,
+      startedAt: Date.UTC(2026, 8, 3, 23, 30),
+      completedAt: Date.UTC(2026, 8, 3, 23, 45),
+    });
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: 'test-member', role: 'owner' as const }),
+    } as unknown as AuthService;
+    const ctrl = new AnalyticsController(db, auth, svc);
+    const chunks: string[] = [];
+    const res = { setHeader: () => {}, write: (c: string) => void chunks.push(c), end: () => {} };
+    await ctrl.exportCsv({ headers: {} }, res, formId, undefined, undefined, undefined);
+    const row = chunks.join('').split('\r\n').find((l) => l.includes('tz-bad'))!;
+    expect(row).toContain('2026-09-03T23:30:00+00:00');
+  });
+});

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { localDayIndex, resolveTimeZone, utcOffsetSegments } from '@quill/shared';
 import { resolveFormLayout } from '@quill/engine';
 import type { Db } from '@quill/db';
@@ -158,6 +158,8 @@ function buildTrends(input: {
  */
 @Injectable()
 export class AnalyticsService {
+  private readonly log = new Logger('AnalyticsService');
+
   constructor(@Inject(DB) private readonly db: Db) {}
 
   /**
@@ -186,7 +188,7 @@ export class AnalyticsService {
   ): Promise<AnalyticsResponse | null> {
     const form = await getFormById(this.db, accountId, formId);
     if (!form) return null;
-    const zone = resolveTimeZone(timeZone);
+    const zone = resolveTimeZone(timeZone, (m) => this.log.warn(m));
     const bucketing = await this.bucketingFor(formId, range, zone);
     const config = form.config as FormConfig;
     const steps = config.steps ?? [];

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { localDayIndex, resolveTimeZone, utcOffsetSegments } from '@quill/shared';
 import { resolveFormLayout } from '@quill/engine';
 import type { Db } from '@quill/db';
 import {
@@ -20,6 +21,8 @@ import {
   type DateRange,
   type DeleteSubmissionResult,
   type SubmissionQuery,
+  firstEventAt,
+  type DayBucketing,
 } from '@quill/db';
 import type {
   AnalyticsResponse,
@@ -93,6 +96,8 @@ const MAX_TREND_DAYS = 366;
  */
 function buildTrends(input: {
   range: DateRange;
+  /** The zone the day buckets were named in (`'UTC'` = the historical behavior). */
+  zone: string;
   dailyViews: { day: number; n: number }[];
   dailyStarts: { day: number; n: number }[];
   completed: CompletedSubmission[];
@@ -119,8 +124,11 @@ function buildTrends(input: {
 
   // Bound by the explicit range when one was given (so "last 30 days" plots 30
   // points even where nothing happened), else by the observed activity span.
-  const fromDay = input.range.from != null ? Math.floor(input.range.from / DAY_MS) : Math.min(...observed);
-  const toDay = input.range.to != null ? Math.floor(input.range.to / DAY_MS) : Math.max(...observed);
+  // The same day naming as the SQL buckets: `localDayIndex` is the JS twin of
+  // the `(col + offset) / 86400000` expression, so the window's edges and the
+  // buckets agree in every zone.
+  const fromDay = input.range.from != null ? localDayIndex(input.range.from, input.zone) : Math.min(...observed);
+  const toDay = input.range.to != null ? localDayIndex(input.range.to, input.zone) : Math.max(...observed);
   if (toDay < fromDay) return [];
 
   const span = Math.min(toDay - fromDay, MAX_TREND_DAYS - 1);
@@ -152,10 +160,34 @@ function buildTrends(input: {
 export class AnalyticsService {
   constructor(@Inject(DB) private readonly db: Db) {}
 
-  /** Funnel summary + question-by-question drop-off for a form over a range. */
-  async funnel(accountId: string, formId: string, range: DateRange): Promise<AnalyticsResponse | null> {
+  /**
+   * The offset segments that let SQL name calendar days in `zone` across the
+   * queried window (one day of slack on each side, so an edge event whose
+   * local day differs from its UTC day is still covered). UTC needs none: the
+   * absent bucketing is the exact SQL this always ran.
+   */
+  private async bucketingFor(formId: string, range: DateRange, zone: string): Promise<DayBucketing | undefined> {
+    if (zone === 'UTC') return undefined;
+    const from = range.from ?? (await firstEventAt(this.db, formId)) ?? Date.now();
+    const to = range.to ?? Date.now();
+    return { segments: utcOffsetSegments(from - DAY_MS, to + DAY_MS, zone) };
+  }
+
+  /**
+   * Funnel summary + question-by-question drop-off for a form over a range.
+   * `timeZone` names the calendar days of the trend buckets (and is echoed
+   * back as `range.timeZone`); absent or unknown = UTC, the historical rule.
+   */
+  async funnel(
+    accountId: string,
+    formId: string,
+    range: DateRange,
+    timeZone?: string | null,
+  ): Promise<AnalyticsResponse | null> {
     const form = await getFormById(this.db, accountId, formId);
     if (!form) return null;
+    const zone = resolveTimeZone(timeZone);
+    const bucketing = await this.bucketingFor(formId, range, zone);
     const config = form.config as FormConfig;
     const steps = config.steps ?? [];
     // Vertical shows every question on one page, so "viewed step X" fires for
@@ -173,9 +205,9 @@ export class AnalyticsService {
           : stepViewCounts(this.db, formId, range),
         partialCount(this.db, formId, range),
         bookingCount(this.db, formId, range),
-        completedSubmissions(this.db, formId, range),
-        dailyViewSessions(this.db, formId, range),
-        dailyStartSessions(this.db, formId, range),
+        completedSubmissions(this.db, formId, range, bucketing),
+        dailyViewSessions(this.db, formId, range, bucketing),
+        dailyStartSessions(this.db, formId, range, bucketing),
       ]);
 
     // One completed-submission read feeds the total, the median and the trend.
@@ -187,7 +219,7 @@ export class AnalyticsService {
     // Median open→complete in whole seconds, or null when no session in range
     // had a derivable open time (never 0 — that would be a fabricated fact).
     const timeToComplete = medianSeconds(durations);
-    const trends = buildTrends({ range, dailyViews, dailyStarts, completed });
+    const trends = buildTrends({ range, zone, dailyViews, dailyStarts, completed });
 
     // rowViews[0] = form views (the cover/landing); rowViews[i+1] = views of
     // step i. Looked up by the step's KEY first (V5-D3) — stable regardless of
@@ -249,7 +281,7 @@ export class AnalyticsService {
       dropoffMode,
       dropoff,
       trends,
-      range: { from: range.from ?? null, to: range.to ?? null },
+      range: { from: range.from ?? null, to: range.to ?? null, timeZone: zone },
     };
   }
 

--- a/apps/api/src/query-params.spec.ts
+++ b/apps/api/src/query-params.spec.ts
@@ -27,9 +27,9 @@ describe("parseBound", () => {
 });
 
 describe("parseTimeZone", () => {
-  it("returns a known zone, UTC for an unknown one, and null when absent", () => {
+  it("returns a known zone, and null for an unknown or absent one (the workspace zone applies)", () => {
     expect(parseTimeZone("America/Bogota")).toBe("America/Bogota");
-    expect(parseTimeZone("Mars/Olympus")).toBe("UTC");
+    expect(parseTimeZone("Mars/Olympus")).toBeNull();
     expect(parseTimeZone(undefined)).toBeNull();
     expect(parseTimeZone("")).toBeNull();
   });

--- a/apps/api/src/query-params.spec.ts
+++ b/apps/api/src/query-params.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseBound, parseTimeZone } from "./query-params";
+
+describe("parseBound", () => {
+  it("passes epoch-ms through and reads ISO instants as-is", () => {
+    expect(parseBound("1700000000000", false)).toBe(1700000000000);
+    expect(parseBound("2026-09-03T10:00:00.000Z", false)).toBe(
+      Date.UTC(2026, 8, 3, 10),
+    );
+    expect(parseBound(undefined, false)).toBeNull();
+    expect(parseBound("nope", false)).toBeNull();
+  });
+
+  it("snaps a bare date to the day bounds in UTC by default", () => {
+    expect(parseBound("2026-09-03", false)).toBe(Date.UTC(2026, 8, 3));
+    expect(parseBound("2026-09-03", true)).toBe(Date.UTC(2026, 8, 4) - 1);
+  });
+
+  it("snaps a bare date to the day bounds in the given zone", () => {
+    expect(parseBound("2026-09-03", false, "America/Bogota")).toBe(
+      Date.UTC(2026, 8, 3, 5),
+    );
+    expect(parseBound("2026-09-03", true, "America/Bogota")).toBe(
+      Date.UTC(2026, 8, 4, 5) - 1,
+    );
+  });
+});
+
+describe("parseTimeZone", () => {
+  it("returns a known zone, UTC for an unknown one, and null when absent", () => {
+    expect(parseTimeZone("America/Bogota")).toBe("America/Bogota");
+    expect(parseTimeZone("Mars/Olympus")).toBe("UTC");
+    expect(parseTimeZone(undefined)).toBeNull();
+    expect(parseTimeZone("")).toBeNull();
+  });
+});

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -25,14 +25,15 @@ export function parseBound(v: string | undefined, endOfDay: boolean, zone: strin
 }
 
 /**
- * Narrow a `?tz=` query to a zone this server can resolve. Absent → null (the
- * caller falls back to the workspace's zone); unknown → UTC, never an error,
- * so a stale link cannot 400 an analytics page.
+ * Narrow a `?tz=` query to a zone this server can resolve. Absent or unknown
+ * → null, so the caller falls back to the workspace's zone: a mistyped or
+ * stale `tz` must neither 400 the page nor silently turn the team's days into
+ * UTC days.
  */
 export function parseTimeZone(v: string | undefined): string | null {
   const zone = v?.trim();
   if (!zone) return null;
-  return isValidTimeZone(zone) ? zone : 'UTC';
+  return isValidTimeZone(zone) ? zone : null;
 }
 
 /** Narrow a raw status query to the allowed filter (defaults to `all`). */

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -5,20 +5,34 @@
  * framework-agnostic so both controllers parse identically.
  */
 import { OUTBOX_KINDS, OUTBOX_STATUSES, type OutboxKind, type OutboxStatus, type SubmissionStatus } from '@quill/db';
+import { dayBoundsInZone, isValidTimeZone } from '@quill/shared';
 
-/** Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. */
-export function parseBound(v: string | undefined, endOfDay: boolean): number | null {
+/**
+ * Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. A
+ * bare date names a whole calendar day in `zone` (UTC when absent): its first
+ * instant, or its last with `endOfDay`.
+ */
+export function parseBound(v: string | undefined, endOfDay: boolean, zone: string = 'UTC'): number | null {
   if (!v) return null;
   if (/^\d+$/.test(v)) return Number(v);
   const t = Date.parse(v);
   if (Number.isNaN(t)) return null;
   if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
-    const d = new Date(t);
-    if (endOfDay) d.setUTCHours(23, 59, 59, 999);
-    else d.setUTCHours(0, 0, 0, 0);
-    return d.getTime();
+    const bounds = dayBoundsInZone(v, zone);
+    return endOfDay ? bounds.to : bounds.from;
   }
   return t;
+}
+
+/**
+ * Narrow a `?tz=` query to a zone this server can resolve. Absent → null (the
+ * caller falls back to the workspace's zone); unknown → UTC, never an error,
+ * so a stale link cannot 400 an analytics page.
+ */
+export function parseTimeZone(v: string | undefined): string | null {
+  const zone = v?.trim();
+  if (!zone) return null;
+  return isValidTimeZone(zone) ? zone : 'UTC';
 }
 
 /** Narrow a raw status query to the allowed filter (defaults to `all`). */

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -186,6 +186,27 @@ describe('WorkspaceService (IAM-backed)', () => {
     await expect(svc.rename(req(), { name: 'Nope' })).rejects.toBeInstanceOf(ForbiddenException);
   });
 
+  it('sets the workspace timezone locally (admin), claims only while unset, and refuses a plain member', async () => {
+    await svc.list(req());
+    const set = await svc.setTimezone(req(), { timezone: 'America/Bogota' });
+    expect(set).toEqual({ accountId: set.accountId, timezone: 'America/Bogota', applied: true });
+    const row = await db.get<{ timezone: string | null }>(sql`SELECT timezone FROM account WHERE id = ${set.accountId}`);
+    expect(row!.timezone).toBe('America/Bogota');
+
+    // A browser's write-once seed does not overwrite an explicit choice.
+    const claim = await svc.setTimezone(req(), { timezone: 'Europe/Madrid', onlyIfUnset: true });
+    expect(claim).toEqual({ accountId: set.accountId, timezone: 'America/Bogota', applied: false });
+
+    // Clearing goes back to UTC (null).
+    expect((await svc.setTimezone(req(), { timezone: null })).timezone).toBeNull();
+  });
+
+  it('a plain member cannot set the workspace timezone', async () => {
+    // Demoted upstream before the first projection, so the guard sees `member`.
+    workspaces[0]!.users![0]!.type = 'MEMBER';
+    await expect(svc.setTimezone(req(), { timezone: 'Asia/Tokyo' })).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('enter re-checks membership and writes last_workspace upstream; a stranger account is a 403', async () => {
     const list = await svc.list(req());
     await svc.enter(req(), list[0]!.accountId);

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -46,6 +46,9 @@ import {
   type MemberStatus,
   type MemberView,
   type WorkspaceRow,
+  claimAccountTimezone,
+  getAccountTimezone,
+  setAccountTimezone,
 } from '@quill/db';
 import { AUTH_PROVIDER, DB, WORKSPACE_PROJECTION } from './tokens';
 import type { AuthProvider, HostPrincipal, ReqLike, UpstreamIdentity } from './auth.provider';
@@ -243,6 +246,26 @@ export class WorkspaceService {
     }
     await renameAccount(this.db, p.accountId, name);
     return { accountId: p.accountId, name };
+  }
+
+  /**
+   * Set the workspace's timezone (admin/owner), a LOCAL fact: the identity
+   * service has no notion of a zone, so nothing goes upstream. `onlyIfUnset`
+   * is the dashboard's write-once seed from the first admin's browser: it
+   * applies only while the column is still NULL and reports whether it did.
+   */
+  async setTimezone(
+    req: ReqLike,
+    input: { timezone: string | null; onlyIfUnset?: boolean },
+  ): Promise<{ accountId: string; timezone: string | null; applied: boolean }> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    if (input.onlyIfUnset) {
+      const applied = input.timezone != null && (await claimAccountTimezone(this.db, p.accountId, input.timezone));
+      return { accountId: p.accountId, timezone: await getAccountTimezone(this.db, p.accountId), applied };
+    }
+    await setAccountTimezone(this.db, p.accountId, input.timezone);
+    return { accountId: p.accountId, timezone: input.timezone, applied: true };
   }
 
   /**

--- a/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { t } from '@quill/shared';
+import { useToast } from '@/components/toast';
+import { browserTimezone } from '@/lib/timezones';
+import { callAction } from '@/lib/call-action';
+import { claimWorkspaceTimezoneAction } from '@/app/admin/workspace-actions';
+
+/** One attempt per tab session, so a refused or slow claim is not retried on every page. */
+const CLAIM_KEY = 'forms.timezone.claimed';
+
+/**
+ * Seeds the workspace timezone from the first admin's browser. Renders
+ * nothing. Runs once per tab session, only while the workspace has no zone
+ * and the viewer may set one; the API keeps the value only while the column
+ * is still NULL, so two admins racing cannot flip it. Says so with a toast
+ * (naming where to change it) only when THIS browser's zone was the one kept.
+ */
+export function WorkspaceTimezoneBootstrap({
+  timezone,
+  canClaim,
+  message,
+}: {
+  timezone: string | null;
+  canClaim: boolean;
+  /** `admin.chrome.timezoneAutoSet`, with a `{zone}` placeholder. */
+  message: string;
+}) {
+  const toast = useToast();
+  const router = useRouter();
+  useEffect(() => {
+    if (timezone != null || !canClaim) return;
+    try {
+      if (sessionStorage.getItem(CLAIM_KEY)) return;
+      sessionStorage.setItem(CLAIM_KEY, '1');
+    } catch {
+      // No storage (private mode, hardened browser): still try once per mount.
+    }
+    const zone = browserTimezone();
+    if (!zone) return;
+    let cancelled = false;
+    void callAction(() => claimWorkspaceTimezoneAction(zone)).then((res) => {
+      if (cancelled || !res || !('applied' in res) || !res.applied) return;
+      toast.success(t(message, { zone }));
+      router.refresh();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [timezone, canClaim, message, toast, router]);
+  return null;
+}

--- a/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
@@ -8,8 +8,8 @@ import { browserTimezone } from '@/lib/timezones';
 import { callAction } from '@/lib/call-action';
 import { claimWorkspaceTimezoneAction } from '@/app/admin/workspace-actions';
 
-/** One attempt per tab session, so a refused or slow claim is not retried on every page. */
-const CLAIM_KEY = 'forms.timezone.claimed';
+/** One attempt per tab session AND workspace, so a refused or slow claim is not retried on every page. */
+const claimKey = (accountId: string) => `forms.timezone.claimed:${accountId}`;
 
 /**
  * Seeds the workspace timezone from the first admin's browser. Renders
@@ -19,10 +19,12 @@ const CLAIM_KEY = 'forms.timezone.claimed';
  * (naming where to change it) only when THIS browser's zone was the one kept.
  */
 export function WorkspaceTimezoneBootstrap({
+  accountId,
   timezone,
   canClaim,
   message,
 }: {
+  accountId: string;
   timezone: string | null;
   canClaim: boolean;
   /** `admin.chrome.timezoneAutoSet`, with a `{zone}` placeholder. */
@@ -33,8 +35,8 @@ export function WorkspaceTimezoneBootstrap({
   useEffect(() => {
     if (timezone != null || !canClaim) return;
     try {
-      if (sessionStorage.getItem(CLAIM_KEY)) return;
-      sessionStorage.setItem(CLAIM_KEY, '1');
+      if (sessionStorage.getItem(claimKey(accountId))) return;
+      sessionStorage.setItem(claimKey(accountId), '1');
     } catch {
       // No storage (private mode, hardened browser): still try once per mount.
     }
@@ -49,6 +51,6 @@ export function WorkspaceTimezoneBootstrap({
     return () => {
       cancelled = true;
     };
-  }, [timezone, canClaim, message, toast, router]);
+  }, [accountId, timezone, canClaim, message, toast, router]);
   return null;
 }

--- a/apps/web/app/admin/_components/workspace-timezone-field.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-field.tsx
@@ -61,7 +61,7 @@ export function WorkspaceTimezoneField({
     setCurrent(next);
     start(async () => {
       const res = await callAction(() => setWorkspaceTimezoneAction(accountId, next || null));
-      if (res && 'ok' in res && res.ok) {
+      if ('ok' in res && res.ok) {
         toast.success(labels.saved);
         router.refresh();
       } else {

--- a/apps/web/app/admin/_components/workspace-timezone-field.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-field.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Select } from '@/components/ui/select';
+import { useToast } from '@/components/toast';
+import { browserTimezones } from '@/lib/timezones';
+import { callAction } from '@/lib/call-action';
+import { setWorkspaceTimezoneAction } from '@/app/admin/workspace-actions';
+
+export interface WorkspaceTimezoneLabels {
+  label: string;
+  /** Explains that the zone is shared by the whole workspace. */
+  help: string;
+  saved: string;
+  error: string;
+  /** Trigger text while nobody has set a zone (UTC applies). */
+  unset: string;
+  utc: string;
+  /** Shown to a member, who sees the value but cannot change it. */
+  readOnly: string;
+}
+
+/**
+ * The ONE workspace timezone, editable by admins/owners from two places (the
+ * workspace's settings page and the submissions table) and read-only for
+ * members. Both surfaces write the same column through the same action; the
+ * `settings` variant carries the explanatory help line, the `inline` one is
+ * compact enough to sit beside a filter.
+ */
+export function WorkspaceTimezoneField({
+  accountId,
+  value,
+  canEdit,
+  variant,
+  locale,
+  labels,
+}: {
+  accountId: string;
+  value: string | null;
+  canEdit: boolean;
+  variant: 'settings' | 'inline';
+  locale: string;
+  labels: WorkspaceTimezoneLabels;
+}) {
+  const toast = useToast();
+  const router = useRouter();
+  const helpId = useId();
+  const [pending, start] = useTransition();
+  const [current, setCurrent] = useState<string>(value ?? '');
+  const zones = browserTimezones() ?? [];
+  const options = [
+    { value: 'UTC', label: labels.utc },
+    // A stored zone this browser cannot enumerate still shows as itself.
+    ...(current && current !== 'UTC' && !zones.includes(current) ? [{ value: current, label: current }] : []),
+    ...zones.filter((z) => z !== 'UTC').map((zone) => ({ value: zone, label: zone })),
+  ];
+
+  const onChange = (next: string) => {
+    const previous = current;
+    setCurrent(next);
+    start(async () => {
+      const res = await callAction(() => setWorkspaceTimezoneAction(accountId, next || null));
+      if (res && 'ok' in res && res.ok) {
+        toast.success(labels.saved);
+        router.refresh();
+      } else {
+        setCurrent(previous);
+        toast.error(labels.error);
+      }
+    });
+  };
+
+  const inline = variant === 'inline';
+  return (
+    <div
+      data-testid={`workspace-timezone-${variant}`}
+      className={inline ? 'flex min-w-0 flex-col gap-1' : 'flex min-w-0 max-w-md flex-col gap-1.5'}
+    >
+      <span className={inline ? 'text-xs font-medium text-muted-foreground' : 'text-2xs uppercase tracking-wide text-faint'}>
+        {labels.label}
+      </span>
+      {canEdit ? (
+        <Select
+          ariaLabel={labels.label}
+          value={current}
+          options={options}
+          placeholder={labels.unset}
+          searchable
+          locale={locale}
+          disabled={pending}
+          onChange={onChange}
+          className={inline ? 'h-9 min-w-[220px] text-sm' : undefined}
+        />
+      ) : (
+        <span
+          className="inline-flex items-center gap-1.5 text-sm text-foreground"
+          title={labels.readOnly}
+          data-testid="workspace-timezone-readonly"
+        >
+          <i aria-hidden className="pi pi-lock text-muted-foreground" style={{ fontSize: 12 }} />
+          {current || labels.unset}
+        </span>
+      )}
+      <p id={helpId} className="text-xs text-muted-foreground">
+        {canEdit ? labels.help : `${labels.help} ${labels.readOnly}`}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/admin/account/brand-kit/brand-kit-panel.tsx
+++ b/apps/web/app/admin/account/brand-kit/brand-kit-panel.tsx
@@ -3,7 +3,8 @@
 import { useMemo, useState, useTransition } from 'react';
 import type { FormBranding, FormButtonStyle, FormFont, FormRadius } from '@quill/engine';
 import { DEFAULT_FORM_FONT } from '@quill/engine';
-import { DEFAULT_ACCENT, DEFAULT_CANVAS, onAccent, readableOn, t, type FormsMessages } from '@quill/shared';
+import { DEFAULT_ACCENT, DEFAULT_CANVAS, formatDateTime, onAccent, readableOn, t, type FormsMessages } from '@quill/shared';
+import { useWorkspaceTimeZone } from '@/components/workspace-timezone';
 import type { BrandKit, FormSummary } from '@/lib/admin-api';
 import { formDesignProps } from '@/lib/form-design';
 import { callAction, isTransportError } from '@/lib/call-action';
@@ -40,6 +41,7 @@ export function BrandKitPanel({
   design: DesignMessages;
   locale: string;
 }) {
+  const timeZone = useWorkspaceTimeZone();
   const [kit, setKit] = useState<BrandKit>(initialKit);
   const [savedAt, setSavedAt] = useState<number | null>(updatedAt);
   const [applied, setApplied] = useState<Record<string, boolean>>(() =>
@@ -339,7 +341,7 @@ export function BrandKitPanel({
           </button>
           {savedAt ? (
             <span className="text-xs text-muted-foreground">
-              {t(bk.updatedAt, { date: new Date(savedAt).toLocaleString(locale) })}
+              {t(bk.updatedAt, { date: formatDateTime(savedAt, { locale, timeZone }) })}
             </span>
           ) : null}
           {toast ? <span className="text-sm text-primary">{toast}</span> : null}

--- a/apps/web/app/admin/account/workspaces/[id]/page.tsx
+++ b/apps/web/app/admin/account/workspaces/[id]/page.tsx
@@ -16,6 +16,7 @@ import { InvitationsTable } from './invitations-table';
 import { MembersTable } from './members-table';
 import { WorkspaceId } from './workspace-id';
 import { WorkspaceName } from './workspace-name';
+import { WorkspaceTimezoneField } from '@/app/admin/_components/workspace-timezone-field';
 
 export const dynamic = 'force-dynamic';
 
@@ -126,6 +127,22 @@ export default async function WorkspacePage({
             workspaceNameSave: s.workspaceNameSave,
             workspaceNameSaved: s.workspaceNameSaved,
             workspaceNameError: s.workspaceNameError,
+          }}
+        />
+        <WorkspaceTimezoneField
+          accountId={accountId}
+          value={me.timezone}
+          canEdit={canManage}
+          variant="settings"
+          locale={locale}
+          labels={{
+            label: s.workspaceTimezone,
+            help: s.workspaceTimezoneHelp,
+            saved: s.workspaceTimezoneSaved,
+            error: s.workspaceTimezoneError,
+            unset: s.workspaceTimezoneUnset,
+            utc: s.workspaceTimezoneUtc,
+            readOnly: messages.submissions.timezoneReadOnly,
           }}
         />
         {canManage ? (

--- a/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
@@ -22,8 +22,11 @@ type Preset = 'all' | 'today' | 'week' | 'month' | 'year' | 'custom';
 export function AnalyticsFilter({
   labels,
   locale,
+  todayIso,
 }: {
   locale: string;
+  /** Today in the WORKSPACE's zone (the server resolves ranges in it). Defaults to UTC. */
+  todayIso?: string;
   labels: {
     today: string;
     week: string;
@@ -58,9 +61,10 @@ export function AnalyticsFilter({
     push(next);
   };
 
-  // Today in UTC — the same reference the server resolves ranges against, so the
-  // picker cannot offer a "future" that is only future in the viewer's timezone.
-  const todayUtc = todayUtcIso();
+  // Today in the workspace zone, the same reference the server resolves ranges
+  // against, so the picker cannot offer a "future" that is only future in the
+  // viewer's own timezone.
+  const todayUtc = todayIso ?? todayUtcIso();
 
   const applyCustom = () => {
     if (!from && !to) return;

--- a/apps/web/app/admin/forms/[id]/analytics/page.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import type { AnalyticsResponse } from '@quill/types';
-import { getMessages, type FormsMessages } from '@quill/shared';
+import { dayBoundsInZone, getMessages, isoDateInZone, t, type FormsMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { FormTabs } from '@/components/ui/form-tabs';
@@ -15,40 +15,38 @@ const DAY_MS = 86_400_000;
 
 type SP = { preset?: string; from?: string; to?: string };
 
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
  * Resolve the URL query into an epoch-ms range the API understands.
  *
- * Day boundaries are UTC and resolved HERE, on the server, deliberately: an
- * analytics number has to be the same for every teammate reading it, so it
- * cannot depend on the viewer's local clock. (A per-account timezone is the
- * follow-up; until then UTC is the one shared reference.) "Last week/month/year"
- * are rolling 7/30/365-day windows, matching how the presets read in Typeform.
+ * Day boundaries are resolved HERE, on the server, in the WORKSPACE's zone:
+ * an analytics number has to be the same for every teammate reading it, so
+ * it depends on the one zone the team shares, never on the viewer's clock.
+ * "Last week/month/year" are rolling 7/30/365-day windows, matching how the
+ * presets read in Typeform.
  */
-function resolveRange(sp: SP): { from?: number; to?: number } {
+function resolveRange(sp: SP, zone: string): { from?: number; to?: number } {
   if (sp.preset === 'custom') {
-    const from = sp.from ? Date.parse(`${sp.from}T00:00:00.000Z`) : NaN;
-    const to = sp.to ? Date.parse(`${sp.to}T23:59:59.999Z`) : NaN;
     return {
-      from: Number.isNaN(from) ? undefined : from,
-      to: Number.isNaN(to) ? undefined : to,
+      from: sp.from && ISO_DATE.test(sp.from) ? dayBoundsInZone(sp.from, zone).from : undefined,
+      to: sp.to && ISO_DATE.test(sp.to) ? dayBoundsInZone(sp.to, zone).to : undefined,
     };
   }
   const now = Date.now();
-  if (sp.preset === 'today') {
-    const startOfDay = Math.floor(now / DAY_MS) * DAY_MS;
-    return { from: startOfDay, to: startOfDay + DAY_MS - 1 };
-  }
+  const today = dayBoundsInZone(isoDateInZone(now, zone), zone);
+  if (sp.preset === 'today') return { from: today.from, to: today.to };
   const days = sp.preset === 'week' ? 7 : sp.preset === 'month' ? 30 : sp.preset === 'year' ? 365 : null;
   // Send BOTH bounds for a rolling window. With only `from`, the trend series
   // ended at the last day that happened to have data, so a quiet stretch made
   // the chart stop short of today and silently misrepresent the window.
   //
-  // `from` snaps to a whole UTC day so the window is N COMPLETE days ending
+  // `from` snaps to a whole local day so the window is N COMPLETE days ending
   // today. Cutting at `now - N days` (an intra-day instant) left the oldest
   // bucket holding only part of its day while the chart drew it as a full one.
   if (days) {
-    const startOfToday = Math.floor(now / DAY_MS) * DAY_MS;
-    return { from: startOfToday - (days - 1) * DAY_MS, to: now };
+    const firstDay = isoDateInZone(today.from - (days - 1) * DAY_MS + DAY_MS / 2, zone);
+    return { from: dayBoundsInZone(firstDay, zone).from, to: now };
   }
   return {};
 }
@@ -64,8 +62,10 @@ export default async function AnalyticsPage({
   const sp = await searchParams;
   const locale = await getLocale();
   const m = getMessages(locale).admin;
-  const range = resolveRange(sp);
-  const rangeKey = `${sp.preset ?? 'all'}:${sp.from ?? ''}:${sp.to ?? ''}`;
+  // The workspace zone names the days: the range cuts, the buckets, the picker's "today".
+  const zone = (await adminApi.me()).timezone ?? 'UTC';
+  const range = resolveRange(sp, zone);
+  const rangeKey = `${sp.preset ?? 'all'}:${sp.from ?? ''}:${sp.to ?? ''}:${zone}`;
 
   return (
     <div className="mx-auto max-w-[1100px] px-6 py-8">
@@ -77,6 +77,7 @@ export default async function AnalyticsPage({
         </div>
         <AnalyticsFilter
           locale={locale}
+          todayIso={isoDateInZone(Date.now(), zone)}
           labels={{
             today: m.analytics.rangeToday,
             week: m.analytics.rangeWeek,
@@ -92,7 +93,7 @@ export default async function AnalyticsPage({
       </div>
 
       <Suspense key={rangeKey} fallback={<AnalyticsSkeleton />}>
-        <AnalyticsData id={id} range={range} m={m.analytics} locale={locale} />
+        <AnalyticsData id={id} range={range} zone={zone} m={m.analytics} locale={locale} />
       </Suspense>
     </div>
   );
@@ -120,17 +121,19 @@ function formatDuration(seconds: number, unit: string): string {
 async function AnalyticsData({
   id,
   range,
+  zone,
   m,
   locale,
 }: {
   id: string;
   range: { from?: number; to?: number };
+  zone: string;
   m: FormsMessages['admin']['analytics'];
   locale: string;
 }) {
   let a: AnalyticsResponse;
   try {
-    a = await adminApi.getAnalytics(id, range);
+    a = await adminApi.getAnalytics(id, { ...range, tz: zone });
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) notFound();
     throw e;
@@ -214,6 +217,10 @@ async function AnalyticsData({
           },
         }}
       />
+      {/* Which zone the days above are cut in; the API echoes the one it used. */}
+      <p className="mt-2 text-xs text-muted-foreground" data-testid="analytics-timezone-note">
+        {t(m.timezoneNote, { zone: a.range.timeZone ?? 'UTC' })}
+      </p>
 
       <section>
         <h2 className="text-lg font-semibold">{m.dropoffTitle}</h2>

--- a/apps/web/app/admin/forms/[id]/analytics/trends-chart.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/trends-chart.tsx
@@ -113,8 +113,9 @@ export function TrendsChart({
   const [metric, setMetric] = useState<MetricKey>('submissions');
   const [plotRef, W] = useMeasuredWidth<HTMLDivElement>();
 
-  // Buckets are whole UTC days, so render their labels in UTC too — otherwise a
-  // point would be titled with the day before/after the data it holds.
+  // Each point's `t` is UTC midnight of the CALENDAR DAY it names (in the
+  // workspace's zone, resolved server-side), so its label is read in UTC:
+  // any other zone could title a point with the day before/after its data.
   const fmtDate = useMemo(
     () => new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric', timeZone: 'UTC' }),
     [locale],

--- a/apps/web/app/admin/forms/[id]/integrations/delivery-history.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/delivery-history.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useId, useState } from 'react';
-import type { FormsMessages, Locale } from '@quill/shared';
+import { formatDateTime, type FormsMessages, type Locale } from '@quill/shared';
+import { useWorkspaceTimeZone } from '@/components/workspace-timezone';
 import { Button } from '@/components/ui/button';
 import { Modal } from '@/components/modal';
 import { cn } from '@/lib/cn';
@@ -263,6 +264,7 @@ function DeliveryRow({
   locale: Locale;
   m: Msgs;
 }) {
+  const timeZone = useWorkspaceTimeZone();
   const [open, setOpen] = useState(false);
   const failed = isFailure(d);
   const isTest = d.action === WEBHOOK_PING_ACTION;
@@ -333,7 +335,7 @@ function DeliveryRow({
           ) : null}
         </div>
         <span className="shrink-0 text-[11px] text-muted-foreground">
-          {new Date(d.updatedAt).toLocaleString(locale)}
+          {formatDateTime(d.updatedAt, { locale, timeZone })}
         </span>
       </button>
 

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -18,6 +18,7 @@ import { Switch } from '@/components/ui/switch';
 import { GoogleSheetsLogo, ProviderLogo } from '@/components/ui/provider-logo';
 import { useToast } from '@/components/toast';
 import { callAction, isTransportError } from '@/lib/call-action';
+import { browserTimezones, isKnownTimezone } from '@/lib/timezones';
 import { useAutosave } from '@/lib/use-autosave';
 import { cn } from '@/lib/cn';
 import { bookingLabel } from '@/lib/booking-fields';
@@ -158,40 +159,6 @@ interface BookingSyncState {
   stageValue: string;
   dateProperty: string;
   hoursProperty: string;
-}
-
-/**
- * Whether the browser can resolve this IANA zone name. Advisory only: it warns
- * the author at the moment they mistype, but the value still saves — the SERVER
- * decides, and its ICU data is the one that matters. Blank is always fine (UTC).
- */
-function isKnownTimezone(value: string): boolean {
-  const zone = value.trim();
-  if (!zone) return true;
-  try {
-    new Intl.DateTimeFormat('en-CA', { timeZone: zone });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * The IANA zones this browser can enumerate, for the Day-timezone picker.
- * Computed once — the list is static for the life of the page. A runtime
- * without `Intl.supportedValuesOf` yields null, and the field falls back to
- * the free-text input (the same degradation `PropertyField` uses).
- */
-let cachedTimezones: string[] | null | undefined;
-function browserTimezones(): string[] | null {
-  if (cachedTimezones !== undefined) return cachedTimezones;
-  try {
-    const zones = Intl.supportedValuesOf('timeZone');
-    cachedTimezones = zones.length > 0 ? zones : null;
-  } catch {
-    cachedTimezones = null;
-  }
-  return cachedTimezones;
 }
 
 /**

--- a/apps/web/app/admin/forms/[id]/submissions/page.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.spec.tsx
@@ -26,12 +26,15 @@ import type { SubmissionsPage as SubmissionsPageData } from '@quill/types';
 
 const getForm = vi.fn();
 const listSubmissions = vi.fn();
+const me = vi.fn();
 
 vi.mock('@/lib/admin-api', () => ({
   adminApi: {
     getForm: (...a: unknown[]) => getForm(...a),
     listSubmissions: (...a: unknown[]) => listSubmissions(...a),
+    me: (...a: unknown[]) => me(...a),
   },
+  isAdminRole: (role: string) => role === 'owner' || role === 'admin',
   // Declared in the factory: `vi.mock` is hoisted above every top-level binding,
   // and the page imports this one eagerly.
   ApiError: class ApiError extends Error {
@@ -166,6 +169,7 @@ async function visit(opts: {
 
   getForm.mockResolvedValue({ id: FORM_ID, config: { version: 1, steps: [] } });
   listSubmissions.mockResolvedValue(page);
+  me.mockResolvedValue({ accountId: 'acc-1', role: 'owner', timezone: 'America/Bogota' });
 
   const shell = await SubmissionsRoute({
     params: Promise.resolve({ id: FORM_ID }),
@@ -314,5 +318,14 @@ describe('submissions pagination — offset past the last row', () => {
     expect(text).toContain('No submissions yet');
     // Still the filtered question — the empty state is not a fallback to `all`.
     expect(queries).toEqual([query({ status: 'completed', offset: 25 })]);
+  });
+});
+
+describe('workspace timezone', () => {
+  it('prints every timestamp in the workspace zone, not the server clock', async () => {
+    // completedAt 2024-05-01T10:05Z reads as 5:05 AM in Bogota (UTC-5).
+    const { text } = await visit({ total: 1, offset: 0, items: 1 });
+    expect(text.replace(/\u202f/g, ' ')).toContain('May 1, 2024, 5:05 AM');
+    expect(text).not.toContain('10:05');
   });
 });

--- a/apps/web/app/admin/forms/[id]/submissions/page.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.tsx
@@ -2,8 +2,9 @@ import { Suspense } from 'react';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import type { FormConfig, SubmissionsPage } from '@quill/types';
-import { getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
-import { adminApi, ApiError } from '@/lib/admin-api';
+import { formatDateTime, getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
+import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
+import { WorkspaceTimezoneField } from '@/app/admin/_components/workspace-timezone-field';
 import { getLocale } from '@/lib/locale';
 import { FormTabs } from '@/components/ui/form-tabs';
 import { Skeleton } from '@/components/skeleton';
@@ -34,6 +35,9 @@ export default async function SubmissionsPage({
   const status = parseStatus(sp.status);
   const offset = Math.max(0, Number(sp.offset ?? 0) || 0);
   const key = `${status}:${offset}`;
+  // The workspace zone every timestamp below is read in, and who may change it.
+  const me = await adminApi.me();
+  const timeZone = me.timezone ?? 'UTC';
 
   const exportQuery = status === 'all' ? '' : `?status=${status}`;
 
@@ -54,17 +58,37 @@ export default async function SubmissionsPage({
             {m.submissions.export}
           </a>
         </div>
-        <SubmissionsFilter
-          labels={{
-            all: m.submissions.statusAll,
-            completed: m.submissions.statusCompleted,
-            partial: m.submissions.statusPartial,
-          }}
-        />
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <SubmissionsFilter
+            labels={{
+              all: m.submissions.statusAll,
+              completed: m.submissions.statusCompleted,
+              partial: m.submissions.statusPartial,
+            }}
+          />
+          {/* The SHARED workspace zone, right where the timestamps are: an
+              admin can fix it here, a member sees which zone applies. */}
+          <WorkspaceTimezoneField
+            accountId={me.accountId}
+            value={me.timezone}
+            canEdit={isAdminRole(me.role)}
+            variant="inline"
+            locale={locale}
+            labels={{
+              label: m.submissions.timezoneLabel,
+              help: m.submissions.timezoneHint,
+              saved: m.settings.workspaceTimezoneSaved,
+              error: m.settings.workspaceTimezoneError,
+              unset: m.settings.workspaceTimezoneUnset,
+              utc: m.settings.workspaceTimezoneUtc,
+              readOnly: m.submissions.timezoneReadOnly,
+            }}
+          />
+        </div>
       </div>
 
       <Suspense key={key} fallback={<Skeleton className="h-80 w-full" />}>
-        <SubmissionsData id={id} status={status} offset={offset} locale={locale} m={m} />
+        <SubmissionsData id={id} status={status} offset={offset} locale={locale} timeZone={timeZone} m={m} />
       </Suspense>
     </div>
   );
@@ -83,12 +107,14 @@ async function SubmissionsData({
   status,
   offset,
   locale,
+  timeZone,
   m,
 }: {
   id: string;
   status: 'all' | 'completed' | 'partial';
   offset: number;
   locale: Locale;
+  timeZone: string;
   m: FormsMessages['admin'];
 }) {
   let form: Awaited<ReturnType<typeof adminApi.getForm>>;
@@ -163,7 +189,7 @@ async function SubmissionsData({
               return (
                 <tr key={row.id} className="border-b border-border last:border-b-0 align-top">
                   <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
-                    {new Date(when).toLocaleString(locale)}
+                    {formatDateTime(when, { locale, timeZone })}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3">
                     <span

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getMessages, t } from '@quill/shared';
+import { formatDate, getMessages, t } from '@quill/shared';
 import { adminApi } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { CopyLinkIcon } from '@/components/copy-link';
@@ -89,7 +89,7 @@ export default async function FormsList() {
                       value without competing with it. */}
                   <p className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
                     <span className="shrink-0 text-faint">
-                      {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
+                      {t(m.updated, { when: formatDate(f.updatedAt, { locale, timeZone: me.timezone ?? 'UTC' }) })}
                     </span>
                     <span aria-hidden className="shrink-0 text-faint">
                       ·

--- a/apps/web/app/admin/integrations/page.tsx
+++ b/apps/web/app/admin/integrations/page.tsx
@@ -23,6 +23,7 @@ export const dynamic = 'force-dynamic';
 export default async function ConnectionsPage() {
   const locale = await getLocale();
   const c = getMessages(locale).admin.connections;
+  const timeZone = (await adminApi.me()).timezone ?? 'UTC';
 
   let data: IntegrationsResponse = { encryptionAvailable: false, providers: [] };
   let loadError = false;
@@ -58,6 +59,7 @@ export default async function ConnectionsPage() {
       />
       <WebhooksSection
         items={webhooks}
+        timeZone={timeZone}
         loadError={webhooksLoadError}
         m={c.webhooks}
         locale={locale}

--- a/apps/web/app/admin/integrations/webhooks-section.spec.tsx
+++ b/apps/web/app/admin/integrations/webhooks-section.spec.tsx
@@ -37,7 +37,7 @@ const webhook = (over: Partial<AccountWebhook> = {}): AccountWebhook => ({
 
 const render = (items: AccountWebhook[], loadError = false): string =>
   renderToStaticMarkup(
-    <WebhooksSection items={items} loadError={loadError} m={m} locale="en" />,
+    <WebhooksSection items={items} loadError={loadError} m={m} locale="en" timeZone="UTC" />,
   );
 
 describe('WebhooksSection', () => {

--- a/apps/web/app/admin/integrations/webhooks-section.tsx
+++ b/apps/web/app/admin/integrations/webhooks-section.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { t, type FormsMessages, type Locale } from '@quill/shared';
+import { formatDateTime, t, type FormsMessages, type Locale } from '@quill/shared';
 import type { AccountWebhook } from '@/lib/admin-api';
 
 type Msgs = FormsMessages['admin']['connections']['webhooks'];
@@ -27,11 +27,14 @@ export function WebhooksSection({
   loadError,
   m,
   locale,
+  timeZone,
 }: {
   items: AccountWebhook[];
   loadError?: boolean;
   m: Msgs;
   locale: Locale;
+  /** The workspace zone the failure timestamp is read in. */
+  timeZone: string;
 }) {
   return (
     <section
@@ -52,7 +55,7 @@ export function WebhooksSection({
       ) : items.length === 0 ? (
         <EmptyState m={m} />
       ) : (
-        <WebhookTable items={items} m={m} locale={locale} />
+        <WebhookTable timeZone={timeZone} items={items} m={m} locale={locale} />
       )}
     </section>
   );
@@ -76,7 +79,17 @@ function EmptyState({ m }: { m: Msgs }) {
   );
 }
 
-function WebhookTable({ items, m, locale }: { items: AccountWebhook[]; m: Msgs; locale: Locale }) {
+function WebhookTable({
+  items,
+  m,
+  locale,
+  timeZone,
+}: {
+  items: AccountWebhook[];
+  m: Msgs;
+  locale: Locale;
+  timeZone: string;
+}) {
   return (
     <>
       {/* Horizontal scroll lives INSIDE this container: a long endpoint must not
@@ -170,7 +183,7 @@ function WebhookTable({ items, m, locale }: { items: AccountWebhook[]; m: Msgs; 
                       <span
                         data-testid="webhook-health"
                         title={`${t(m.lastFailure, {
-                          date: new Date(w.failures.lastAt).toLocaleString(locale),
+                          date: formatDateTime(w.failures.lastAt, { locale, timeZone }),
                         })}${w.failures.lastError ? `\n${w.failures.lastError}` : ''}`}
                         className="inline-flex items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive"
                       >

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -86,6 +86,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           bootstrap). Staff entering an estate workspace never seed it: the
           zone belongs to the team that works there, not to whoever looked. */}
       <WorkspaceTimezoneBootstrap
+        accountId={me.accountId}
         timezone={me.timezone}
         canClaim={isAdminRole(me.role) && me.accessGrant !== 'staff'}
         message={chrome.timezoneAutoSet}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from 'react';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getMessages } from '@quill/shared';
-import { adminApi, ApiError } from '@/lib/admin-api';
+import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
+import { WorkspaceTimeZoneProvider } from '@/components/workspace-timezone';
+import { WorkspaceTimezoneBootstrap } from './_components/workspace-timezone-bootstrap';
 import { AdminShell } from '@/components/admin-shell';
 import { getLocale } from '@/lib/locale';
 import { getThemePref } from '@/lib/theme.server';
@@ -79,6 +81,15 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           landingDistinctId: sanitizeLandingDistinctId(jar.get(PH_ID_COOKIE)?.value),
         }}
       />
+      {/* The workspace's zone for every client component that prints a date,
+          and the one-time seed from the first admin's browser (see the
+          bootstrap). Staff entering an estate workspace never seed it: the
+          zone belongs to the team that works there, not to whoever looked. */}
+      <WorkspaceTimezoneBootstrap
+        timezone={me.timezone}
+        canClaim={isAdminRole(me.role) && me.accessGrant !== 'staff'}
+        message={chrome.timezoneAutoSet}
+      />
       <AdminShell
         initialCollapsed={initialCollapsed}
         themePref={await getThemePref()}
@@ -89,7 +100,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
         staff={me.staff}
         user={{ displayName: me.displayName, email: me.email }}
       >
-        {children}
+        <WorkspaceTimeZoneProvider timeZone={me.timezone}>{children}</WorkspaceTimeZoneProvider>
       </AdminShell>
     </ToastProvider>
   );

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -167,3 +167,43 @@ export async function renameWorkspaceAction(
   revalidatePath('/admin', 'layout');
   return { ok: true };
 }
+
+/** Outcome of a timezone write, machine-readable so the client can localize. */
+export type WorkspaceTimezoneState = { ok: true; timezone: string | null } | { ok: false } | null;
+
+/**
+ * Set the workspace's timezone (admin/owner), for the settings page and the
+ * submissions dropdown. `accountId` names the workspace so Account settings
+ * can change any workspace the caller administers without switching into it.
+ */
+export async function setWorkspaceTimezoneAction(
+  accountId: string,
+  timezone: string | null,
+): Promise<WorkspaceTimezoneState> {
+  try {
+    const res = await adminApi.setWorkspaceTimezone({ timezone }, { workspace: accountId });
+    revalidatePath('/admin', 'layout');
+    return { ok: true, timezone: res.timezone };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}
+
+/**
+ * The write-once seed: the first admin's browser offers its zone, and the API
+ * keeps it only while the workspace has none. `applied` tells the caller
+ * whether THIS call was the one that set it (and so whether to say so).
+ */
+export async function claimWorkspaceTimezoneAction(
+  timezone: string,
+): Promise<{ applied: boolean; timezone: string | null }> {
+  try {
+    const res = await adminApi.setWorkspaceTimezone({ timezone, onlyIfUnset: true });
+    if (res.applied) revalidatePath('/admin', 'layout');
+    return { applied: res.applied, timezone: res.timezone };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { applied: false, timezone: null };
+  }
+}

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -169,7 +169,7 @@ export async function renameWorkspaceAction(
 }
 
 /** Outcome of a timezone write, machine-readable so the client can localize. */
-export type WorkspaceTimezoneState = { ok: true; timezone: string | null } | { ok: false } | null;
+export type WorkspaceTimezoneState = { ok: true; timezone: string | null } | { ok: false };
 
 /**
  * Set the workspace's timezone (admin/owner), for the settings page and the

--- a/apps/web/components/workspace-timezone.tsx
+++ b/apps/web/components/workspace-timezone.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * The workspace's timezone for CLIENT components that print a date. Server
+ * components read it from `/v1/me` directly; this carries the same value down
+ * to the client tree so both sides format the same instant the same way
+ * (null → UTC, deterministic, so hydration never disagrees).
+ */
+const WorkspaceTimeZoneContext = createContext<string>("UTC");
+
+export function WorkspaceTimeZoneProvider({
+  timeZone,
+  children,
+}: {
+  timeZone: string | null | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <WorkspaceTimeZoneContext.Provider value={timeZone || "UTC"}>
+      {children}
+    </WorkspaceTimeZoneContext.Provider>
+  );
+}
+
+/** The workspace zone, `'UTC'` when unset or outside the provider. */
+export function useWorkspaceTimeZone(): string {
+  return useContext(WorkspaceTimeZoneContext);
+}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -211,6 +211,8 @@ export interface Me {
    * pages themselves read the cookie, not this.
    */
   locale: 'en' | 'es' | null;
+  /** The workspace's IANA timezone, or null while nobody has set one (UTC). */
+  timezone: string | null;
 }
 
 /**
@@ -602,7 +604,7 @@ export const adminApi = {
     req<{ reverted: string[] }>('POST', '/v1/branding/revert', { formIds }),
 
   // Analytics + submissions (this track)
-  getAnalytics: (id: string, range: { from?: number; to?: number } = {}) =>
+  getAnalytics: (id: string, range: { from?: number; to?: number; tz?: string } = {}) =>
     req<AnalyticsResponse>('GET', `/v1/forms/${id}/analytics${qs(range)}`),
   listSubmissions: (id: string, q: SubmissionsQuery = {}) =>
     req<SubmissionsPage>('GET', `/v1/forms/${id}/submissions${qs({ ...q })}`),
@@ -656,6 +658,14 @@ export const adminApi = {
   /** Rename the workspace the caller is acting in (admin/owner), or `opts.workspace`. */
   renameWorkspace: (name: string, opts?: ReqOptions) =>
     req<{ accountId: string; name: string }>('PATCH', '/v1/workspaces/current', { name }, opts),
+  /** Set (null = UTC) or, with `onlyIfUnset`, seed the workspace's timezone. */
+  setWorkspaceTimezone: (input: { timezone: string | null; onlyIfUnset?: boolean }, opts?: ReqOptions) =>
+    req<{ accountId: string; timezone: string | null; applied: boolean }>(
+      'PATCH',
+      '/v1/workspaces/current/timezone',
+      input,
+      opts,
+    ),
   /** Tell the API the caller is about to open this workspace (membership re-checked; remembered upstream). */
   enterWorkspace: (accountId: string) => req<{ ok: true }>('POST', `/v1/workspaces/${accountId}/enter`),
   /** Type-to-find: own workspaces filtered by name; staff also get the estate. */

--- a/apps/web/lib/timezones.ts
+++ b/apps/web/lib/timezones.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser-side helpers for IANA timezone pickers. Advisory only: the SERVER's
+ * ICU data decides what a zone means; these keep the UI honest at the moment
+ * of typing and give a searchable list where the runtime can enumerate one.
+ */
+
+/** Whether this browser can resolve the IANA zone name. Blank is always fine (UTC). */
+export function isKnownTimezone(value: string): boolean {
+  const zone = value.trim();
+  if (!zone) return true;
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The IANA zones this browser can enumerate. Computed once: the list is static
+ * for the life of the page. A runtime without `Intl.supportedValuesOf` yields
+ * null, and callers fall back to a free-text input.
+ */
+let cachedTimezones: string[] | null | undefined;
+export function browserTimezones(): string[] | null {
+  if (cachedTimezones !== undefined) return cachedTimezones;
+  try {
+    const zones = Intl.supportedValuesOf("timeZone");
+    cachedTimezones = zones.length > 0 ? zones : null;
+  } catch {
+    cachedTimezones = null;
+  }
+  return cachedTimezones;
+}
+
+/** The zone this browser runs in, or null when the runtime will not say. */
+export function browserTimezone(): string | null {
+  try {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return zone && isKnownTimezone(zone) ? zone : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/db/migrations/postgres/0020_account_timezone.sql
+++ b/packages/db/migrations/postgres/0020_account_timezone.sql
@@ -1,0 +1,9 @@
+-- Workspace timezone: additive.
+--
+-- Every date the admin shows was rendered on the server clock (UTC) and the
+-- analytics day buckets were UTC days, so a team in Bogota read yesterday's
+-- evening submissions as today's. `account.timezone` is the IANA zone the
+-- whole workspace reads dates in: the submissions table, the analytics day
+-- cuts and the CSV's local columns. NULL means UTC, exactly as before, until
+-- the first admin's browser claims it (UPDATE ... WHERE timezone IS NULL).
+ALTER TABLE account ADD COLUMN IF NOT EXISTS timezone TEXT;

--- a/packages/db/migrations/sqlite/0020_account_timezone.sql
+++ b/packages/db/migrations/sqlite/0020_account_timezone.sql
@@ -1,0 +1,2 @@
+-- Workspace timezone: additive. See the Postgres twin for the why.
+ALTER TABLE account ADD COLUMN timezone TEXT;

--- a/packages/db/src/account-timezone.spec.ts
+++ b/packages/db/src/account-timezone.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * The workspace timezone column (migration 0020): read, set, clear, and the
+ * write-once claim the dashboard uses to seed it from the first admin's
+ * browser. In-memory SQLite locally; DATABASE_URL for the Postgres parity job.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createDb, sql, type Db } from "./client";
+import { migrate } from "./migrate";
+import {
+  claimAccountTimezone,
+  getAccountTimezone,
+  setAccountTimezone,
+} from "./workspaces";
+import { getMe } from "./forms";
+
+let db: Db;
+let accountId: string;
+let memberId: string;
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? "file::memory:");
+  await migrate(db);
+  accountId = randomUUID();
+  memberId = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${"t" + accountId.slice(0, 7)}, ${"Test"}, ${Date.now()})`,
+  );
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, role, status, created_at)
+        VALUES (${memberId}, ${accountId}, ${"o@x.com"}, ${"owner"}, ${"active"}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  await db.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+  await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  await db.close();
+});
+
+describe("account timezone", () => {
+  it("starts unset, sets, and clears back to null", async () => {
+    expect(await getAccountTimezone(db, accountId)).toBeNull();
+    await setAccountTimezone(db, accountId, "America/Bogota");
+    expect(await getAccountTimezone(db, accountId)).toBe("America/Bogota");
+    await setAccountTimezone(db, accountId, null);
+    expect(await getAccountTimezone(db, accountId)).toBeNull();
+  });
+
+  it("claims only while unset: the first browser wins, later ones do not overwrite", async () => {
+    expect(await claimAccountTimezone(db, accountId, "America/Bogota")).toBe(
+      true,
+    );
+    expect(await claimAccountTimezone(db, accountId, "Europe/Madrid")).toBe(
+      false,
+    );
+    expect(await getAccountTimezone(db, accountId)).toBe("America/Bogota");
+  });
+
+  it("rides along on /me", async () => {
+    await setAccountTimezone(db, accountId, "Asia/Tokyo");
+    expect((await getMe(db, accountId, memberId))?.timezone).toBe("Asia/Tokyo");
+  });
+});

--- a/packages/db/src/analytics.spec.ts
+++ b/packages/db/src/analytics.spec.ts
@@ -311,7 +311,7 @@ describe('day buckets in a zone (offset segments)', () => {
     ],
   };
 
-  it('keeps 04:30Z and 08:30Z on the same New York day, while UTC splits them from 23:30Z', async () => {
+  it('splits 04:30Z (still Mar 7 in New York) from 08:30Z (Mar 8), where UTC puts both on Mar 8', async () => {
     // 04:30Z Mar 8 = 23:30 EST Mar 7; 08:30Z Mar 8 = 04:30 EDT Mar 8.
     await ev('a', 'view', Date.UTC(2026, 2, 8, 4, 30));
     await ev('b', 'view', Date.UTC(2026, 2, 8, 8, 30));

--- a/packages/db/src/analytics.spec.ts
+++ b/packages/db/src/analytics.spec.ts
@@ -299,3 +299,38 @@ describe('step-view attribution — by authored key vs legacy index', () => {
     expect((await stepViewCounts(db, formId)).byKey.get('q1')).toBe(2);
   });
 });
+
+describe('day buckets in a zone (offset segments)', () => {
+  // 2026-03-08: New York goes from -05:00 to -04:00 at 07:00Z.
+  const NY_SPRING = Date.UTC(2026, 2, 8, 7, 0, 0);
+  const HOUR = 3_600_000;
+  const bucketing = {
+    segments: [
+      { from: NY_SPRING - 3 * 86_400_000, offsetMs: -5 * HOUR },
+      { from: NY_SPRING, offsetMs: -4 * HOUR },
+    ],
+  };
+
+  it('keeps 04:30Z and 08:30Z on the same New York day, while UTC splits them from 23:30Z', async () => {
+    // 04:30Z Mar 8 = 23:30 EST Mar 7; 08:30Z Mar 8 = 04:30 EDT Mar 8.
+    await ev('a', 'view', Date.UTC(2026, 2, 8, 4, 30));
+    await ev('b', 'view', Date.UTC(2026, 2, 8, 8, 30));
+    await ev('c', 'view', Date.UTC(2026, 2, 7, 23, 30));
+    const utc = await dailyViewSessions(db, formId);
+    expect(utc.map((d) => d.n)).toEqual([1, 2]); // Mar 7 (c), Mar 8 (a, b)
+    const ny = await dailyViewSessions(db, formId, undefined, bucketing);
+    expect(ny.map((d) => d.n)).toEqual([2, 1]); // Mar 7 (c, a), Mar 8 (b)
+    const mar7 = Math.floor((Date.UTC(2026, 2, 7) - 5 * HOUR + 5 * HOUR) / 86_400_000);
+    expect(ny[0]!.day).toBe(mar7);
+  });
+
+  it('a single segment is a plain shifted bucket, and completed submissions bucket the same way', async () => {
+    const bogota = { segments: [{ from: 0, offsetMs: -5 * HOUR }] };
+    // 2026-09-04T03:30Z is Sep 3 in Bogota.
+    await sub('s1', { startedAt: Date.UTC(2026, 8, 4, 3, 0), completedAt: Date.UTC(2026, 8, 4, 3, 30) });
+    const utc = await completedSubmissions(db, formId);
+    const bog = await completedSubmissions(db, formId, undefined, bogota);
+    expect(utc[0]!.day).toBe(Math.floor(Date.UTC(2026, 8, 4) / 86_400_000));
+    expect(bog[0]!.day).toBe(Math.floor(Date.UTC(2026, 8, 3) / 86_400_000));
+  });
+});

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -491,10 +491,17 @@ export async function deleteSubmissionForAccount(
   return exists ? 'forbidden' : 'absent';
 }
 
-/** The earliest `form_event` of a form (epoch-ms), or null with no events yet. */
+/**
+ * The earliest activity of a form (epoch-ms): its first `form_event` or its
+ * first submission, whichever is older (a submission can predate every event
+ * when the beacons were lost). Null with nothing yet. Bounds the offset
+ * segments of an unbounded analytics range, so every row falls inside one.
+ */
 export async function firstEventAt(db: Db, formId: string): Promise<number | null> {
-  const row = await db.get<{ t: number | string | null }>(
-    sql`SELECT MIN(created_at) AS t FROM form_event WHERE form_id = ${formId}`,
+  const row = await db.get<{ e: number | string | null; s: number | string | null }>(
+    sql`SELECT (SELECT MIN(created_at) FROM form_event WHERE form_id = ${formId}) AS e,
+               (SELECT MIN(started_at) FROM submission WHERE form_id = ${formId}) AS s`,
   );
-  return row?.t == null ? null : Number(row.t);
+  const candidates = [row?.e, row?.s].filter((v): v is number | string => v != null).map(Number);
+  return candidates.length ? Math.min(...candidates) : null;
 }

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -18,6 +18,40 @@ export interface DateRange {
 }
 
 /**
+ * How to name the CALENDAR DAY an epoch-ms instant falls on. Absent = UTC
+ * days, byte-for-byte the SQL this module always ran. Otherwise the UTC
+ * offset of the workspace's zone across the queried window, as segments that
+ * start where the offset changes (`utcOffsetSegments` in @quill/shared): one
+ * for a fixed-offset zone, two or three across a DST year. The day expression
+ * becomes `(col + offset) / 86400000` with the offset picked by a CASE over
+ * the segment starts, so bucketing stays inside SQL (COUNT DISTINCT needs it
+ * there) and stays dialect-neutral.
+ */
+export interface DayBucketing {
+  segments: Array<{ from: number; offsetMs: number }>;
+}
+
+/** The whole-day index of `col` under `bucketing` (UTC days when absent). */
+function localDayExpr(col: SQL, bucketing?: DayBucketing): SQL {
+  const segments = bucketing?.segments ?? [];
+  // 86400000 is a SQL literal (not a bound param) so both engines do INTEGER
+  // division and bucket to a whole day.
+  if (segments.length === 0) return sql`(${col} / 86400000)`;
+  // Offsets and boundaries are inlined as INTEGER literals, like the day
+  // length: a bound number reaches SQLite as a REAL and the division stops
+  // truncating, which splits one day into fractional buckets. They are
+  // computed integers (whole minutes of offset, epoch-ms instants), never
+  // caller input, so inlining is safe.
+  const int = (n: number) => sql.raw(String(Math.trunc(n)));
+  if (segments.length === 1) return sql`((${col} + ${int(segments[0]!.offsetMs)}) / 86400000)`;
+  const branches = segments
+    .slice(0, -1)
+    .map((seg, i) => sql`WHEN ${col} < ${int(segments[i + 1]!.from)} THEN ${int(seg.offsetMs)}`);
+  const last = segments[segments.length - 1]!;
+  return sql`((${col} + (CASE ${sql.join(branches, sql` `)} ELSE ${int(last.offsetMs)} END)) / 86400000)`;
+}
+
+/**
  * Build the `AND col >= from AND col <= to` fragment for an optional range.
  * Each bound is independent; an empty range contributes no SQL. `col` is a
  * fixed internal identifier fragment (never user input).
@@ -257,6 +291,7 @@ export async function completedSubmissions(
   db: Db,
   formId: string,
   range?: DateRange,
+  bucketing?: DayBucketing,
 ): Promise<CompletedSubmission[]> {
   const rows = await db.all<{
     day: number | string;
@@ -268,7 +303,7 @@ export async function completedSubmissions(
     // do INTEGER division and bucket to a whole day. The open timestamp comes
     // back RAW (not COALESCEd in SQL) so the caller can tell "no open signal"
     // apart from "opened and completed instantly" — see below.
-    sql`SELECT (${submissionAnchor()} / 86400000) AS day,
+    sql`SELECT ${localDayExpr(submissionAnchor(), bucketing)} AS day,
                s.completed_at AS completed_at,
                s.started_at AS started_at,
                (SELECT MIN(e.created_at) FROM form_event e
@@ -303,8 +338,9 @@ export async function completedSubmissions(
  * lands in exactly one bucket, in every metric, instead of splitting its views
  * into one day and its start into another.
  */
-function dailySessionsQuery(formId: string, eventFilter: SQL, range?: DateRange): SQL {
-  return sql`SELECT (a.anchor / 86400000) AS day, COUNT(DISTINCT a.session_id) AS n
+function dailySessionsQuery(formId: string, eventFilter: SQL, range?: DateRange, bucketing?: DayBucketing): SQL {
+  const day = localDayExpr(sql`a.anchor`, bucketing);
+  return sql`SELECT ${day} AS day, COUNT(DISTINCT a.session_id) AS n
       FROM (
         SELECT session_id, MIN(created_at) AS anchor FROM form_event
         WHERE form_id = ${formId} GROUP BY session_id
@@ -313,7 +349,7 @@ function dailySessionsQuery(formId: string, eventFilter: SQL, range?: DateRange)
         SELECT session_id FROM form_event WHERE form_id = ${formId} AND ${eventFilter}
       )
       ${andRange(sql`a.anchor`, range)}
-      GROUP BY (a.anchor / 86400000)`;
+      GROUP BY ${day}`;
 }
 
 /** Per-day unique sessions that viewed the form (trend series for Views). */
@@ -321,9 +357,10 @@ export async function dailyViewSessions(
   db: Db,
   formId: string,
   range?: DateRange,
+  bucketing?: DayBucketing,
 ): Promise<{ day: number; n: number }[]> {
   const rows = await db.all<{ day: number | string; n: number | string }>(
-    dailySessionsQuery(formId, sql`type = 'view'`, range),
+    dailySessionsQuery(formId, sql`type = 'view'`, range, bucketing),
   );
   return rows.map((r) => ({ day: Number(r.day), n: Number(r.n) }));
 }
@@ -334,9 +371,10 @@ export async function dailyStartSessions(
   db: Db,
   formId: string,
   range?: DateRange,
+  bucketing?: DayBucketing,
 ): Promise<{ day: number; n: number }[]> {
   const rows = await db.all<{ day: number | string; n: number | string }>(
-    dailySessionsQuery(formId, sql`type IN ('start', 'step_complete')`, range),
+    dailySessionsQuery(formId, sql`type IN ('start', 'step_complete')`, range, bucketing),
   );
   return rows.map((r) => ({ day: Number(r.day), n: Number(r.n) }));
 }
@@ -451,4 +489,12 @@ export async function deleteSubmissionForAccount(
     sql`SELECT id FROM submission WHERE id = ${submissionId} LIMIT 1`,
   );
   return exists ? 'forbidden' : 'absent';
+}
+
+/** The earliest `form_event` of a form (epoch-ms), or null with no events yet. */
+export async function firstEventAt(db: Db, formId: string): Promise<number | null> {
+  const row = await db.get<{ t: number | string | null }>(
+    sql`SELECT MIN(created_at) AS t FROM form_event WHERE form_id = ${formId}`,
+  );
+  return row?.t == null ? null : Number(row.t);
 }

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -101,6 +101,8 @@ export interface MeView {
    * un-sliceable by campaign, which is most of the reason to measure it.
    */
   attribution: Attribution | null;
+  /** The workspace's IANA timezone (0020), or null for UTC. */
+  timezone: string | null;
   /** `'staff'` when the caller is in this workspace by access grant, not by membership (0016). */
   accessGrant: 'staff' | null;
   /**
@@ -129,8 +131,9 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     attribution: unknown;
     access_grant: string | null;
     locale: string | null;
+    timezone: string | null;
   }>(
-    sql`SELECT a.code, a.name, a.vanity_slug, a.onboarding_completed_at, a.attribution,
+    sql`SELECT a.code, a.name, a.vanity_slug, a.onboarding_completed_at, a.attribution, a.timezone,
                m.handle, m.display_name, m.email, m.role, m.status, m.access_grant, m.locale
         FROM account a JOIN member m ON m.account_id = a.id
         WHERE a.id = ${accountId} AND m.id = ${memberId} LIMIT 1`,
@@ -157,6 +160,7 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     // dashboard page. Unreadable tags degrade to "not known", never to a 500.
     attribution: parseAttributionColumn(row.attribution),
     accessGrant: row.access_grant === 'staff' ? 'staff' : null,
+    timezone: row.timezone ?? null,
     // Narrowed here, not trusted: the column is plain text and predates this
     // field, so an unrecognised value reads as "never chose" instead of
     // reaching a catalog that has no such locale.

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -24,6 +24,12 @@ export const account = pgTable('account', {
   /** Milestone CLAIM: epoch-ms of the first form view. Same write-once discipline. */
   firstViewedAt: bigint('first_viewed_at', { mode: 'number' }),
   /**
+   * The workspace's IANA timezone (0020): the zone every date in the admin,
+   * the analytics day buckets and the CSV local columns are read in. NULL =
+   * UTC until the first admin's browser claims it (`claimAccountTimezone`).
+   */
+  timezone: text('timezone'),
+  /**
    * Onboarding wizard state AND result (see 0011) — `accountOnboardingSchema` in
    * @quill/types. Written on every step advance, so a row with a `lastStep` and
    * no `onboardingCompletedAt` IS the drop-off record.

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -32,6 +32,8 @@ export const account = sqliteTable('account', {
   activatedAt: integer('activated_at'),
   /** Milestone CLAIM: epoch-ms of the first form view. Same write-once discipline. */
   firstViewedAt: integer('first_viewed_at'),
+  /** The workspace's IANA timezone (0020); NULL = UTC. See the Postgres twin. */
+  timezone: text('timezone'),
   /**
    * Onboarding wizard state AND result (TEXT JSON, see 0011) —
    * `accountOnboardingSchema` in @quill/types. Written on every step advance, so

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -611,3 +611,33 @@ export async function getMemberUpstreamRef(
   if (!r) return null;
   return { externalId: r.external_id ?? null, workspaceUserId: r.iam_workspace_user_id ?? null, email: r.email ?? null };
 }
+
+// --- Workspace timezone (0020) ---------------------------------------------
+
+/** The workspace's IANA zone, or null (= UTC) when nobody has set one. */
+export async function getAccountTimezone(db: Db, accountId: string): Promise<string | null> {
+  const row = await db.get<{ timezone: string | null }>(
+    sql`SELECT timezone FROM account WHERE id = ${accountId} LIMIT 1`,
+  );
+  return row?.timezone ?? null;
+}
+
+/** Set (or clear, with null) the workspace's zone. Validation is the API's job. */
+export async function setAccountTimezone(db: Db, accountId: string, timezone: string | null): Promise<void> {
+  await db.run(sql`UPDATE account SET timezone = ${timezone} WHERE id = ${accountId}`);
+}
+
+/**
+ * Write-once seed: the first admin to load the dashboard offers their
+ * browser's zone, and it sticks only while the column is still NULL, so two
+ * teammates in different zones cannot flip it back and forth. Same
+ * UPDATE ... WHERE IS NULL discipline as the milestone claims.
+ */
+export async function claimAccountTimezone(db: Db, accountId: string, timezone: string): Promise<boolean> {
+  const claimed = await db.get<{ id: string }>(
+    sql`UPDATE account SET timezone = ${timezone}
+        WHERE id = ${accountId} AND timezone IS NULL
+        RETURNING id`,
+  );
+  return Boolean(claimed);
+}

--- a/packages/shared/src/datetime.spec.ts
+++ b/packages/shared/src/datetime.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  dayBoundsInZone,
+  formatDate,
+  formatDateTime,
+  formatIsoWithOffset,
+  isValidTimeZone,
+  isoDateInZone,
+  localDayIndex,
+  resolveTimeZone,
+  tzOffsetMs,
+  utcOffsetSegments,
+  zonedMidnightMs,
+} from "./datetime";
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+// New York springs forward on 2026-03-08 at 07:00Z (02:00 EST -> 03:00 EDT).
+const NY_SPRING = Date.UTC(2026, 2, 8, 7, 0, 0);
+
+describe("zone validation", () => {
+  it("accepts IANA names the runtime knows and rejects the rest", () => {
+    expect(isValidTimeZone("America/Bogota")).toBe(true);
+    expect(isValidTimeZone("UTC")).toBe(true);
+    expect(isValidTimeZone("Mars/Olympus")).toBe(false);
+    expect(isValidTimeZone("")).toBe(false);
+  });
+
+  it("resolveTimeZone falls back to UTC with a warning instead of throwing", () => {
+    const warnings: string[] = [];
+    expect(resolveTimeZone("Mars/Olympus", (m) => warnings.push(m))).toBe(
+      "UTC",
+    );
+    expect(warnings).toHaveLength(1);
+    expect(resolveTimeZone(null)).toBe("UTC");
+    expect(resolveTimeZone("America/Bogota")).toBe("America/Bogota");
+  });
+});
+
+describe("offsets and day math", () => {
+  it("knows the offset on both sides of a DST change", () => {
+    expect(tzOffsetMs(NY_SPRING - 1, "America/New_York")).toBe(-5 * HOUR);
+    expect(tzOffsetMs(NY_SPRING, "America/New_York")).toBe(-4 * HOUR);
+    expect(tzOffsetMs(NY_SPRING, "America/Bogota")).toBe(-5 * HOUR);
+    expect(tzOffsetMs(NY_SPRING, "UTC")).toBe(0);
+  });
+
+  it("buckets an instant into the calendar day of the zone", () => {
+    // 2026-09-04T03:30Z is still Sep 3 in Bogota.
+    const t = Date.UTC(2026, 8, 4, 3, 30);
+    expect(localDayIndex(t, "UTC")).toBe(Math.floor(t / DAY));
+    expect(localDayIndex(t, "America/Bogota")).toBe(Math.floor(t / DAY) - 1);
+    expect(isoDateInZone(t, "America/Bogota")).toBe("2026-09-03");
+    expect(isoDateInZone(t, "UTC")).toBe("2026-09-04");
+  });
+
+  it("finds local midnight, including on the day the clocks jump", () => {
+    expect(zonedMidnightMs("2026-09-03", "America/Bogota")).toBe(
+      Date.UTC(2026, 8, 3, 5),
+    );
+    expect(zonedMidnightMs("2026-03-08", "America/New_York")).toBe(
+      Date.UTC(2026, 2, 8, 5),
+    );
+    // A zone where midnight itself is skipped lands on the first instant that exists.
+    expect(zonedMidnightMs("2026-09-06", "America/Santiago")).toBe(
+      Date.UTC(2026, 8, 6, 4),
+    );
+  });
+
+  it("dayBoundsInZone spans exactly the local day, 23 hours on the spring-forward day", () => {
+    const b = dayBoundsInZone("2026-09-03", "America/Bogota");
+    expect(b).toEqual({
+      from: Date.UTC(2026, 8, 3, 5),
+      to: Date.UTC(2026, 8, 4, 5) - 1,
+    });
+    const ny = dayBoundsInZone("2026-03-08", "America/New_York");
+    expect(ny.to - ny.from + 1).toBe(23 * HOUR);
+  });
+});
+
+describe("utcOffsetSegments", () => {
+  it("is one segment for a fixed-offset zone and for UTC", () => {
+    expect(
+      utcOffsetSegments(
+        Date.UTC(2026, 0, 1),
+        Date.UTC(2026, 11, 31),
+        "America/Bogota",
+      ),
+    ).toEqual([{ from: Date.UTC(2026, 0, 1), offsetMs: -5 * HOUR }]);
+    expect(utcOffsetSegments(0, DAY, "UTC")).toEqual([
+      { from: 0, offsetMs: 0 },
+    ]);
+  });
+
+  it("splits at the exact minute of a DST change", () => {
+    const segments = utcOffsetSegments(
+      NY_SPRING - 3 * DAY,
+      NY_SPRING + 3 * DAY,
+      "America/New_York",
+    );
+    expect(segments).toEqual([
+      { from: NY_SPRING - 3 * DAY, offsetMs: -5 * HOUR },
+      { from: NY_SPRING, offsetMs: -4 * HOUR },
+    ]);
+  });
+});
+
+describe("formatting", () => {
+  it("formats a date-time in the zone and locale", () => {
+    const t = Date.UTC(2026, 8, 3, 23, 30);
+    // Newer ICU prints a narrow no-break space before AM/PM; the assertion is about the zone.
+    const plain = (s: string) => s.replace(/\u202f/g, " ");
+    expect(
+      plain(formatDateTime(t, { locale: "en", timeZone: "America/Bogota" })),
+    ).toBe("Sep 3, 2026, 6:30 PM");
+    expect(plain(formatDateTime(t, { locale: "en", timeZone: "UTC" }))).toBe(
+      "Sep 3, 2026, 11:30 PM",
+    );
+    expect(formatDate(t, { locale: "en", timeZone: "Asia/Tokyo" })).toBe(
+      "Sep 4, 2026",
+    );
+  });
+
+  it("writes an ISO timestamp with the zone offset, UTC as +00:00", () => {
+    const t = Date.UTC(2026, 8, 3, 23, 30, 15);
+    expect(formatIsoWithOffset(t, "America/Bogota")).toBe(
+      "2026-09-03T18:30:15-05:00",
+    );
+    expect(formatIsoWithOffset(t, "UTC")).toBe("2026-09-03T23:30:15+00:00");
+    expect(formatIsoWithOffset(t, "Asia/Kolkata")).toBe(
+      "2026-09-04T05:00:15+05:30",
+    );
+  });
+
+  it("never throws on an invalid zone: everything resolves in UTC", () => {
+    const t = Date.UTC(2026, 8, 3, 23, 30);
+    expect(formatIsoWithOffset(t, "Mars/Olympus")).toBe(
+      "2026-09-03T23:30:00+00:00",
+    );
+    expect(isoDateInZone(t, "Mars/Olympus")).toBe("2026-09-03");
+  });
+});

--- a/packages/shared/src/datetime.ts
+++ b/packages/shared/src/datetime.ts
@@ -1,0 +1,267 @@
+/**
+ * Timezone-aware date math on top of `Intl` alone (this repo carries no date
+ * library). Isomorphic: the same code names calendar days on the server (day
+ * buckets, CSV export) and formats timestamps in the browser.
+ *
+ * Every function tolerates an unknown zone by resolving it as UTC (with an
+ * optional warning), never by throwing: a mistyped zone in a setting must not
+ * take a page or a query down with it.
+ */
+
+export const DAY_MS = 86_400_000;
+const MINUTE_MS = 60_000;
+
+/** Whether this runtime's ICU data knows `zone` as an IANA name. */
+export function isValidTimeZone(zone: string | null | undefined): boolean {
+  const name = zone?.trim();
+  if (!name) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: name });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `zone` when the runtime knows it, else `'UTC'` (warning the caller). */
+export function resolveTimeZone(
+  zone: string | null | undefined,
+  warn?: (message: string) => void,
+): string {
+  const name = zone?.trim();
+  if (!name) return "UTC";
+  if (isValidTimeZone(name)) return name;
+  warn?.(`timezone: unknown zone ${JSON.stringify(name)}, using UTC instead`);
+  return "UTC";
+}
+
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+/** A cached parts formatter for one zone; `hourCycle: 'h23'` keeps midnight as 0. */
+function partsFormatter(zone: string): Intl.DateTimeFormat {
+  let f = formatters.get(zone);
+  if (!f) {
+    f = new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    formatters.set(zone, f);
+  }
+  return f;
+}
+
+interface WallClock {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+/** The wall-clock reading of `epochMs` in a (resolved) zone. */
+function wallClock(epochMs: number, zone: string): WallClock {
+  // Read BY PART TYPE, never by parsing a formatted string: the order of a
+  // formatted date depends on ICU data, the part types do not.
+  const parts = partsFormatter(zone).formatToParts(new Date(epochMs));
+  const at = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? NaN);
+  const hour = at("hour");
+  return {
+    year: at("year"),
+    month: at("month"),
+    day: at("day"),
+    // Some ICU builds print midnight as 24 even under h23.
+    hour: hour === 24 ? 0 : hour,
+    minute: at("minute"),
+    second: at("second"),
+  };
+}
+
+/** The zone's UTC offset at `epochMs`, in ms (negative west of Greenwich). */
+export function tzOffsetMs(epochMs: number, zone: string): number {
+  const name = resolveTimeZone(zone);
+  if (name === "UTC") return 0;
+  const w = wallClock(epochMs, name);
+  const asUtc = Date.UTC(
+    w.year,
+    w.month - 1,
+    w.day,
+    w.hour,
+    w.minute,
+    w.second,
+  );
+  // Offsets are whole minutes; rounding drops the sub-second part of `epochMs`.
+  return Math.round((asUtc - epochMs) / MINUTE_MS) * MINUTE_MS;
+}
+
+/**
+ * The calendar day `epochMs` falls on in `zone`, as a day index (days since
+ * the epoch of that LOCAL day). The JS twin of the SQL bucketing expression
+ * `(col + offset) / 86400000`, so trends built here and buckets built there
+ * agree by construction.
+ */
+export function localDayIndex(epochMs: number, zone: string): number {
+  return Math.floor((epochMs + tzOffsetMs(epochMs, zone)) / DAY_MS);
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** `YYYY-MM-DD` of the calendar day `epochMs` falls on in `zone`. */
+export function isoDateInZone(epochMs: number, zone: string): string {
+  const w = wallClock(epochMs, resolveTimeZone(zone));
+  return `${String(w.year).padStart(4, "0")}-${pad2(w.month)}-${pad2(w.day)}`;
+}
+
+function parseIso(isoDate: string): {
+  year: number;
+  month: number;
+  day: number;
+} {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!m)
+    throw new Error(`expected YYYY-MM-DD, got ${JSON.stringify(isoDate)}`);
+  return { year: Number(m[1]), month: Number(m[2]), day: Number(m[3]) };
+}
+
+/**
+ * The instant local midnight of `isoDate` happens in `zone`. Two passes over
+ * the offset (the offset AT the guessed instant may differ from the offset at
+ * the naive one around a DST change). When midnight itself does not exist
+ * (the clocks jump from 23:59 to 01:00), the first instant of that local day
+ * is returned instead.
+ */
+export function zonedMidnightMs(isoDate: string, zone: string): number {
+  const name = resolveTimeZone(zone);
+  const { year, month, day } = parseIso(isoDate);
+  const naive = Date.UTC(year, month - 1, day);
+  if (name === "UTC") return naive;
+  let candidate = naive - tzOffsetMs(naive, name);
+  const second = tzOffsetMs(candidate, name);
+  candidate = naive - second;
+  const target = `${String(year).padStart(4, "0")}-${pad2(month)}-${pad2(day)}`;
+  const w = wallClock(candidate, name);
+  if (
+    isoDateInZone(candidate, name) === target &&
+    w.hour === 0 &&
+    w.minute === 0
+  )
+    return candidate;
+  // A skipped midnight: walk forward minute by minute (a DST gap is an hour or
+  // two) to the first instant that reads as the wanted day.
+  let t = candidate;
+  for (let i = 0; i < 3 * 60; i++) {
+    if (isoDateInZone(t, name) === target) return t;
+    t += MINUTE_MS;
+  }
+  return candidate;
+}
+
+function addDaysIso(isoDate: string, days: number): string {
+  const { year, month, day } = parseIso(isoDate);
+  return new Date(Date.UTC(year, month - 1, day + days))
+    .toISOString()
+    .slice(0, 10);
+}
+
+/** The epoch-ms window `[from, to]` of the whole local day `isoDate` in `zone`. */
+export function dayBoundsInZone(
+  isoDate: string,
+  zone: string,
+): { from: number; to: number } {
+  const from = zonedMidnightMs(isoDate, zone);
+  const next = zonedMidnightMs(addDaysIso(isoDate, 1), zone);
+  return { from, to: next - 1 };
+}
+
+/** One stretch of constant UTC offset; `from` is inclusive, the next segment ends it. */
+export interface OffsetSegment {
+  from: number;
+  offsetMs: number;
+}
+
+/**
+ * The UTC offset of `zone` across `[from, to]`, as segments that start where
+ * the offset changes (to the minute). Walks in daily steps and bisects each
+ * change, so a year of a DST zone is two or three segments and a fixed-offset
+ * zone (or UTC) is always exactly one. This is what lets SQL bucket days in
+ * a zone with a CASE over a handful of boundaries instead of per-row math.
+ */
+export function utcOffsetSegments(
+  from: number,
+  to: number,
+  zone: string,
+): OffsetSegment[] {
+  const name = resolveTimeZone(zone);
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  const off = (t: number) => tzOffsetMs(t, name);
+  const segments: OffsetSegment[] = [{ from: start, offsetMs: off(start) }];
+  if (name === "UTC") return segments;
+  let t = start;
+  while (t < end) {
+    const next = Math.min(t + DAY_MS, end);
+    const before = off(t);
+    if (off(next) !== before) {
+      // Bisect on the minute grid for the first minute with the new offset.
+      let lo = Math.floor(t / MINUTE_MS);
+      let hi = Math.ceil(next / MINUTE_MS);
+      while (hi - lo > 1) {
+        const mid = lo + Math.floor((hi - lo) / 2);
+        if (off(mid * MINUTE_MS) === before) lo = mid;
+        else hi = mid;
+      }
+      const at = hi * MINUTE_MS;
+      segments.push({ from: at, offsetMs: off(at) });
+    }
+    t = next;
+  }
+  return segments;
+}
+
+export interface FormatOptions {
+  locale: string;
+  timeZone: string;
+}
+
+/** `Sep 3, 2026, 6:30 PM` in the locale, read in the zone. */
+export function formatDateTime(
+  epochMs: number,
+  options: FormatOptions,
+): string {
+  return new Intl.DateTimeFormat(options.locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: resolveTimeZone(options.timeZone),
+  }).format(new Date(epochMs));
+}
+
+/** `Sep 3, 2026` in the locale, read in the zone. */
+export function formatDate(epochMs: number, options: FormatOptions): string {
+  return new Intl.DateTimeFormat(options.locale, {
+    dateStyle: "medium",
+    timeZone: resolveTimeZone(options.timeZone),
+  }).format(new Date(epochMs));
+}
+
+/** `2026-09-03T18:30:15-05:00`: the wall-clock reading plus the zone's offset (UTC = `+00:00`). */
+export function formatIsoWithOffset(epochMs: number, zone: string): string {
+  const name = resolveTimeZone(zone);
+  const w = wallClock(epochMs, name);
+  const offset = tzOffsetMs(epochMs, name);
+  const sign = offset < 0 ? "-" : "+";
+  const abs = Math.abs(offset) / MINUTE_MS;
+  return (
+    `${String(w.year).padStart(4, "0")}-${pad2(w.month)}-${pad2(w.day)}` +
+    `T${pad2(w.hour)}:${pad2(w.minute)}:${pad2(w.second)}` +
+    `${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`
+  );
+}

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -126,6 +126,8 @@ export interface FormsMessages {
       collapse: string;
       expand: string;
       openNav: string;
+      /** Toast when the first admin's browser seeds the workspace zone. // {zone} */
+      timezoneAutoSet: string;
       /** The colour-scheme toggle. `next` names what one more click will do, so an
        *  icon-only control still announces its effect rather than only its state. */
       theme: {
@@ -288,6 +290,13 @@ export interface FormsMessages {
       subtitle: string;
       /** The renameable workspace name (admin/owner). */
       workspaceName: string;
+      /** The shared IANA zone every date in this workspace is read in. */
+      workspaceTimezone: string;
+      workspaceTimezoneHelp: string;
+      workspaceTimezoneSaved: string;
+      workspaceTimezoneError: string;
+      workspaceTimezoneUnset: string;
+      workspaceTimezoneUtc: string;
       workspaceNameSave: string;
       workspaceNameSaved: string;
       workspaceNameError: string;
@@ -1087,6 +1096,8 @@ export interface FormsMessages {
       rangeFrom: string;
       rangeTo: string;
       rangeApply: string;
+      /** Under the trends chart: which zone the days are cut in. // {zone} */
+      timezoneNote: string;
       /** Trends chart (per-day series, metric switchable). */
       trendsTitle: string;
       trendsSubtitle: string;
@@ -1114,6 +1125,10 @@ export interface FormsMessages {
       title: string;
       subtitle: string;
       statusAll: string;
+      /** The shared workspace zone, editable from the table by admins. */
+      timezoneLabel: string;
+      timezoneHint: string;
+      timezoneReadOnly: string;
       statusCompleted: string;
       statusPartial: string;
       badgeCompleted: string;
@@ -1744,6 +1759,7 @@ export const en: FormsMessages = {
     },
     chrome: {
       collapse: 'Collapse sidebar',
+      timezoneAutoSet: 'Workspace timezone set to {zone}. Change it in Account settings or on the submissions page.',
       expand: 'Expand sidebar',
       openNav: 'Open navigation',
       theme: {
@@ -1883,6 +1899,13 @@ export const en: FormsMessages = {
       title: 'Settings',
       subtitle: 'Your workspace and team.',
       workspaceName: 'Workspace name',
+      workspaceTimezone: 'Workspace timezone',
+      workspaceTimezoneHelp:
+        'Shared by everyone in this workspace. Every date in the dashboard, the analytics day cuts and the local columns of the CSV export are read in this zone.',
+      workspaceTimezoneSaved: 'Workspace timezone saved.',
+      workspaceTimezoneError: 'Could not save the timezone. Please try again.',
+      workspaceTimezoneUnset: 'Not set (UTC)',
+      workspaceTimezoneUtc: 'UTC',
       workspaceNameSave: 'Save',
       workspaceNameSaved: 'Workspace renamed.',
       workspaceNameError: 'Could not rename the workspace.',
@@ -2609,6 +2632,7 @@ export const en: FormsMessages = {
       rangeFrom: 'From',
       rangeTo: 'To',
       rangeApply: 'Apply',
+      timezoneNote: 'Days in {zone}',
       trendsTitle: 'Trends',
       trendsSubtitle: 'Daily movement over the selected range.',
       trendsMetricLabel: 'Metric',
@@ -2634,6 +2658,9 @@ export const en: FormsMessages = {
       title: 'Submissions',
       subtitle: 'Every response to this form.',
       statusAll: 'All',
+      timezoneLabel: 'Workspace timezone',
+      timezoneHint: 'Dates below are read in this zone. It is shared by the whole workspace.',
+      timezoneReadOnly: 'Only an admin can change it.',
       statusCompleted: 'Completed',
       statusPartial: 'Partial',
       badgeCompleted: 'Completed',
@@ -3224,6 +3251,7 @@ export const es: FormsMessages = {
     },
     chrome: {
       collapse: 'Contraer barra lateral',
+      timezoneAutoSet: 'Zona horaria del workspace fijada en {zone}. Cámbiala en Ajustes de cuenta o en la página de respuestas.',
       expand: 'Expandir barra lateral',
       openNav: 'Abrir navegación',
       theme: {
@@ -3364,6 +3392,13 @@ export const es: FormsMessages = {
       title: 'Ajustes',
       subtitle: 'Tu espacio de trabajo y tu equipo.',
       workspaceName: 'Nombre del workspace',
+      workspaceTimezone: 'Zona horaria del workspace',
+      workspaceTimezoneHelp:
+        'La comparten todos en este workspace. Cada fecha del panel, los cortes por día de las analíticas y las columnas locales del CSV se leen en esta zona.',
+      workspaceTimezoneSaved: 'Zona horaria del workspace guardada.',
+      workspaceTimezoneError: 'No se pudo guardar la zona horaria. Inténtalo de nuevo.',
+      workspaceTimezoneUnset: 'Sin definir (UTC)',
+      workspaceTimezoneUtc: 'UTC',
       workspaceNameSave: 'Guardar',
       workspaceNameSaved: 'Workspace renombrado.',
       workspaceNameError: 'No se pudo renombrar el workspace.',
@@ -4093,6 +4128,7 @@ export const es: FormsMessages = {
       rangeFrom: 'Desde',
       rangeTo: 'Hasta',
       rangeApply: 'Aplicar',
+      timezoneNote: 'Días en {zone}',
       trendsTitle: 'Tendencias',
       trendsSubtitle: 'Movimiento diario en el rango seleccionado.',
       trendsMetricLabel: 'Métrica',
@@ -4118,6 +4154,9 @@ export const es: FormsMessages = {
       title: 'Respuestas',
       subtitle: 'Todas las respuestas a este formulario.',
       statusAll: 'Todas',
+      timezoneLabel: 'Zona horaria del workspace',
+      timezoneHint: 'Las fechas de abajo se leen en esta zona. La comparte todo el workspace.',
+      timezoneReadOnly: 'Solo un administrador puede cambiarla.',
       statusCompleted: 'Completadas',
       statusPartial: 'Parciales',
       badgeCompleted: 'Completada',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './growth';
 export * from './nav';
 export * from './countries';
 export * from './i18n';
+export * from './datetime';

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -9,7 +9,7 @@
  * has somewhere obvious to prove the same thing.
  */
 import { describe, expect, it } from 'vitest';
-import { formConfigSchema, hasExtraHubspotDestination } from './index';
+import { formConfigSchema, hasExtraHubspotDestination, workspaceTimezoneSchema } from './index';
 
 /** The smallest config the schema accepts — one step, nothing configured. */
 function baseConfig() {
@@ -195,5 +195,18 @@ describe('hasExtraHubspotDestination', () => {
     it('still ignores webhooks on both sides', () => {
       expect(hasExtraHubspotDestination([webhook, webhook, hubspot], [hubspot])).toBe(false);
     });
+  });
+});
+
+describe('workspace timezone input', () => {
+  it('accepts a known IANA zone or null, rejects garbage and an unknown zone', () => {
+    expect(workspaceTimezoneSchema.parse({ timezone: 'America/Bogota' })).toEqual({ timezone: 'America/Bogota' });
+    expect(workspaceTimezoneSchema.parse({ timezone: null, onlyIfUnset: true })).toEqual({
+      timezone: null,
+      onlyIfUnset: true,
+    });
+    expect(() => workspaceTimezoneSchema.parse({ timezone: 'Mars/Olympus' })).toThrow();
+    expect(() => workspaceTimezoneSchema.parse({ timezone: 'drop table' })).toThrow();
+    expect(() => workspaceTimezoneSchema.parse({})).toThrow();
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1406,7 +1406,7 @@ export const timeZoneSchema = z
   .trim()
   .min(1)
   .max(64)
-  .regex(/^[A-Za-z0-9_+\-]+(?:\/[A-Za-z0-9_+\-]+)*$/, 'Not a timezone name.')
+  .regex(/^[A-Za-z0-9_+-]+(?:\/[A-Za-z0-9_+-]+)*$/, 'Not a timezone name.')
   .refine(
     (zone) => {
       try {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1298,7 +1298,10 @@ export type DropoffRow = z.infer<typeof dropoffRowSchema>;
  * (a missing day would draw a misleading straight line across it).
  */
 export const trendPointSchema = z.object({
-  /** Epoch ms at the START of the day bucket (UTC). */
+  /**
+   * Epoch ms of UTC midnight of the CALENDAR DAY this bucket names, in the
+   * zone the response was resolved in (`range.timeZone`). Render it in UTC.
+   */
   t: z.number().int(),
   /** Unique sessions that viewed the form that day. */
   views: z.number().int(),
@@ -1353,7 +1356,12 @@ export const analyticsResponseSchema = z.object({
   /** Gap-filled per-day series for the Trends chart (oldest → newest). */
   trends: z.array(trendPointSchema),
   /** Echoes the resolved range (epoch ms) so the client can render it. */
-  range: z.object({ from: z.number().nullable(), to: z.number().nullable() }),
+  range: z.object({
+    from: z.number().nullable(),
+    to: z.number().nullable(),
+    /** The zone the day buckets were named in (absent on older responses = UTC). */
+    timeZone: z.string().optional(),
+  }),
 });
 export type AnalyticsResponse = z.infer<typeof analyticsResponseSchema>;
 
@@ -1386,6 +1394,38 @@ export const workspaceRenameSchema = z.object({
   name: z.string().trim().min(1, 'A name is required.').max(80),
 });
 export type WorkspaceRenameInput = z.infer<typeof workspaceRenameSchema>;
+
+/**
+ * An IANA timezone name the runtime knows (`America/Bogota`, `UTC`). The
+ * regex keeps the shape honest before `Intl` is asked, and `Intl` is the
+ * source of truth: a zone this server cannot resolve is rejected here rather
+ * than silently read as UTC everywhere later.
+ */
+export const timeZoneSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9_+\-]+(?:\/[A-Za-z0-9_+\-]+)*$/, 'Not a timezone name.')
+  .refine(
+    (zone) => {
+      try {
+        new Intl.DateTimeFormat('en-US', { timeZone: zone });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Unknown timezone.' },
+  );
+
+/** PATCH /v1/workspaces/current/timezone: set, clear (null), or seed only while unset. */
+export const workspaceTimezoneSchema = z.object({
+  timezone: timeZoneSchema.nullable(),
+  /** True = a write-once claim from the browser's zone; false/absent = an explicit choice. */
+  onlyIfUnset: z.boolean().optional(),
+});
+export type WorkspaceTimezoneInput = z.infer<typeof workspaceTimezoneSchema>;
 
 export const memberInviteSchema = z.object({
   email: z.string().email().max(320),


### PR DESCRIPTION
## Why

Every timestamp in the dashboard was rendered on the server clock (UTC) and the analytics buckets were UTC days, so a team in Bogota read its evening submissions as tomorrow's, and nothing let them change it.

## What

One IANA zone per workspace (`account.timezone`, migration 0020), shared by everyone in it.

- **Default**: the first owner or admin to open the dashboard while the zone is unset seeds it from their browser. It is a write-once claim (`UPDATE ... WHERE timezone IS NULL`), so two admins in different zones cannot flip it, and a toast names where to change it. Staff entering an estate workspace never seed it. Until then dates read in UTC, exactly as before. No geo-IP.
- **Two places to change it**, writing the same column through `PATCH /v1/workspaces/current/timezone` (admin/owner; its own route because `PATCH workspaces/current` goes upstream and the identity service has no zone): Account settings under the workspace name, and a searchable dropdown beside the submissions filter labelled "Workspace timezone" with the note that it is shared. A member sees the value with a lock.
- **Dates**: forms list, submissions table, delivery history, webhook health, brand kit stamp, all through `formatDateTime` / `formatDate` in `@quill/shared` (Intl only, no new dependency). An unknown zone renders as UTC with a warning, never a 500.
- **Analytics**: day buckets are named in the workspace zone inside SQL (`(col + offset) / 86400000`, offset chosen by a CASE over the DST boundaries of the queried window, so `COUNT(DISTINCT session_id)` stays in the query); presets and custom dates cut at local midnight; the picker's "today" is the zone's today; `?tz=` overrides per request; `range.timeZone` is echoed; a caption under the trends chart names the zone.
- **CSV**: `started_at` / `completed_at` stay UTC (`Z`); `started_at_local` / `completed_at_local` are ISO with the zone offset (`2026-09-03T18:30:15-05:00`).

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` and `pnpm build` pass; dash-check clean.
- Specs: `datetime.spec.ts` (DST New York 2026-03-08: offsets on both sides, two segments, a 23-hour day; Bogota one segment; ISO offsets; invalid zone never throws), `account-timezone.spec.ts` (set, claim once, no overwrite, null clears, on `/me`), `analytics.spec.ts` (04:30Z and 08:30Z of March 8 land on different New York days from 23:30Z), `workspace.service.spec.ts` (admin sets, claim only while unset, member forbidden), `query-params.spec.ts`, `analytics.service.spec.ts` (a submission at D1+2h falls on the previous Bogota day; CSV headers and `-05:00` values; invalid zone exports `+00:00`), `submissions/page.spec.tsx` (timestamps in the workspace zone).
- `build + start`: first dashboard load as owner showed the toast once and `account.timezone` held the browser's zone; a submission stored at `2026-09-04T03:30Z` reads `3 sept 2026, 21:30` in the submissions table next to the dropdown, and Analytics "Today" counts it with the caption "Días en America/Guatemala".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
