### PR TITLE
feat(forms): folders and keyboard search on the forms list

### DIFF
--- a/.changeset/form-folders.md
+++ b/.changeset/form-folders.md
@@ -1,0 +1,36 @@
+---
+'@quill/db': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+Folders and keyboard search on the forms list.
+
+A workspace with more than a screenful of forms had one flat list and no
+way to find or group anything. The forms page is now one list grouped by
+folder, searchable from the keyboard.
+
+- **Folders** (`form_folder`, migration 0021): flat, one level, named only,
+  unique per workspace without regard to case, alphabetical. A form is filed
+  in at most one (`form.folder_id`, null = unfiled, which every existing form
+  is). Deleting a folder unfiles its forms and never deletes them. Any active
+  member may organise forms, the same rule as creating them.
+- **API**: `GET/POST /v1/folders`, `PATCH/DELETE /v1/folders/:id` (409
+  `NAME_TAKEN`, idempotent delete), `PATCH /v1/forms/:id/folder` (`{ folderId
+  | null }`), `POST /v1/forms` accepts `folderId`, duplicating keeps the
+  folder, `GET /v1/forms` returns `folderId`. Moving never touches
+  `updated_at`.
+- **List**: "Unfiled" first, then each folder as a collapsible section (the
+  fold is remembered per browser) with its count, a "New form" that creates
+  straight into it, and Rename / Delete behind a kebab. Rows drag onto a
+  section by their grip; the row kebab's "Move to folder" is the keyboard
+  route to the same move. Without folders the list looks exactly as before,
+  and every row keeps its test ids.
+- **Search**: a search box over the loaded list, focused with Ctrl/Cmd+K or
+  `/` (outside inputs), matching name or link without case or accents,
+  highlighting the hit, hiding sections without one, Escape clears, arrows
+  walk the rows and Enter opens the editor.
+- `@quill/types`: `folderInputSchema`, `folderViewSchema`,
+  `formFolderPatchSchema`, `formCreateInputSchema`, `formViewSchema.folderId`.
+  `@quill/db`: `NAME_TAKEN` on `CrudResult`, `folders.ts`.
+- i18n: `admin.forms.search*`, `admin.forms.*folder*`, `dialog.deleteFolderTitle` (EN + ES).

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -48,6 +48,11 @@ import {
   getMemberProfileRaw,
   setMemberLocale,
   setMemberProfile,
+  createFolder,
+  deleteFolder,
+  listFolders,
+  renameFolder,
+  setFormFolder,
 } from '@quill/db';
 import {
   defaultSubmissionTemplate,
@@ -73,6 +78,9 @@ import {
   onboardingProgressSchema,
   workspaceCreateSchema,
   workspaceRenameSchema,
+  folderInputSchema,
+  formCreateInputSchema,
+  formFolderPatchSchema,
 } from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
@@ -116,6 +124,11 @@ function maskForm<T extends { config: unknown; draftConfig?: unknown }>(form: T)
     config: maskConfigSecrets(form.config),
     ...(form.draftConfig != null ? { draftConfig: maskConfigSecrets(form.draftConfig) } : {}),
   };
+}
+
+/** The client shape of a folder: the account id never leaves the server. */
+function folderView(f: { id: string; name: string; createdAt: number; updatedAt: number }) {
+  return { id: f.id, name: f.name, createdAt: f.createdAt, updatedAt: f.updatedAt };
 }
 
 /** Host-authed CRUD for forms + submissions + members, and identity/vanity. */
@@ -462,7 +475,9 @@ export class AdminCrudController {
   @HttpCode(201)
   async createForm(@Req() req: ReqLike, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
-    const input = parse(formInputSchema, body);
+    // The create schema (not the shared input one): only creation may name a
+    // folder; PUT /v1/forms/:id never moves a form, PATCH /forms/:id/folder does.
+    const input = parse(formCreateInputSchema, body);
     // The other path that AUTHORS a `destinations` array (PUT /forms/:id stages
     // a draft, and drafts strip the key; duplicate copies stored state and is
     // exempt — see `hasExtraHubspotDestination`). Same one-HubSpot rule as
@@ -621,6 +636,51 @@ export class AdminCrudController {
     const existing = await getFormById(this.db, p.accountId, id);
     if (!existing) return; // idempotent — already gone (204)
     await deleteForm(this.db, p.accountId, id);
+  }
+
+  // --- Form folders (0021) ----------------------------------------------------
+  //
+  // Organising forms is the same right as creating them: any active member of
+  // the workspace, no admin gate (mirrors POST /v1/forms above).
+
+  /** The account's folders, alphabetically. */
+  @Get('folders')
+  async listFolders(@Req() req: ReqLike) {
+    const p = await this.auth.resolveHost(req);
+    return (await listFolders(this.db, p.accountId)).map(folderView);
+  }
+
+  /** Create a folder. 409 NAME_TAKEN when the account already has that name (case-insensitively). */
+  @Post('folders')
+  @HttpCode(201)
+  async createFolder(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const input = parse(folderInputSchema, body);
+    return folderView(unwrapCrud(await createFolder(this.db, p.accountId, input.name)));
+  }
+
+  /** Rename a folder. 404 for another account's folder, 409 NAME_TAKEN on a clash. */
+  @Patch('folders/:id')
+  async renameFolder(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const input = parse(folderInputSchema, body);
+    return folderView(unwrapCrud(await renameFolder(this.db, p.accountId, id, input.name)));
+  }
+
+  /** Delete a folder: its forms are unfiled, never deleted. Idempotent (204 either way). */
+  @Delete('folders/:id')
+  @HttpCode(204)
+  async deleteFolder(@Req() req: ReqLike, @Param('id') id: string) {
+    const p = await this.auth.resolveHost(req);
+    await deleteFolder(this.db, p.accountId, id);
+  }
+
+  /** File a form in a folder (null unfiles). 404 for a form or folder outside the account. */
+  @Patch('forms/:id/folder')
+  async setFormFolder(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const input = parse(formFolderPatchSchema, body);
+    return unwrapCrud(await setFormFolder(this.db, p.accountId, id, input.folderId));
   }
 
   /**

--- a/apps/api/src/folders.controller.spec.ts
+++ b/apps/api/src/folders.controller.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * The folder routes on the host-authed controller: create (201 / 409
+ * NAME_TAKEN), rename, delete (idempotent 204), move a form (404 for a
+ * stranger's folder), create a form straight into a folder, and the role
+ * rule: any active member may organise forms, exactly like creating them.
+ * In-memory SQLite through the real controller and the local auth provider.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ConflictException, NotFoundException } from "@nestjs/common";
+import { createDb, migrate, seed, sql, type Db } from "@quill/db";
+import { AdminCrudController } from "./admin-crud.controller";
+import { AdminService } from "./admin.service";
+import { AuthService } from "./auth.service";
+import { LocalAuthProvider } from "./auth.provider";
+import type { ReqLike } from "./auth.provider";
+
+let db: Db;
+let controller: AdminCrudController;
+let accountId: string;
+let formId: string;
+
+const asOwner = (): ReqLike => ({ headers: {} });
+const asMember = (): ReqLike => ({
+  headers: { "x-quill-email": "member@example.com" },
+});
+
+async function conflictCode(run: Promise<unknown>): Promise<string> {
+  try {
+    await run;
+  } catch (e) {
+    if (e instanceof ConflictException)
+      return (e.getResponse() as { error?: string }).error ?? "";
+    throw e;
+  }
+  throw new Error("expected a ConflictException");
+}
+
+beforeEach(async () => {
+  db = await createDb("file::memory:");
+  await migrate(db);
+  await seed(db); // account "acme" + demo form "lead-qualifier" + owner alex@example.com
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: "test",
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
+  });
+  const auth = new AuthService(db, provider);
+  const admin = new AdminService(db);
+  controller = new AdminCrudController(
+    db,
+    auth,
+    admin,
+    {} as never,
+    {} as never,
+  );
+  const account = await db.get<{ id: string }>(
+    sql`SELECT id FROM account WHERE code = 'acme' LIMIT 1`,
+  );
+  accountId = account!.id;
+  const form = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE slug = 'lead-qualifier' LIMIT 1`,
+  );
+  formId = form!.id;
+  // A plain member of acme (the local provider signs anyone in by email).
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, role, status, created_at)
+        VALUES (${randomUUID()}, ${accountId}, ${"member@example.com"}, ${"member"}, ${"active"}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe("folders", () => {
+  it("creates, lists alphabetically and refuses a duplicate name (case-insensitively) with 409 NAME_TAKEN", async () => {
+    const sales = await controller.createFolder(asOwner(), { name: "Sales" });
+    expect(sales.name).toBe("Sales");
+    await controller.createFolder(asOwner(), { name: "archive" });
+    expect(
+      (await controller.listFolders(asOwner())).map((f) => f.name),
+    ).toEqual(["archive", "Sales"]);
+    expect(
+      await conflictCode(controller.createFolder(asOwner(), { name: "SALES" })),
+    ).toBe("NAME_TAKEN");
+  });
+
+  it("renames a folder, and deleting twice is idempotent", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    expect(
+      (await controller.renameFolder(asOwner(), f.id, { name: "Ventas" })).name,
+    ).toBe("Ventas");
+    await controller.deleteFolder(asOwner(), f.id);
+    await controller.deleteFolder(asOwner(), f.id); // gone already: still 204
+    expect(await controller.listFolders(asOwner())).toEqual([]);
+    await expect(
+      controller.renameFolder(asOwner(), f.id, { name: "x" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("moves a form into a folder and back out; a stranger folder is 404", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    expect(
+      await controller.setFormFolder(asOwner(), formId, { folderId: f.id }),
+    ).toEqual({ id: formId, folderId: f.id });
+    expect(
+      (await controller.listForms(asOwner())).find((x) => x.id === formId)
+        ?.folderId,
+    ).toBe(f.id);
+    expect(
+      await controller.setFormFolder(asOwner(), formId, { folderId: null }),
+    ).toEqual({ id: formId, folderId: null });
+    await expect(
+      controller.setFormFolder(asOwner(), formId, { folderId: "nope" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("a form is created straight into a folder, and a duplicate inherits it", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    const created = await controller.createForm(asOwner(), {
+      name: "Quiz",
+      folderId: f.id,
+    });
+    expect(created.folderId).toBe(f.id);
+    const copy = await controller.duplicateForm(asOwner(), created.id);
+    expect(copy.folderId).toBe(f.id);
+    await expect(
+      controller.createForm(asOwner(), { name: "Quiz 2", folderId: "nope" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("deleting a folder unfiles its forms and keeps them", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    await controller.setFormFolder(asOwner(), formId, { folderId: f.id });
+    await controller.deleteFolder(asOwner(), f.id);
+    const row = (await controller.listForms(asOwner())).find(
+      (x) => x.id === formId,
+    );
+    expect(row).toBeDefined();
+    expect(row!.folderId).toBeNull();
+  });
+
+  it("a plain member may create folders and move forms (the same rule as creating forms)", async () => {
+    const f = await controller.createFolder(asMember(), { name: "Mine" });
+    expect(
+      await controller.setFormFolder(asMember(), formId, { folderId: f.id }),
+    ).toEqual({ id: formId, folderId: f.id });
+  });
+});

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -72,6 +72,8 @@ export const openapiSpec = {
     '/v1/forms': {
       get: { summary: 'List forms (host)', security: [{ hostSession: [] }], responses: { '200': { description: 'Forms' } } },
       post: { summary: 'Create a form (host)', security: [{ hostSession: [] }], responses: { '201': { description: 'Created' } } },
+        description:
+          'Body { name, slug?, config?, folderId? }. `folderId` files the new form in one of the workspace folders (404 for a folder outside it); absent = unfiled.',
     },
     '/v1/forms/{id}': {
       get: { summary: 'Get a form (host)', security: [{ hostSession: [] }], responses: { '200': { description: 'Form' } } },

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -97,6 +97,53 @@ export const openapiSpec = {
         },
       },
     },
+    '/v1/folders': {
+      get: {
+        summary: "The workspace's form folders, alphabetically (host)",
+        security: [{ hostSession: [] }],
+        responses: { '200': { description: 'Array of { id, name, createdAt, updatedAt }' } },
+      },
+      post: {
+        summary: 'Create a form folder (host)',
+        description:
+          'Body { name } (1 to 80 characters, trimmed). Folders are flat and named only; a name is unique per workspace without regard to case. Any active member may create one, the same rule as creating a form.',
+        security: [{ hostSession: [] }],
+        responses: {
+          '201': { description: 'Created' },
+          '409': { description: 'NAME_TAKEN' },
+        },
+      },
+    },
+    '/v1/folders/{id}': {
+      patch: {
+        summary: 'Rename a form folder (host)',
+        description: 'Body { name }. 404 for a folder of another workspace, 409 NAME_TAKEN on a clash.',
+        security: [{ hostSession: [] }],
+        responses: {
+          '200': { description: 'Renamed' },
+          '404': { description: 'No such folder in this workspace' },
+          '409': { description: 'NAME_TAKEN' },
+        },
+      },
+      delete: {
+        summary: 'Delete a form folder (host)',
+        description: 'The forms inside are unfiled, never deleted. Idempotent: deleting an absent folder is still 204.',
+        security: [{ hostSession: [] }],
+        responses: { '204': { description: 'Deleted (or already gone)' } },
+      },
+    },
+    '/v1/forms/{id}/folder': {
+      patch: {
+        summary: 'Move a form into a folder, or unfile it (host)',
+        description:
+          'Body { folderId } where null unfiles. The key is required. 404 when the form or the folder is not in this workspace. The form\'s updated_at is untouched.',
+        security: [{ hostSession: [] }],
+        responses: {
+          '200': { description: '{ id, folderId }' },
+          '404': { description: 'No such form or folder in this workspace' },
+        },
+      },
+    },
     '/v1/forms/{id}/publish': {
       post: {
         summary: 'Publish a pending draft config (host)',

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -12,8 +12,11 @@ export async function createFormAction(formData: FormData): Promise<void> {
   // `layout` already means slides (the engine's back-compat default), so a
   // slides form keeps the exact config shape every existing form has.
   const layout = String(formData.get('layout') ?? '');
+  // The folder preselected by a section's "New form" (or picked in the dialog).
+  const folderId = String(formData.get('folderId') ?? '').trim() || null;
   const created = await adminApi.createForm({
     name,
+    ...(folderId ? { folderId } : {}),
     ...(layout === 'vertical' ? { config: { version: 1, steps: [], layout: 'vertical' } } : {}),
   });
   revalidatePath('/admin');

--- a/apps/web/app/admin/forms/create-form.tsx
+++ b/apps/web/app/admin/forms/create-form.tsx
@@ -5,7 +5,9 @@ import { useFormStatus } from 'react-dom';
 import { Modal } from '@/components/modal';
 import { cn } from '@/lib/cn';
 import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
 import { createFormAction } from '@/app/admin/actions';
+import type { Folder } from '@/lib/admin-api';
 
 interface Labels {
   create: string;
@@ -21,6 +23,9 @@ interface Labels {
   layoutSlidesDesc: string;
   layoutVertical: string;
   layoutVerticalDesc: string;
+  /** Folder picker (only when the surface has folders). */
+  folderLabel?: string;
+  folderNone?: string;
 }
 
 function SubmitButton({ label }: { label: string }) {
@@ -45,17 +50,32 @@ function SubmitButton({ label }: { label: string }) {
 export function CreateForm({
   labels,
   variant = 'button',
+  size,
+  triggerLabel,
   cardTitle,
   cardDesc,
+  folders = [],
+  defaultFolderId = null,
+  locale = 'en',
 }: {
   labels: Labels;
   variant?: 'button' | 'outline' | 'card';
+  /** Button size override (a folder header uses `sm`). */
+  size?: 'sm' | 'default';
+  /** Trigger text override (the header says "New form", the dialog keeps its title). */
+  triggerLabel?: string;
   cardTitle?: string;
   cardDesc?: string;
+  /** The workspace's folders; with any, the dialog offers a folder picker. */
+  folders?: Folder[];
+  /** Preselected folder (a section's own "New form"). */
+  defaultFolderId?: string | null;
+  locale?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [nameError, setNameError] = useState(false);
   const [layout, setLayout] = useState<'slides' | 'vertical'>('slides');
+  const [folderId, setFolderId] = useState<string>(defaultFolderId ?? '');
 
   // Every open starts clean and every dismissal clears the error, so a Cancel
   // (or ESC, or overlay click) can't leave a stale "name required" on the next,
@@ -63,6 +83,7 @@ export function CreateForm({
   const openDialog = () => {
     setNameError(false);
     setLayout('slides');
+    setFolderId(defaultFolderId ?? '');
     setOpen(true);
   };
   const closeDialog = () => {
@@ -84,8 +105,8 @@ export function CreateForm({
         {cardDesc ? <span className="text-sm text-muted-foreground">{cardDesc}</span> : null}
       </button>
     ) : (
-      <Button variant={variant === 'outline' ? 'outline' : 'default'} onClick={openDialog}>
-        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {labels.create}
+      <Button variant={variant === 'outline' ? 'outline' : 'default'} size={size} onClick={openDialog}>
+        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {triggerLabel ?? labels.create}
       </Button>
     );
 
@@ -135,6 +156,22 @@ export function CreateForm({
               </span>
             ) : null}
           </label>
+          {folders.length > 0 && labels.folderLabel ? (
+            <label className="flex flex-col gap-1.5 text-sm">
+              <span className="font-medium">{labels.folderLabel}</span>
+              <input type="hidden" name="folderId" value={folderId} />
+              <Select
+                ariaLabel={labels.folderLabel}
+                value={folderId}
+                locale={locale}
+                options={[
+                  { value: '', label: labels.folderNone ?? '' },
+                  ...folders.map((f) => ({ value: f.id, label: f.name })),
+                ]}
+                onChange={setFolderId}
+              />
+            </label>
+          ) : null}
 
           {/* Layout picker: two visual cards. Rides the form as a hidden input
               so the server action reads one flat FormData — no client fetch. */}

--- a/apps/web/app/admin/forms/folder-actions.ts
+++ b/apps/web/app/admin/forms/folder-actions.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { unstable_rethrow } from "next/navigation";
+import { adminApi, ApiError, type Folder } from "@/lib/admin-api";
+
+/** Every surface that lists forms by folder. */
+function revalidateForms(): void {
+  revalidatePath("/admin/forms");
+  revalidatePath("/admin");
+}
+
+export type FolderWriteState =
+  | { ok: true; folder: Folder }
+  | { ok: false; code: "NAME_TAKEN" | "INVALID" | "FAILED" };
+
+function failure(e: unknown): FolderWriteState {
+  unstable_rethrow(e);
+  if (e instanceof ApiError && e.status === 409)
+    return { ok: false, code: "NAME_TAKEN" };
+  if (e instanceof ApiError && e.status === 400)
+    return { ok: false, code: "INVALID" };
+  return { ok: false, code: "FAILED" };
+}
+
+export async function createFolderAction(
+  name: string,
+): Promise<FolderWriteState> {
+  try {
+    const folder = await adminApi.createFolder(name.trim());
+    revalidateForms();
+    return { ok: true, folder };
+  } catch (e) {
+    return failure(e);
+  }
+}
+
+export async function renameFolderAction(
+  id: string,
+  name: string,
+): Promise<FolderWriteState> {
+  try {
+    const folder = await adminApi.renameFolder(id, name.trim());
+    revalidateForms();
+    return { ok: true, folder };
+  } catch (e) {
+    return failure(e);
+  }
+}
+
+/** Delete a folder: its forms are unfiled, never deleted. */
+export async function deleteFolderAction(id: string): Promise<{ ok: boolean }> {
+  try {
+    await adminApi.deleteFolder(id);
+    revalidateForms();
+    return { ok: true };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}
+
+/** File a form in a folder (null unfiles). */
+export async function moveFormAction(
+  formId: string,
+  folderId: string | null,
+): Promise<{ ok: boolean }> {
+  try {
+    await adminApi.setFormFolder(formId, folderId);
+    revalidateForms();
+    return { ok: true };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}

--- a/apps/web/app/admin/forms/folder-dialog.tsx
+++ b/apps/web/app/admin/forms/folder-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useId, useState, useTransition } from "react";
+import { Modal } from "@/components/modal";
+import { Button } from "@/components/ui/button";
+import { callAction } from "@/lib/call-action";
+import {
+  createFolderAction,
+  renameFolderAction,
+  type FolderWriteState,
+} from "./folder-actions";
+
+export interface FolderDialogLabels {
+  newFolderTitle: string;
+  renameFolderTitle: string;
+  folderCreate: string;
+  folderSave: string;
+  folderNameLabel: string;
+  folderNamePlaceholder: string;
+  folderNameRequired: string;
+  folderNameTaken: string;
+  actionFailed: string;
+  cancel: string;
+}
+
+/**
+ * Create or rename a folder. One dialog for both: the only differences are the
+ * title, the submit label and which action runs. A duplicate name comes back
+ * as an inline error on the field (409 NAME_TAKEN), never as a toast the
+ * person has to hunt for while the dialog is still open.
+ */
+export function FolderDialog({
+  open,
+  onClose,
+  onDone,
+  mode,
+  initialName = "",
+  folderId,
+  labels,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onDone?: (state: Extract<FolderWriteState, { ok: true }>) => void;
+  mode: "create" | "rename";
+  initialName?: string;
+  /** Required for `rename`. */
+  folderId?: string;
+  labels: FolderDialogLabels;
+}) {
+  const [pending, start] = useTransition();
+  const [error, setError] = useState<"required" | "taken" | "failed" | null>(
+    null,
+  );
+  const [name, setName] = useState(initialName);
+  const errorId = useId();
+  const labelId = useId();
+
+  const close = () => {
+    setError(null);
+    onClose();
+  };
+
+  const submit = () => {
+    const value = name.trim();
+    if (!value) {
+      setError("required");
+      return;
+    }
+    start(async () => {
+      const res = await callAction(() =>
+        mode === "create"
+          ? createFolderAction(value)
+          : renameFolderAction(folderId ?? "", value),
+      );
+      if (res && "ok" in res && res.ok) {
+        setError(null);
+        onDone?.(res);
+        onClose();
+        return;
+      }
+      setError(
+        res && "code" in res && res.code === "NAME_TAKEN" ? "taken" : "failed",
+      );
+    });
+  };
+
+  const message =
+    error === "required"
+      ? labels.folderNameRequired
+      : error === "taken"
+        ? labels.folderNameTaken
+        : error === "failed"
+          ? labels.actionFailed
+          : null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={close}
+      title={
+        mode === "create" ? labels.newFolderTitle : labels.renameFolderTitle
+      }
+      labelId={labelId}
+    >
+      <form
+        data-testid="folder-dialog"
+        noValidate
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+        className="flex flex-col gap-4"
+      >
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium">{labels.folderNameLabel}</span>
+          <input
+            name="name"
+            value={name}
+            autoFocus
+            autoComplete="off"
+            maxLength={80}
+            placeholder={labels.folderNamePlaceholder}
+            aria-invalid={message ? true : undefined}
+            aria-describedby={message ? errorId : undefined}
+            data-testid="folder-name-input"
+            onChange={(e) => {
+              setName(e.target.value);
+              setError(null);
+            }}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          {message ? (
+            <span
+              id={errorId}
+              role="alert"
+              className="text-xs text-destructive"
+              data-testid="folder-name-error"
+            >
+              {message}
+            </span>
+          ) : null}
+        </label>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={close}
+            disabled={pending}
+          >
+            {labels.cancel}
+          </Button>
+          <Button
+            type="submit"
+            disabled={pending}
+            data-testid="folder-dialog-submit"
+            className="min-w-[120px]"
+          >
+            {mode === "create" ? labels.folderCreate : labels.folderSave}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/app/admin/forms/form-row-actions.tsx
+++ b/apps/web/app/admin/forms/form-row-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { getMessages } from '@quill/shared';
 import { duplicateFormAction, deleteFormAction } from '@/app/admin/actions';
 import { clientLocale } from '@/lib/client-locale';
@@ -63,6 +63,21 @@ export function FormRowActions({
     if (open) menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
   }, [open]);
 
+  // Arrows walk every item (Duplicate, the folder radios, Delete) so "Move to
+  // folder" is reachable from the keyboard, which is the whole point of it.
+  function onMenuKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"], [role="menuitemradio"]') ?? [],
+    );
+    if (items.length === 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const at = items.indexOf(document.activeElement as HTMLElement);
+    if (e.key === 'ArrowDown') items[at < 0 || at === items.length - 1 ? 0 : at + 1]?.focus();
+    else items[at <= 0 ? items.length - 1 : at - 1]?.focus();
+  }
+
   const itemClass =
     'flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:outline-none';
 
@@ -86,6 +101,7 @@ export function FormRowActions({
           ref={menuRef}
           role="menu"
           aria-label={labels.menu}
+          onKeyDown={onMenuKeyDown}
           className="absolute right-0 z-50 mt-2 w-52 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
         >
           <button
@@ -114,13 +130,12 @@ export function FormRowActions({
                     role="menuitemradio"
                     aria-checked={checked}
                     tabIndex={-1}
-                    disabled={pending || checked}
                     data-testid={`form-row-move-${folder.id ?? 'none'}`}
                     onClick={() => {
                       setOpen(false);
-                      onMove(folder.id);
+                      if (!checked) onMove(folder.id);
                     }}
-                    className={`${itemClass} disabled:opacity-60`}
+                    className={itemClass}
                   >
                     <i
                       aria-hidden

--- a/apps/web/app/admin/forms/form-row-actions.tsx
+++ b/apps/web/app/admin/forms/form-row-actions.tsx
@@ -6,6 +6,17 @@ import { duplicateFormAction, deleteFormAction } from '@/app/admin/actions';
 import { clientLocale } from '@/lib/client-locale';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import { callAction } from '@/lib/call-action';
+import type { Folder } from '@/lib/admin-api';
+
+export interface FormRowActionLabels {
+  menu: string;
+  duplicate: string;
+  delete: string;
+  deleteConfirm: string;
+  /** "Move to folder" group + the unfile choice; absent = no folders on this surface. */
+  moveTo?: string;
+  moveBack?: string;
+}
 
 /**
  * Overflow menu for a form row (WAI-ARIA menu-button). The cross-links
@@ -17,14 +28,16 @@ import { callAction } from '@/lib/call-action';
 export function FormRowActions({
   id,
   labels,
+  folders = [],
+  currentFolderId = null,
+  onMove,
 }: {
   id: string;
-  labels: {
-    menu: string;
-    duplicate: string;
-    delete: string;
-    deleteConfirm: string;
-  };
+  labels: FormRowActionLabels;
+  /** The workspace's folders, for the "Move to folder" radio group (keyboard fallback to drag). */
+  folders?: Folder[];
+  currentFolderId?: string | null;
+  onMove?: (folderId: string | null) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [pending, start] = useTransition();
@@ -89,6 +102,37 @@ export function FormRowActions({
             <i aria-hidden className="pi pi-copy text-muted-foreground" style={{ fontSize: 13 }} />
             {labels.duplicate}
           </button>
+          {onMove && labels.moveTo && folders.length > 0 ? (
+            <div role="group" aria-label={labels.moveTo} className="my-1 border-y border-border py-1">
+              <p className="px-2 pb-1 pt-0.5 text-2xs font-medium uppercase tracking-wide text-faint">{labels.moveTo}</p>
+              {[{ id: null as string | null, name: labels.moveBack ?? '' }, ...folders].map((folder) => {
+                const checked = (folder.id ?? null) === (currentFolderId ?? null);
+                return (
+                  <button
+                    key={folder.id ?? 'none'}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={checked}
+                    tabIndex={-1}
+                    disabled={pending || checked}
+                    data-testid={`form-row-move-${folder.id ?? 'none'}`}
+                    onClick={() => {
+                      setOpen(false);
+                      onMove(folder.id);
+                    }}
+                    className={`${itemClass} disabled:opacity-60`}
+                  >
+                    <i
+                      aria-hidden
+                      className={`pi ${checked ? 'pi-check' : 'pi-folder'} text-muted-foreground`}
+                      style={{ fontSize: 13 }}
+                    />
+                    <span className="truncate">{folder.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
           <button
             type="button"
             role="menuitem"

--- a/apps/web/app/admin/forms/form-row.tsx
+++ b/apps/web/app/admin/forms/form-row.tsx
@@ -20,7 +20,6 @@ const iconBtn =
   "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 export interface FormRowLabels {
-  updated: string;
   edit: string;
   submissions: string;
   analytics: string;

--- a/apps/web/app/admin/forms/form-row.tsx
+++ b/apps/web/app/admin/forms/form-row.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import Link from "next/link";
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@/lib/cn";
+import { CopyLinkIcon } from "@/components/copy-link";
+import type { Folder, FormSummary } from "@/lib/admin-api";
+import type { MatchRange } from "@/lib/forms-search";
+import { FormRowActions, type FormRowActionLabels } from "./form-row-actions";
+
+/** First-class row actions (user feedback: nothing hidden behind the kebab).
+ *  Secondary buttons collapse to icon-only below `md`; the aria-label/title
+ *  keep them nameable; the kebab holds Duplicate/Move/Delete. Tokens only. */
+const primaryBtn =
+  "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const secondaryBtn =
+  "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const iconBtn =
+  "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export interface FormRowLabels {
+  updated: string;
+  edit: string;
+  submissions: string;
+  analytics: string;
+  connect: string;
+  copy: string;
+  copied: string;
+  openForm: string;
+  dragHandle: string;
+}
+
+/** The name with the matched ranges wrapped in `<mark>`. */
+export function Highlight({
+  text,
+  ranges,
+}: {
+  text: string;
+  ranges: MatchRange[];
+}) {
+  if (ranges.length === 0) return <>{text}</>;
+  const parts: React.ReactNode[] = [];
+  let at = 0;
+  ranges.forEach(([start, end], i) => {
+    if (start > at) parts.push(text.slice(at, start));
+    parts.push(
+      <mark key={i} className="rounded-sm bg-primary/25 px-0.5 text-inherit">
+        {text.slice(start, end)}
+      </mark>,
+    );
+    at = end;
+  });
+  if (at < text.length) parts.push(text.slice(at));
+  return <>{parts}</>;
+}
+
+/**
+ * One form in the list. The markup (and every `data-testid`) is exactly what
+ * the flat list rendered before folders existed, so the e2e that pins the row
+ * still finds it; folders add a drag grip (listeners on the grip ONLY, so the
+ * links and buttons keep working as links and buttons) and a "Move to folder"
+ * entry in the kebab.
+ */
+export function FormRow({
+  form,
+  publicPath,
+  updatedLabel,
+  nameRanges,
+  folders,
+  labels,
+  actionLabels,
+  onMove,
+  draggable = true,
+}: {
+  form: FormSummary;
+  publicPath: string;
+  /** The already-formatted "Updated {when}" line. */
+  updatedLabel: string;
+  nameRanges: MatchRange[];
+  folders: Folder[];
+  labels: FormRowLabels;
+  actionLabels: FormRowActionLabels;
+  onMove: (formId: string, folderId: string | null) => void;
+  draggable?: boolean;
+}) {
+  const editHref = `/admin/forms/${form.id}/edit`;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: form.id,
+    data: { type: "form", name: form.name },
+    disabled: !draggable,
+  });
+  return (
+    <li
+      ref={setNodeRef}
+      data-testid="form-row"
+      data-form-id={form.id}
+      style={{
+        transform: transform
+          ? CSS.Translate.toString({ ...transform, x: 0, y: 0 })
+          : undefined,
+      }}
+      className={cn(
+        "flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card px-5 py-4 transition-colors hover:border-primary-edge/60",
+        isDragging && "opacity-40",
+      )}
+    >
+      {draggable ? (
+        <button
+          ref={setActivatorNodeRef}
+          type="button"
+          data-testid="form-row-grip"
+          aria-label={labels.dragHandle}
+          title={labels.dragHandle}
+          className="flex h-9 w-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-faint transition-colors hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          {...attributes}
+          {...listeners}
+        >
+          <i aria-hidden className="pi pi-bars" style={{ fontSize: 14 }} />
+        </button>
+      ) : null}
+      <div className="min-w-0 flex-1 basis-60">
+        <Link
+          href={editHref}
+          data-form-link
+          className="block w-fit max-w-full truncate text-base font-semibold tracking-tight transition-colors hover:text-primary"
+        >
+          <Highlight text={form.name} ranges={nameRanges} />
+        </Link>
+        {/* The row's two facts are not equally interesting. The public path is
+            what someone came here to copy, so it keeps the body tier; the
+            timestamp and the separator drop to `text-faint`. */}
+        <p className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
+          <span className="shrink-0 text-faint">{updatedLabel}</span>
+          <span aria-hidden className="shrink-0 text-faint">
+            ·
+          </span>
+          <span
+            className="min-w-0 truncate font-mono text-muted-foreground"
+            title={publicPath}
+          >
+            {publicPath}
+          </span>
+        </p>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+        <Link
+          data-testid="form-row-edit"
+          href={editHref}
+          className={primaryBtn}
+          title={labels.edit}
+        >
+          <i aria-hidden className="pi pi-pencil" style={{ fontSize: 13 }} />
+          {labels.edit}
+        </Link>
+        <Link
+          data-testid="form-row-submissions"
+          href={`/admin/forms/${form.id}/submissions`}
+          className={secondaryBtn}
+          aria-label={labels.submissions}
+          title={labels.submissions}
+        >
+          <i aria-hidden className="pi pi-inbox" style={{ fontSize: 13 }} />
+          <span className="hidden md:inline">{labels.submissions}</span>
+        </Link>
+        <Link
+          data-testid="form-row-analytics"
+          href={`/admin/forms/${form.id}/analytics`}
+          className={secondaryBtn}
+          aria-label={labels.analytics}
+          title={labels.analytics}
+        >
+          <i aria-hidden className="pi pi-chart-bar" style={{ fontSize: 13 }} />
+          <span className="hidden md:inline">{labels.analytics}</span>
+        </Link>
+        <Link
+          data-testid="form-row-connect"
+          href={`${editHref}?tab=connect`}
+          className={secondaryBtn}
+          aria-label={labels.connect}
+          title={labels.connect}
+        >
+          <i aria-hidden className="pi pi-link" style={{ fontSize: 13 }} />
+          <span className="hidden md:inline">{labels.connect}</span>
+        </Link>
+        <CopyLinkIcon
+          path={publicPath}
+          labels={{ copy: labels.copy, copied: labels.copied }}
+          testId="form-row-copy"
+          className={iconBtn}
+        />
+        <a
+          data-testid="form-row-open"
+          href={publicPath}
+          target="_blank"
+          rel="noreferrer"
+          className={iconBtn}
+          aria-label={labels.openForm}
+          title={labels.openForm}
+        >
+          <i
+            aria-hidden
+            className="pi pi-external-link"
+            style={{ fontSize: 14 }}
+          />
+        </a>
+        <FormRowActions
+          id={form.id}
+          labels={actionLabels}
+          folders={folders}
+          currentFolderId={form.folderId}
+          onMove={(folderId) => onMove(form.id, folderId)}
+        />
+      </div>
+    </li>
+  );
+}

--- a/apps/web/app/admin/forms/forms-explorer.spec.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.spec.tsx
@@ -1,0 +1,169 @@
+/**
+ * The explorer's static shape: Unfiled first, folders alphabetically as
+ * collapsible sections with counts, every row testid the flat list had, and
+ * the search box. Rendered through static markup in plain node (dnd-kit and
+ * the dialogs render their inert shells fine without a DOM).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => {}, push: () => {} }),
+}));
+vi.mock("@/components/toast", () => ({
+  useToast: () => ({ success: () => {}, error: () => {}, info: () => {} }),
+}));
+
+import { FormsExplorer, type FormsExplorerProps } from "./forms-explorer";
+
+const labels: FormsExplorerProps["labels"] = {
+  searchPlaceholder: "Search forms",
+  searchLabel: "Search forms by name or link",
+  searchClear: "Clear",
+  searchEmpty: "No forms match",
+  searchResults: "{count} forms match",
+  searchShortcut: "Ctrl K",
+  unfiled: "Unfiled",
+  folderCount: "{count} forms",
+  folderCountOne: "1 form",
+  renameFolder: "Rename",
+  deleteFolder: "Delete folder",
+  deleteFolderConfirm: "Delete {name}? {count}",
+  folderMenu: "Folder actions",
+  collapse: "Collapse",
+  expand: "Expand",
+  createIn: "New form",
+  moveFailed: "Could not move",
+  dropHere: "Drop here",
+  updated: "Updated {when}",
+};
+
+function render(overrides: Partial<FormsExplorerProps> = {}) {
+  const props: FormsExplorerProps = {
+    forms: [
+      {
+        id: "a",
+        name: "Lead Qualifier",
+        slug: "lead-qualifier",
+        brandAppliedAt: null,
+        folderId: "sales",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        id: "b",
+        name: "Survey",
+        slug: "survey",
+        brandAppliedAt: null,
+        folderId: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ],
+    folders: [{ id: "sales", name: "Sales", createdAt: 1, updatedAt: 1 }],
+    accountCode: "acme",
+    handle: "alex",
+    locale: "en",
+    updatedByForm: { a: "Updated today", b: "Updated today" },
+    labels,
+    rowLabels: {
+      updated: "Updated {when}",
+      edit: "Edit",
+      submissions: "Submissions",
+      analytics: "Analytics",
+      connect: "Connect",
+      copy: "Copy link",
+      copied: "Copied",
+      openForm: "Open form",
+      dragHandle: "Drag",
+    },
+    actionLabels: {
+      menu: "Actions",
+      duplicate: "Duplicate",
+      delete: "Delete",
+      deleteConfirm: "Sure?",
+      moveTo: "Move to folder",
+      moveBack: "No folder",
+    },
+    dialogLabels: {
+      newFolderTitle: "Create a folder",
+      renameFolderTitle: "Rename folder",
+      folderCreate: "Create",
+      folderSave: "Save",
+      folderNameLabel: "Folder name",
+      folderNamePlaceholder: "e.g. Sales",
+      folderNameRequired: "Required",
+      folderNameTaken: "Taken",
+      actionFailed: "Failed",
+      cancel: "Cancel",
+    },
+    createLabels: {
+      create: "Create form",
+      createTitle: "Create a new form",
+      nameLabel: "Name",
+      namePlaceholder: "e.g.",
+      nameRequired: "Required",
+      cancel: "Cancel",
+      layoutLabel: "Layout",
+      layoutSlides: "Slides",
+      layoutSlidesDesc: "",
+      layoutVertical: "One page",
+      layoutVerticalDesc: "",
+      folderLabel: "Folder",
+      folderNone: "No folder",
+    },
+    ...overrides,
+  };
+  return renderToStaticMarkup(<FormsExplorer {...props} />);
+}
+
+describe("FormsExplorer", () => {
+  it("renders Unfiled first, then folders, each as a collapsible section with a count", () => {
+    const html = render();
+    const unfiledAt = html.indexOf('data-testid="unfiled-section"');
+    const salesAt = html.indexOf('data-testid="folder-section"');
+    expect(unfiledAt).toBeGreaterThan(-1);
+    expect(salesAt).toBeGreaterThan(unfiledAt);
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain("1 form");
+    expect(html).toContain('data-folder-id="sales"');
+  });
+
+  it("keeps every row testid the flat list had, plus a grip and the search box", () => {
+    const html = render();
+    for (const id of [
+      "form-row",
+      "form-row-edit",
+      "form-row-submissions",
+      "form-row-analytics",
+      "form-row-connect",
+      "form-row-copy",
+      "form-row-open",
+      "form-row-menu",
+      "form-row-grip",
+    ])
+      expect(html).toContain(`data-testid="${id}"`);
+    expect(html).toContain('data-testid="forms-search"');
+    expect(html).toContain('href="/acme/alex/lead-qualifier"');
+  });
+
+  it("without folders it is the flat list: one section, no folder chrome", () => {
+    const html = render({
+      folders: [],
+      forms: [
+        {
+          id: "b",
+          name: "Survey",
+          slug: "survey",
+          brandAppliedAt: null,
+          folderId: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+    expect(html).not.toContain('data-testid="folder-section"');
+    expect(html).not.toContain('data-testid="folder-menu"');
+    expect((html.match(/data-testid="form-row"/g) ?? []).length).toBe(1);
+  });
+});

--- a/apps/web/app/admin/forms/forms-explorer.spec.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.spec.tsx
@@ -35,7 +35,6 @@ const labels: FormsExplorerProps["labels"] = {
   createIn: "New form",
   moveFailed: "Could not move",
   dropHere: "Drop here",
-  updated: "Updated {when}",
 };
 
 function render(overrides: Partial<FormsExplorerProps> = {}) {
@@ -67,7 +66,6 @@ function render(overrides: Partial<FormsExplorerProps> = {}) {
     updatedByForm: { a: "Updated today", b: "Updated today" },
     labels,
     rowLabels: {
-      updated: "Updated {when}",
       edit: "Edit",
       submissions: "Submissions",
       analytics: "Analytics",
@@ -164,6 +162,10 @@ describe("FormsExplorer", () => {
     });
     expect(html).not.toContain('data-testid="folder-section"');
     expect(html).not.toContain('data-testid="folder-menu"');
+
+    expect(html).not.toContain('data-testid="unfiled-section"');
+
+    expect(html).not.toContain('data-testid="form-row-grip"');
     expect((html.match(/data-testid="form-row"/g) ?? []).length).toBe(1);
   });
 });

--- a/apps/web/app/admin/forms/forms-explorer.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.tsx
@@ -69,7 +69,6 @@ export interface FormsExplorerLabels {
   createIn: string;
   moveFailed: string;
   dropHere: string;
-  updated: string;
 }
 
 export interface FormsExplorerProps {
@@ -123,8 +122,15 @@ export function FormsExplorer(props: FormsExplorerProps) {
     }
   }, []);
 
-  // Fresh server data supersedes any optimistic move still recorded here.
-  useEffect(() => setOverrides(new Map()), [forms]);
+  // Fresh server data supersedes an optimistic move once it SHOWS that move;
+  // one still in flight keeps its override, so two moves in a row do not
+  // snap the second back while the first refresh lands.
+  useEffect(() => {
+    setOverrides((prev) => {
+      const next = new Map([...prev].filter(([id, folderId]) => forms.find((f) => f.id === id)?.folderId !== folderId));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [forms]);
 
   const effectiveForms = useMemo(
     () =>
@@ -186,11 +192,15 @@ export function FormsExplorer(props: FormsExplorerProps) {
     }, []),
   );
 
-  // Roving focus over the row titles: arrows walk them, Enter opens (a link).
+  // Roving focus over the VISIBLE row titles: arrows walk them, Enter opens
+  // (a link). Keys inside a dialog, a menu or a listbox belong to that widget.
   function onListKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"], input, textarea, select'))
+      return;
     const items = Array.from(
-      listRef.current?.querySelectorAll<HTMLElement>("[data-form-link]") ?? [],
+      listRef.current?.querySelectorAll<HTMLElement>("ul:not([hidden]) [data-form-link]") ?? [],
     );
     if (items.length === 0) return;
     const active = document.activeElement as HTMLElement | null;
@@ -224,6 +234,12 @@ export function FormsExplorer(props: FormsExplorerProps) {
   };
 
   const searchId = useId();
+  // The chord's glyph follows the platform; read after mount (the server has no platform).
+  const [shortcutLabel, setShortcutLabel] = useState(labels.searchShortcut);
+  useEffect(() => {
+    if (/Mac|iPhone|iPad/.test(navigator.platform)) setShortcutLabel('\u2318 K');
+  }, []);
+  const flat = folders.length === 0;
   return (
     <DndContext
       id={dndId}
@@ -259,7 +275,7 @@ export function FormsExplorer(props: FormsExplorerProps) {
               if (e.key === "ArrowDown") {
                 e.preventDefault();
                 listRef.current
-                  ?.querySelector<HTMLElement>("[data-form-link]")
+                  ?.querySelector<HTMLElement>("ul:not([hidden]) [data-form-link]")
                   ?.focus();
               }
             }}
@@ -268,7 +284,7 @@ export function FormsExplorer(props: FormsExplorerProps) {
           <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 text-2xs text-faint">
             {query ? null : (
               <kbd className="rounded border border-border px-1.5 py-0.5 font-mono">
-                {labels.searchShortcut}
+                {shortcutLabel}
               </kbd>
             )}
           </span>
@@ -311,7 +327,26 @@ export function FormsExplorer(props: FormsExplorerProps) {
             {labels.searchEmpty}
           </p>
         ) : null}
-        {sections.map((section) => (
+        {flat && !searching && sections[0] ? (
+          /* No folders yet: the flat list this page always had, no section chrome, no grip. */
+          <ul role="list" className="flex flex-col gap-3">
+            {sections[0].forms.map((f) => (
+              <FormRow
+                key={f.id}
+                form={f}
+                publicPath={`/${props.accountCode}/${props.handle}/${f.slug}`}
+                updatedLabel={props.updatedByForm[f.id] ?? ''}
+                nameRanges={f.match.nameRanges}
+                folders={folders}
+                labels={props.rowLabels}
+                actionLabels={props.actionLabels}
+                onMove={move}
+                draggable={false}
+              />
+            ))}
+          </ul>
+        ) : null}
+        {(flat && !searching ? [] : sections).map((section) => (
           <FolderSection
             key={section.id ?? UNFILED}
             section={section}
@@ -399,7 +434,7 @@ function FolderSection({
     setMenuOpen(false);
     const ok = await confirmDialog({
       title: getMessages(clientLocale()).dialog.deleteFolderTitle,
-      message: t(labels.deleteFolderConfirm, { name, count: section.total }),
+      message: t(labels.deleteFolderConfirm, { name, forms: count }),
       confirmLabel: labels.deleteFolder,
       destructive: true,
     });

--- a/apps/web/app/admin/forms/forms-explorer.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  rectIntersection,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { getMessages, t } from "@quill/shared";
+import { cn } from "@/lib/cn";
+import { callAction } from "@/lib/call-action";
+import { clientLocale } from "@/lib/client-locale";
+import {
+  groupBySections,
+  normalize,
+  type FormSection,
+} from "@/lib/forms-search";
+import { useGlobalShortcut } from "@/lib/use-global-shortcut";
+import type { Folder, FormSummary } from "@/lib/admin-api";
+import { useToast } from "@/components/toast";
+import { useConfirmDialog } from "@/components/ui/confirm-dialog";
+import { CreateForm } from "./create-form";
+import { FolderDialog, type FolderDialogLabels } from "./folder-dialog";
+import { FormRow, type FormRowLabels } from "./form-row";
+import type { FormRowActionLabels } from "./form-row-actions";
+import { deleteFolderAction, moveFormAction } from "./folder-actions";
+
+/** Per-viewer collapse state (never shared: how you fold your list is yours). */
+const COLLAPSED_KEY = "forms.folders.collapsed";
+
+/** dnd-kit droppable ids: the folder id, or this marker for Unfiled. */
+const UNFILED = "__unfiled__";
+
+export interface FormsExplorerLabels {
+  searchPlaceholder: string;
+  searchLabel: string;
+  searchClear: string;
+  searchEmpty: string;
+  searchResults: string;
+  searchShortcut: string;
+  unfiled: string;
+  folderCount: string;
+  folderCountOne: string;
+  renameFolder: string;
+  deleteFolder: string;
+  deleteFolderConfirm: string;
+  folderMenu: string;
+  collapse: string;
+  expand: string;
+  createIn: string;
+  moveFailed: string;
+  dropHere: string;
+  updated: string;
+}
+
+export interface FormsExplorerProps {
+  forms: FormSummary[];
+  folders: Folder[];
+  accountCode: string;
+  handle: string;
+  locale: string;
+  /** Already-formatted "Updated {when}" per form id (formatted on the server, one clock). */
+  updatedByForm: Record<string, string>;
+  labels: FormsExplorerLabels;
+  rowLabels: FormRowLabels;
+  actionLabels: FormRowActionLabels;
+  dialogLabels: FolderDialogLabels;
+  createLabels: React.ComponentProps<typeof CreateForm>["labels"];
+}
+
+/**
+ * The forms list with folders and search. ONE list: every folder is a
+ * collapsible section (Unfiled first), rows drag onto section headers, the
+ * kebab's "Move to folder" is the keyboard-only route to the same move, and
+ * the search box filters the loaded list by name or slug, expanding the
+ * sections with a hit and hiding the rest. Without folders it looks exactly
+ * like the flat list it replaces.
+ */
+export function FormsExplorer(props: FormsExplorerProps) {
+  const { forms, folders, labels } = props;
+  const router = useRouter();
+  const toast = useToast();
+  const [query, setQuery] = useState("");
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const [overrides, setOverrides] = useState<Map<string, string | null>>(
+    () => new Map(),
+  );
+  const [dragging, setDragging] = useState<{ id: string; name: string } | null>(
+    null,
+  );
+  const [, start] = useTransition();
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const dndId = useId();
+
+  // Collapse state is read AFTER mount: the server cannot know this viewer's
+  // localStorage, and reading it during render would hydrate to a mismatch.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(COLLAPSED_KEY);
+      if (raw) setCollapsed(new Set(JSON.parse(raw) as string[]));
+    } catch {
+      // No storage, or a stale value: everything starts expanded.
+    }
+  }, []);
+
+  // Fresh server data supersedes any optimistic move still recorded here.
+  useEffect(() => setOverrides(new Map()), [forms]);
+
+  const effectiveForms = useMemo(
+    () =>
+      forms.map((f) =>
+        overrides.has(f.id)
+          ? { ...f, folderId: overrides.get(f.id) ?? null }
+          : f,
+      ),
+    [forms, overrides],
+  );
+  const sections = useMemo(
+    () => groupBySections(effectiveForms, folders, query),
+    [effectiveForms, folders, query],
+  );
+  const searching = normalize(query).length > 0;
+  const matches = sections.reduce((n, s) => n + s.forms.length, 0);
+
+  const toggle = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      try {
+        localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...next]));
+      } catch {
+        // Best effort only.
+      }
+      return next;
+    });
+  };
+
+  const move = useCallback(
+    (formId: string, folderId: string | null) => {
+      const current =
+        effectiveForms.find((f) => f.id === formId)?.folderId ?? null;
+      if (current === folderId) return;
+      setOverrides((prev) => new Map(prev).set(formId, folderId));
+      start(async () => {
+        const res = await callAction(() => moveFormAction(formId, folderId));
+        if (res && "ok" in res && res.ok) {
+          router.refresh();
+        } else {
+          setOverrides((prev) => {
+            const next = new Map(prev);
+            next.delete(formId);
+            return next;
+          });
+          toast.error(labels.moveFailed);
+        }
+      });
+    },
+    [effectiveForms, router, toast, labels.moveFailed],
+  );
+
+  // Cmd/Ctrl+K and `/` focus the search box from anywhere on the page.
+  useGlobalShortcut(
+    useCallback((shortcut) => {
+      if (shortcut === "search") searchRef.current?.focus();
+    }, []),
+  );
+
+  // Roving focus over the row titles: arrows walk them, Enter opens (a link).
+  function onListKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>("[data-form-link]") ?? [],
+    );
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement | null;
+    const at = active ? items.indexOf(active) : -1;
+    e.preventDefault();
+    if (e.key === "ArrowDown")
+      items[at < 0 || at === items.length - 1 ? 0 : at + 1]?.focus();
+    else if (at <= 0) searchRef.current?.focus();
+    else items[at - 1]?.focus();
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor),
+  );
+  // Prefer the section the pointer is actually inside; a row dragged past every
+  // section edge still snaps to the nearest one rather than nowhere.
+  const collision: CollisionDetection = (args) => {
+    const within = pointerWithin(args);
+    return within.length > 0 ? within : rectIntersection(args);
+  };
+  const onDragStart = (e: DragStartEvent) => {
+    const data = e.active.data.current as { name?: string } | undefined;
+    setDragging({ id: String(e.active.id), name: data?.name ?? "" });
+  };
+  const onDragEnd = (e: DragEndEvent) => {
+    setDragging(null);
+    const over = e.over?.id;
+    if (over == null) return;
+    move(String(e.active.id), over === UNFILED ? null : String(over));
+  };
+
+  const searchId = useId();
+  return (
+    <DndContext
+      id={dndId}
+      sensors={sensors}
+      collisionDetection={collision}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragCancel={() => setDragging(null)}
+    >
+      <div className="mb-4">
+        <div className="relative max-w-md">
+          <i
+            aria-hidden
+            className="pi pi-search pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            style={{ fontSize: 13 }}
+          />
+          <input
+            ref={searchRef}
+            id={searchId}
+            type="search"
+            value={query}
+            data-testid="forms-search"
+            aria-label={labels.searchLabel}
+            placeholder={labels.searchPlaceholder}
+            autoComplete="off"
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                if (query) setQuery("");
+                else searchRef.current?.blur();
+              }
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                listRef.current
+                  ?.querySelector<HTMLElement>("[data-form-link]")
+                  ?.focus();
+              }
+            }}
+            className="h-10 w-full rounded-md border border-input bg-background pl-9 pr-24 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 text-2xs text-faint">
+            {query ? null : (
+              <kbd className="rounded border border-border px-1.5 py-0.5 font-mono">
+                {labels.searchShortcut}
+              </kbd>
+            )}
+          </span>
+          {query ? (
+            <button
+              type="button"
+              aria-label={labels.searchClear}
+              onClick={() => {
+                setQuery("");
+                searchRef.current?.focus();
+              }}
+              className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
+            </button>
+          ) : null}
+        </div>
+        <p
+          role="status"
+          aria-live="polite"
+          className={cn(
+            "mt-1 text-xs text-muted-foreground",
+            !searching && "sr-only",
+          )}
+        >
+          {searching ? t(labels.searchResults, { count: matches }) : ""}
+        </p>
+      </div>
+
+      <div
+        ref={listRef}
+        onKeyDown={onListKeyDown}
+        className="flex flex-col gap-6"
+      >
+        {searching && matches === 0 ? (
+          <p
+            data-testid="forms-search-empty"
+            className="rounded-xl border border-dashed border-border bg-card/40 p-8 text-center text-sm text-muted-foreground"
+          >
+            {labels.searchEmpty}
+          </p>
+        ) : null}
+        {sections.map((section) => (
+          <FolderSection
+            key={section.id ?? UNFILED}
+            section={section}
+            expanded={searching || !collapsed.has(section.id ?? UNFILED)}
+            onToggle={() => toggle(section.id ?? UNFILED)}
+            onMove={move}
+            dragging={dragging != null}
+            {...props}
+          />
+        ))}
+      </div>
+
+      <DragOverlay dropAnimation={null}>
+        {dragging ? (
+          <div className="rounded-xl border border-primary-edge bg-card px-5 py-3 text-sm font-semibold shadow-lg">
+            {dragging.name}
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+function FolderSection({
+  section,
+  expanded,
+  onToggle,
+  onMove,
+  dragging,
+  folders,
+  accountCode,
+  handle,
+  locale,
+  updatedByForm,
+  labels,
+  rowLabels,
+  actionLabels,
+  dialogLabels,
+  createLabels,
+}: FormsExplorerProps & {
+  section: FormSection<FormSummary>;
+  expanded: boolean;
+  onToggle: () => void;
+  onMove: (formId: string, folderId: string | null) => void;
+  dragging: boolean;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const { confirm: confirmDialog, dialog } = useConfirmDialog();
+  const [renaming, setRenaming] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [, start] = useTransition();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const headingId = useId();
+  const listId = useId();
+  const droppableId = section.id ?? UNFILED;
+  const { setNodeRef, isOver } = useDroppable({
+    id: droppableId,
+    data: { type: "folder" },
+  });
+  const isFolder = section.id != null;
+  const name = section.name ?? labels.unfiled;
+  const count =
+    section.total === 1
+      ? labels.folderCountOne
+      : t(labels.folderCount, { count: section.total });
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node))
+        setMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) =>
+      e.key === "Escape" && setMenuOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [menuOpen]);
+
+  const remove = async () => {
+    setMenuOpen(false);
+    const ok = await confirmDialog({
+      title: getMessages(clientLocale()).dialog.deleteFolderTitle,
+      message: t(labels.deleteFolderConfirm, { name, count: section.total }),
+      confirmLabel: labels.deleteFolder,
+      destructive: true,
+    });
+    if (!ok || !section.id) return;
+    const id = section.id;
+    start(async () => {
+      const res = await callAction(() => deleteFolderAction(id));
+      if (res && "ok" in res && res.ok) router.refresh();
+      else toast.error(dialogLabels.actionFailed);
+    });
+  };
+
+  const itemClass =
+    "flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:outline-none";
+
+  return (
+    <section
+      ref={setNodeRef}
+      aria-labelledby={headingId}
+      data-testid={isFolder ? "folder-section" : "unfiled-section"}
+      data-folder-id={section.id ?? ""}
+      className={cn(
+        "rounded-xl transition-colors",
+        dragging && "outline outline-1 outline-dashed outline-border",
+        isOver && "bg-primary/10 outline-primary-edge",
+      )}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 px-1 py-1">
+        <button
+          type="button"
+          id={headingId}
+          aria-expanded={expanded}
+          aria-controls={listId}
+          data-testid="folder-toggle"
+          onClick={onToggle}
+          title={expanded ? labels.collapse : labels.expand}
+          className="flex min-w-0 items-center gap-2 rounded-md py-1 pr-2 text-left text-sm font-semibold text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i
+            aria-hidden
+            className={cn(
+              "pi text-muted-foreground",
+              expanded ? "pi-chevron-down" : "pi-chevron-right",
+            )}
+            style={{ fontSize: 11 }}
+          />
+          <i
+            aria-hidden
+            className={cn(
+              "pi text-muted-foreground",
+              isFolder ? "pi-folder" : "pi-inbox",
+            )}
+            style={{ fontSize: 14 }}
+          />
+          <span className="truncate">{name}</span>
+          <span
+            data-testid="folder-count"
+            className="rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-muted-foreground"
+          >
+            {count}
+          </span>
+          {isOver ? (
+            <span className="text-2xs text-primary">{labels.dropHere}</span>
+          ) : null}
+        </button>
+        <div className="flex items-center gap-1">
+          <CreateForm
+            labels={createLabels}
+            variant="outline"
+            size="sm"
+            triggerLabel={labels.createIn}
+            folders={folders}
+            defaultFolderId={section.id}
+            locale={locale}
+          />
+          {isFolder ? (
+            <div ref={menuRef} className="relative">
+              <button
+                type="button"
+                data-testid="folder-menu"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                aria-label={labels.folderMenu}
+                title={labels.folderMenu}
+                onClick={() => setMenuOpen((o) => !o)}
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <i
+                  aria-hidden
+                  className="pi pi-ellipsis-v"
+                  style={{ fontSize: 14 }}
+                />
+              </button>
+              {menuOpen ? (
+                <div
+                  role="menu"
+                  aria-label={labels.folderMenu}
+                  className="absolute right-0 z-50 mt-1 w-48 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    data-testid="folder-rename"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setRenaming(true);
+                    }}
+                    className={itemClass}
+                  >
+                    <i
+                      aria-hidden
+                      className="pi pi-pencil text-muted-foreground"
+                      style={{ fontSize: 13 }}
+                    />
+                    {labels.renameFolder}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    data-testid="folder-delete"
+                    onClick={() => void remove()}
+                    className="flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none"
+                  >
+                    <i
+                      aria-hidden
+                      className="pi pi-trash"
+                      style={{ fontSize: 13 }}
+                    />
+                    {labels.deleteFolder}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <ul
+        id={listId}
+        role="list"
+        hidden={!expanded}
+        className="flex flex-col gap-3"
+      >
+        {section.forms.map((f) => (
+          <FormRow
+            key={f.id}
+            form={f}
+            publicPath={`/${accountCode}/${handle}/${f.slug}`}
+            updatedLabel={updatedByForm[f.id] ?? ""}
+            nameRanges={f.match.nameRanges}
+            folders={folders}
+            labels={rowLabels}
+            actionLabels={actionLabels}
+            onMove={onMove}
+          />
+        ))}
+      </ul>
+
+      {isFolder && section.id ? (
+        <FolderDialog
+          key={`${section.id}:${renaming ? "open" : "closed"}`}
+          open={renaming}
+          onClose={() => setRenaming(false)}
+          onDone={() => router.refresh()}
+          mode="rename"
+          folderId={section.id}
+          initialName={section.name ?? ""}
+          labels={dialogLabels}
+        />
+      ) : null}
+      {dialog}
+    </section>
+  );
+}

--- a/apps/web/app/admin/forms/new-folder-button.tsx
+++ b/apps/web/app/admin/forms/new-folder-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { FolderDialog, type FolderDialogLabels } from "./folder-dialog";
+
+/** The header's "New folder" trigger and its dialog. */
+export function NewFolderButton({
+  label,
+  labels,
+}: {
+  label: string;
+  labels: FolderDialogLabels;
+}) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  return (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => setOpen(true)}
+        data-testid="new-folder"
+      >
+        <i aria-hidden className="pi pi-folder-plus" style={{ fontSize: 12 }} />{" "}
+        {label}
+      </Button>
+      <FolderDialog
+        key={open ? "open" : "closed"}
+        open={open}
+        onClose={() => setOpen(false)}
+        onDone={() => router.refresh()}
+        mode="create"
+        labels={labels}
+      />
+    </>
+  );
+}

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -106,10 +106,8 @@ export default async function FormsList() {
             createIn: m.createIn,
             moveFailed: m.moveFailed,
             dropHere: m.dropHere,
-            updated: m.updated,
           }}
           rowLabels={{
-            updated: m.updated,
             edit: m.edit,
             submissions: messages.nav.submissions,
             analytics: messages.nav.analytics,

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -1,29 +1,24 @@
-import Link from 'next/link';
 import { getMessages, t } from '@quill/shared';
 import { adminApi } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
-import { CopyLinkIcon } from '@/components/copy-link';
 import { PageHeader } from '@/components/ui/page-header';
 import { CreateForm } from './create-form';
-import { FormRowActions } from './form-row-actions';
+import { FormsExplorer } from './forms-explorer';
+import { NewFolderButton } from './new-folder-button';
 
 export const dynamic = 'force-dynamic';
 
-/** First-class row actions (user feedback: nothing hidden behind the kebab).
- *  Secondary buttons collapse to icon-only below `md` — the aria-label/title
- *  keep them nameable; the kebab holds only Duplicate/Delete. Tokens only. */
-const primaryBtn =
-  'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-const secondaryBtn =
-  'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-const iconBtn =
-  'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-
+/**
+ * The forms list: one list, grouped by folder (Unfiled first), searchable by
+ * keyboard. Stays a server component: it fetches, formats the dates once on
+ * the server clock, and hands the explorer plain data; every interaction
+ * (search, collapse, drag, move, folder dialogs) lives in the client tree.
+ */
 export default async function FormsList() {
   const locale = await getLocale();
   const messages = getMessages(locale).admin;
   const m = messages.forms;
-  const [me, forms] = await Promise.all([adminApi.me(), adminApi.listForms()]);
+  const [me, forms, folders] = await Promise.all([adminApi.me(), adminApi.listForms(), adminApi.listFolders()]);
 
   const createLabels = {
     create: m.create,
@@ -37,23 +32,43 @@ export default async function FormsList() {
     layoutSlidesDesc: m.layoutSlidesDesc,
     layoutVertical: m.layoutVertical,
     layoutVerticalDesc: m.layoutVerticalDesc,
+    folderLabel: m.folderLabel,
+    folderNone: m.folderNone,
   };
-  const rowLabels = {
-    menu: m.actions,
-    duplicate: m.duplicate,
-    delete: m.delete,
-    deleteConfirm: m.deleteConfirm,
+  const dialogLabels = {
+    newFolderTitle: m.newFolderTitle,
+    renameFolderTitle: m.renameFolderTitle,
+    folderCreate: m.folderCreate,
+    folderSave: m.folderSave,
+    folderNameLabel: m.folderNameLabel,
+    folderNamePlaceholder: m.folderNamePlaceholder,
+    folderNameRequired: m.folderNameRequired,
+    folderNameTaken: m.folderNameTaken,
+    actionFailed: m.actionFailed,
+    cancel: m.cancel,
   };
+  // Formatted once on the server clock, the same way the flat list did; the
+  // workspace-timezone change switches this to the shared formatter.
+  const updatedByForm = Object.fromEntries(
+    forms.map((f) => [f.id, t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })]),
+  );
 
   return (
     <div className="mx-auto max-w-[1520px] px-6 py-10 sm:px-8">
       <PageHeader
         title={m.title}
         subtitle={m.subtitle}
-        action={forms.length > 0 ? <CreateForm labels={createLabels} /> : undefined}
+        action={
+          forms.length > 0 || folders.length > 0 ? (
+            <div className="flex items-center gap-2">
+              <NewFolderButton label={m.newFolder} labels={dialogLabels} />
+              <CreateForm labels={createLabels} folders={folders} locale={locale} />
+            </div>
+          ) : undefined
+        }
       />
 
-      {forms.length === 0 ? (
+      {forms.length === 0 && folders.length === 0 ? (
         <div className="flex flex-col items-center gap-4 rounded-xl border border-dashed border-border bg-card/40 p-12 text-center">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
             <i aria-hidden className="pi pi-file-edit" style={{ fontSize: 20 }} />
@@ -65,99 +80,56 @@ export default async function FormsList() {
           <CreateForm labels={createLabels} />
         </div>
       ) : (
-        <ul className="flex flex-col gap-3">
-          {forms.map((f) => {
-            const publicPath = `/${me.accountCode}/${me.handle ?? 'me'}/${f.slug}`;
-            const editHref = `/admin/forms/${f.id}/edit`;
-            return (
-              <li
-                key={f.id}
-                data-testid="form-row"
-                className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card px-5 py-4 transition-colors hover:border-primary-edge/60"
-              >
-                <div className="min-w-0 flex-1 basis-60">
-                  <Link
-                    href={editHref}
-                    className="block w-fit max-w-full truncate text-base font-semibold tracking-tight transition-colors hover:text-primary"
-                  >
-                    {f.name}
-                  </Link>
-                  {/* The row's two facts are not equally interesting. The public
-                      path is what someone came here to copy, so it keeps the body
-                      tier; the timestamp and the separator drop to `text-faint` —
-                      the quiet step exists exactly so metadata can sit beside a
-                      value without competing with it. */}
-                  <p className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
-                    <span className="shrink-0 text-faint">
-                      {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
-                    </span>
-                    <span aria-hidden className="shrink-0 text-faint">
-                      ·
-                    </span>
-                    <span className="min-w-0 truncate font-mono text-muted-foreground" title={publicPath}>
-                      {publicPath}
-                    </span>
-                  </p>
-                </div>
-
-                <div className="flex shrink-0 flex-wrap items-center gap-1.5">
-                  <Link data-testid="form-row-edit" href={editHref} className={primaryBtn} title={m.edit}>
-                    <i aria-hidden className="pi pi-pencil" style={{ fontSize: 13 }} />
-                    {m.edit}
-                  </Link>
-                  <Link
-                    data-testid="form-row-submissions"
-                    href={`/admin/forms/${f.id}/submissions`}
-                    className={secondaryBtn}
-                    aria-label={messages.nav.submissions}
-                    title={messages.nav.submissions}
-                  >
-                    <i aria-hidden className="pi pi-inbox" style={{ fontSize: 13 }} />
-                    <span className="hidden md:inline">{messages.nav.submissions}</span>
-                  </Link>
-                  <Link
-                    data-testid="form-row-analytics"
-                    href={`/admin/forms/${f.id}/analytics`}
-                    className={secondaryBtn}
-                    aria-label={messages.nav.analytics}
-                    title={messages.nav.analytics}
-                  >
-                    <i aria-hidden className="pi pi-chart-bar" style={{ fontSize: 13 }} />
-                    <span className="hidden md:inline">{messages.nav.analytics}</span>
-                  </Link>
-                  <Link
-                    data-testid="form-row-connect"
-                    href={`${editHref}?tab=connect`}
-                    className={secondaryBtn}
-                    aria-label={m.connect}
-                    title={m.connect}
-                  >
-                    <i aria-hidden className="pi pi-link" style={{ fontSize: 13 }} />
-                    <span className="hidden md:inline">{m.connect}</span>
-                  </Link>
-                  <CopyLinkIcon
-                    path={publicPath}
-                    labels={{ copy: m.copy, copied: m.copied }}
-                    testId="form-row-copy"
-                    className={iconBtn}
-                  />
-                  <a
-                    data-testid="form-row-open"
-                    href={publicPath}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={iconBtn}
-                    aria-label={m.openForm}
-                    title={m.openForm}
-                  >
-                    <i aria-hidden className="pi pi-external-link" style={{ fontSize: 14 }} />
-                  </a>
-                  <FormRowActions id={f.id} labels={rowLabels} />
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+        <FormsExplorer
+          forms={forms}
+          folders={folders}
+          accountCode={me.accountCode}
+          handle={me.handle ?? 'me'}
+          locale={locale}
+          updatedByForm={updatedByForm}
+          labels={{
+            searchPlaceholder: m.searchPlaceholder,
+            searchLabel: m.searchLabel,
+            searchClear: m.searchClear,
+            searchEmpty: m.searchEmpty,
+            searchResults: m.searchResults,
+            searchShortcut: m.searchShortcut,
+            unfiled: m.unfiled,
+            folderCount: m.folderCount,
+            folderCountOne: m.folderCountOne,
+            renameFolder: m.renameFolder,
+            deleteFolder: m.deleteFolder,
+            deleteFolderConfirm: m.deleteFolderConfirm,
+            folderMenu: m.folderMenu,
+            collapse: m.collapse,
+            expand: m.expand,
+            createIn: m.createIn,
+            moveFailed: m.moveFailed,
+            dropHere: m.dropHere,
+            updated: m.updated,
+          }}
+          rowLabels={{
+            updated: m.updated,
+            edit: m.edit,
+            submissions: messages.nav.submissions,
+            analytics: messages.nav.analytics,
+            connect: m.connect,
+            copy: m.copy,
+            copied: m.copied,
+            openForm: m.openForm,
+            dragHandle: m.dragHandle,
+          }}
+          actionLabels={{
+            menu: m.actions,
+            duplicate: m.duplicate,
+            delete: m.delete,
+            deleteConfirm: m.deleteConfirm,
+            moveTo: m.moveTo,
+            moveBack: m.moveBack,
+          }}
+          dialogLabels={dialogLabels}
+          createLabels={createLabels}
+        />
       )}
     </div>
   );

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -260,6 +260,16 @@ export interface FormSummary {
   slug: string;
   /** Epoch-ms of the last brand-kit apply; null when never applied or reverted. */
   brandAppliedAt: number | null;
+  /** The folder the form is filed in; null = unfiled. */
+  folderId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** A form folder: flat, named only, unique per workspace without regard to case. */
+export interface Folder {
+  id: string;
+  name: string;
   createdAt: number;
   updatedAt: number;
 }
@@ -574,7 +584,7 @@ export const adminApi = {
   // Forms
   listForms: () => req<FormSummary[]>('GET', '/v1/forms'),
   getForm: (id: string) => req<FormDetail>('GET', `/v1/forms/${id}`),
-  createForm: (b: { name: string; slug?: string; config?: unknown }) =>
+  createForm: (b: { name: string; slug?: string; config?: unknown; folderId?: string | null }) =>
     req<FormDetail>('POST', '/v1/forms', b),
   updateForm: (id: string, b: { name?: string; config?: unknown }) =>
     req<FormDetail>('PUT', `/v1/forms/${id}`, b),
@@ -590,6 +600,15 @@ export const adminApi = {
   /** Publish the pending draft config (no-op when no draft is pending). */
   publishForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/publish`),
   deleteForm: (id: string) => req<void>('DELETE', `/v1/forms/${id}`),
+
+  // Form folders
+  listFolders: () => req<Folder[]>('GET', '/v1/folders'),
+  createFolder: (name: string) => req<Folder>('POST', '/v1/folders', { name }),
+  renameFolder: (id: string, name: string) => req<Folder>('PATCH', `/v1/folders/${id}`, { name }),
+  deleteFolder: (id: string) => req<void>('DELETE', `/v1/folders/${id}`),
+  /** File a form in a folder; null unfiles it. */
+  setFormFolder: (id: string, folderId: string | null) =>
+    req<{ id: string; folderId: string | null }>('PATCH', `/v1/forms/${id}/folder`, { folderId }),
 
   // Workspace brand kit (reads open to members; writes + apply/revert admin/owner)
   getBranding: () => req<BrandingResponse>('GET', '/v1/branding'),

--- a/apps/web/lib/forms-search.spec.ts
+++ b/apps/web/lib/forms-search.spec.ts
@@ -47,6 +47,16 @@ describe("matchForm", () => {
     });
   });
 
+  it("keeps a decomposed accent inside the highlight and survives a no-break space", () => {
+    // "o" + combining acute, the NFD form some inputs produce.
+    const decomposed = { name: "Satisfaccio\u0301n total", slug: "x" };
+    expect(matchForm(decomposed, "satisfaccion")).toEqual({ matched: true, nameRanges: [[0, 13]] });
+    expect(matchForm({ name: "Lead\u00a0Qualifier", slug: "x" }, "qualifier")).toEqual({
+      matched: true,
+      nameRanges: [[5, 14]],
+    });
+  });
+
   it("an empty query matches everything with no ranges", () => {
     expect(matchForm(forms[2]!, "   ")).toEqual({
       matched: true,

--- a/apps/web/lib/forms-search.spec.ts
+++ b/apps/web/lib/forms-search.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { groupBySections, matchForm, normalize } from "./forms-search";
+
+const forms = [
+  {
+    id: "a",
+    name: "Lead Qualifier",
+    slug: "lead-qualifier",
+    folderId: "sales",
+  },
+  {
+    id: "b",
+    name: "Encuesta de satisfacción",
+    slug: "encuesta",
+    folderId: null,
+  },
+  { id: "c", name: "Demo request", slug: "demo-request", folderId: "sales" },
+  { id: "d", name: "Archived quiz", slug: "quiz", folderId: "old" },
+];
+const folders = [
+  { id: "old", name: "Archive" },
+  { id: "sales", name: "Sales" },
+];
+
+describe("normalize", () => {
+  it("lower-cases and strips accents so a query matches without them", () => {
+    expect(normalize("Satisfacción")).toBe("satisfaccion");
+    expect(normalize("  LEAD ")).toBe("lead");
+  });
+});
+
+describe("matchForm", () => {
+  it("matches the name or the slug, and reports the matched ranges on the name", () => {
+    expect(matchForm(forms[0]!, "lead")).toEqual({
+      matched: true,
+      nameRanges: [[0, 4]],
+    });
+    // Only the slug matches: no highlight ranges on the name, but still a hit.
+    expect(matchForm(forms[1]!, "encuesta")).toMatchObject({ matched: true });
+    expect(matchForm(forms[1]!, "satisfaccion")).toEqual({
+      matched: true,
+      nameRanges: [[12, 24]],
+    });
+    expect(matchForm(forms[0]!, "zzz")).toEqual({
+      matched: false,
+      nameRanges: [],
+    });
+  });
+
+  it("an empty query matches everything with no ranges", () => {
+    expect(matchForm(forms[2]!, "   ")).toEqual({
+      matched: true,
+      nameRanges: [],
+    });
+  });
+});
+
+describe("groupBySections", () => {
+  it("puts Unfiled first, then folders alphabetically, each with its forms in list order", () => {
+    const sections = groupBySections(forms, folders, "");
+    expect(sections.map((s) => s.id)).toEqual([null, "old", "sales"]);
+    expect(sections.map((s) => s.forms.map((f) => f.id))).toEqual([
+      ["b"],
+      ["d"],
+      ["a", "c"],
+    ]);
+    expect(sections.map((s) => s.total)).toEqual([1, 1, 2]);
+  });
+
+  it("keeps an empty folder as a section (so it can be a drop target) when there is no query", () => {
+    const sections = groupBySections(
+      forms,
+      [...folders, { id: "new", name: "New" }],
+      "",
+    );
+    expect(sections.find((s) => s.id === "new")).toMatchObject({
+      forms: [],
+      total: 0,
+    });
+  });
+
+  it("with a query, hides sections without a match and keeps the total for the count", () => {
+    const sections = groupBySections(forms, folders, "demo");
+    expect(sections.map((s) => s.id)).toEqual(["sales"]);
+    expect(sections[0]!.forms.map((f) => f.id)).toEqual(["c"]);
+    expect(sections[0]!.total).toBe(2);
+  });
+
+  it("a form whose folder no longer exists shows as unfiled rather than vanishing", () => {
+    const sections = groupBySections(
+      [{ id: "x", name: "Orphan", slug: "orphan", folderId: "gone" }],
+      folders,
+      "",
+    );
+    expect(sections[0]!.forms.map((f) => f.id)).toEqual(["x"]);
+  });
+});

--- a/apps/web/lib/forms-search.ts
+++ b/apps/web/lib/forms-search.ts
@@ -27,7 +27,11 @@ export interface FormMatch {
 
 /** Lower-case, accents stripped, trimmed. Same recipe as `slugify`'s first steps. */
 export function normalize(value: string): string {
-  return value.normalize("NFKD").replace(/[̀-ͯ]/g, "").toLowerCase().trim();
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
 }
 
 /**
@@ -43,7 +47,14 @@ function rangesOnOriginal(
   if (!normalizedQuery) return ranges;
   // Per-character normalized forms, so the map back is exact.
   const chars = [...original];
-  const normChars = chars.map((c) => normalize(c) || (c === " " ? " " : ""));
+  // Not `normalize` itself: that trims, and a space (or a no-break space) in
+  // the middle of a name must stay a character or every index after it drifts.
+  const normChars = chars.map((c) =>
+    c
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase(),
+  );
   const flat = normChars.join("");
   // Offsets: the original char index at which each normalized char starts.
   const origIndexAt: number[] = [];
@@ -55,7 +66,10 @@ function rangesOnOriginal(
     const at = flat.indexOf(normalizedQuery, from);
     if (at < 0) break;
     const startChar = origIndexAt[at]!;
-    const endChar = origIndexAt[at + normalizedQuery.length - 1]! + 1;
+    let endChar = origIndexAt[at + normalizedQuery.length - 1]! + 1;
+    // A decomposed accent (a base letter followed by a combining mark) has no
+    // normalized form of its own; keep it inside the highlight of its letter.
+    while (endChar < chars.length && normChars[endChar] === '') endChar += 1;
     // Convert char (code point) indexes to string indexes.
     const start = chars.slice(0, startChar).join("").length;
     const end = chars.slice(0, endChar).join("").length;

--- a/apps/web/lib/forms-search.ts
+++ b/apps/web/lib/forms-search.ts
@@ -1,0 +1,137 @@
+/**
+ * Client-side search and grouping for the forms list. Pure: the list is
+ * already loaded, so filtering by name or slug happens in the browser with no
+ * round trip. Matching ignores case and accents on both sides, the way the
+ * slugifier does, so "satisfaccion" finds "Satisfacción".
+ */
+
+export interface SearchableForm {
+  id: string;
+  name: string;
+  slug: string;
+  folderId: string | null;
+}
+
+export interface SearchableFolder {
+  id: string;
+  name: string;
+}
+
+/** A character range `[start, end)` on the ORIGINAL name, for highlighting. */
+export type MatchRange = [number, number];
+
+export interface FormMatch {
+  matched: boolean;
+  nameRanges: MatchRange[];
+}
+
+/** Lower-case, accents stripped, trimmed. Same recipe as `slugify`'s first steps. */
+export function normalize(value: string): string {
+  return value.normalize("NFKD").replace(/[̀-ͯ]/g, "").toLowerCase().trim();
+}
+
+/**
+ * Map an index in the normalized string back to the original. Accents are
+ * combining marks that `normalize` removed, so the original index only ever
+ * runs ahead of the normalized one; walk both in step.
+ */
+function rangesOnOriginal(
+  original: string,
+  normalizedQuery: string,
+): MatchRange[] {
+  const ranges: MatchRange[] = [];
+  if (!normalizedQuery) return ranges;
+  // Per-character normalized forms, so the map back is exact.
+  const chars = [...original];
+  const normChars = chars.map((c) => normalize(c) || (c === " " ? " " : ""));
+  const flat = normChars.join("");
+  // Offsets: the original char index at which each normalized char starts.
+  const origIndexAt: number[] = [];
+  chars.forEach((c, i) => {
+    for (let k = 0; k < normChars[i]!.length; k++) origIndexAt.push(i);
+  });
+  let from = 0;
+  for (;;) {
+    const at = flat.indexOf(normalizedQuery, from);
+    if (at < 0) break;
+    const startChar = origIndexAt[at]!;
+    const endChar = origIndexAt[at + normalizedQuery.length - 1]! + 1;
+    // Convert char (code point) indexes to string indexes.
+    const start = chars.slice(0, startChar).join("").length;
+    const end = chars.slice(0, endChar).join("").length;
+    ranges.push([start, end]);
+    from = at + normalizedQuery.length;
+  }
+  return ranges;
+}
+
+/** Whether `form` matches `query` by name or slug; ranges are on the name only. */
+export function matchForm(
+  form: Pick<SearchableForm, "name" | "slug">,
+  query: string,
+): FormMatch {
+  const q = normalize(query);
+  if (!q) return { matched: true, nameRanges: [] };
+  const nameRanges = rangesOnOriginal(form.name, q);
+  const matched = nameRanges.length > 0 || normalize(form.slug).includes(q);
+  return { matched, nameRanges: matched ? nameRanges : [] };
+}
+
+export interface FormSection<F extends SearchableForm = SearchableForm> {
+  /** The folder id, or null for the unfiled section. */
+  id: string | null;
+  /** The folder name; null for the unfiled section (the caller labels it). */
+  name: string | null;
+  /** The forms to show (filtered by the query), in list order. */
+  forms: Array<F & { match: FormMatch }>;
+  /** How many forms the folder holds regardless of the query (the header count). */
+  total: number;
+}
+
+/**
+ * Group forms into sections: Unfiled first, then every folder alphabetically
+ * (as the API lists them). Without a query every folder is a section, even an
+ * empty one, so it can receive a drop. With a query, sections without a match
+ * disappear and the ones left keep their full count.
+ */
+export function groupBySections<F extends SearchableForm>(
+  forms: F[],
+  folders: SearchableFolder[],
+  query: string,
+): FormSection<F>[] {
+  const known = new Set(folders.map((f) => f.id));
+  const byFolder = new Map<string | null, Array<F & { match: FormMatch }>>();
+  const totals = new Map<string | null, number>();
+  const keyOf = (f: F) =>
+    f.folderId && known.has(f.folderId) ? f.folderId : null;
+  for (const form of forms) {
+    const key = keyOf(form);
+    totals.set(key, (totals.get(key) ?? 0) + 1);
+    const match = matchForm(form, query);
+    if (!match.matched) continue;
+    const list = byFolder.get(key) ?? [];
+    list.push({ ...form, match });
+    byFolder.set(key, list);
+  }
+  const searching = normalize(query).length > 0;
+  const sections: FormSection<F>[] = [];
+  const unfiled = byFolder.get(null) ?? [];
+  if (!searching || unfiled.length > 0)
+    sections.push({
+      id: null,
+      name: null,
+      forms: unfiled,
+      total: totals.get(null) ?? 0,
+    });
+  for (const folder of folders) {
+    const list = byFolder.get(folder.id) ?? [];
+    if (searching && list.length === 0) continue;
+    sections.push({
+      id: folder.id,
+      name: folder.name,
+      forms: list,
+      total: totals.get(folder.id) ?? 0,
+    });
+  }
+  return sections;
+}

--- a/apps/web/lib/use-global-shortcut.spec.ts
+++ b/apps/web/lib/use-global-shortcut.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { isEditableTarget, shortcutFor } from "./use-global-shortcut";
+
+function key(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    defaultPrevented: false,
+    ...init,
+  } as KeyboardEvent;
+}
+
+describe("shortcutFor", () => {
+  it("Cmd/Ctrl+K focuses search from anywhere, even inside an input", () => {
+    expect(
+      shortcutFor(key({ key: "k", metaKey: true }), {
+        editable: false,
+        dialogOpen: false,
+      }),
+    ).toBe("search");
+    expect(
+      shortcutFor(key({ key: "K", ctrlKey: true }), {
+        editable: true,
+        dialogOpen: false,
+      }),
+    ).toBe("search");
+  });
+
+  it("a bare slash focuses search only outside editable fields and with no dialog open", () => {
+    expect(
+      shortcutFor(key({ key: "/" }), { editable: false, dialogOpen: false }),
+    ).toBe("search");
+    expect(
+      shortcutFor(key({ key: "/" }), { editable: true, dialogOpen: false }),
+    ).toBeNull();
+    expect(
+      shortcutFor(key({ key: "/" }), { editable: false, dialogOpen: true }),
+    ).toBeNull();
+  });
+
+  it("ignores anything already handled, and unrelated keys", () => {
+    expect(
+      shortcutFor(key({ key: "/", defaultPrevented: true }), {
+        editable: false,
+        dialogOpen: false,
+      }),
+    ).toBeNull();
+    expect(
+      shortcutFor(key({ key: "k" }), { editable: false, dialogOpen: false }),
+    ).toBeNull();
+    expect(
+      shortcutFor(key({ key: "k", metaKey: true, altKey: true }), {
+        editable: false,
+        dialogOpen: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("isEditableTarget", () => {
+  const el = (tag: string, extra: Record<string, unknown> = {}) =>
+    ({
+      tagName: tag,
+      isContentEditable: false,
+      ...extra,
+    }) as unknown as EventTarget;
+  it("treats inputs, textareas, selects and contenteditable as editable", () => {
+    expect(isEditableTarget(el("INPUT"))).toBe(true);
+    expect(isEditableTarget(el("TEXTAREA"))).toBe(true);
+    expect(isEditableTarget(el("SELECT"))).toBe(true);
+    expect(isEditableTarget(el("DIV", { isContentEditable: true }))).toBe(true);
+    expect(isEditableTarget(el("DIV"))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});

--- a/apps/web/lib/use-global-shortcut.ts
+++ b/apps/web/lib/use-global-shortcut.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** Inputs, textareas, selects and anything contenteditable: a slash there is typing. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || typeof target !== "object") return false;
+  const el = target as { tagName?: string; isContentEditable?: boolean };
+  const tag = (el.tagName ?? "").toUpperCase();
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable === true
+  );
+}
+
+export type GlobalShortcut = "search";
+
+/**
+ * Which shortcut a keydown means, or null. Cmd/Ctrl+K works everywhere (it
+ * is the universal "find" chord and never types a character); a bare `/`
+ * only outside editable fields and while no dialog is open, because there it
+ * is a character someone is typing.
+ */
+export function shortcutFor(
+  e: Pick<
+    KeyboardEvent,
+    "key" | "metaKey" | "ctrlKey" | "altKey" | "defaultPrevented"
+  >,
+  ctx: { editable: boolean; dialogOpen: boolean },
+): GlobalShortcut | null {
+  if (e.defaultPrevented || e.altKey) return null;
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") return "search";
+  if (
+    !e.metaKey &&
+    !e.ctrlKey &&
+    e.key === "/" &&
+    !ctx.editable &&
+    !ctx.dialogOpen
+  )
+    return "search";
+  return null;
+}
+
+/** One document keydown listener that routes the page's shortcuts to `onShortcut`. */
+export function useGlobalShortcut(
+  onShortcut: (shortcut: GlobalShortcut, e: KeyboardEvent) => void,
+): void {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const shortcut = shortcutFor(e, {
+        editable: isEditableTarget(e.target),
+        dialogOpen: document.querySelector('[role="dialog"]') != null,
+      });
+      if (!shortcut) return;
+      e.preventDefault();
+      onShortcut(shortcut, e);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onShortcut]);
+}

--- a/apps/web/lib/use-global-shortcut.ts
+++ b/apps/web/lib/use-global-shortcut.ts
@@ -51,7 +51,7 @@ export function useGlobalShortcut(
     const onKeyDown = (e: KeyboardEvent) => {
       const shortcut = shortcutFor(e, {
         editable: isEditableTarget(e.target),
-        dialogOpen: document.querySelector('[role="dialog"]') != null,
+        dialogOpen: document.querySelector('[role="dialog"], [role="alertdialog"]') != null,
       });
       if (!shortcut) return;
       e.preventDefault();

--- a/packages/db/migrations/postgres/0021_form_folders.sql
+++ b/packages/db/migrations/postgres/0021_form_folders.sql
@@ -1,0 +1,20 @@
+-- Form folders: additive.
+--
+-- A workspace with more than a screenful of forms had one flat list and no
+-- way to group it. `form_folder` is that grouping: flat (one level), named
+-- only, unique per account without regard to case (the expression index on
+-- lower(name)), and a form belongs to at most one (`form.folder_id`, NULL =
+-- unfiled, which is what every existing form is). Deleting a folder unfiles
+-- its forms (ON DELETE SET NULL, and the repo does it explicitly too) and
+-- never deletes them.
+CREATE TABLE IF NOT EXISTS form_folder (
+  id          TEXT PRIMARY KEY,
+  account_id  TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  created_at  BIGINT NOT NULL,
+  updated_at  BIGINT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS form_folder_account_name_uq ON form_folder (account_id, lower(name));
+
+ALTER TABLE form ADD COLUMN IF NOT EXISTS folder_id TEXT REFERENCES form_folder(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS form_account_folder_idx ON form (account_id, folder_id);

--- a/packages/db/migrations/sqlite/0021_form_folders.sql
+++ b/packages/db/migrations/sqlite/0021_form_folders.sql
@@ -1,0 +1,12 @@
+-- Form folders: additive. See the Postgres twin for the why.
+CREATE TABLE IF NOT EXISTS form_folder (
+  id          TEXT PRIMARY KEY,
+  account_id  TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS form_folder_account_name_uq ON form_folder (account_id, lower(name));
+
+ALTER TABLE form ADD COLUMN folder_id TEXT REFERENCES form_folder(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS form_account_folder_idx ON form (account_id, folder_id);

--- a/packages/db/src/crud.ts
+++ b/packages/db/src/crud.ts
@@ -7,6 +7,13 @@ export type CrudResult<T> =
   | { ok: true; value: T }
   | {
       ok: false;
-      reason: 'NOT_FOUND' | 'SLUG_TAKEN' | 'SLUG_INVALID' | 'CONFLICT' | 'LAST_OWNER' | 'EMAIL_TAKEN';
+      reason:
+        | 'NOT_FOUND'
+        | 'SLUG_TAKEN'
+        | 'SLUG_INVALID'
+        | 'CONFLICT'
+        | 'LAST_OWNER'
+        | 'EMAIL_TAKEN'
+        | 'NAME_TAKEN';
       message?: string;
     };

--- a/packages/db/src/folders.spec.ts
+++ b/packages/db/src/folders.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Form folders (migration 0021): flat, one level, one folder per form, a name
+ * unique per account without regard to case. Deleting a folder unfiles its
+ * forms and never deletes them. In-memory SQLite locally; DATABASE_URL for the
+ * Postgres parity job (the expression index is the part worth proving there).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createDb, sql, type Db } from "./client";
+import { migrate } from "./migrate";
+import { createForm, duplicateForm, getFormById, listForms } from "./forms";
+import {
+  createFolder,
+  deleteFolder,
+  getFolderById,
+  listFolders,
+  renameFolder,
+  setFormFolder,
+} from "./folders";
+
+let db: Db;
+let accountId: string;
+let otherAccountId: string;
+
+async function insertAccount(): Promise<string> {
+  const id = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${id}, ${"t" + id.slice(0, 7)}, ${"Test"}, ${Date.now()})`,
+  );
+  return id;
+}
+
+async function form(name: string, folderId?: string | null): Promise<string> {
+  const r = await createForm(db, accountId, {
+    name,
+    ...(folderId ? { folderId } : {}),
+  });
+  if (!r.ok) throw new Error(r.reason);
+  return r.value.id;
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? "file::memory:");
+  await migrate(db);
+  accountId = await insertAccount();
+  otherAccountId = await insertAccount();
+});
+
+afterEach(async () => {
+  for (const id of [accountId, otherAccountId]) {
+    await db.run(sql`DELETE FROM form WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM form_folder WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${id}`);
+  }
+  await db.close();
+});
+
+describe("folders", () => {
+  it("lists alphabetically without regard to case", async () => {
+    await createFolder(db, accountId, "sales");
+    await createFolder(db, accountId, "Archive");
+    await createFolder(db, accountId, "marketing");
+    expect((await listFolders(db, accountId)).map((f) => f.name)).toEqual([
+      "Archive",
+      "marketing",
+      "sales",
+    ]);
+  });
+
+  it("a name is unique per account without regard to case, and free in another account", async () => {
+    const first = await createFolder(db, accountId, "Sales");
+    expect(first.ok).toBe(true);
+    const dup = await createFolder(db, accountId, " sales ");
+    expect(dup).toEqual({ ok: false, reason: "NAME_TAKEN" });
+    expect((await createFolder(db, otherAccountId, "sales")).ok).toBe(true);
+  });
+
+  it("renames, refusing another folder’s name and allowing a case change of its own", async () => {
+    const a = await createFolder(db, accountId, "Sales");
+    await createFolder(db, accountId, "Marketing");
+    if (!a.ok) throw new Error("setup");
+    expect(await renameFolder(db, accountId, a.value.id, "marketing")).toEqual({
+      ok: false,
+      reason: "NAME_TAKEN",
+    });
+    const renamed = await renameFolder(db, accountId, a.value.id, "SALES");
+    expect(renamed.ok && renamed.value.name).toBe("SALES");
+    expect(await renameFolder(db, otherAccountId, a.value.id, "x")).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+
+  it("a form moves into a folder, out of it, and shows its folder in the list", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    if (!f.ok) throw new Error("setup");
+    const id = await form("Quiz");
+    expect(await setFormFolder(db, accountId, id, f.value.id)).toEqual({
+      ok: true,
+      value: { id, folderId: f.value.id },
+    });
+    expect(
+      (await listForms(db, accountId)).find((x) => x.id === id)?.folderId,
+    ).toBe(f.value.id);
+    expect((await getFormById(db, accountId, id))?.folderId).toBe(f.value.id);
+    expect(await setFormFolder(db, accountId, id, null)).toEqual({
+      ok: true,
+      value: { id, folderId: null },
+    });
+    expect(
+      (await listForms(db, accountId)).find((x) => x.id === id)?.folderId,
+    ).toBeNull();
+  });
+
+  it("moving does not touch updated_at, and refuses a folder or form of another account", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    const foreign = await createFolder(db, otherAccountId, "Theirs");
+    if (!f.ok || !foreign.ok) throw new Error("setup");
+    const id = await form("Quiz");
+    const before = (await getFormById(db, accountId, id))!.updatedAt;
+    await setFormFolder(db, accountId, id, f.value.id);
+    expect((await getFormById(db, accountId, id))!.updatedAt).toBe(before);
+    expect(await setFormFolder(db, accountId, id, foreign.value.id)).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+    expect(await setFormFolder(db, otherAccountId, id, null)).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+
+  it("deleting a folder unfiles its forms and keeps them; a second delete is a no-op", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    if (!f.ok) throw new Error("setup");
+    const id = await form("Quiz", f.value.id);
+    expect((await getFormById(db, accountId, id))?.folderId).toBe(f.value.id);
+    expect(await deleteFolder(db, accountId, f.value.id)).toBe(true);
+    expect((await getFormById(db, accountId, id))?.folderId).toBeNull();
+    expect(await getFolderById(db, accountId, f.value.id)).toBeNull();
+    expect(await deleteFolder(db, accountId, f.value.id)).toBe(false);
+    expect(await deleteFolder(db, otherAccountId, f.value.id)).toBe(false);
+  });
+
+  it("a form is created inside a folder, and a duplicate inherits it", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    if (!f.ok) throw new Error("setup");
+    const id = await form("Quiz", f.value.id);
+    const copy = await duplicateForm(db, accountId, id);
+    expect(copy.ok && copy.value.folderId).toBe(f.value.id);
+    // A folder of another account cannot be named at creation either.
+    const foreign = await createFolder(db, otherAccountId, "Theirs");
+    if (!foreign.ok) throw new Error("setup");
+    expect(
+      await createForm(db, accountId, {
+        name: "X",
+        folderId: foreign.value.id,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+});

--- a/packages/db/src/folders.ts
+++ b/packages/db/src/folders.ts
@@ -1,0 +1,208 @@
+/**
+ * Form folders (see 0021): flat, one level, named only. A folder is unique per
+ * account without regard to case; a form is filed in at most one. Deleting a
+ * folder unfiles its forms and never deletes them. Moving a form never touches
+ * its `updated_at`: filing is organisation, not authoring.
+ */
+import { randomUUID } from "node:crypto";
+import { sql, type Db } from "./client";
+import type { CrudResult } from "./crud";
+
+export interface FormFolder {
+  id: string;
+  accountId: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface DatabaseError {
+  code?: string;
+  constraint?: string;
+  constraint_name?: string;
+  message?: string;
+  cause?: unknown;
+  driverError?: unknown;
+}
+
+/** True only for the (account_id, lower(name)) unique index, on either engine. */
+function isFolderNameUniqueViolation(error: unknown): boolean {
+  const e =
+    error && typeof error === "object" ? (error as DatabaseError) : undefined;
+  if (!e) return false;
+  if (
+    e.code === "23505" &&
+    (e.constraint === "form_folder_account_name_uq" ||
+      e.constraint_name === "form_folder_account_name_uq")
+  )
+    return true;
+  // SQLite names an EXPRESSION index by the index, not by its columns.
+  return (
+    e.code === "SQLITE_CONSTRAINT_UNIQUE" &&
+    typeof e.message === "string" &&
+    e.message.includes("form_folder_account_name_uq")
+  );
+}
+
+function isFolderNameConflict(error: unknown): boolean {
+  const e =
+    error && typeof error === "object" ? (error as DatabaseError) : undefined;
+  return (
+    isFolderNameUniqueViolation(error) ||
+    isFolderNameUniqueViolation(e?.cause) ||
+    isFolderNameUniqueViolation(e?.driverError)
+  );
+}
+
+function mapFolder(r: Record<string, unknown>): FormFolder {
+  return {
+    id: String(r.id),
+    accountId: String(r.account_id),
+    name: String(r.name),
+    createdAt: Number(r.created_at),
+    updatedAt: Number(r.updated_at),
+  };
+}
+
+/** The account's folders, alphabetically without regard to case. */
+export async function listFolders(
+  db: Db,
+  accountId: string,
+): Promise<FormFolder[]> {
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT id, account_id, name, created_at, updated_at FROM form_folder
+        WHERE account_id = ${accountId} ORDER BY lower(name) ASC, created_at ASC`,
+  );
+  return rows.map(mapFolder);
+}
+
+export async function getFolderById(
+  db: Db,
+  accountId: string,
+  id: string,
+): Promise<FormFolder | null> {
+  const row = await db.get<Record<string, unknown>>(
+    sql`SELECT id, account_id, name, created_at, updated_at FROM form_folder
+        WHERE account_id = ${accountId} AND id = ${id} LIMIT 1`,
+  );
+  return row ? mapFolder(row) : null;
+}
+
+/** Another folder of the account already using `name` (case-insensitively), excluding `exceptId`. */
+async function nameTaken(
+  db: Db,
+  accountId: string,
+  name: string,
+  exceptId?: string,
+): Promise<boolean> {
+  const row = await db.get<{ id: string }>(
+    sql`SELECT id FROM form_folder
+        WHERE account_id = ${accountId} AND lower(name) = lower(${name})
+          ${exceptId ? sql`AND id <> ${exceptId}` : sql``}
+        LIMIT 1`,
+  );
+  return Boolean(row);
+}
+
+/**
+ * Create a folder. The pre-check gives the common case a clean NAME_TAKEN; the
+ * unique index (and the catch below) closes the race two writers could open.
+ */
+export async function createFolder(
+  db: Db,
+  accountId: string,
+  rawName: string,
+): Promise<CrudResult<FormFolder>> {
+  const name = rawName.trim();
+  if (!name)
+    return { ok: false, reason: "CONFLICT", message: "A name is required." };
+  if (await nameTaken(db, accountId, name))
+    return { ok: false, reason: "NAME_TAKEN" };
+  const id = randomUUID();
+  const now = Date.now();
+  try {
+    await db.run(
+      sql`INSERT INTO form_folder (id, account_id, name, created_at, updated_at)
+          VALUES (${id}, ${accountId}, ${name}, ${now}, ${now})`,
+    );
+  } catch (error) {
+    if (isFolderNameConflict(error)) return { ok: false, reason: "NAME_TAKEN" };
+    throw error;
+  }
+  const created = await getFolderById(db, accountId, id);
+  return created
+    ? { ok: true, value: created }
+    : { ok: false, reason: "CONFLICT" };
+}
+
+export async function renameFolder(
+  db: Db,
+  accountId: string,
+  id: string,
+  rawName: string,
+): Promise<CrudResult<FormFolder>> {
+  const name = rawName.trim();
+  if (!name)
+    return { ok: false, reason: "CONFLICT", message: "A name is required." };
+  const existing = await getFolderById(db, accountId, id);
+  if (!existing) return { ok: false, reason: "NOT_FOUND" };
+  if (await nameTaken(db, accountId, name, id))
+    return { ok: false, reason: "NAME_TAKEN" };
+  try {
+    await db.run(
+      sql`UPDATE form_folder SET name = ${name}, updated_at = ${Date.now()}
+          WHERE account_id = ${accountId} AND id = ${id}`,
+    );
+  } catch (error) {
+    if (isFolderNameConflict(error)) return { ok: false, reason: "NAME_TAKEN" };
+    throw error;
+  }
+  const renamed = await getFolderById(db, accountId, id);
+  return renamed
+    ? { ok: true, value: renamed }
+    : { ok: false, reason: "NOT_FOUND" };
+}
+
+/**
+ * Delete a folder: its forms are unfiled first (explicitly, so the result does
+ * not depend on the engine enforcing the foreign key), then the row goes.
+ * Returns whether a folder was actually deleted; a repeat is false, not an error.
+ */
+export async function deleteFolder(
+  db: Db,
+  accountId: string,
+  id: string,
+): Promise<boolean> {
+  const existing = await getFolderById(db, accountId, id);
+  if (!existing) return false;
+  await db.run(
+    sql`UPDATE form SET folder_id = NULL WHERE account_id = ${accountId} AND folder_id = ${id}`,
+  );
+  await db.run(
+    sql`DELETE FROM form_folder WHERE account_id = ${accountId} AND id = ${id}`,
+  );
+  return true;
+}
+
+/**
+ * File a form in a folder of the same account, or unfile it with null.
+ * `updated_at` is deliberately untouched: the form did not change, its
+ * shelf did.
+ */
+export async function setFormFolder(
+  db: Db,
+  accountId: string,
+  formId: string,
+  folderId: string | null,
+): Promise<CrudResult<{ id: string; folderId: string | null }>> {
+  const form = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE account_id = ${accountId} AND id = ${formId} LIMIT 1`,
+  );
+  if (!form) return { ok: false, reason: "NOT_FOUND" };
+  if (folderId != null && !(await getFolderById(db, accountId, folderId)))
+    return { ok: false, reason: "NOT_FOUND" };
+  await db.run(
+    sql`UPDATE form SET folder_id = ${folderId} WHERE account_id = ${accountId} AND id = ${formId}`,
+  );
+  return { ok: true, value: { id: formId, folderId } };
+}

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -191,6 +191,8 @@ export interface FormRow {
    * `accountId`, never by this.
    */
   createdBy: string | null;
+  /** The folder this form is filed in (0021); null = unfiled. */
+  folderId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -201,6 +203,8 @@ export interface FormSummary {
   slug: string;
   /** Epoch-ms of the last brand-kit apply; null when never applied or reverted. */
   brandAppliedAt: number | null;
+  /** The folder this form is filed in (0021); null = unfiled. */
+  folderId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -216,6 +220,7 @@ function mapForm(r: Record<string, unknown>): FormRow {
     publishedAt: r.published_at == null ? null : Number(r.published_at),
     brandAppliedAt: r.brand_applied_at == null ? null : Number(r.brand_applied_at),
     createdBy: r.created_by == null ? null : String(r.created_by),
+    folderId: r.folder_id == null ? null : String(r.folder_id),
     createdAt: Number(r.created_at),
     updatedAt: Number(r.updated_at),
   };
@@ -328,7 +333,7 @@ function isFormAccountSlugConflict(error: unknown): boolean {
 
 export async function listForms(db: Db, accountId: string): Promise<FormSummary[]> {
   const rows = await db.all<Record<string, unknown>>(
-    sql`SELECT id, name, slug, brand_applied_at, created_at, updated_at FROM form
+    sql`SELECT id, name, slug, brand_applied_at, folder_id, created_at, updated_at FROM form
         WHERE account_id = ${accountId} ORDER BY updated_at DESC, created_at DESC`,
   );
   return rows.map((r) => ({
@@ -336,6 +341,7 @@ export async function listForms(db: Db, accountId: string): Promise<FormSummary[
     name: String(r.name),
     slug: String(r.slug),
     brandAppliedAt: r.brand_applied_at == null ? null : Number(r.brand_applied_at),
+    folderId: r.folder_id == null ? null : String(r.folder_id),
     createdAt: Number(r.created_at),
     updatedAt: Number(r.updated_at),
   }));
@@ -430,7 +436,7 @@ export async function getFormById(db: Db, accountId: string, id: string): Promis
 export async function createForm(
   db: Db,
   accountId: string,
-  input: { name: string; slug?: string; config?: unknown },
+  input: { name: string; slug?: string; config?: unknown; folderId?: string | null },
   /**
    * `member.id` of the author, for per-user analytics (migration 0010).
    * MUST come from the resolved principal, never from request input — this is
@@ -440,6 +446,15 @@ export async function createForm(
   createdBy?: string | null,
 ): Promise<CrudResult<FormRow>> {
   const config = input.config ?? { version: 1, steps: [] };
+  // A folder is named by id and must be this account's: filing a form into a
+  // stranger's folder would leak its existence and misfile the form.
+  const folderId = input.folderId ?? null;
+  if (folderId != null) {
+    const folder = await db.get<{ id: string }>(
+      sql`SELECT id FROM form_folder WHERE account_id = ${accountId} AND id = ${folderId} LIMIT 1`,
+    );
+    if (!folder) return { ok: false, reason: 'NOT_FOUND', message: 'No such folder.' };
+  }
 
   for (let attempt = 0; attempt < FORM_SLUG_INSERT_ATTEMPTS; attempt++) {
     const slug = await uniqueFormSlug(db, accountId, input.slug ?? input.name);
@@ -447,9 +462,9 @@ export async function createForm(
     const now = Date.now();
     try {
       await db.run(
-        sql`INSERT INTO form (id, account_id, name, slug, config, created_by, created_at, updated_at)
+        sql`INSERT INTO form (id, account_id, name, slug, config, created_by, folder_id, created_at, updated_at)
             VALUES (${id}, ${accountId}, ${input.name}, ${slug}, ${jsonParam(config)},
-                    ${createdBy ?? null}, ${now}, ${now})`,
+                    ${createdBy ?? null}, ${folderId}, ${now}, ${now})`,
       );
     } catch (error) {
       if (attempt + 1 < FORM_SLUG_INSERT_ATTEMPTS && isFormAccountSlugConflict(error)) continue;
@@ -814,6 +829,8 @@ export async function duplicateForm(
     {
       name: `${src.name} (copy)`,
       slug: src.slug,
+      // The copy lands on the same shelf as the original.
+      folderId: src.folderId,
       // NOT verbatim: the HubSpot mirror-form pointer is the original's, and a
       // copy that inherits it delivers its submissions AS the original.
       config: withoutOwnedMirrorState(src.config),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,6 +6,7 @@
 export * from './client';
 export * from './crud';
 export * from './forms';
+export * from './folders';
 export * from './bookings';
 export * from './account-integrations';
 export * from './account-branding';

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -170,6 +170,26 @@ export const notificationSetting = pgTable(
 
 // --- Forms domain ------------------------------------------------------------
 
+/**
+ * A form folder (see 0021): flat, one level, named only, unique per account
+ * without regard to case (the lower(name) expression index lives in the
+ * migration, since Drizzle's index builder cannot express it). Declared before
+ * `form`, which points at it.
+ */
+export const formFolder = pgTable(
+  'form_folder',
+  {
+    id: text('id').primaryKey(),
+    accountId: text('account_id').notNull(),
+    name: text('name').notNull(),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (t) => ({
+    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
+  }),
+);
+
 export const form = pgTable(
   'form',
   {
@@ -188,6 +208,8 @@ export const form = pgTable(
     brandAppliedAt: bigint('brand_applied_at', { mode: 'number' }),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled. */
+    folderId: text('folder_id'),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },
@@ -320,6 +342,7 @@ export const pgSchema = {
   outbox,
   notificationSetting,
   form,
+  formFolder,
   formAlias,
   submission,
   formEvent,

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -185,9 +185,9 @@ export const formFolder = pgTable(
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },
-  (t) => ({
-    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
-  }),
+  // The (account_id, lower(name)) unique index lives in the migration only:
+  // Drizzle cannot express an expression index, and this file declares what
+  // the migration creates, nothing more.
 );
 
 export const form = pgTable(
@@ -208,13 +208,14 @@ export const form = pgTable(
     brandAppliedAt: bigint('brand_applied_at', { mode: 'number' }),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
-    /** The folder this form is filed in (see 0021); NULL = unfiled. */
-    folderId: text('folder_id'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled, and a deleted folder unfiles. */
+    folderId: text('folder_id').references(() => formFolder.id, { onDelete: 'set null' }),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },
   (t) => ({
     formAccountSlugUq: uniqueIndex('form_account_slug_uq').on(t.accountId, t.slug),
+    formAccountFolderIdx: index('form_account_folder_idx').on(t.accountId, t.folderId),
   }),
 );
 

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -181,9 +181,9 @@ export const formFolder = sqliteTable(
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
-  (t) => ({
-    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
-  }),
+  // The (account_id, lower(name)) unique index lives in the migration only:
+  // Drizzle cannot express an expression index, and this file declares what
+  // the migration creates, nothing more.
 );
 
 export const form = sqliteTable(
@@ -206,13 +206,14 @@ export const form = sqliteTable(
     brandAppliedAt: integer('brand_applied_at'),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
-    /** The folder this form is filed in (see 0021); NULL = unfiled. */
-    folderId: text('folder_id'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled, and a deleted folder unfiles. */
+    folderId: text('folder_id').references(() => formFolder.id, { onDelete: 'set null' }),
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
   (t) => ({
     formAccountSlugUq: uniqueIndex('form_account_slug_uq').on(t.accountId, t.slug),
+    formAccountFolderIdx: index('form_account_folder_idx').on(t.accountId, t.folderId),
   }),
 );
 

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -166,6 +166,26 @@ export const notificationSetting = sqliteTable(
 // --- Forms domain ------------------------------------------------------------
 
 /** A form: one versioned JSON `config` blob drives the whole public flow. */
+/**
+ * A form folder (see 0021): flat, one level, named only, unique per account
+ * without regard to case (the lower(name) expression index lives in the
+ * migration, since Drizzle's index builder cannot express it). Declared before
+ * `form`, which points at it.
+ */
+export const formFolder = sqliteTable(
+  'form_folder',
+  {
+    id: text('id').primaryKey(),
+    accountId: text('account_id').notNull(),
+    name: text('name').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (t) => ({
+    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
+  }),
+);
+
 export const form = sqliteTable(
   'form',
   {
@@ -186,6 +206,8 @@ export const form = sqliteTable(
     brandAppliedAt: integer('brand_applied_at'),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled. */
+    folderId: text('folder_id'),
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
@@ -321,6 +343,7 @@ export const sqliteSchema = {
   outbox,
   notificationSetting,
   form,
+  formFolder,
   formAlias,
   submission,
   formEvent,

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -510,6 +510,44 @@ export interface FormsMessages {
       open: string;
       connect: string;
       openForm: string;
+      /** Search box over the loaded list (name or slug, no case, no accents). */
+      searchPlaceholder: string;
+      searchLabel: string;
+      searchClear: string;
+      searchEmpty: string;
+      /** "{count} results" live announcement. */
+      searchResults: string;
+      /** The keyboard hint shown inside the search box. */
+      searchShortcut: string;
+      /** Folders: sections of the list. */
+      unfiled: string;
+      folderCount: string; // {count}
+      folderCountOne: string;
+      newFolder: string;
+      newFolderTitle: string;
+      folderCreate: string;
+      renameFolder: string;
+      renameFolderTitle: string;
+      folderSave: string;
+      folderNameLabel: string;
+      folderNamePlaceholder: string;
+      folderNameRequired: string;
+      folderNameTaken: string;
+      deleteFolder: string;
+      deleteFolderConfirm: string; // {name} {count}
+      folderMenu: string;
+      collapse: string;
+      expand: string;
+      /** "New form" on a folder header, creating straight into it. */
+      createIn: string;
+      folderLabel: string;
+      folderNone: string;
+      moveTo: string;
+      moveBack: string;
+      moveFailed: string;
+      dragHandle: string;
+      dropHere: string;
+      actionFailed: string;
     };
     /** The form editor (builder). */
     editor: {
@@ -1653,6 +1691,7 @@ export interface FormsMessages {
     cancel: string;
     /** Per-surface dialog titles (the body reuses each surface's *Confirm copy). */
     deleteFormTitle: string;
+    deleteFolderTitle: string;
     deleteQuestionTitle: string;
     deleteSubmissionTitle: string;
     removeMemberTitle: string;
@@ -2078,6 +2117,39 @@ export const en: FormsMessages = {
       open: 'Open',
       connect: 'Connect',
       openForm: 'Open form',
+      searchPlaceholder: 'Search forms',
+      searchLabel: 'Search forms by name or link',
+      searchClear: 'Clear search',
+      searchEmpty: 'No forms match your search.',
+      searchResults: '{count} forms match',
+      searchShortcut: 'Ctrl K',
+      unfiled: 'Unfiled',
+      folderCount: '{count} forms',
+      folderCountOne: '1 form',
+      newFolder: 'New folder',
+      newFolderTitle: 'Create a folder',
+      folderCreate: 'Create folder',
+      renameFolder: 'Rename',
+      renameFolderTitle: 'Rename folder',
+      folderSave: 'Save',
+      folderNameLabel: 'Folder name',
+      folderNamePlaceholder: 'e.g. Sales',
+      folderNameRequired: 'Give the folder a name.',
+      folderNameTaken: 'A folder with that name already exists.',
+      deleteFolder: 'Delete folder',
+      deleteFolderConfirm: 'Delete “{name}”? Its {count} forms are kept and move to Unfiled.',
+      folderMenu: 'Folder actions',
+      collapse: 'Collapse',
+      expand: 'Expand',
+      createIn: 'New form',
+      folderLabel: 'Folder',
+      folderNone: 'No folder',
+      moveTo: 'Move to folder',
+      moveBack: 'No folder',
+      moveFailed: 'Could not move the form. Please try again.',
+      dragHandle: 'Drag to a folder',
+      dropHere: 'Drop to move here',
+      actionFailed: 'Something went wrong. Please try again.',
     },
     editor: {
       back: 'Back to forms',
@@ -3133,6 +3205,7 @@ export const en: FormsMessages = {
     confirm: 'Confirm',
     cancel: 'Cancel',
     deleteFormTitle: 'Delete form',
+    deleteFolderTitle: 'Delete folder',
     deleteQuestionTitle: 'Delete question',
     deleteSubmissionTitle: 'Delete submission',
     removeMemberTitle: 'Remove member',
@@ -3560,6 +3633,39 @@ export const es: FormsMessages = {
       open: 'Abrir',
       connect: 'Conectar',
       openForm: 'Abrir formulario',
+      searchPlaceholder: 'Buscar formularios',
+      searchLabel: 'Buscar formularios por nombre o enlace',
+      searchClear: 'Limpiar búsqueda',
+      searchEmpty: 'Ningún formulario coincide con tu búsqueda.',
+      searchResults: '{count} formularios coinciden',
+      searchShortcut: 'Ctrl K',
+      unfiled: 'Sin carpeta',
+      folderCount: '{count} formularios',
+      folderCountOne: '1 formulario',
+      newFolder: 'Nueva carpeta',
+      newFolderTitle: 'Crear una carpeta',
+      folderCreate: 'Crear carpeta',
+      renameFolder: 'Renombrar',
+      renameFolderTitle: 'Renombrar carpeta',
+      folderSave: 'Guardar',
+      folderNameLabel: 'Nombre de la carpeta',
+      folderNamePlaceholder: 'p. ej. Ventas',
+      folderNameRequired: 'Ponle un nombre a la carpeta.',
+      folderNameTaken: 'Ya existe una carpeta con ese nombre.',
+      deleteFolder: 'Eliminar carpeta',
+      deleteFolderConfirm: '¿Eliminar “{name}”? Sus {count} formularios se conservan y pasan a Sin carpeta.',
+      folderMenu: 'Acciones de la carpeta',
+      collapse: 'Contraer',
+      expand: 'Expandir',
+      createIn: 'Nuevo formulario',
+      folderLabel: 'Carpeta',
+      folderNone: 'Sin carpeta',
+      moveTo: 'Mover a carpeta',
+      moveBack: 'Sin carpeta',
+      moveFailed: 'No se pudo mover el formulario. Inténtalo de nuevo.',
+      dragHandle: 'Arrastra a una carpeta',
+      dropHere: 'Suelta para mover aquí',
+      actionFailed: 'Algo salió mal. Inténtalo de nuevo.',
     },
     editor: {
       back: 'Volver a formularios',
@@ -4622,6 +4728,7 @@ export const es: FormsMessages = {
     confirm: 'Confirmar',
     cancel: 'Cancelar',
     deleteFormTitle: 'Eliminar formulario',
+    deleteFolderTitle: 'Eliminar carpeta',
     deleteQuestionTitle: 'Eliminar pregunta',
     deleteSubmissionTitle: 'Eliminar respuesta',
     removeMemberTitle: 'Quitar miembro',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -534,7 +534,7 @@ export interface FormsMessages {
       folderNameRequired: string;
       folderNameTaken: string;
       deleteFolder: string;
-      deleteFolderConfirm: string; // {name} {count}
+      deleteFolderConfirm: string; // {name} {forms} (the already-pluralised count label)
       folderMenu: string;
       collapse: string;
       expand: string;
@@ -2137,7 +2137,7 @@ export const en: FormsMessages = {
       folderNameRequired: 'Give the folder a name.',
       folderNameTaken: 'A folder with that name already exists.',
       deleteFolder: 'Delete folder',
-      deleteFolderConfirm: 'Delete “{name}”? Its {count} forms are kept and move to Unfiled.',
+      deleteFolderConfirm: 'Delete “{name}”? The forms inside ({forms}) are kept and move to Unfiled.',
       folderMenu: 'Folder actions',
       collapse: 'Collapse',
       expand: 'Expand',
@@ -3653,7 +3653,7 @@ export const es: FormsMessages = {
       folderNameRequired: 'Ponle un nombre a la carpeta.',
       folderNameTaken: 'Ya existe una carpeta con ese nombre.',
       deleteFolder: 'Eliminar carpeta',
-      deleteFolderConfirm: '¿Eliminar “{name}”? Sus {count} formularios se conservan y pasan a Sin carpeta.',
+      deleteFolderConfirm: '¿Eliminar “{name}”? Los formularios que contiene ({forms}) se conservan y pasan a Sin carpeta.',
       folderMenu: 'Acciones de la carpeta',
       collapse: 'Contraer',
       expand: 'Expandir',

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -9,7 +9,14 @@
  * has somewhere obvious to prove the same thing.
  */
 import { describe, expect, it } from 'vitest';
-import { formConfigSchema, hasExtraHubspotDestination } from './index';
+import {
+  folderInputSchema,
+  folderViewSchema,
+  formConfigSchema,
+  formCreateInputSchema,
+  formFolderPatchSchema,
+  hasExtraHubspotDestination,
+} from './index';
 
 /** The smallest config the schema accepts — one step, nothing configured. */
 function baseConfig() {
@@ -195,5 +202,22 @@ describe('hasExtraHubspotDestination', () => {
     it('still ignores webhooks on both sides', () => {
       expect(hasExtraHubspotDestination([webhook, webhook, hubspot], [hubspot])).toBe(false);
     });
+  });
+});
+
+describe('folder schemas', () => {
+  it('trims and bounds a folder name, and the move patch requires the key', () => {
+    expect(folderInputSchema.parse({ name: '  Sales  ' })).toEqual({ name: 'Sales' });
+    expect(() => folderInputSchema.parse({ name: '   ' })).toThrow();
+    expect(() => folderInputSchema.parse({ name: 'x'.repeat(81) })).toThrow();
+    expect(formFolderPatchSchema.parse({ folderId: null })).toEqual({ folderId: null });
+    expect(formFolderPatchSchema.parse({ folderId: 'f1' })).toEqual({ folderId: 'f1' });
+    expect(() => formFolderPatchSchema.parse({})).toThrow();
+  });
+
+  it('create input carries an optional folderId; the view carries it too', () => {
+    expect(formCreateInputSchema.parse({ name: 'Quiz', folderId: 'f1' }).folderId).toBe('f1');
+    expect(formCreateInputSchema.parse({ name: 'Quiz' }).folderId).toBeUndefined();
+    expect(folderViewSchema.parse({ id: 'f1', name: 'Sales', createdAt: 1, updatedAt: 1 }).name).toBe('Sales');
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1140,6 +1140,32 @@ export const formInputSchema = z.object({
 });
 export type FormInput = z.infer<typeof formInputSchema>;
 
+// --- Form folders (0021) -------------------------------------------------------
+
+/** A folder name: trimmed, 1 to 80 characters. Unique per account without regard to case (the API answers 409 NAME_TAKEN). */
+export const folderNameSchema = z.string().trim().min(1).max(80);
+/** Body of POST /v1/folders and PATCH /v1/folders/:id. */
+export const folderInputSchema = z.object({ name: folderNameSchema });
+export type FolderInput = z.infer<typeof folderInputSchema>;
+
+export const folderViewSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+export type FolderView = z.infer<typeof folderViewSchema>;
+
+/** Body of PATCH /v1/forms/:id/folder: the key is required, null unfiles. */
+export const formFolderPatchSchema = z.object({ folderId: z.string().min(1).nullable() });
+export type FormFolderPatch = z.infer<typeof formFolderPatchSchema>;
+
+/** POST /v1/forms may file the new form straight into a folder (PUT /v1/forms/:id never moves it). */
+export const formCreateInputSchema = formInputSchema.extend({
+  folderId: z.string().min(1).nullable().optional(),
+});
+export type FormCreateInput = z.infer<typeof formCreateInputSchema>;
+
 /**
  * Body of PUT /v1/forms/:id/slug: the form's new public URL segment.
  *
@@ -1163,6 +1189,8 @@ export const formViewSchema = z.object({
   draftConfig: formConfigSchema.nullable().optional(),
   /** Epoch-ms of the last publish (ADDITIVE; null when never published). */
   publishedAt: z.number().nullable().optional(),
+  /** The folder the form is filed in (ADDITIVE, 0021; null = unfiled). */
+  folderId: z.string().nullable().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/qa/e2e/v15-form-folders.spec.ts
+++ b/qa/e2e/v15-form-folders.spec.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * Folders + keyboard search on the forms list (V15).
+ *
+ * Seeded through the API (folders and forms alike) so the assertions are
+ * about the list, not about the create dialog. Names carry a random tag: the
+ * QA database survives between runs and folder names are unique per
+ * workspace without regard to case, so a fixed name would 409 on the second
+ * run. Every test cleans up its own folder and forms.
+ */
+
+const API = "http://localhost:4400";
+
+function tag() {
+  return randomUUID().slice(0, 8);
+}
+
+async function createFolder(request: APIRequestContext, name: string) {
+  const res = await request.post(`${API}/v1/folders`, { data: { name } });
+  expect(res.status(), "POST /v1/folders should create the folder").toBe(201);
+  return (await res.json()) as { id: string; name: string };
+}
+
+async function createForm(
+  request: APIRequestContext,
+  name: string,
+  folderId?: string,
+) {
+  const res = await request.post(`${API}/v1/forms`, {
+    data: {
+      name,
+      config: { version: 1, steps: [] },
+      ...(folderId ? { folderId } : {}),
+    },
+  });
+  expect(res.status(), "POST /v1/forms should create the form").toBe(201);
+  return (await res.json()) as {
+    id: string;
+    slug: string;
+    folderId: string | null;
+  };
+}
+
+async function folderOf(
+  request: APIRequestContext,
+  formId: string,
+): Promise<string | null> {
+  const res = await request.get(`${API}/v1/forms`);
+  const rows = (await res.json()) as Array<{
+    id: string;
+    folderId: string | null;
+  }>;
+  return rows.find((r) => r.id === formId)?.folderId ?? null;
+}
+
+async function cleanup(
+  request: APIRequestContext,
+  ids: { forms: string[]; folders: string[] },
+) {
+  for (const id of ids.forms) await request.delete(`${API}/v1/forms/${id}`);
+  for (const id of ids.folders) await request.delete(`${API}/v1/folders/${id}`);
+}
+
+function section(page: Page, folderId: string) {
+  return page.locator(
+    `[data-testid="folder-section"][data-folder-id="${folderId}"]`,
+  );
+}
+
+test.describe("forms list: folders and search", () => {
+  test("sections: Unfiled first, folders alphabetically, counts, and the fold survives a reload", async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const beta = await createFolder(request, `qa-${t}-Beta`);
+    const alpha = await createFolder(request, `qa-${t}-alpha`);
+    const inBeta = await createForm(request, `qa-${t}-in-beta`, beta.id);
+    const loose = await createForm(request, `qa-${t}-loose`);
+    try {
+      await page.goto("/admin/forms");
+      const unfiled = page.getByTestId("unfiled-section");
+      await expect(unfiled).toBeVisible();
+      // Unfiled comes first in DOM order, then the folders alphabetically (case-insensitive).
+      const order = await page
+        .locator(
+          '[data-testid="unfiled-section"], [data-testid="folder-section"]',
+        )
+        .evaluateAll((els) =>
+          els.map((el) => el.getAttribute("data-folder-id")),
+        );
+      expect(order[0]).toBe("");
+      expect(order.indexOf(alpha.id)).toBeLessThan(order.indexOf(beta.id));
+      await expect(
+        section(page, beta.id).getByTestId("folder-count"),
+      ).toHaveText(/1 form/);
+      await expect(
+        section(page, beta.id).locator(`[data-form-id="${inBeta.id}"]`),
+      ).toBeVisible();
+      await expect(
+        unfiled.locator(`[data-form-id="${loose.id}"]`),
+      ).toBeVisible();
+
+      // Collapse Beta, reload: still collapsed (per-browser memory).
+      await section(page, beta.id).getByTestId("folder-toggle").click();
+      await expect(
+        section(page, beta.id).getByTestId("folder-toggle"),
+      ).toHaveAttribute("aria-expanded", "false");
+      await page.reload();
+      await expect(
+        section(page, beta.id).getByTestId("folder-toggle"),
+      ).toHaveAttribute("aria-expanded", "false");
+      await expect(
+        section(page, beta.id).locator(`[data-form-id="${inBeta.id}"]`),
+      ).toBeHidden();
+    } finally {
+      await cleanup(request, {
+        forms: [inBeta.id, loose.id],
+        folders: [alpha.id, beta.id],
+      });
+    }
+  });
+
+  test("search: Ctrl+K focuses, matches without accents, highlights, hides empty sections, Escape clears", async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const folder = await createFolder(request, `qa-${t}-Ventas`);
+    const hit = await createForm(request, `qa-${t}-Satisfacción`, folder.id);
+    const miss = await createForm(request, `qa-${t}-Other`);
+    try {
+      await page.goto("/admin/forms");
+      await page.keyboard.press("Control+K");
+      await expect(page.getByTestId("forms-search")).toBeFocused();
+      await page.keyboard.type("satisfaccion");
+      await expect(page.locator(`[data-form-id="${hit.id}"] mark`)).toHaveText(
+        "Satisfacción",
+      );
+      await expect(page.locator(`[data-form-id="${miss.id}"]`)).toHaveCount(0);
+      await expect(
+        section(page, folder.id).getByTestId("folder-toggle"),
+      ).toHaveAttribute("aria-expanded", "true");
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("forms-search")).toHaveValue("");
+      await expect(page.locator(`[data-form-id="${miss.id}"]`)).toBeVisible();
+      // Arrow down from the box lands on the first row title; Enter opens the editor.
+      await page.getByTestId("forms-search").focus();
+      await page.keyboard.press("ArrowDown");
+      await expect(page.locator("[data-form-link]").first()).toBeFocused();
+    } finally {
+      await cleanup(request, {
+        forms: [hit.id, miss.id],
+        folders: [folder.id],
+      });
+    }
+  });
+
+  test('move: kebab "Move to folder", drag by the grip, and deleting a folder keeps its forms', async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const folder = await createFolder(request, `qa-${t}-Sales`);
+    const form = await createForm(request, `qa-${t}-mover`);
+    try {
+      await page.goto("/admin/forms");
+      const row = page.locator(`[data-form-id="${form.id}"]`);
+      await row.getByTestId("form-row-menu").click();
+      await page.getByTestId(`form-row-move-${folder.id}`).click();
+      await expect(
+        section(page, folder.id).locator(`[data-form-id="${form.id}"]`),
+      ).toBeVisible();
+      await expect.poll(() => folderOf(request, form.id)).toBe(folder.id);
+
+      // Drag it back to Unfiled by the grip (pointer sensor needs > 6px of travel).
+      const grip = section(page, folder.id)
+        .locator(`[data-form-id="${form.id}"]`)
+        .getByTestId("form-row-grip");
+      const target = page
+        .getByTestId("unfiled-section")
+        .getByTestId("folder-toggle");
+      const from = (await grip.boundingBox())!;
+      const to = (await target.boundingBox())!;
+      await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(
+        from.x + from.width / 2 + 12,
+        from.y + from.height / 2 + 12,
+        { steps: 4 },
+      );
+      await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, {
+        steps: 12,
+      });
+      await page.mouse.up();
+      await expect(
+        page
+          .getByTestId("unfiled-section")
+          .locator(`[data-form-id="${form.id}"]`),
+      ).toBeVisible();
+      await expect.poll(() => folderOf(request, form.id)).toBeNull();
+
+      // Back into the folder, then delete the folder: the form survives, unfiled.
+      await row.getByTestId("form-row-menu").click();
+      await page.getByTestId(`form-row-move-${folder.id}`).click();
+      await expect.poll(() => folderOf(request, form.id)).toBe(folder.id);
+      await section(page, folder.id).getByTestId("folder-menu").click();
+      await page.getByTestId("folder-delete").click();
+      await page
+        .getByRole("dialog")
+        .getByRole("button", { name: /delete folder|eliminar carpeta/i })
+        .click();
+      await expect(section(page, folder.id)).toHaveCount(0);
+      await expect(
+        page
+          .getByTestId("unfiled-section")
+          .locator(`[data-form-id="${form.id}"]`),
+      ).toBeVisible();
+      await expect.poll(() => folderOf(request, form.id)).toBeNull();
+    } finally {
+      await cleanup(request, { forms: [form.id], folders: [folder.id] });
+    }
+  });
+
+  test("folder names are unique per workspace without regard to case: the dialog says so inline", async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const folder = await createFolder(request, `qa-${t}-Marketing`);
+    try {
+      await page.goto("/admin/forms");
+      await page.getByTestId("new-folder").click();
+      await page.getByTestId("folder-name-input").fill(`qa-${t}-MARKETING`);
+      await page.getByTestId("folder-dialog-submit").click();
+      await expect(page.getByTestId("folder-name-error")).toBeVisible();
+      // Renaming the folder to its own name in another case is fine.
+      await page.keyboard.press("Escape");
+      await section(page, folder.id).getByTestId("folder-menu").click();
+      await page.getByTestId("folder-rename").click();
+      await page.getByTestId("folder-name-input").fill(`qa-${t}-marketing`);
+      await page.getByTestId("folder-dialog-submit").click();
+      await expect(
+        section(page, folder.id).getByTestId("folder-toggle"),
+      ).toContainText(`qa-${t}-marketing`);
+    } finally {
+      await cleanup(request, { forms: [], folders: [folder.id] });
+    }
+  });
+});


### PR DESCRIPTION
## Why

A workspace with more than a screenful of forms had one flat list and no way to find or group anything.

## What

One list grouped by folder, searchable from the keyboard.

- **Folders** (`form_folder`, migration 0021): flat, one level, named only, unique per workspace without regard to case (`lower(name)` index), alphabetical, no manual order and no colors. A form is filed in at most one (`form.folder_id`, null = unfiled, which every existing form is). Deleting a folder unfiles its forms and never deletes them. Duplicating keeps the folder. Any active member may organise forms, the same rule as creating them.
- **API**: `GET/POST /v1/folders`, `PATCH/DELETE /v1/folders/:id` (409 `NAME_TAKEN`, idempotent delete), `PATCH /v1/forms/:id/folder` (`{ folderId | null }`, key required), `POST /v1/forms` accepts `folderId`, `GET /v1/forms` returns `folderId`. Moving never touches `updated_at`. `PUT /v1/forms/:id` is unchanged. OpenAPI documented.
- **List**: "Unfiled" first, then each folder as a collapsible section (the fold is remembered per browser in localStorage, read after mount) with its count, a "New form" that opens the create dialog with the folder preselected, and Rename / Delete behind a kebab (delete confirms and says the forms move to Unfiled). Rows drag onto a section by their grip (`@dnd-kit`, already a dependency: pointer distance 6, keyboard sensor, `pointerWithin` with `rectIntersection` fallback, optimistic move with revert and a toast on failure); the row kebab's "Move to folder" (`menuitemradio`) is the keyboard route to the same move. Every row keeps the test ids the flat list had, and without folders the list looks exactly as before.
- **Search**: `<input type=search>` over the loaded list, focused with Ctrl/Cmd+K or `/` (outside editable fields and with no dialog open), matching name or link without case or accents, highlighting the hit with `<mark>`, hiding sections without one and expanding the ones with a hit, a live results count, Escape clears, arrows walk the row titles and Enter opens the editor.
- i18n: `admin.forms.search*`, `admin.forms.*folder*`, `dialog.deleteFolderTitle` (EN + ES).

Out of scope, as agreed: nested folders, manual order, colors, a global command palette. The dashboard home, public routes, slug uniqueness (still per account) and permissions are untouched.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (16/16) and `pnpm build` pass; dash-check clean.
- Specs: `packages/db/src/folders.spec.ts` (two accounts: order, `sales` vs `Sales`, rename, move visible in `listForms`, `updated_at` untouched, delete unfiles, cross-account 404s, create/duplicate with a folder), `apps/api/src/folders.controller.spec.ts` (201, 409 NAME_TAKEN, idempotent 204, move and unfile, 404 stranger folder, member may organise), `forms-search.spec.ts`, `use-global-shortcut.spec.ts`, `forms-explorer.spec.tsx` (static markup: section order, counts, every row test id, the flat look without folders), plus the folder schemas in the types spec.
- New e2e `qa/e2e/v15-form-folders.spec.ts` (sections and fold across reload, search with highlight and Ctrl+K, kebab move, drag by grip, delete keeps forms, inline NAME_TAKEN). Written against the QA harness; not run in this session because the QA instance was not up.
- `build + start`, driven with Playwright: the page hydrates, Unfiled and Sales render with counts, search "satisfaccion" narrows to the Sales section and highlights "satisfacción", Escape clears, Ctrl+K focuses the box, collapsing Sales survives a reload, the kebab moves a form into Sales, and dragging it by the grip onto Unfiled moves it back (both confirmed through `GET /v1/forms`).

Note: this branch was cut from `develop` before #153 (workspace timezone); the "Updated" date on the row keeps the previous formatting and switches to the shared formatter once both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
