### PR TITLE
release: owner notification with answers, form language and labels, workspace timezone, folders and search

### DIFF
--- a/.changeset/docs-nav-link.md
+++ b/.changeset/docs-nav-link.md
@@ -1,0 +1,14 @@
+---
+'@quill/shared': patch
+---
+
+A "Docs" item in the rail, in the reader's language.
+
+The left nav gains a permanent "Docs" entry (book icon) right above "Dapta
+Agents". It opens the Forms documentation in a new tab: the English site for
+an English interface, the Spanish site for a Spanish one. The URL lives in the
+message catalog (`admin.chrome.docsHref`) because the shell only receives the
+localized messages, and it carries the same in-app UTM tags as the other suite
+doors (`utm_source=forms`, `utm_medium=sidebar`).
+
+- i18n: `admin.chrome.docsHref` and `admin.chrome.nav.docs` (EN + ES).

--- a/.changeset/form-folders.md
+++ b/.changeset/form-folders.md
@@ -1,0 +1,36 @@
+---
+'@quill/db': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+Folders and keyboard search on the forms list.
+
+A workspace with more than a screenful of forms had one flat list and no
+way to find or group anything. The forms page is now one list grouped by
+folder, searchable from the keyboard.
+
+- **Folders** (`form_folder`, migration 0021): flat, one level, named only,
+  unique per workspace without regard to case, alphabetical. A form is filed
+  in at most one (`form.folder_id`, null = unfiled, which every existing form
+  is). Deleting a folder unfiles its forms and never deletes them. Any active
+  member may organise forms, the same rule as creating them.
+- **API**: `GET/POST /v1/folders`, `PATCH/DELETE /v1/folders/:id` (409
+  `NAME_TAKEN`, idempotent delete), `PATCH /v1/forms/:id/folder` (`{ folderId
+  | null }`), `POST /v1/forms` accepts `folderId`, duplicating keeps the
+  folder, `GET /v1/forms` returns `folderId`. Moving never touches
+  `updated_at`.
+- **List**: "Unfiled" first, then each folder as a collapsible section (the
+  fold is remembered per browser) with its count, a "New form" that creates
+  straight into it, and Rename / Delete behind a kebab. Rows drag onto a
+  section by their grip; the row kebab's "Move to folder" is the keyboard
+  route to the same move. Without folders the list looks exactly as before,
+  and every row keeps its test ids.
+- **Search**: a search box over the loaded list, focused with Ctrl/Cmd+K or
+  `/` (outside inputs), matching name or link without case or accents,
+  highlighting the hit, hiding sections without one, Escape clears, arrows
+  walk the rows and Enter opens the editor.
+- `@quill/types`: `folderInputSchema`, `folderViewSchema`,
+  `formFolderPatchSchema`, `formCreateInputSchema`, `formViewSchema.folderId`.
+  `@quill/db`: `NAME_TAKEN` on `CrudResult`, `folders.ts`.
+- i18n: `admin.forms.search*`, `admin.forms.*folder*`, `dialog.deleteFolderTitle` (EN + ES).

--- a/.changeset/form-language-and-labels.md
+++ b/.changeset/form-language-and-labels.md
@@ -1,0 +1,31 @@
+---
+'@quill/types': minor
+'@quill/engine': patch
+'@quill/shared': minor
+---
+
+A form can name its language and its button copy.
+
+Until now the public form's chrome (Start, Back, Next, Submit, the progress
+counter, the thank-you copy, the confirmation email) followed each visitor's
+browser, with no way for the author to decide. Two additive config fields fix
+that; a form saved before they existed renders exactly as it did.
+
+- `config.language` (`en` | `es`, absent = Auto). Precedence on the public
+  page: `?lang=` on the URL, then the form's language, then the browser,
+  then English. The page description, the social card, the `lang` attribute
+  on the form's subtree and the respondent's confirmation email follow the
+  same resolution (the submission now carries the locale the respondent saw).
+- `config.labels` (`back`, `next`, `submit`, up to 80 characters each) at the
+  form level. A step's own `buttonText` still wins for that step; the cover
+  keeps `cover.ctaText`. `resolveFormLabels(config, locale)` in `@quill/shared`
+  is the single resolver both renderers and the builder preview use.
+- Design tab: a Language selector (Auto / English / Spanish) and Button text
+  fields (Submit only on the one-page layout) at the top of the panel, with
+  the stock copy of the chosen language as placeholders. The live preview and
+  the Preview modal render in the FORM's language, not the editor's.
+- New forms are stamped with their author's language (dashboard "New form"
+  and the onboarding wizard alike). Existing forms stay on Auto.
+- The public error boundary and the 404 speak the visitor's language.
+- i18n: `admin.editor.design.language*` / `labels*` / `label*`, and
+  `renderer.error*` / `notFound*` (EN + ES).

--- a/.changeset/owner-email-answers.md
+++ b/.changeset/owner-email-answers.md
@@ -1,0 +1,43 @@
+---
+'@quill/engine': minor
+'@quill/notifications': minor
+'@quill/db': patch
+'@quill/shared': patch
+---
+
+The owner notice now carries the answers, a working submissions link and a real HTML body.
+
+Until now the "new submission" email told the owner that someone answered and
+nothing else: the answers were never passed to the template, the
+`{{formLink}}` token had no producer (so the "View submissions" line always
+dropped out and custom templates looked half rendered), and the HTML body was
+a bare `<p>` with `<br/>` separators, which most clients showed as plain text.
+
+- `summarizeAnswers(config, answers)` in the engine resolves a submission to
+  `{label, value}` rows in step order: the question the respondent actually
+  saw, option values mapped back to their labels, multi-selects joined with
+  commas, bookings as `YYYY-MM-DD HH:mm UTC`, values capped at 2000 characters.
+- New `{{answers}}` token, available in both submission emails and included
+  by default in the owner notice only (blank line, the answers, blank line,
+  then the link). In text it renders one `Label: value` line per answer; in
+  HTML a two-column table with every cell escaped.
+- `{{formLink}}` now points the owner at `PUBLIC_APP_URL/admin/forms/:id/submissions`
+  (absent in a bare fork without `PUBLIC_APP_URL`; never on the respondent receipt).
+- Every email is a complete responsive HTML document (doctype, viewport,
+  600px card, system font stack, real `</body></html>` so the transactional
+  service can splice its footer). Stock and custom bodies follow one rule: a
+  line is dropped only when it has tokens and all of them resolved empty, so
+  blank spacer lines and sign-offs survive. Runs of blank lines left behind by
+  dropped lines collapse to one, and leading or trailing blank lines are
+  trimmed.
+- Migration 0019 appends `{{answers}}` to every custom owner-notice body that
+  lacks it (account and per-form rows), so templates edited before the token
+  existed also get the answers. Idempotent.
+- An owner without an email no longer enqueues a row that fails five times;
+  rows already queued with no recipient are skipped once instead of retried.
+- Settings and the Connect tab show an "Answers" variable chip and a permanent
+  notice on the owner notice when its body lacks `{{answers}}`; the preview
+  sample shows the answers block. The respondent card no longer offers the
+  `{{formLink}}` chip, which that email never produces. The chip label reads
+  "Submissions link".
+- i18n: `admin.notifications.tokenAnswers`, `answersMissing` (EN + ES).

--- a/.changeset/workspace-timezone.md
+++ b/.changeset/workspace-timezone.md
@@ -1,0 +1,43 @@
+---
+'@quill/db': minor
+'@quill/types': minor
+'@quill/shared': minor
+---
+
+A workspace timezone: every date in the admin, the analytics day cuts and the CSV local columns read in one shared zone.
+
+Until now every timestamp in the dashboard was rendered on the server's clock
+(UTC) and the analytics buckets were UTC days, so a team in Bogota read its
+evening submissions as tomorrow's. The workspace now carries one IANA zone
+(`account.timezone`, migration 0020) that everyone in it shares.
+
+- **Default**: the first owner or admin to open the dashboard while the zone
+  is unset seeds it from their browser (a write-once claim, so two admins in
+  different zones cannot flip it), with a toast saying where to change it.
+  Staff entering an estate workspace never seed it. Until then dates read in
+  UTC, exactly as before.
+- **Two places to change it**, both writing the same column through
+  `PATCH /v1/workspaces/current/timezone` (admin/owner): Account settings,
+  under the workspace name, and a dropdown beside the submissions filter.
+  A member sees the zone with a lock and the note that only an admin can
+  change it.
+- **Dates**: the forms list, the submissions table, the delivery history,
+  the webhook health line and the brand kit stamp all go through
+  `formatDateTime` / `formatDate` in `@quill/shared` (Intl only; an unknown
+  zone renders as UTC with a warning, never a 500).
+- **Analytics**: day buckets are named in the workspace zone inside SQL
+  (`(col + offset) / 86400000` with the offset picked by a CASE over the DST
+  boundaries of the queried window), the range presets and custom dates cut
+  at local midnight, the picker's "today" is the zone's today, `?tz=` can
+  override per request, the response echoes `range.timeZone`, and a caption
+  under the trends chart names the zone.
+- **CSV export** keeps `started_at` / `completed_at` in UTC (`Z`) and adds
+  `started_at_local` / `completed_at_local` as ISO with the zone offset
+  (`2026-09-03T18:30:15-05:00`).
+- `@quill/shared`: `datetime.ts` (`isValidTimeZone`, `resolveTimeZone`,
+  `tzOffsetMs`, `localDayIndex`, `zonedMidnightMs`, `dayBoundsInZone`,
+  `isoDateInZone`, `utcOffsetSegments`, `formatDateTime`, `formatDate`,
+  `formatIsoWithOffset`). `@quill/types`: `timeZoneSchema`,
+  `workspaceTimezoneSchema`, `analyticsResponseSchema.range.timeZone`.
+- i18n: `admin.settings.workspaceTimezone*`, `admin.submissions.timezone*`,
+  `admin.analytics.timezoneNote`, `admin.chrome.timezoneAutoSet` (EN + ES).

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -48,6 +48,11 @@ import {
   getMemberProfileRaw,
   setMemberLocale,
   setMemberProfile,
+  createFolder,
+  deleteFolder,
+  listFolders,
+  renameFolder,
+  setFormFolder,
 } from '@quill/db';
 import {
   defaultSubmissionTemplate,
@@ -73,6 +78,9 @@ import {
   onboardingProgressSchema,
   workspaceCreateSchema,
   workspaceRenameSchema,
+  folderInputSchema,
+  formCreateInputSchema,
+  formFolderPatchSchema,
 } from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
@@ -116,6 +124,11 @@ function maskForm<T extends { config: unknown; draftConfig?: unknown }>(form: T)
     config: maskConfigSecrets(form.config),
     ...(form.draftConfig != null ? { draftConfig: maskConfigSecrets(form.draftConfig) } : {}),
   };
+}
+
+/** The client shape of a folder: the account id never leaves the server. */
+function folderView(f: { id: string; name: string; createdAt: number; updatedAt: number }) {
+  return { id: f.id, name: f.name, createdAt: f.createdAt, updatedAt: f.updatedAt };
 }
 
 /** Host-authed CRUD for forms + submissions + members, and identity/vanity. */
@@ -462,7 +475,9 @@ export class AdminCrudController {
   @HttpCode(201)
   async createForm(@Req() req: ReqLike, @Body() body: unknown) {
     const p = await this.auth.resolveHost(req);
-    const input = parse(formInputSchema, body);
+    // The create schema (not the shared input one): only creation may name a
+    // folder; PUT /v1/forms/:id never moves a form, PATCH /forms/:id/folder does.
+    const input = parse(formCreateInputSchema, body);
     // The other path that AUTHORS a `destinations` array (PUT /forms/:id stages
     // a draft, and drafts strip the key; duplicate copies stored state and is
     // exempt — see `hasExtraHubspotDestination`). Same one-HubSpot rule as
@@ -621,6 +636,51 @@ export class AdminCrudController {
     const existing = await getFormById(this.db, p.accountId, id);
     if (!existing) return; // idempotent — already gone (204)
     await deleteForm(this.db, p.accountId, id);
+  }
+
+  // --- Form folders (0021) ----------------------------------------------------
+  //
+  // Organising forms is the same right as creating them: any active member of
+  // the workspace, no admin gate (mirrors POST /v1/forms above).
+
+  /** The account's folders, alphabetically. */
+  @Get('folders')
+  async listFolders(@Req() req: ReqLike) {
+    const p = await this.auth.resolveHost(req);
+    return (await listFolders(this.db, p.accountId)).map(folderView);
+  }
+
+  /** Create a folder. 409 NAME_TAKEN when the account already has that name (case-insensitively). */
+  @Post('folders')
+  @HttpCode(201)
+  async createFolder(@Req() req: ReqLike, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const input = parse(folderInputSchema, body);
+    return folderView(unwrapCrud(await createFolder(this.db, p.accountId, input.name)));
+  }
+
+  /** Rename a folder. 404 for another account's folder, 409 NAME_TAKEN on a clash. */
+  @Patch('folders/:id')
+  async renameFolder(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const input = parse(folderInputSchema, body);
+    return folderView(unwrapCrud(await renameFolder(this.db, p.accountId, id, input.name)));
+  }
+
+  /** Delete a folder: its forms are unfiled, never deleted. Idempotent (204 either way). */
+  @Delete('folders/:id')
+  @HttpCode(204)
+  async deleteFolder(@Req() req: ReqLike, @Param('id') id: string) {
+    const p = await this.auth.resolveHost(req);
+    await deleteFolder(this.db, p.accountId, id);
+  }
+
+  /** File a form in a folder (null unfiles). 404 for a form or folder outside the account. */
+  @Patch('forms/:id/folder')
+  async setFormFolder(@Req() req: ReqLike, @Param('id') id: string, @Body() body: unknown) {
+    const p = await this.auth.resolveHost(req);
+    const input = parse(formFolderPatchSchema, body);
+    return unwrapCrud(await setFormFolder(this.db, p.accountId, id, input.folderId));
   }
 
   /**

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -73,6 +73,7 @@ import {
   onboardingProgressSchema,
   workspaceCreateSchema,
   workspaceRenameSchema,
+  workspaceTimezoneSchema,
 } from '@quill/types';
 import { ZodError } from 'zod';
 import { AdminService } from './admin.service';
@@ -336,6 +337,17 @@ export class AdminCrudController {
   async renameWorkspace(@Req() req: ReqLike, @Body() body: unknown) {
     const input = parse(workspaceRenameSchema, body);
     return this.ws().rename(req, input);
+  }
+
+  /**
+   * Set the workspace's timezone (admin/owner). Its own route rather than a
+   * field on `PATCH workspaces/current`: that one goes upstream to the identity
+   * service, which has no zone, and this one never leaves this database.
+   */
+  @Patch('workspaces/current/timezone')
+  async setWorkspaceTimezone(@Req() req: ReqLike, @Body() body: unknown) {
+    const input = parse(workspaceTimezoneSchema, body);
+    return this.ws().setTimezone(req, input);
   }
 
   /**

--- a/apps/api/src/admin.service.ts
+++ b/apps/api/src/admin.service.ts
@@ -214,7 +214,11 @@ export class AdminService {
       p.accountId,
       {
         name: this.templateFormName(templateId, template.name, input.locale),
-        ...(template.config ? { config: template.config } : {}),
+        // The wizard's language becomes the form's (Auto only for forms that
+        // predate the field), the same rule as "New form" in the dashboard.
+        ...(template.config || input.locale
+          ? { config: { ...(template.config ?? { version: 1 as const, steps: [] }), ...(input.locale ? { language: input.locale } : {}) } }
+          : {}),
       },
       p.memberId,
     );

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   Inject,
+  Logger,
   NotFoundException,
   Param,
   Query,
@@ -39,6 +40,8 @@ function iso(ms: number | null): string {
  */
 @Controller('v1')
 export class AnalyticsController {
+  private readonly log = new Logger('AnalyticsController');
+
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(AuthService) private readonly auth: AuthService,
@@ -59,7 +62,9 @@ export class AnalyticsController {
     @Query('tz') tz?: string,
   ) {
     const p = await this.auth.resolveHost(req);
-    const zone = resolveTimeZone(parseTimeZone(tz) ?? (await getAccountTimezone(this.db, p.accountId)));
+    const zone = resolveTimeZone(parseTimeZone(tz) ?? (await getAccountTimezone(this.db, p.accountId)), (m) =>
+      this.log.warn(m),
+    );
     const result = await this.analytics.funnel(
       p.accountId,
       id,
@@ -97,7 +102,7 @@ export class AnalyticsController {
     const stepKeys = (config.steps ?? []).map((s) => s.key);
     const filename = `${form.slug || 'submissions'}-submissions.csv`;
     // An unknown stored zone exports as UTC (+00:00) rather than failing the download.
-    const zone = resolveTimeZone(await getAccountTimezone(this.db, p.accountId));
+    const zone = resolveTimeZone(await getAccountTimezone(this.db, p.accountId), (m) => this.log.warn(m));
     const local = (ms: number | null) => (ms == null ? '' : formatIsoWithOffset(ms, zone));
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');

--- a/apps/api/src/analytics.controller.ts
+++ b/apps/api/src/analytics.controller.ts
@@ -11,13 +11,14 @@ import {
   Res,
 } from '@nestjs/common';
 import type { Db } from '@quill/db';
-import { getFormById } from '@quill/db';
+import { getAccountTimezone, getFormById } from '@quill/db';
+import { formatIsoWithOffset, resolveTimeZone } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
 import { AuthService, type ReqLike } from './auth.service';
 import { AnalyticsService } from './analytics.service';
 import { DB } from './tokens';
 import { csvRow } from './csv';
-import { parseBound, parseStatus } from './query-params';
+import { parseBound, parseStatus, parseTimeZone } from './query-params';
 
 /** A minimal response shape (structurally satisfied by the express Response). */
 interface StreamRes {
@@ -44,19 +45,27 @@ export class AnalyticsController {
     @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
   ) {}
 
-  /** Funnel metrics + per-step drop-off for a form over an optional date range. */
+  /**
+   * Funnel metrics + per-step drop-off for a form over an optional date range.
+   * Days are named in `?tz=`, else the workspace's zone, else UTC; a bare
+   * `YYYY-MM-DD` bound is a whole day in that zone.
+   */
   @Get('forms/:id/analytics')
   async formAnalytics(
     @Req() req: ReqLike,
     @Param('id') id: string,
     @Query('from') from?: string,
     @Query('to') to?: string,
+    @Query('tz') tz?: string,
   ) {
     const p = await this.auth.resolveHost(req);
-    const result = await this.analytics.funnel(p.accountId, id, {
-      from: parseBound(from, false),
-      to: parseBound(to, true),
-    });
+    const zone = resolveTimeZone(parseTimeZone(tz) ?? (await getAccountTimezone(this.db, p.accountId)));
+    const result = await this.analytics.funnel(
+      p.accountId,
+      id,
+      { from: parseBound(from, false, zone), to: parseBound(to, true, zone) },
+      zone,
+    );
     if (!result) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Not found.' });
     return result;
   }
@@ -64,6 +73,9 @@ export class AnalyticsController {
   /**
    * Stream the form's submissions as CSV. Answers flatten to one column per
    * configured step key (form config order), after the fixed metadata columns.
+   * `started_at` / `completed_at` stay UTC ISO (`Z`), and `*_local` twins carry
+   * the same instants read in the workspace's zone with their offset, so a
+   * spreadsheet shows the team's clock without losing the machine one.
    * Uses the un-paginated export query (`allSubmissionsForExport`) — the table
    * query caps `limit` at 200, so paging through it would silently truncate and
    * skip rows on large exports. Rows are still written incrementally.
@@ -84,17 +96,32 @@ export class AnalyticsController {
     const config = form.config as FormConfig;
     const stepKeys = (config.steps ?? []).map((s) => s.key);
     const filename = `${form.slug || 'submissions'}-submissions.csv`;
+    // An unknown stored zone exports as UTC (+00:00) rather than failing the download.
+    const zone = resolveTimeZone(await getAccountTimezone(this.db, p.accountId));
+    const local = (ms: number | null) => (ms == null ? '' : formatIsoWithOffset(ms, zone));
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.setHeader('Cache-Control', 'no-store');
 
-    res.write(csvRow(['id', 'session_id', 'status', 'score', 'started_at', 'completed_at', ...stepKeys]));
+    res.write(
+      csvRow([
+        'id',
+        'session_id',
+        'status',
+        'score',
+        'started_at',
+        'completed_at',
+        'started_at_local',
+        'completed_at_local',
+        ...stepKeys,
+      ]),
+    );
 
     const rows = await this.analytics.exportSubmissions(id, {
       status: parseStatus(status),
-      from: parseBound(from, false),
-      to: parseBound(to, true),
+      from: parseBound(from, false, zone),
+      to: parseBound(to, true, zone),
     });
     for (const s of rows) {
       const data = (s.data ?? {}) as Record<string, unknown>;
@@ -107,6 +134,8 @@ export class AnalyticsController {
           s.score,
           iso(s.startedAt),
           iso(s.completedAt),
+          local(s.startedAt),
+          local(s.completedAt),
           ...stepKeys.map((k) => data[k]),
         ]),
       );

--- a/apps/api/src/analytics.service.spec.ts
+++ b/apps/api/src/analytics.service.spec.ts
@@ -594,3 +594,77 @@ describe('parseIntParam (NaN guard for limit/offset)', () => {
     expect(page.items.length).toBeGreaterThan(0);
   });
 });
+
+describe('workspace timezone: day cuts and the CSV local columns', () => {
+  const HOUR = 3_600_000;
+  // D1 = a UTC midnight; a submission at D1 + 2h is the PREVIOUS day in Bogota.
+  const D1 = Math.floor(NOW / DAY) * DAY + 10 * DAY;
+
+  it('buckets a submission at D1+2h into the previous day in Bogota, and names the zone', async () => {
+    await insertSubmission({
+      session: 'tz-1',
+      data: { role: 'founder' },
+      score: 10,
+      startedAt: D1 + HOUR,
+      completedAt: D1 + 2 * HOUR,
+    });
+    const utc = await svc.funnel(accountId, formId, { from: D1 - DAY, to: D1 + DAY - 1 });
+    const bogota = await svc.funnel(accountId, formId, { from: D1 - DAY, to: D1 + DAY - 1 }, 'America/Bogota');
+    const dayOf = (r: typeof utc, t: number) => r!.trends.find((p) => p.t === t)?.submissions ?? 0;
+    expect(dayOf(utc, D1)).toBe(1);
+    expect(dayOf(utc, D1 - DAY)).toBe(0);
+    expect(dayOf(bogota, D1 - DAY)).toBe(1);
+    expect(dayOf(bogota, D1)).toBe(0);
+    expect(bogota!.range.timeZone).toBe('America/Bogota');
+    expect(utc!.range.timeZone).toBe('UTC');
+  });
+
+  it('an unknown zone resolves as UTC rather than failing the request', async () => {
+    const r = await svc.funnel(accountId, formId, {}, 'Mars/Olympus');
+    expect(r!.range.timeZone).toBe('UTC');
+  });
+
+  it('the CSV keeps the UTC columns and adds started_at_local / completed_at_local in the zone', async () => {
+    await db.run(sql`UPDATE account SET timezone = 'America/Bogota' WHERE id = ${accountId}`);
+    await insertSubmission({
+      session: 'tz-csv',
+      data: { role: 'founder' },
+      score: 10,
+      startedAt: Date.UTC(2026, 8, 3, 23, 30),
+      completedAt: Date.UTC(2026, 8, 4, 0, 15),
+    });
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: 'test-member', role: 'owner' as const }),
+    } as unknown as AuthService;
+    const ctrl = new AnalyticsController(db, auth, svc);
+    const chunks: string[] = [];
+    const res = { setHeader: () => {}, write: (c: string) => void chunks.push(c), end: () => {} };
+    await ctrl.exportCsv({ headers: {} }, res, formId, undefined, undefined, undefined);
+    const lines = chunks.join('').trimEnd().split('\r\n');
+    expect(lines[0]).toMatch(/^id,session_id,status,score,started_at,completed_at,started_at_local,completed_at_local,/);
+    const row = lines.find((l) => l.includes('tz-csv'))!;
+    expect(row).toContain('2026-09-03T23:30:00.000Z');
+    expect(row).toContain('2026-09-03T18:30:00-05:00');
+    expect(row).toContain('2026-09-03T19:15:00-05:00');
+  });
+
+  it('an invalid workspace zone exports local columns as +00:00', async () => {
+    await db.run(sql`UPDATE account SET timezone = 'Mars/Olympus' WHERE id = ${accountId}`);
+    await insertSubmission({
+      session: 'tz-bad',
+      data: { role: 'founder' },
+      score: 10,
+      startedAt: Date.UTC(2026, 8, 3, 23, 30),
+      completedAt: Date.UTC(2026, 8, 3, 23, 45),
+    });
+    const auth = {
+      resolveHost: async () => ({ accountId, memberId: 'test-member', role: 'owner' as const }),
+    } as unknown as AuthService;
+    const ctrl = new AnalyticsController(db, auth, svc);
+    const chunks: string[] = [];
+    const res = { setHeader: () => {}, write: (c: string) => void chunks.push(c), end: () => {} };
+    await ctrl.exportCsv({ headers: {} }, res, formId, undefined, undefined, undefined);
+    const row = chunks.join('').split('\r\n').find((l) => l.includes('tz-bad'))!;
+    expect(row).toContain('2026-09-03T23:30:00+00:00');
+  });
+});

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { localDayIndex, resolveTimeZone, utcOffsetSegments } from '@quill/shared';
 import { resolveFormLayout } from '@quill/engine';
 import type { Db } from '@quill/db';
@@ -158,6 +158,8 @@ function buildTrends(input: {
  */
 @Injectable()
 export class AnalyticsService {
+  private readonly log = new Logger('AnalyticsService');
+
   constructor(@Inject(DB) private readonly db: Db) {}
 
   /**
@@ -186,7 +188,7 @@ export class AnalyticsService {
   ): Promise<AnalyticsResponse | null> {
     const form = await getFormById(this.db, accountId, formId);
     if (!form) return null;
-    const zone = resolveTimeZone(timeZone);
+    const zone = resolveTimeZone(timeZone, (m) => this.log.warn(m));
     const bucketing = await this.bucketingFor(formId, range, zone);
     const config = form.config as FormConfig;
     const steps = config.steps ?? [];

--- a/apps/api/src/analytics.service.ts
+++ b/apps/api/src/analytics.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { localDayIndex, resolveTimeZone, utcOffsetSegments } from '@quill/shared';
 import { resolveFormLayout } from '@quill/engine';
 import type { Db } from '@quill/db';
 import {
@@ -20,6 +21,8 @@ import {
   type DateRange,
   type DeleteSubmissionResult,
   type SubmissionQuery,
+  firstEventAt,
+  type DayBucketing,
 } from '@quill/db';
 import type {
   AnalyticsResponse,
@@ -93,6 +96,8 @@ const MAX_TREND_DAYS = 366;
  */
 function buildTrends(input: {
   range: DateRange;
+  /** The zone the day buckets were named in (`'UTC'` = the historical behavior). */
+  zone: string;
   dailyViews: { day: number; n: number }[];
   dailyStarts: { day: number; n: number }[];
   completed: CompletedSubmission[];
@@ -119,8 +124,11 @@ function buildTrends(input: {
 
   // Bound by the explicit range when one was given (so "last 30 days" plots 30
   // points even where nothing happened), else by the observed activity span.
-  const fromDay = input.range.from != null ? Math.floor(input.range.from / DAY_MS) : Math.min(...observed);
-  const toDay = input.range.to != null ? Math.floor(input.range.to / DAY_MS) : Math.max(...observed);
+  // The same day naming as the SQL buckets: `localDayIndex` is the JS twin of
+  // the `(col + offset) / 86400000` expression, so the window's edges and the
+  // buckets agree in every zone.
+  const fromDay = input.range.from != null ? localDayIndex(input.range.from, input.zone) : Math.min(...observed);
+  const toDay = input.range.to != null ? localDayIndex(input.range.to, input.zone) : Math.max(...observed);
   if (toDay < fromDay) return [];
 
   const span = Math.min(toDay - fromDay, MAX_TREND_DAYS - 1);
@@ -152,10 +160,34 @@ function buildTrends(input: {
 export class AnalyticsService {
   constructor(@Inject(DB) private readonly db: Db) {}
 
-  /** Funnel summary + question-by-question drop-off for a form over a range. */
-  async funnel(accountId: string, formId: string, range: DateRange): Promise<AnalyticsResponse | null> {
+  /**
+   * The offset segments that let SQL name calendar days in `zone` across the
+   * queried window (one day of slack on each side, so an edge event whose
+   * local day differs from its UTC day is still covered). UTC needs none: the
+   * absent bucketing is the exact SQL this always ran.
+   */
+  private async bucketingFor(formId: string, range: DateRange, zone: string): Promise<DayBucketing | undefined> {
+    if (zone === 'UTC') return undefined;
+    const from = range.from ?? (await firstEventAt(this.db, formId)) ?? Date.now();
+    const to = range.to ?? Date.now();
+    return { segments: utcOffsetSegments(from - DAY_MS, to + DAY_MS, zone) };
+  }
+
+  /**
+   * Funnel summary + question-by-question drop-off for a form over a range.
+   * `timeZone` names the calendar days of the trend buckets (and is echoed
+   * back as `range.timeZone`); absent or unknown = UTC, the historical rule.
+   */
+  async funnel(
+    accountId: string,
+    formId: string,
+    range: DateRange,
+    timeZone?: string | null,
+  ): Promise<AnalyticsResponse | null> {
     const form = await getFormById(this.db, accountId, formId);
     if (!form) return null;
+    const zone = resolveTimeZone(timeZone);
+    const bucketing = await this.bucketingFor(formId, range, zone);
     const config = form.config as FormConfig;
     const steps = config.steps ?? [];
     // Vertical shows every question on one page, so "viewed step X" fires for
@@ -173,9 +205,9 @@ export class AnalyticsService {
           : stepViewCounts(this.db, formId, range),
         partialCount(this.db, formId, range),
         bookingCount(this.db, formId, range),
-        completedSubmissions(this.db, formId, range),
-        dailyViewSessions(this.db, formId, range),
-        dailyStartSessions(this.db, formId, range),
+        completedSubmissions(this.db, formId, range, bucketing),
+        dailyViewSessions(this.db, formId, range, bucketing),
+        dailyStartSessions(this.db, formId, range, bucketing),
       ]);
 
     // One completed-submission read feeds the total, the median and the trend.
@@ -187,7 +219,7 @@ export class AnalyticsService {
     // Median open→complete in whole seconds, or null when no session in range
     // had a derivable open time (never 0 — that would be a fabricated fact).
     const timeToComplete = medianSeconds(durations);
-    const trends = buildTrends({ range, dailyViews, dailyStarts, completed });
+    const trends = buildTrends({ range, zone, dailyViews, dailyStarts, completed });
 
     // rowViews[0] = form views (the cover/landing); rowViews[i+1] = views of
     // step i. Looked up by the step's KEY first (V5-D3) — stable regardless of
@@ -249,7 +281,7 @@ export class AnalyticsService {
       dropoffMode,
       dropoff,
       trends,
-      range: { from: range.from ?? null, to: range.to ?? null },
+      range: { from: range.from ?? null, to: range.to ?? null, timeZone: zone },
     };
   }
 

--- a/apps/api/src/email-effects.spec.ts
+++ b/apps/api/src/email-effects.spec.ts
@@ -22,7 +22,8 @@ import {
   type Db,
 } from '@quill/db';
 import { SubmissionNotifier, LogOnlyEmailProvider } from '@quill/notifications';
-import { EmailEffects } from './email-effects';
+import type { ServerEnv } from '@quill/config/env';
+import { EmailEffects, OutboxSkipError } from './email-effects';
 
 let db: Db;
 let effects: EmailEffects;
@@ -214,5 +215,76 @@ describe('submission_received uses the same merge', () => {
       formId,
     );
     expect(await listOutbox(db, { kind: 'email' })).toHaveLength(1); // unchanged
+  });
+});
+
+describe('formLink (owner notice only)', () => {
+  it('points the owner at the submissions page when PUBLIC_APP_URL is set', async () => {
+    const withEnv = new EmailEffects(
+      new SubmissionNotifier(new LogOnlyEmailProvider()),
+      db,
+      undefined,
+      { PUBLIC_APP_URL: 'https://forms.example.com/' } as ServerEnv,
+    );
+    await withEnv.enqueueSubmissionReceived(
+      accountId,
+      { submissionId: 'sub-link', formName: 'Lead Qualifier', respondentEmail: null },
+      formId,
+    );
+    const rows = await listOutbox(db, { kind: 'email' });
+    const p = JSON.parse(rows[0]!.payload!) as { formLink: string | null };
+    expect(p.formLink).toBe(`https://forms.example.com/admin/forms/${formId}/submissions`);
+  });
+
+  it('carries no link in a bare fork without PUBLIC_APP_URL, and never on the respondent receipt', async () => {
+    await effects.enqueueSubmissionReceived(
+      accountId,
+      { submissionId: 'sub-nolink', formName: 'Lead Qualifier', respondentEmail: null },
+      formId,
+    );
+    await enqueueConfirmed();
+    const rows = await listOutbox(db, { kind: 'email' });
+    for (const row of rows) {
+      const p = JSON.parse(row.payload!) as { formLink?: string | null };
+      expect(p.formLink ?? null).toBeNull();
+    }
+  });
+});
+
+describe('no recipient', () => {
+  it('an account whose owner has no email enqueues nothing (instead of a row that fails 5 times)', async () => {
+    const lonely = 'acc-lonely';
+    await db.run(
+      sql`INSERT INTO account (id, code, name, created_at) VALUES (${lonely}, 'lonely', 'Lonely', ${Date.now()})`,
+    );
+    await effects.enqueueSubmissionReceived(lonely, {
+      submissionId: 'sub-lonely',
+      formName: 'Orphan',
+      respondentEmail: null,
+    });
+    expect(await listOutbox(db, { kind: 'email' })).toHaveLength(0);
+  });
+
+  it('deliver() skips (never retries) an owner notice already enqueued with an empty `to`', async () => {
+    // The typical stuck row: the respondent left an email, the owner has none.
+    // The owner notice is addressed to `to` alone, so that email is no recipient.
+    const payload = JSON.stringify({
+      accountId,
+      submissionId: 'sub-empty',
+      formName: 'Orphan',
+      to: [],
+      respondentEmail: 'lead@acme.io',
+    });
+    await expect(effects.deliver('submission_received', payload)).rejects.toBeInstanceOf(OutboxSkipError);
+  });
+
+  it('deliver() skips a receipt with neither a respondent email nor a `to`, but sends one addressed by respondentEmail', async () => {
+    const base = { accountId, submissionId: 'sub-r', formName: 'Orphan', to: [] };
+    await expect(
+      effects.deliver('submission_confirmed', JSON.stringify(base)),
+    ).rejects.toBeInstanceOf(OutboxSkipError);
+    await expect(
+      effects.deliver('submission_confirmed', JSON.stringify({ ...base, respondentEmail: 'lead@acme.io' })),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -86,6 +86,12 @@ export class EmailEffects {
             ORDER BY created_at ASC LIMIT 1`,
       );
       const to = n.to ?? (owner?.email ? [owner.email] : []);
+      // Nobody to tell: every adapter throws on an empty recipient list, so a
+      // row enqueued here would burn its whole retry schedule for nothing.
+      if (to.length === 0) {
+        this.log.warn(`submission_received for account ${accountId} has no recipient: not enqueued`);
+        return;
+      }
       // Snapshot the toggle AND the custom copy, already merged form → account →
       // stock (absent rows = enabled with the stock template, the fork-friendly
       // default). Snapshotting here means the worker renders the copy the owner
@@ -95,6 +101,10 @@ export class EmailEffects {
       const payload: SubmissionNotification = {
         ...n,
         accountId,
+        // Where the owner reads the answers. Absent in a bare fork with no
+        // PUBLIC_APP_URL, or when the caller carries no form: the template
+        // drops the line rather than printing a broken link.
+        formLink: n.formLink ?? this.submissionsLink(formId),
         // Stamped into the payload, not merely used to resolve the template
         // above: `outbox` has no form column, so a row that does not NAME its
         // form cannot be attributed to one, and every email this queue has ever
@@ -158,6 +168,17 @@ export class EmailEffects {
     }
   }
 
+  /** An absolute app URL for `path`, or null in a bare fork with no PUBLIC_APP_URL. */
+  private appUrl(path: string): string | null {
+    const base = this.env?.PUBLIC_APP_URL;
+    return base ? `${base.replace(/\/$/, '')}${path}` : null;
+  }
+
+  /** Where the owner reads the answers; null without a form or an app URL. */
+  private submissionsLink(formId: string | null | undefined): string | null {
+    return formId ? this.appUrl(`/admin/forms/${formId}/submissions`) : null;
+  }
+
   /**
    * Tell an invited person they were invited.
    *
@@ -190,7 +211,7 @@ export class EmailEffects {
         invitedBy: input.invitedBy ?? null,
         // Empty in a bare fork with no PUBLIC_APP_URL — the template drops the
         // line rather than printing a broken link.
-        signInLink: this.env?.PUBLIC_APP_URL ? `${this.env!.PUBLIC_APP_URL.replace(/\/$/, '')}/login` : null,
+        signInLink: this.appUrl('/login'),
         locale: input.locale ?? null,
       };
       await enqueueOutbox(this.db, {
@@ -203,6 +224,19 @@ export class EmailEffects {
     } catch (err) {
       this.log.error(`failed to enqueue member_invited: ${String(err)}`);
     }
+  }
+
+  /**
+   * A row with nobody to address is a DECISION (skip once), not a transport
+   * failure to retry: rows enqueued before the producer guarded against an
+   * empty recipient list would otherwise fail five times each. Mirrors how
+   * the notifier addresses each email: the owner notice goes to `to` only,
+   * the receipt to `respondentEmail` with `to` as the fallback.
+   */
+  private assertRecipient(action: EmailKind, n: SubmissionNotification): void {
+    const to = Array.isArray(n.to) ? n.to.filter(Boolean) : [];
+    const addressed = action === 'submission_confirmed' ? Boolean(n.respondentEmail) || to.length > 0 : to.length > 0;
+    if (!addressed) throw new OutboxSkipError('no recipient');
   }
 
   /**
@@ -229,9 +263,11 @@ export class EmailEffects {
         );
         return;
       case 'submission_received':
+        this.assertRecipient(action, n);
         await this.notifier.sendSubmissionReceived(n);
         return;
       case 'submission_confirmed':
+        this.assertRecipient(action, n);
         await this.notifier.sendSubmissionConfirmed(n);
         return;
       default:

--- a/apps/api/src/email-effects.ts
+++ b/apps/api/src/email-effects.ts
@@ -122,8 +122,8 @@ export class EmailEffects {
    * notification_setting mechanism (`submission_confirmed`; absent rows =
    * enabled, the fork-friendly default), merged form → account → stock. No
    * respondent email in the answers → nothing to address, so it no-ops. Locale:
-   * the public surface does not persist the respondent's language yet, so the
-   * caller's value is used as-is (unset normalizes to English in the notifier).
+   * the caller resolves it (the language the respondent saw, else the form's
+   * own); unset normalizes to English in the notifier.
    * Never rejects — the caller fire-and-forgets with `void`.
    */
   async enqueueSubmissionConfirmed(

--- a/apps/api/src/folders.controller.spec.ts
+++ b/apps/api/src/folders.controller.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * The folder routes on the host-authed controller: create (201 / 409
+ * NAME_TAKEN), rename, delete (idempotent 204), move a form (404 for a
+ * stranger's folder), create a form straight into a folder, and the role
+ * rule: any active member may organise forms, exactly like creating them.
+ * In-memory SQLite through the real controller and the local auth provider.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ConflictException, NotFoundException } from "@nestjs/common";
+import { createDb, migrate, seed, sql, type Db } from "@quill/db";
+import { AdminCrudController } from "./admin-crud.controller";
+import { AdminService } from "./admin.service";
+import { AuthService } from "./auth.service";
+import { LocalAuthProvider } from "./auth.provider";
+import type { ReqLike } from "./auth.provider";
+
+let db: Db;
+let controller: AdminCrudController;
+let accountId: string;
+let formId: string;
+
+const asOwner = (): ReqLike => ({ headers: {} });
+const asMember = (): ReqLike => ({
+  headers: { "x-quill-email": "member@example.com" },
+});
+
+async function conflictCode(run: Promise<unknown>): Promise<string> {
+  try {
+    await run;
+  } catch (e) {
+    if (e instanceof ConflictException)
+      return (e.getResponse() as { error?: string }).error ?? "";
+    throw e;
+  }
+  throw new Error("expected a ConflictException");
+}
+
+beforeEach(async () => {
+  db = await createDb("file::memory:");
+  await migrate(db);
+  await seed(db); // account "acme" + demo form "lead-qualifier" + owner alex@example.com
+  const provider = new LocalAuthProvider(db, {
+    NODE_ENV: "test",
+    DEV_LOGIN_EMAIL: undefined,
+    AUTH_LOCAL_STRICT: undefined,
+    SEED_DEMO_FORM: false,
+    ONBOARDING_WIZARD: false,
+  });
+  const auth = new AuthService(db, provider);
+  const admin = new AdminService(db);
+  controller = new AdminCrudController(
+    db,
+    auth,
+    admin,
+    {} as never,
+    {} as never,
+  );
+  const account = await db.get<{ id: string }>(
+    sql`SELECT id FROM account WHERE code = 'acme' LIMIT 1`,
+  );
+  accountId = account!.id;
+  const form = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE slug = 'lead-qualifier' LIMIT 1`,
+  );
+  formId = form!.id;
+  // A plain member of acme (the local provider signs anyone in by email).
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, role, status, created_at)
+        VALUES (${randomUUID()}, ${accountId}, ${"member@example.com"}, ${"member"}, ${"active"}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  await db.close();
+});
+
+describe("folders", () => {
+  it("creates, lists alphabetically and refuses a duplicate name (case-insensitively) with 409 NAME_TAKEN", async () => {
+    const sales = await controller.createFolder(asOwner(), { name: "Sales" });
+    expect(sales.name).toBe("Sales");
+    await controller.createFolder(asOwner(), { name: "archive" });
+    expect(
+      (await controller.listFolders(asOwner())).map((f) => f.name),
+    ).toEqual(["archive", "Sales"]);
+    expect(
+      await conflictCode(controller.createFolder(asOwner(), { name: "SALES" })),
+    ).toBe("NAME_TAKEN");
+  });
+
+  it("renames a folder, and deleting twice is idempotent", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    expect(
+      (await controller.renameFolder(asOwner(), f.id, { name: "Ventas" })).name,
+    ).toBe("Ventas");
+    await controller.deleteFolder(asOwner(), f.id);
+    await controller.deleteFolder(asOwner(), f.id); // gone already: still 204
+    expect(await controller.listFolders(asOwner())).toEqual([]);
+    await expect(
+      controller.renameFolder(asOwner(), f.id, { name: "x" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("moves a form into a folder and back out; a stranger folder is 404", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    expect(
+      await controller.setFormFolder(asOwner(), formId, { folderId: f.id }),
+    ).toEqual({ id: formId, folderId: f.id });
+    expect(
+      (await controller.listForms(asOwner())).find((x) => x.id === formId)
+        ?.folderId,
+    ).toBe(f.id);
+    expect(
+      await controller.setFormFolder(asOwner(), formId, { folderId: null }),
+    ).toEqual({ id: formId, folderId: null });
+    await expect(
+      controller.setFormFolder(asOwner(), formId, { folderId: "nope" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("a form is created straight into a folder, and a duplicate inherits it", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    const created = await controller.createForm(asOwner(), {
+      name: "Quiz",
+      folderId: f.id,
+    });
+    expect(created.folderId).toBe(f.id);
+    const copy = await controller.duplicateForm(asOwner(), created.id);
+    expect(copy.folderId).toBe(f.id);
+    await expect(
+      controller.createForm(asOwner(), { name: "Quiz 2", folderId: "nope" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("deleting a folder unfiles its forms and keeps them", async () => {
+    const f = await controller.createFolder(asOwner(), { name: "Sales" });
+    await controller.setFormFolder(asOwner(), formId, { folderId: f.id });
+    await controller.deleteFolder(asOwner(), f.id);
+    const row = (await controller.listForms(asOwner())).find(
+      (x) => x.id === formId,
+    );
+    expect(row).toBeDefined();
+    expect(row!.folderId).toBeNull();
+  });
+
+  it("a plain member may create folders and move forms (the same rule as creating forms)", async () => {
+    const f = await controller.createFolder(asMember(), { name: "Mine" });
+    expect(
+      await controller.setFormFolder(asMember(), formId, { folderId: f.id }),
+    ).toEqual({ id: formId, folderId: f.id });
+  });
+});

--- a/apps/api/src/notifications.controller.spec.ts
+++ b/apps/api/src/notifications.controller.spec.ts
@@ -73,6 +73,7 @@ describe('GET /v1/notifications', () => {
       'score',
       'outcomeLabel',
       'formLink',
+      'answers',
     ]);
   });
 });

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -72,6 +72,8 @@ export const openapiSpec = {
     '/v1/forms': {
       get: { summary: 'List forms (host)', security: [{ hostSession: [] }], responses: { '200': { description: 'Forms' } } },
       post: { summary: 'Create a form (host)', security: [{ hostSession: [] }], responses: { '201': { description: 'Created' } } },
+        description:
+          'Body { name, slug?, config?, folderId? }. `folderId` files the new form in one of the workspace folders (404 for a folder outside it); absent = unfiled.',
     },
     '/v1/forms/{id}': {
       get: { summary: 'Get a form (host)', security: [{ hostSession: [] }], responses: { '200': { description: 'Form' } } },

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -97,6 +97,53 @@ export const openapiSpec = {
         },
       },
     },
+    '/v1/folders': {
+      get: {
+        summary: "The workspace's form folders, alphabetically (host)",
+        security: [{ hostSession: [] }],
+        responses: { '200': { description: 'Array of { id, name, createdAt, updatedAt }' } },
+      },
+      post: {
+        summary: 'Create a form folder (host)',
+        description:
+          'Body { name } (1 to 80 characters, trimmed). Folders are flat and named only; a name is unique per workspace without regard to case. Any active member may create one, the same rule as creating a form.',
+        security: [{ hostSession: [] }],
+        responses: {
+          '201': { description: 'Created' },
+          '409': { description: 'NAME_TAKEN' },
+        },
+      },
+    },
+    '/v1/folders/{id}': {
+      patch: {
+        summary: 'Rename a form folder (host)',
+        description: 'Body { name }. 404 for a folder of another workspace, 409 NAME_TAKEN on a clash.',
+        security: [{ hostSession: [] }],
+        responses: {
+          '200': { description: 'Renamed' },
+          '404': { description: 'No such folder in this workspace' },
+          '409': { description: 'NAME_TAKEN' },
+        },
+      },
+      delete: {
+        summary: 'Delete a form folder (host)',
+        description: 'The forms inside are unfiled, never deleted. Idempotent: deleting an absent folder is still 204.',
+        security: [{ hostSession: [] }],
+        responses: { '204': { description: 'Deleted (or already gone)' } },
+      },
+    },
+    '/v1/forms/{id}/folder': {
+      patch: {
+        summary: 'Move a form into a folder, or unfile it (host)',
+        description:
+          'Body { folderId } where null unfiles. The key is required. 404 when the form or the folder is not in this workspace. The form\'s updated_at is untouched.',
+        security: [{ hostSession: [] }],
+        responses: {
+          '200': { description: '{ id, folderId }' },
+          '404': { description: 'No such form or folder in this workspace' },
+        },
+      },
+    },
     '/v1/forms/{id}/publish': {
       post: {
         summary: 'Publish a pending draft config (host)',

--- a/apps/api/src/query-params.spec.ts
+++ b/apps/api/src/query-params.spec.ts
@@ -27,9 +27,9 @@ describe("parseBound", () => {
 });
 
 describe("parseTimeZone", () => {
-  it("returns a known zone, UTC for an unknown one, and null when absent", () => {
+  it("returns a known zone, and null for an unknown or absent one (the workspace zone applies)", () => {
     expect(parseTimeZone("America/Bogota")).toBe("America/Bogota");
-    expect(parseTimeZone("Mars/Olympus")).toBe("UTC");
+    expect(parseTimeZone("Mars/Olympus")).toBeNull();
     expect(parseTimeZone(undefined)).toBeNull();
     expect(parseTimeZone("")).toBeNull();
   });

--- a/apps/api/src/query-params.spec.ts
+++ b/apps/api/src/query-params.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseBound, parseTimeZone } from "./query-params";
+
+describe("parseBound", () => {
+  it("passes epoch-ms through and reads ISO instants as-is", () => {
+    expect(parseBound("1700000000000", false)).toBe(1700000000000);
+    expect(parseBound("2026-09-03T10:00:00.000Z", false)).toBe(
+      Date.UTC(2026, 8, 3, 10),
+    );
+    expect(parseBound(undefined, false)).toBeNull();
+    expect(parseBound("nope", false)).toBeNull();
+  });
+
+  it("snaps a bare date to the day bounds in UTC by default", () => {
+    expect(parseBound("2026-09-03", false)).toBe(Date.UTC(2026, 8, 3));
+    expect(parseBound("2026-09-03", true)).toBe(Date.UTC(2026, 8, 4) - 1);
+  });
+
+  it("snaps a bare date to the day bounds in the given zone", () => {
+    expect(parseBound("2026-09-03", false, "America/Bogota")).toBe(
+      Date.UTC(2026, 8, 3, 5),
+    );
+    expect(parseBound("2026-09-03", true, "America/Bogota")).toBe(
+      Date.UTC(2026, 8, 4, 5) - 1,
+    );
+  });
+});
+
+describe("parseTimeZone", () => {
+  it("returns a known zone, UTC for an unknown one, and null when absent", () => {
+    expect(parseTimeZone("America/Bogota")).toBe("America/Bogota");
+    expect(parseTimeZone("Mars/Olympus")).toBe("UTC");
+    expect(parseTimeZone(undefined)).toBeNull();
+    expect(parseTimeZone("")).toBeNull();
+  });
+});

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -25,14 +25,15 @@ export function parseBound(v: string | undefined, endOfDay: boolean, zone: strin
 }
 
 /**
- * Narrow a `?tz=` query to a zone this server can resolve. Absent → null (the
- * caller falls back to the workspace's zone); unknown → UTC, never an error,
- * so a stale link cannot 400 an analytics page.
+ * Narrow a `?tz=` query to a zone this server can resolve. Absent or unknown
+ * → null, so the caller falls back to the workspace's zone: a mistyped or
+ * stale `tz` must neither 400 the page nor silently turn the team's days into
+ * UTC days.
  */
 export function parseTimeZone(v: string | undefined): string | null {
   const zone = v?.trim();
   if (!zone) return null;
-  return isValidTimeZone(zone) ? zone : 'UTC';
+  return isValidTimeZone(zone) ? zone : null;
 }
 
 /** Narrow a raw status query to the allowed filter (defaults to `all`). */

--- a/apps/api/src/query-params.ts
+++ b/apps/api/src/query-params.ts
@@ -5,20 +5,34 @@
  * framework-agnostic so both controllers parse identically.
  */
 import { OUTBOX_KINDS, OUTBOX_STATUSES, type OutboxKind, type OutboxStatus, type SubmissionStatus } from '@quill/db';
+import { dayBoundsInZone, isValidTimeZone } from '@quill/shared';
 
-/** Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. */
-export function parseBound(v: string | undefined, endOfDay: boolean): number | null {
+/**
+ * Parse a date bound: epoch-ms passthrough, or a YYYY-MM-DD / ISO string. A
+ * bare date names a whole calendar day in `zone` (UTC when absent): its first
+ * instant, or its last with `endOfDay`.
+ */
+export function parseBound(v: string | undefined, endOfDay: boolean, zone: string = 'UTC'): number | null {
   if (!v) return null;
   if (/^\d+$/.test(v)) return Number(v);
   const t = Date.parse(v);
   if (Number.isNaN(t)) return null;
   if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
-    const d = new Date(t);
-    if (endOfDay) d.setUTCHours(23, 59, 59, 999);
-    else d.setUTCHours(0, 0, 0, 0);
-    return d.getTime();
+    const bounds = dayBoundsInZone(v, zone);
+    return endOfDay ? bounds.to : bounds.from;
   }
   return t;
+}
+
+/**
+ * Narrow a `?tz=` query to a zone this server can resolve. Absent → null (the
+ * caller falls back to the workspace's zone); unknown → UTC, never an error,
+ * so a stale link cannot 400 an analytics page.
+ */
+export function parseTimeZone(v: string | undefined): string | null {
+  const zone = v?.trim();
+  if (!zone) return null;
+  return isValidTimeZone(zone) ? zone : 'UTC';
 }
 
 /** Narrow a raw status query to the allowed filter (defaults to `all`). */

--- a/apps/api/src/submission.service.spec.ts
+++ b/apps/api/src/submission.service.spec.ts
@@ -87,6 +87,30 @@ describe('submit', () => {
     expect(payload.respondentEmail).toBe('lead@acme.io');
   });
 
+  it('both emails carry the answers as resolved {label, value} rows in step order', async () => {
+    await svc.submit('acme', 'lead-qualifier', {
+      sessionId: 'sess-answers',
+      data: { role: 'founder', team_size: 20, company: 'Acme', email: 'lead@acme.io' },
+    });
+    await flushEffects();
+    const outbox = await listOutbox(db, { kind: 'email' });
+    expect(outbox).toHaveLength(2);
+    for (const row of outbox) {
+      const payload = JSON.parse(row.payload!) as { answers: Array<{ label: string; value: string }> };
+      expect(payload.answers.map((a) => a.label)).toEqual([
+        'What best describes you?',
+        'How big is your team?',
+        'What company do you work at?',
+        'Where should we send the results?',
+      ]);
+      // Option VALUE → option LABEL, numbers stringified.
+      expect(payload.answers[0]!.value).not.toBe('founder');
+      expect(payload.answers[1]!.value).toBe('20');
+      expect(payload.answers[2]!.value).toBe('Acme');
+      expect(payload.answers[3]!.value).toBe('lead@acme.io');
+    }
+  });
+
   it('a re-landed complete enqueues NO second round of effects', async () => {
     // `callActionWithRetry` cannot abort an in-flight request, so a complete
     // that landed slowly IS retried and this method runs twice for one real

--- a/apps/api/src/submission.service.spec.ts
+++ b/apps/api/src/submission.service.spec.ts
@@ -87,6 +87,34 @@ describe('submit', () => {
     expect(payload.respondentEmail).toBe('lead@acme.io');
   });
 
+  it('the respondent receipt renders in the language the respondent saw, then the form language, then none', async () => {
+    const localeOf = async (sessionId: string, extra: Record<string, unknown>, language?: 'en' | 'es') => {
+      if (language) {
+        const form = await db.get<{ id: string; config: string }>(
+          sql`SELECT id, config FROM form WHERE slug = 'lead-qualifier' LIMIT 1`,
+        );
+        const config = JSON.parse(form!.config) as Record<string, unknown>;
+        await db.run(
+          sql`UPDATE form SET config = ${JSON.stringify({ ...config, language })} WHERE id = ${form!.id}`,
+        );
+      }
+      await svc.submit('acme', 'lead-qualifier', {
+        sessionId,
+        data: { role: 'founder', team_size: 20, email: 'lead@acme.io' },
+        ...extra,
+      });
+      await flushEffects();
+      const rows = await listOutbox(db, { kind: 'email' });
+      const confirmed = rows.filter((r) => r.action === 'submission_confirmed').pop()!;
+      return (JSON.parse(confirmed.payload!) as { locale: string | null }).locale;
+    };
+    expect(await localeOf('sess-loc-none', {})).toBeNull();
+    expect(await localeOf('sess-loc-seen', { locale: 'es' })).toBe('es');
+    expect(await localeOf('sess-loc-form', {}, 'es')).toBe('es');
+    // What the respondent SAW wins over the form default (a ?lang=en link on a Spanish form).
+    expect(await localeOf('sess-loc-both', { locale: 'en' }, 'es')).toBe('en');
+  });
+
   it('a re-landed complete enqueues NO second round of effects', async () => {
     // `callActionWithRetry` cannot abort an in-flight request, so a complete
     // that landed slowly IS retried and this method runs twice for one real

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -172,6 +172,9 @@ export class SubmissionService {
             submissionId: row.id,
             formName: form.name,
             respondentEmail,
+            // The language the respondent saw (the page resolved ?lang and the
+            // browser), else the form's own language; null = English.
+            locale: input.locale ?? config.language ?? null,
           },
           form.id,
         );

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -13,7 +13,7 @@ import {
   getAccountOwner,
   type SubmissionRow,
 } from '@quill/db';
-import { computeScore, resolveOutcome, type FormConfig } from '@quill/engine';
+import { computeScore, resolveOutcome, summarizeAnswers, type FormConfig } from '@quill/engine';
 import {
   memberProfileSchema,
   submissionSchema,
@@ -149,6 +149,11 @@ export class SubmissionService {
 
     if (!input.partial && !reCompleted) {
       const respondentEmail = pickEmail(input.data);
+      // The answers as the owner reads them (labels, option labels, step
+      // order): resolved once here, printed by the `{{answers}}` token in
+      // either email. The respondent copy carries them too so a custom receipt
+      // can echo what was submitted.
+      const answers = summarizeAnswers(config, input.data);
       // form.id lets the effect apply any per-form template override
       // (precedence form → account → stock, resolved inside the effect).
       void this.email.enqueueSubmissionReceived(
@@ -159,6 +164,7 @@ export class SubmissionService {
           respondentEmail,
           score,
           outcomeLabel: outcome?.label ?? null,
+          answers,
         },
         form.id,
       );
@@ -172,6 +178,7 @@ export class SubmissionService {
             submissionId: row.id,
             formName: form.name,
             respondentEmail,
+            answers,
           },
           form.id,
         );

--- a/apps/api/src/workspace.service.spec.ts
+++ b/apps/api/src/workspace.service.spec.ts
@@ -186,6 +186,27 @@ describe('WorkspaceService (IAM-backed)', () => {
     await expect(svc.rename(req(), { name: 'Nope' })).rejects.toBeInstanceOf(ForbiddenException);
   });
 
+  it('sets the workspace timezone locally (admin), claims only while unset, and refuses a plain member', async () => {
+    await svc.list(req());
+    const set = await svc.setTimezone(req(), { timezone: 'America/Bogota' });
+    expect(set).toEqual({ accountId: set.accountId, timezone: 'America/Bogota', applied: true });
+    const row = await db.get<{ timezone: string | null }>(sql`SELECT timezone FROM account WHERE id = ${set.accountId}`);
+    expect(row!.timezone).toBe('America/Bogota');
+
+    // A browser's write-once seed does not overwrite an explicit choice.
+    const claim = await svc.setTimezone(req(), { timezone: 'Europe/Madrid', onlyIfUnset: true });
+    expect(claim).toEqual({ accountId: set.accountId, timezone: 'America/Bogota', applied: false });
+
+    // Clearing goes back to UTC (null).
+    expect((await svc.setTimezone(req(), { timezone: null })).timezone).toBeNull();
+  });
+
+  it('a plain member cannot set the workspace timezone', async () => {
+    // Demoted upstream before the first projection, so the guard sees `member`.
+    workspaces[0]!.users![0]!.type = 'MEMBER';
+    await expect(svc.setTimezone(req(), { timezone: 'Asia/Tokyo' })).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('enter re-checks membership and writes last_workspace upstream; a stranger account is a 403', async () => {
     const list = await svc.list(req());
     await svc.enter(req(), list[0]!.accountId);

--- a/apps/api/src/workspace.service.ts
+++ b/apps/api/src/workspace.service.ts
@@ -46,6 +46,9 @@ import {
   type MemberStatus,
   type MemberView,
   type WorkspaceRow,
+  claimAccountTimezone,
+  getAccountTimezone,
+  setAccountTimezone,
 } from '@quill/db';
 import { AUTH_PROVIDER, DB, WORKSPACE_PROJECTION } from './tokens';
 import type { AuthProvider, HostPrincipal, ReqLike, UpstreamIdentity } from './auth.provider';
@@ -243,6 +246,26 @@ export class WorkspaceService {
     }
     await renameAccount(this.db, p.accountId, name);
     return { accountId: p.accountId, name };
+  }
+
+  /**
+   * Set the workspace's timezone (admin/owner), a LOCAL fact: the identity
+   * service has no notion of a zone, so nothing goes upstream. `onlyIfUnset`
+   * is the dashboard's write-once seed from the first admin's browser: it
+   * applies only while the column is still NULL and reports whether it did.
+   */
+  async setTimezone(
+    req: ReqLike,
+    input: { timezone: string | null; onlyIfUnset?: boolean },
+  ): Promise<{ accountId: string; timezone: string | null; applied: boolean }> {
+    const p = await this.auth.resolveHost(req);
+    assertAdmin(p);
+    if (input.onlyIfUnset) {
+      const applied = input.timezone != null && (await claimAccountTimezone(this.db, p.accountId, input.timezone));
+      return { accountId: p.accountId, timezone: await getAccountTimezone(this.db, p.accountId), applied };
+    }
+    await setAccountTimezone(this.db, p.accountId, input.timezone);
+    return { accountId: p.accountId, timezone: input.timezone, applied: true };
   }
 
   /**

--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -12,7 +12,7 @@ import type { BookingCallbackInput } from '@quill/types';
 export async function submitFormAction(
   accountCode: string,
   slug: string,
-  payload: { sessionId: string; data: Record<string, unknown>; partial?: boolean },
+  payload: { sessionId: string; data: Record<string, unknown>; partial?: boolean; locale?: 'en' | 'es' },
 ): Promise<{ ok: boolean; score?: number; outcome?: string | null; message?: string }> {
   const res = await postSubmission(accountCode, slug, payload);
   return { ok: res.ok, score: res.score, outcome: res.outcome, message: res.message };

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-labels.spec.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-labels.spec.tsx
@@ -1,0 +1,108 @@
+/**
+ * The renderers print the form's OWN button copy: the author's overrides,
+ * else the stock copy of the language the page resolved. Pinned through
+ * static markup so the public form and the builder preview (same component)
+ * cannot drift from `resolveFormLabels`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// `next/font/google` resolves at build time and has no runtime in vitest; the
+// renderers only need a className from it.
+vi.mock("next/font/google", () => {
+  const font = () => ({
+    className: "font",
+    variable: "--font",
+    style: { fontFamily: "font" },
+  });
+  return {
+    DM_Sans: font,
+    Figtree: font,
+    Fraunces: font,
+    IBM_Plex_Mono: font,
+    Inter: font,
+    Manrope: font,
+    Playfair_Display: font,
+    Poppins: font,
+    Space_Grotesk: font,
+    Work_Sans: font,
+  };
+});
+
+import { FormRenderer } from "./form-renderer";
+import { VerticalFormRenderer } from "./vertical-form-renderer";
+
+const step = { key: "q1", type: "text" as const, question: "Your name?" };
+
+function slides(
+  config: Record<string, unknown>,
+  locale: string,
+  startAt?: number | "cover",
+) {
+  return renderToStaticMarkup(
+    <FormRenderer
+      accountCode="acme"
+      slug="f"
+      name="F"
+      config={{ version: 1, steps: [step], ...config } as never}
+      locale={locale}
+      startAt={startAt}
+    />,
+  );
+}
+
+describe("button copy on the public form", () => {
+  it("the cover CTA is the author text, else the stock Start of the locale", () => {
+    expect(
+      slides(
+        { cover: { enabled: true, headline: "Hi", ctaText: "Vamos" } },
+        "en",
+        "cover",
+      ),
+    ).toContain("Vamos");
+    expect(
+      slides({ cover: { enabled: true, headline: "Hi" } }, "es", "cover"),
+    ).toContain("Comenzar");
+  });
+
+  it("the last step submits with the form-level label, else the stock Submit of the locale", () => {
+    expect(slides({ labels: { submit: "Send it" } }, "es", 0)).toContain(
+      "Send it",
+    );
+    expect(slides({}, "es", 0)).toContain("Enviar");
+    expect(slides({}, "en", 0)).toContain("Submit");
+  });
+
+  it("a step’s own buttonText still wins over the form-level label", () => {
+    const html = slides(
+      {
+        labels: { submit: "Send it" },
+        steps: [{ ...step, buttonText: "Go go" }],
+      },
+      "en",
+      0,
+    );
+    expect(html).toContain("Go go");
+    expect(html).not.toContain("Send it");
+  });
+
+  it("the one-page layout submits with the same resolver", () => {
+    const html = renderToStaticMarkup(
+      <VerticalFormRenderer
+        accountCode="acme"
+        slug="f"
+        name="F"
+        config={
+          {
+            version: 1,
+            steps: [step],
+            layout: "vertical",
+            labels: { submit: "Listo" },
+          } as never
+        }
+        locale="en"
+      />,
+    );
+    expect(html).toContain("Listo");
+  });
+});

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -31,7 +31,7 @@ import {
   type FormStep,
   type FormOutcome,
 } from '@quill/engine';
-import { getMessages } from '@quill/shared';
+import { getMessages, resolveFormLabels } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
 import { formDesignProps } from '@/lib/form-design';
 import { FormLogo } from '@/components/public/form-logo';
@@ -80,6 +80,9 @@ export function FormRenderer({
   startAt?: number | 'cover';
 }) {
   const m = getMessages(locale).renderer;
+  // The form's button copy: author overrides, else the stock copy of `locale`.
+  const formLocale = locale === 'es' ? 'es' : 'en';
+  const labels = resolveFormLabels(config, formLocale);
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
   // The cover SCREEN: null when switched off, which is what gates the `cover`
   // phase, the Start CTA and the back-to-cover step.
@@ -253,6 +256,8 @@ export function FormRenderer({
           submitFormAction(accountCode, slug, {
             sessionId,
             data: withData(finalAnswers),
+            // What the respondent SAW, so the confirmation email matches.
+            locale: formLocale,
           }),
         { timeoutMs: 8_000 },
       );
@@ -664,7 +669,7 @@ export function FormRenderer({
         </div>
         <div className="pf__cover-footer">
           <button type="button" className="pf__btn" onClick={start}>
-            {coverScreen.ctaText ?? m.start}
+            {labels.start}
           </button>
           {/* Under the CTA: every respondent sees the cover, so this is the
               highest-value slot for the attribution and it displaces nothing. */}
@@ -743,7 +748,7 @@ export function FormRenderer({
         <header className="pf__topbar">
           <div className="pf__topbar-inner">
             {index > 0 || coverScreen ? (
-              <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+              <button type="button" className="pf__back" onClick={back} aria-label={labels.back}>
                 ←
               </button>
             ) : (
@@ -812,7 +817,7 @@ export function FormRenderer({
       <header className="pf__topbar">
         <div className="pf__topbar-inner">
           {index > 0 || coverScreen ? (
-            <button type="button" className="pf__back" onClick={back} aria-label={m.back}>
+            <button type="button" className="pf__back" onClick={back} aria-label={labels.back}>
               ←
             </button>
           ) : (
@@ -861,7 +866,7 @@ export function FormRenderer({
 
               {showContinue ? (
                 <button type="button" className="pf__btn pf__btn--inline" onClick={submitCurrent}>
-                  {step.buttonText ?? (index + 1 === steps.length ? m.submit : m.next)}
+                  {step.buttonText ?? (index + 1 === steps.length ? labels.submit : labels.next)}
                 </button>
               ) : null}
             </div>

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -376,6 +376,7 @@ export function FormRenderer({
               sessionId,
               data: withData(nextAnswers),
               partial: true,
+              locale: formLocale,
             }),
           );
         }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/opengraph-image.tsx
@@ -105,15 +105,12 @@ export default async function OgImage({
   const config = form?.config;
   const cover = config?.cover;
   const style = resolveCardStyle(config?.branding);
-  // The same locale rule the page uses, which for a social crawler means English:
-  // they send no `Accept-Language`, and neither does a respondent with no
-  // preference — who would land on the English page too. So the card agrees with
-  // the page it opens, which is the property worth holding. It is NOT the same as
-  // being right: a Spanish form shared into a Spanish channel still says "Start".
-  // Fixing that needs a language ON THE FORM. The account has none, and the
-  // owner's `member.locale` is their dashboard language rather than their
-  // audience's, so guessing from it would trade one wrong answer for another.
-  const messages = getMessages(await publicLocale());
+  // The same locale rule the page uses: the form's own language when the author
+  // set one, else the browser, which for a social crawler means English (they
+  // send no `Accept-Language`). So the card agrees with the page it opens. A
+  // form left on Auto and shared into a Spanish channel still says "Start";
+  // setting the language in Design is the fix, not guessing from the owner.
+  const messages = getMessages(await publicLocale(undefined, config?.language ?? null));
 
   const headline =
     cover?.headline?.trim() ||

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -17,12 +17,16 @@ import { VerticalFormRenderer } from './vertical-form-renderer';
  */
 export async function generateMetadata({
   params,
+  searchParams,
 }: {
-  params: Promise<{ accountCode: string; handle: string; slug: string; lang?: string }>;
+  params: Promise<{ accountCode: string; handle: string; slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }): Promise<Metadata> {
   const { accountCode, handle, slug } = await params;
   const form = await getPublicForm(accountCode, slug);
   if (!form) return {};
+  const query = await searchParams;
+  const lang = typeof query.lang === 'string' ? query.lang : undefined;
   // NOTE: this function deliberately does NOT redirect, even though it runs
   // before the page and looks like the earlier, better place to do it. Next 16
   // has already begun streaming by the time either one resolves, so a redirect
@@ -32,7 +36,9 @@ export async function generateMetadata({
   // returning metadata at all. So the redirect stays in the page (for people,
   // whose browsers follow it) and this function keeps naming the canonical URL
   // (for everything that does not run scripts).
-  const locale = await publicLocale();
+  // The same rule as the page body: ?lang, then the form's language, then
+  // the browser. The description must agree with the page it describes.
+  const locale = await publicLocale(lang, form.config.language ?? null);
   // The author-set public title wins over the private dashboard name.
   const title = publicTitle(form.config, form.name);
   const description =
@@ -152,13 +158,14 @@ export default async function PublicFormPage({
   const { accountCode, handle, slug } = await params;
   const query = await searchParams;
   const lang = typeof query.lang === 'string' ? query.lang : undefined;
-  const locale = await publicLocale(lang);
   // Embedded render (?embed=1): same form, sized by its content instead of the
   // viewport, reporting its height to the host page's embed.js (iframe embeds).
   const embedded = query.embed === '1';
 
   const form = await getPublicForm(accountCode, slug);
   if (!form) notFound();
+  // ?lang, then the form's own language (Auto = absent), then the browser.
+  const locale = await publicLocale(lang, form.config.language ?? null);
 
   // Reached through a slug this form USED to answer to: the author renamed the
   // link and the alias ledger resolved the old one (see migration 0017). Move

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -46,7 +46,7 @@ import {
   type FormOutcome,
   type FormReveal,
 } from '@quill/engine';
-import { getMessages, t } from '@quill/shared';
+import { getMessages, resolveFormLabels, t } from '@quill/shared';
 import type { FormConfig } from '@quill/types';
 import { FormLogo } from '@/components/public/form-logo';
 import { ClientLogosMarquee } from '@/components/public/client-logos-marquee';
@@ -165,6 +165,9 @@ export function VerticalFormRenderer({
   locale?: string;
 }) {
   const m = getMessages(locale).renderer;
+  // The form's button copy: author overrides, else the stock copy of `locale`.
+  const formLocale = locale === 'es' ? 'es' : 'en';
+  const labels = resolveFormLabels(config, formLocale);
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
   // The cover HERO: null when switched off, which is what gates the hero block.
   const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
@@ -312,6 +315,8 @@ export function VerticalFormRenderer({
           submitFormAction(accountCode, slug, {
             sessionId,
             data: withData(finalAnswers),
+            // What the respondent SAW, so the confirmation email matches.
+            locale: formLocale,
           }),
         { timeoutMs: 8_000 },
       );
@@ -774,7 +779,7 @@ export function VerticalFormRenderer({
                 </p>
               ) : null}
               <button type="button" className="pf__btn" onClick={() => void submitAll()}>
-                {m.submit}
+                {labels.submit}
               </button>
             </div>
           ) : null}

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -416,6 +416,7 @@ export function VerticalFormRenderer({
             sessionId,
             data: withData(nextAnswers),
             partial: true,
+            locale: formLocale,
           }),
         );
       }

--- a/apps/web/app/[accountCode]/error.tsx
+++ b/apps/web/app/[accountCode]/error.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-/** R22 error boundary for the public form subtree — a real Retry, no dead end. */
+import { getMessages } from '@quill/shared';
+import { publicClientLocale } from '@/lib/client-locale';
+
+/** R22 error boundary for the public form subtree: a real Retry, no dead end. */
 export default function PublicError({ reset }: { error: Error; reset: () => void }) {
+  // A client boundary has no request to read: ?lang, then the browser.
+  const m = getMessages(publicClientLocale()).renderer;
   return (
     <main className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center gap-4 px-6 text-center">
-      <h1 className="text-2xl font-semibold">This page didn’t load</h1>
-      <p className="text-muted-foreground">Something went wrong reaching the forms service.</p>
+      <h1 className="text-2xl font-semibold">{m.errorTitle}</h1>
+      <p className="text-muted-foreground">{m.errorBody}</p>
       <button
         type="button"
         onClick={reset}
         className="rounded-md bg-primary px-5 py-2 font-semibold text-primary-foreground transition-transform active:scale-[0.98]"
       >
-        Try again
+        {m.errorRetry}
       </button>
     </main>
   );

--- a/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { t } from '@quill/shared';
+import { useToast } from '@/components/toast';
+import { browserTimezone } from '@/lib/timezones';
+import { callAction } from '@/lib/call-action';
+import { claimWorkspaceTimezoneAction } from '@/app/admin/workspace-actions';
+
+/** One attempt per tab session, so a refused or slow claim is not retried on every page. */
+const CLAIM_KEY = 'forms.timezone.claimed';
+
+/**
+ * Seeds the workspace timezone from the first admin's browser. Renders
+ * nothing. Runs once per tab session, only while the workspace has no zone
+ * and the viewer may set one; the API keeps the value only while the column
+ * is still NULL, so two admins racing cannot flip it. Says so with a toast
+ * (naming where to change it) only when THIS browser's zone was the one kept.
+ */
+export function WorkspaceTimezoneBootstrap({
+  timezone,
+  canClaim,
+  message,
+}: {
+  timezone: string | null;
+  canClaim: boolean;
+  /** `admin.chrome.timezoneAutoSet`, with a `{zone}` placeholder. */
+  message: string;
+}) {
+  const toast = useToast();
+  const router = useRouter();
+  useEffect(() => {
+    if (timezone != null || !canClaim) return;
+    try {
+      if (sessionStorage.getItem(CLAIM_KEY)) return;
+      sessionStorage.setItem(CLAIM_KEY, '1');
+    } catch {
+      // No storage (private mode, hardened browser): still try once per mount.
+    }
+    const zone = browserTimezone();
+    if (!zone) return;
+    let cancelled = false;
+    void callAction(() => claimWorkspaceTimezoneAction(zone)).then((res) => {
+      if (cancelled || !res || !('applied' in res) || !res.applied) return;
+      toast.success(t(message, { zone }));
+      router.refresh();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [timezone, canClaim, message, toast, router]);
+  return null;
+}

--- a/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-bootstrap.tsx
@@ -8,8 +8,8 @@ import { browserTimezone } from '@/lib/timezones';
 import { callAction } from '@/lib/call-action';
 import { claimWorkspaceTimezoneAction } from '@/app/admin/workspace-actions';
 
-/** One attempt per tab session, so a refused or slow claim is not retried on every page. */
-const CLAIM_KEY = 'forms.timezone.claimed';
+/** One attempt per tab session AND workspace, so a refused or slow claim is not retried on every page. */
+const claimKey = (accountId: string) => `forms.timezone.claimed:${accountId}`;
 
 /**
  * Seeds the workspace timezone from the first admin's browser. Renders
@@ -19,10 +19,12 @@ const CLAIM_KEY = 'forms.timezone.claimed';
  * (naming where to change it) only when THIS browser's zone was the one kept.
  */
 export function WorkspaceTimezoneBootstrap({
+  accountId,
   timezone,
   canClaim,
   message,
 }: {
+  accountId: string;
   timezone: string | null;
   canClaim: boolean;
   /** `admin.chrome.timezoneAutoSet`, with a `{zone}` placeholder. */
@@ -33,8 +35,8 @@ export function WorkspaceTimezoneBootstrap({
   useEffect(() => {
     if (timezone != null || !canClaim) return;
     try {
-      if (sessionStorage.getItem(CLAIM_KEY)) return;
-      sessionStorage.setItem(CLAIM_KEY, '1');
+      if (sessionStorage.getItem(claimKey(accountId))) return;
+      sessionStorage.setItem(claimKey(accountId), '1');
     } catch {
       // No storage (private mode, hardened browser): still try once per mount.
     }
@@ -49,6 +51,6 @@ export function WorkspaceTimezoneBootstrap({
     return () => {
       cancelled = true;
     };
-  }, [timezone, canClaim, message, toast, router]);
+  }, [accountId, timezone, canClaim, message, toast, router]);
   return null;
 }

--- a/apps/web/app/admin/_components/workspace-timezone-field.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-field.tsx
@@ -61,7 +61,7 @@ export function WorkspaceTimezoneField({
     setCurrent(next);
     start(async () => {
       const res = await callAction(() => setWorkspaceTimezoneAction(accountId, next || null));
-      if (res && 'ok' in res && res.ok) {
+      if ('ok' in res && res.ok) {
         toast.success(labels.saved);
         router.refresh();
       } else {

--- a/apps/web/app/admin/_components/workspace-timezone-field.tsx
+++ b/apps/web/app/admin/_components/workspace-timezone-field.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Select } from '@/components/ui/select';
+import { useToast } from '@/components/toast';
+import { browserTimezones } from '@/lib/timezones';
+import { callAction } from '@/lib/call-action';
+import { setWorkspaceTimezoneAction } from '@/app/admin/workspace-actions';
+
+export interface WorkspaceTimezoneLabels {
+  label: string;
+  /** Explains that the zone is shared by the whole workspace. */
+  help: string;
+  saved: string;
+  error: string;
+  /** Trigger text while nobody has set a zone (UTC applies). */
+  unset: string;
+  utc: string;
+  /** Shown to a member, who sees the value but cannot change it. */
+  readOnly: string;
+}
+
+/**
+ * The ONE workspace timezone, editable by admins/owners from two places (the
+ * workspace's settings page and the submissions table) and read-only for
+ * members. Both surfaces write the same column through the same action; the
+ * `settings` variant carries the explanatory help line, the `inline` one is
+ * compact enough to sit beside a filter.
+ */
+export function WorkspaceTimezoneField({
+  accountId,
+  value,
+  canEdit,
+  variant,
+  locale,
+  labels,
+}: {
+  accountId: string;
+  value: string | null;
+  canEdit: boolean;
+  variant: 'settings' | 'inline';
+  locale: string;
+  labels: WorkspaceTimezoneLabels;
+}) {
+  const toast = useToast();
+  const router = useRouter();
+  const helpId = useId();
+  const [pending, start] = useTransition();
+  const [current, setCurrent] = useState<string>(value ?? '');
+  const zones = browserTimezones() ?? [];
+  const options = [
+    { value: 'UTC', label: labels.utc },
+    // A stored zone this browser cannot enumerate still shows as itself.
+    ...(current && current !== 'UTC' && !zones.includes(current) ? [{ value: current, label: current }] : []),
+    ...zones.filter((z) => z !== 'UTC').map((zone) => ({ value: zone, label: zone })),
+  ];
+
+  const onChange = (next: string) => {
+    const previous = current;
+    setCurrent(next);
+    start(async () => {
+      const res = await callAction(() => setWorkspaceTimezoneAction(accountId, next || null));
+      if (res && 'ok' in res && res.ok) {
+        toast.success(labels.saved);
+        router.refresh();
+      } else {
+        setCurrent(previous);
+        toast.error(labels.error);
+      }
+    });
+  };
+
+  const inline = variant === 'inline';
+  return (
+    <div
+      data-testid={`workspace-timezone-${variant}`}
+      className={inline ? 'flex min-w-0 flex-col gap-1' : 'flex min-w-0 max-w-md flex-col gap-1.5'}
+    >
+      <span className={inline ? 'text-xs font-medium text-muted-foreground' : 'text-2xs uppercase tracking-wide text-faint'}>
+        {labels.label}
+      </span>
+      {canEdit ? (
+        <Select
+          ariaLabel={labels.label}
+          value={current}
+          options={options}
+          placeholder={labels.unset}
+          searchable
+          locale={locale}
+          disabled={pending}
+          onChange={onChange}
+          className={inline ? 'h-9 min-w-[220px] text-sm' : undefined}
+        />
+      ) : (
+        <span
+          className="inline-flex items-center gap-1.5 text-sm text-foreground"
+          title={labels.readOnly}
+          data-testid="workspace-timezone-readonly"
+        >
+          <i aria-hidden className="pi pi-lock text-muted-foreground" style={{ fontSize: 12 }} />
+          {current || labels.unset}
+        </span>
+      )}
+      <p id={helpId} className="text-xs text-muted-foreground">
+        {canEdit ? labels.help : `${labels.help} ${labels.readOnly}`}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/admin/account/brand-kit/brand-kit-panel.tsx
+++ b/apps/web/app/admin/account/brand-kit/brand-kit-panel.tsx
@@ -3,7 +3,8 @@
 import { useMemo, useState, useTransition } from 'react';
 import type { FormBranding, FormButtonStyle, FormFont, FormRadius } from '@quill/engine';
 import { DEFAULT_FORM_FONT } from '@quill/engine';
-import { DEFAULT_ACCENT, DEFAULT_CANVAS, onAccent, readableOn, t, type FormsMessages } from '@quill/shared';
+import { DEFAULT_ACCENT, DEFAULT_CANVAS, formatDateTime, onAccent, readableOn, t, type FormsMessages } from '@quill/shared';
+import { useWorkspaceTimeZone } from '@/components/workspace-timezone';
 import type { BrandKit, FormSummary } from '@/lib/admin-api';
 import { formDesignProps } from '@/lib/form-design';
 import { callAction, isTransportError } from '@/lib/call-action';
@@ -40,6 +41,7 @@ export function BrandKitPanel({
   design: DesignMessages;
   locale: string;
 }) {
+  const timeZone = useWorkspaceTimeZone();
   const [kit, setKit] = useState<BrandKit>(initialKit);
   const [savedAt, setSavedAt] = useState<number | null>(updatedAt);
   const [applied, setApplied] = useState<Record<string, boolean>>(() =>
@@ -339,7 +341,7 @@ export function BrandKitPanel({
           </button>
           {savedAt ? (
             <span className="text-xs text-muted-foreground">
-              {t(bk.updatedAt, { date: new Date(savedAt).toLocaleString(locale) })}
+              {t(bk.updatedAt, { date: formatDateTime(savedAt, { locale, timeZone }) })}
             </span>
           ) : null}
           {toast ? <span className="text-sm text-primary">{toast}</span> : null}

--- a/apps/web/app/admin/account/notifications/notification-settings.tsx
+++ b/apps/web/app/admin/account/notifications/notification-settings.tsx
@@ -12,6 +12,7 @@ import {
 import type { NotificationSettingView } from '@/lib/admin-api';
 import { saveNotificationAction, resetNotificationAction } from './actions';
 import { callAction } from '@/lib/call-action';
+import { hasToken } from '@/lib/notification-preview';
 
 export interface NotificationLabels {
   heading: string;
@@ -42,7 +43,14 @@ export interface NotificationLabels {
   tokenScore: string;
   tokenOutcomeLabel: string;
   tokenFormLink: string;
+  tokenAnswers: string;
+  answersMissing: string;
   formOverrideNote: string;
+}
+
+/** `{{formLink}}` is produced for the owner notice only; do not offer a dead chip on the receipt. */
+function visibleTokens(key: string, tokens: string[]): string[] {
+  return key === 'submission_confirmed' ? tokens.filter((t) => t !== 'formLink') : tokens;
 }
 
 /**
@@ -126,7 +134,11 @@ function NotificationEmailCard({
     score: labels.tokenScore,
     outcomeLabel: labels.tokenOutcomeLabel,
     formLink: labels.tokenFormLink,
+    answers: labels.tokenAnswers,
   };
+  // The owner notice exists to carry the answers; a body without the token
+  // silently sends an email with nothing useful in it, so say so permanently.
+  const answersMissing = setting.emailKey === 'submission_received' && !hasToken(value.body, 'answers');
 
   /** Reconcile local state with a freshly-persisted setting. */
   function applyPersisted(next: NotificationSettingView) {
@@ -199,7 +211,7 @@ function NotificationEmailCard({
       <NotificationEmailFields
         value={value}
         onChange={setValue}
-        tokens={setting.tokens}
+        tokens={visibleTokens(setting.emailKey, setting.tokens)}
         labels={{
           enabledLabel: labels.enabledLabel,
           enabledHint: labels.enabledHint,
@@ -211,6 +223,7 @@ function NotificationEmailCard({
           previewSubject: labels.previewSubject,
           tokenLabels,
         }}
+        notice={answersMissing ? labels.answersMissing : null}
       />
 
       {/* Actions */}

--- a/apps/web/app/admin/account/workspaces/[id]/page.tsx
+++ b/apps/web/app/admin/account/workspaces/[id]/page.tsx
@@ -16,6 +16,7 @@ import { InvitationsTable } from './invitations-table';
 import { MembersTable } from './members-table';
 import { WorkspaceId } from './workspace-id';
 import { WorkspaceName } from './workspace-name';
+import { WorkspaceTimezoneField } from '@/app/admin/_components/workspace-timezone-field';
 
 export const dynamic = 'force-dynamic';
 
@@ -126,6 +127,22 @@ export default async function WorkspacePage({
             workspaceNameSave: s.workspaceNameSave,
             workspaceNameSaved: s.workspaceNameSaved,
             workspaceNameError: s.workspaceNameError,
+          }}
+        />
+        <WorkspaceTimezoneField
+          accountId={accountId}
+          value={me.timezone}
+          canEdit={canManage}
+          variant="settings"
+          locale={locale}
+          labels={{
+            label: s.workspaceTimezone,
+            help: s.workspaceTimezoneHelp,
+            saved: s.workspaceTimezoneSaved,
+            error: s.workspaceTimezoneError,
+            unset: s.workspaceTimezoneUnset,
+            utc: s.workspaceTimezoneUtc,
+            readOnly: messages.submissions.timezoneReadOnly,
           }}
         />
         {canManage ? (

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -12,8 +12,11 @@ export async function createFormAction(formData: FormData): Promise<void> {
   // `layout` already means slides (the engine's back-compat default), so a
   // slides form keeps the exact config shape every existing form has.
   const layout = String(formData.get('layout') ?? '');
+  // The folder preselected by a section's "New form" (or picked in the dialog).
+  const folderId = String(formData.get('folderId') ?? '').trim() || null;
   const created = await adminApi.createForm({
     name,
+    ...(folderId ? { folderId } : {}),
     ...(layout === 'vertical' ? { config: { version: 1, steps: [], layout: 'vertical' } } : {}),
   });
   revalidatePath('/admin');

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect, unstable_rethrow } from 'next/navigation';
 import { lockedOptionValues } from '@quill/engine';
 import { adminApi, ApiError } from '@/lib/admin-api';
+import { getLocale } from '@/lib/locale';
 
 /** Create a form and jump straight into its editor. */
 export async function createFormAction(formData: FormData): Promise<void> {
@@ -12,9 +13,13 @@ export async function createFormAction(formData: FormData): Promise<void> {
   // `layout` already means slides (the engine's back-compat default), so a
   // slides form keeps the exact config shape every existing form has.
   const layout = String(formData.get('layout') ?? '');
+  // A new form speaks its author's language explicitly (Auto stays for forms
+  // that predate the field): the person building it in Spanish expects Spanish
+  // buttons, not whatever each visitor's browser asks for.
+  const language = await getLocale();
   const created = await adminApi.createForm({
     name,
-    ...(layout === 'vertical' ? { config: { version: 1, steps: [], layout: 'vertical' } } : {}),
+    config: { version: 1, steps: [], language, ...(layout === 'vertical' ? { layout: 'vertical' } : {}) },
   });
   revalidatePath('/admin');
   revalidatePath('/admin/forms');

--- a/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/analytics-filter.tsx
@@ -22,8 +22,11 @@ type Preset = 'all' | 'today' | 'week' | 'month' | 'year' | 'custom';
 export function AnalyticsFilter({
   labels,
   locale,
+  todayIso,
 }: {
   locale: string;
+  /** Today in the WORKSPACE's zone (the server resolves ranges in it). Defaults to UTC. */
+  todayIso?: string;
   labels: {
     today: string;
     week: string;
@@ -58,9 +61,10 @@ export function AnalyticsFilter({
     push(next);
   };
 
-  // Today in UTC — the same reference the server resolves ranges against, so the
-  // picker cannot offer a "future" that is only future in the viewer's timezone.
-  const todayUtc = todayUtcIso();
+  // Today in the workspace zone, the same reference the server resolves ranges
+  // against, so the picker cannot offer a "future" that is only future in the
+  // viewer's own timezone.
+  const todayUtc = todayIso ?? todayUtcIso();
 
   const applyCustom = () => {
     if (!from && !to) return;

--- a/apps/web/app/admin/forms/[id]/analytics/page.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import type { AnalyticsResponse } from '@quill/types';
-import { getMessages, type FormsMessages } from '@quill/shared';
+import { dayBoundsInZone, getMessages, isoDateInZone, t, type FormsMessages } from '@quill/shared';
 import { adminApi, ApiError } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { FormTabs } from '@/components/ui/form-tabs';
@@ -15,40 +15,38 @@ const DAY_MS = 86_400_000;
 
 type SP = { preset?: string; from?: string; to?: string };
 
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
  * Resolve the URL query into an epoch-ms range the API understands.
  *
- * Day boundaries are UTC and resolved HERE, on the server, deliberately: an
- * analytics number has to be the same for every teammate reading it, so it
- * cannot depend on the viewer's local clock. (A per-account timezone is the
- * follow-up; until then UTC is the one shared reference.) "Last week/month/year"
- * are rolling 7/30/365-day windows, matching how the presets read in Typeform.
+ * Day boundaries are resolved HERE, on the server, in the WORKSPACE's zone:
+ * an analytics number has to be the same for every teammate reading it, so
+ * it depends on the one zone the team shares, never on the viewer's clock.
+ * "Last week/month/year" are rolling 7/30/365-day windows, matching how the
+ * presets read in Typeform.
  */
-function resolveRange(sp: SP): { from?: number; to?: number } {
+function resolveRange(sp: SP, zone: string): { from?: number; to?: number } {
   if (sp.preset === 'custom') {
-    const from = sp.from ? Date.parse(`${sp.from}T00:00:00.000Z`) : NaN;
-    const to = sp.to ? Date.parse(`${sp.to}T23:59:59.999Z`) : NaN;
     return {
-      from: Number.isNaN(from) ? undefined : from,
-      to: Number.isNaN(to) ? undefined : to,
+      from: sp.from && ISO_DATE.test(sp.from) ? dayBoundsInZone(sp.from, zone).from : undefined,
+      to: sp.to && ISO_DATE.test(sp.to) ? dayBoundsInZone(sp.to, zone).to : undefined,
     };
   }
   const now = Date.now();
-  if (sp.preset === 'today') {
-    const startOfDay = Math.floor(now / DAY_MS) * DAY_MS;
-    return { from: startOfDay, to: startOfDay + DAY_MS - 1 };
-  }
+  const today = dayBoundsInZone(isoDateInZone(now, zone), zone);
+  if (sp.preset === 'today') return { from: today.from, to: today.to };
   const days = sp.preset === 'week' ? 7 : sp.preset === 'month' ? 30 : sp.preset === 'year' ? 365 : null;
   // Send BOTH bounds for a rolling window. With only `from`, the trend series
   // ended at the last day that happened to have data, so a quiet stretch made
   // the chart stop short of today and silently misrepresent the window.
   //
-  // `from` snaps to a whole UTC day so the window is N COMPLETE days ending
+  // `from` snaps to a whole local day so the window is N COMPLETE days ending
   // today. Cutting at `now - N days` (an intra-day instant) left the oldest
   // bucket holding only part of its day while the chart drew it as a full one.
   if (days) {
-    const startOfToday = Math.floor(now / DAY_MS) * DAY_MS;
-    return { from: startOfToday - (days - 1) * DAY_MS, to: now };
+    const firstDay = isoDateInZone(today.from - (days - 1) * DAY_MS + DAY_MS / 2, zone);
+    return { from: dayBoundsInZone(firstDay, zone).from, to: now };
   }
   return {};
 }
@@ -64,8 +62,10 @@ export default async function AnalyticsPage({
   const sp = await searchParams;
   const locale = await getLocale();
   const m = getMessages(locale).admin;
-  const range = resolveRange(sp);
-  const rangeKey = `${sp.preset ?? 'all'}:${sp.from ?? ''}:${sp.to ?? ''}`;
+  // The workspace zone names the days: the range cuts, the buckets, the picker's "today".
+  const zone = (await adminApi.me()).timezone ?? 'UTC';
+  const range = resolveRange(sp, zone);
+  const rangeKey = `${sp.preset ?? 'all'}:${sp.from ?? ''}:${sp.to ?? ''}:${zone}`;
 
   return (
     <div className="mx-auto max-w-[1100px] px-6 py-8">
@@ -77,6 +77,7 @@ export default async function AnalyticsPage({
         </div>
         <AnalyticsFilter
           locale={locale}
+          todayIso={isoDateInZone(Date.now(), zone)}
           labels={{
             today: m.analytics.rangeToday,
             week: m.analytics.rangeWeek,
@@ -92,7 +93,7 @@ export default async function AnalyticsPage({
       </div>
 
       <Suspense key={rangeKey} fallback={<AnalyticsSkeleton />}>
-        <AnalyticsData id={id} range={range} m={m.analytics} locale={locale} />
+        <AnalyticsData id={id} range={range} zone={zone} m={m.analytics} locale={locale} />
       </Suspense>
     </div>
   );
@@ -120,17 +121,19 @@ function formatDuration(seconds: number, unit: string): string {
 async function AnalyticsData({
   id,
   range,
+  zone,
   m,
   locale,
 }: {
   id: string;
   range: { from?: number; to?: number };
+  zone: string;
   m: FormsMessages['admin']['analytics'];
   locale: string;
 }) {
   let a: AnalyticsResponse;
   try {
-    a = await adminApi.getAnalytics(id, range);
+    a = await adminApi.getAnalytics(id, { ...range, tz: zone });
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) notFound();
     throw e;
@@ -214,6 +217,10 @@ async function AnalyticsData({
           },
         }}
       />
+      {/* Which zone the days above are cut in; the API echoes the one it used. */}
+      <p className="mt-2 text-xs text-muted-foreground" data-testid="analytics-timezone-note">
+        {t(m.timezoneNote, { zone: a.range.timeZone ?? 'UTC' })}
+      </p>
 
       <section>
         <h2 className="text-lg font-semibold">{m.dropoffTitle}</h2>

--- a/apps/web/app/admin/forms/[id]/analytics/trends-chart.tsx
+++ b/apps/web/app/admin/forms/[id]/analytics/trends-chart.tsx
@@ -113,8 +113,9 @@ export function TrendsChart({
   const [metric, setMetric] = useState<MetricKey>('submissions');
   const [plotRef, W] = useMeasuredWidth<HTMLDivElement>();
 
-  // Buckets are whole UTC days, so render their labels in UTC too — otherwise a
-  // point would be titled with the day before/after the data it holds.
+  // Each point's `t` is UTC midnight of the CALENDAR DAY it names (in the
+  // workspace's zone, resolved server-side), so its label is read in UTC:
+  // any other zone could title a point with the day before/after its data.
   const fmtDate = useMemo(
     () => new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric', timeZone: 'UTC' }),
     [locale],

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -14,6 +14,7 @@ import {
   uniqueKey,
 } from '@quill/engine';
 import { onAccent, DEFAULT_ACCENT, getMessages } from '@quill/shared';
+import { resolveFormLabels } from '@quill/shared';
 import { clientLocale } from '@/lib/client-locale';
 import { cn } from '@/lib/cn';
 import { iconForStep, hasOptions } from './question-types';
@@ -165,6 +166,9 @@ export function CanvasQuestion({
         : { background: accent, color: accentText };
   const progress = total > 0 ? Math.round(((index + 1) / total) * 100) : 0;
   const isLast = index + 1 >= total;
+  // The same resolver the public form and the preview use: the author's
+  // overrides, else the stock copy of the FORM's language (not the editor's).
+  const formLabels = resolveFormLabels(config, config.language ?? (clientLocale() === 'es' ? 'es' : 'en'));
 
   // A reveal is not a question — it asks nothing, has no title, no description
   // and no Next button, and the respondent sees a spinner over the configured
@@ -234,7 +238,7 @@ export function CanvasQuestion({
               )}
               style={btnStyle}
             >
-              {step.buttonText || (isLast ? m.canvas.submit : m.canvas.next)}
+              {step.buttonText || (isLast ? formLabels.submit : formLabels.next)}
               <i aria-hidden className="pi pi-arrow-right" style={{ fontSize: 12 }} />
             </button>
           </div>

--- a/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/connect-emails-section.tsx
@@ -10,7 +10,7 @@ import {
   type NotificationEmailValue,
 } from '@/components/notification-email-fields';
 import type { DeliveryKind, FormNotificationView, NotificationEmailKey } from '@/lib/admin-api';
-import { interpolate, NOTIFICATION_SAMPLE as SAMPLE } from '@/lib/notification-preview';
+import { hasToken, interpolate, NOTIFICATION_SAMPLE as SAMPLE } from '@/lib/notification-preview';
 import { DeliveryHistory } from '../../integrations/delivery-history';
 import {
   loadFormNotificationsAction,
@@ -132,6 +132,11 @@ export function ConnectEmailsSection({
   );
 }
 
+/** `{{formLink}}` is produced for the owner notice only; do not offer a dead chip on the receipt. */
+function visibleTokens(key: NotificationEmailKey, tokens: string[]): string[] {
+  return key === 'submission_confirmed' ? tokens.filter((t) => t !== 'formLink') : tokens;
+}
+
 /** One email's per-form card: inherit state or the expanded override editor. */
 function FormEmailCard({
   formId,
@@ -186,7 +191,11 @@ function FormEmailCard({
     score: nm.tokenScore,
     outcomeLabel: nm.tokenOutcomeLabel,
     formLink: nm.tokenFormLink,
+    answers: nm.tokenAnswers,
   };
+  // The owner notice exists to carry the answers; a body without the token
+  // silently sends an email with nothing useful in it, so say so permanently.
+  const answersMissing = key === 'submission_received' && !hasToken(value.body, 'answers');
 
   function openEditor() {
     setValue({
@@ -292,7 +301,7 @@ function FormEmailCard({
           <NotificationEmailFields
             value={value}
             onChange={setValue}
-            tokens={setting.tokens}
+            tokens={visibleTokens(key, setting.tokens)}
             labels={{
               enabledLabel: nm.enabledLabel,
               enabledHint: nm.enabledHint,
@@ -305,6 +314,7 @@ function FormEmailCard({
               tokenLabels,
             }}
             testIdPrefix={`connect-email-${key}`}
+            notice={answersMissing ? nm.answersMissing : null}
           />
           <div className="mt-4 flex items-center justify-end gap-2">
             <Button

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { FormBranding, FormConfig, FormCover, FormLayout } from '@quill/engine';
+import type { FormBranding, FormConfig, FormCover, FormLabels, FormLanguage, FormLayout } from '@quill/engine';
+import { getMessages } from '@quill/shared';
 import {
   DEFAULT_FORM_FONT,
   FORM_BACKGROUND_STYLES,
@@ -24,7 +25,7 @@ import {
   t,
 } from '@quill/shared';
 import { Switch } from '@/components/ui/switch';
-import { Field, InlineField, NumberField, PanelSection, SegmentedToggle, TextField } from './fields';
+import { Field, InlineField, NumberField, PanelSection, SegmentedToggle, SelectField, TextField } from './fields';
 import { ColorPicker } from './color-picker';
 import { FontPicker } from './font-picker';
 import { ThemePresets } from './theme-presets';
@@ -53,6 +54,8 @@ export function DesignPanel({
   locale,
   layout,
   onTitleChange,
+  onLanguageChange,
+  onLabelsChange,
   onLayoutChange,
   hasReveal,
   onEndRevealChange,
@@ -70,6 +73,10 @@ export function DesignPanel({
   layout: FormLayout;
   /** Set/clear the PUBLIC title (empty = fall back to the dashboard name). */
   onTitleChange: (title: string) => void;
+  /** The form's language; null = Auto (the visitor's browser). */
+  onLanguageChange: (language: FormLanguage | null) => void;
+  /** Patch the form-level button copy (null clears a field back to stock). */
+  onLabelsChange: (patch: Partial<FormLabels>) => void;
   onLayoutChange: (next: FormLayout) => void;
   /** Vertical's single end-of-form reveal (a form-level fact, not a question). */
   hasReveal: boolean;
@@ -90,6 +97,11 @@ export function DesignPanel({
   const vertical = layout === 'vertical';
 
   const d = m.design;
+  // The stock button copy of the language the form will render in, shown as
+  // placeholders so an author sees exactly what an empty field falls back to.
+  const stockLabels = getMessages(config.language ?? (locale === 'es' ? 'es' : 'en')).renderer;
+  // One page has no Back/Next: only Submit is offered there.
+  const labelKeys: Array<'back' | 'next' | 'submit'> = vertical ? ['submit'] : ['back', 'next', 'submit'];
   const branding = config.branding ?? {};
   const design = resolveDesign(branding);
   const cover = config.cover ?? {};
@@ -115,6 +127,43 @@ export function DesignPanel({
     <div className="grid h-full min-h-0 gap-4 px-4 py-6 sm:px-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,46%)] lg:overflow-hidden">
       {/* ── Controls ───────────────────────────────────────────────────── */}
       <div className="flex min-w-0 flex-col gap-4 lg:overflow-y-auto lg:pr-1">
+        <PanelSection title={d.languageTitle} subtitle={d.languageHint}>
+          <div className="max-w-[520px]">
+            <SelectField
+              aria-label={d.languageTitle}
+              value={config.language ?? ''}
+              onChange={(e) => {
+                const v = e.target.value;
+                onLanguageChange(v === 'en' || v === 'es' ? v : null);
+              }}
+            >
+              <option value="">{d.languageAuto}</option>
+              <option value="en">{d.languageEn}</option>
+              <option value="es">{d.languageEs}</option>
+            </SelectField>
+          </div>
+        </PanelSection>
+
+        <PanelSection title={d.labelsTitle} subtitle={d.labelsHint}>
+          <div className={cn('grid max-w-[520px] gap-3', !vertical && 'sm:grid-cols-3')}>
+            {labelKeys.map((key) => (
+              <Field
+                key={key}
+                htmlFor={`form-label-${key}`}
+                label={key === 'back' ? d.labelBack : key === 'next' ? d.labelNext : d.labelSubmit}
+              >
+                <TextField
+                  id={`form-label-${key}`}
+                  value={config.labels?.[key] ?? ''}
+                  placeholder={stockLabels[key]}
+                  maxLength={80}
+                  onChange={(e) => onLabelsChange({ [key]: e.target.value.trim() ? e.target.value : null })}
+                />
+              </Field>
+            ))}
+          </div>
+        </PanelSection>
+
         <PanelSection title={d.publicTitle} subtitle={d.publicTitleHint}>
           <div className="max-w-[520px]">
             <TextField
@@ -531,6 +580,7 @@ export function DesignPanel({
           config={config}
           name={name}
           locale={locale}
+          formLocale={config.language ?? locale}
           layout={layout}
           m={m.preview}
         />

--- a/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/design-panel.tsx
@@ -157,7 +157,7 @@ export function DesignPanel({
                   value={config.labels?.[key] ?? ''}
                   placeholder={stockLabels[key]}
                   maxLength={80}
-                  onChange={(e) => onLabelsChange({ [key]: e.target.value.trim() ? e.target.value : null })}
+                  onChange={(e) => onLabelsChange({ [key]: e.target.value === '' ? null : e.target.value })}
                 />
               </Field>
             ))}

--- a/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/device-preview-modal.tsx
@@ -87,6 +87,7 @@ export function DevicePreviewModal({
             config={config}
             name={name}
             locale={locale}
+            formLocale={config.language ?? locale}
             layout={layout}
             m={m}
             hideAddressBar

--- a/apps/web/app/admin/forms/[id]/edit/_components/preview-frame.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/preview-frame.tsx
@@ -78,6 +78,7 @@ export function PreviewFrame({
   config,
   name,
   locale,
+  formLocale,
   layout,
   hideAddressBar = false,
   endSlot,
@@ -90,8 +91,14 @@ export function PreviewFrame({
   config: FormConfig;
   /** The form's dashboard name; the public title is resolved here. */
   name: string;
-  /** Drives both the renderer's chrome copy and this frame's own strings. */
+  /** This frame's own strings (the editor's language). */
   locale: string;
+  /**
+   * The language the FORM renders in (its `language`, else the editor's), so
+   * the preview shows what a visitor will see rather than the author's own
+   * dashboard preference. Absent = `locale`.
+   */
+  formLocale?: string;
   layout: FormLayout;
   /**
    * Drop the address bar. The Preview modal already sits above the editor
@@ -151,9 +158,17 @@ export function PreviewFrame({
             : 0
         : screen;
 
+  const rendererLocale = (formLocale ?? locale) === 'es' ? 'es' : 'en';
   const payload = useMemo<Omit<PreviewConfigMessage, 'channel' | 'type'>>(
-    () => ({ revision, config, name: publicTitle(config, name), locale, layout, screen: effectiveScreen }),
-    [revision, config, name, locale, layout, effectiveScreen],
+    () => ({
+      revision,
+      config,
+      name: publicTitle(config, name),
+      locale: rendererLocale,
+      layout,
+      screen: effectiveScreen,
+    }),
+    [revision, config, name, rendererLocale, layout, effectiveScreen],
   );
 
   useEffect(() => {

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -3,15 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import type {
-  FormConfig,
-  FormStep,
-  FormCover,
-  FormBranding,
-  FormOutcome,
-  FormEnding,
-  FormLayout,
-} from '@quill/engine';
+import type { FormBranding, FormConfig, FormCover, FormEnding, FormLabels, FormLanguage, FormLayout, FormOutcome, FormStep } from '@quill/engine';
 import {
   normalizeConfig,
   renameStepKey as engineRenameStepKey,
@@ -502,6 +494,10 @@ export function FormEditor({
 
   // Public title (V7): what the tab/OG/cover show. Empty clears back to `name`.
   const setTitle = (title: string) => mutate((c) => ({ ...c, title: title.trim() ? title : null }));
+  // Form language (null = Auto) and the form-level button copy.
+  const setLanguage = (language: FormLanguage | null) => mutate((c) => ({ ...c, language }));
+  const patchLabels = (patch: Partial<FormLabels>) =>
+    mutate((c) => ({ ...c, labels: { ...c.labels, ...patch } }));
   const patchCover = (patch: Partial<FormCover>) =>
     mutate((c) => ({ ...c, cover: { ...c.cover, ...patch } }));
   const patchBranding = (patch: Partial<FormBranding>) =>
@@ -1063,6 +1059,8 @@ export function FormEditor({
             locale={locale}
             layout={layout}
             onTitleChange={setTitle}
+            onLanguageChange={setLanguage}
+            onLabelsChange={patchLabels}
             onLayoutChange={setLayout}
             hasReveal={hasReveal}
             onEndRevealChange={setEndReveal}

--- a/apps/web/app/admin/forms/[id]/integrations/delivery-history.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/delivery-history.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useId, useState } from 'react';
-import type { FormsMessages, Locale } from '@quill/shared';
+import { formatDateTime, type FormsMessages, type Locale } from '@quill/shared';
+import { useWorkspaceTimeZone } from '@/components/workspace-timezone';
 import { Button } from '@/components/ui/button';
 import { Modal } from '@/components/modal';
 import { cn } from '@/lib/cn';
@@ -263,6 +264,7 @@ function DeliveryRow({
   locale: Locale;
   m: Msgs;
 }) {
+  const timeZone = useWorkspaceTimeZone();
   const [open, setOpen] = useState(false);
   const failed = isFailure(d);
   const isTest = d.action === WEBHOOK_PING_ACTION;
@@ -333,7 +335,7 @@ function DeliveryRow({
           ) : null}
         </div>
         <span className="shrink-0 text-[11px] text-muted-foreground">
-          {new Date(d.updatedAt).toLocaleString(locale)}
+          {formatDateTime(d.updatedAt, { locale, timeZone })}
         </span>
       </button>
 

--- a/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/integrations/integrations-editor.tsx
@@ -18,6 +18,7 @@ import { Switch } from '@/components/ui/switch';
 import { GoogleSheetsLogo, ProviderLogo } from '@/components/ui/provider-logo';
 import { useToast } from '@/components/toast';
 import { callAction, isTransportError } from '@/lib/call-action';
+import { browserTimezones, isKnownTimezone } from '@/lib/timezones';
 import { useAutosave } from '@/lib/use-autosave';
 import { cn } from '@/lib/cn';
 import { bookingLabel } from '@/lib/booking-fields';
@@ -158,40 +159,6 @@ interface BookingSyncState {
   stageValue: string;
   dateProperty: string;
   hoursProperty: string;
-}
-
-/**
- * Whether the browser can resolve this IANA zone name. Advisory only: it warns
- * the author at the moment they mistype, but the value still saves — the SERVER
- * decides, and its ICU data is the one that matters. Blank is always fine (UTC).
- */
-function isKnownTimezone(value: string): boolean {
-  const zone = value.trim();
-  if (!zone) return true;
-  try {
-    new Intl.DateTimeFormat('en-CA', { timeZone: zone });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * The IANA zones this browser can enumerate, for the Day-timezone picker.
- * Computed once — the list is static for the life of the page. A runtime
- * without `Intl.supportedValuesOf` yields null, and the field falls back to
- * the free-text input (the same degradation `PropertyField` uses).
- */
-let cachedTimezones: string[] | null | undefined;
-function browserTimezones(): string[] | null {
-  if (cachedTimezones !== undefined) return cachedTimezones;
-  try {
-    const zones = Intl.supportedValuesOf('timeZone');
-    cachedTimezones = zones.length > 0 ? zones : null;
-  } catch {
-    cachedTimezones = null;
-  }
-  return cachedTimezones;
 }
 
 /**

--- a/apps/web/app/admin/forms/[id]/submissions/page.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.spec.tsx
@@ -26,12 +26,15 @@ import type { SubmissionsPage as SubmissionsPageData } from '@quill/types';
 
 const getForm = vi.fn();
 const listSubmissions = vi.fn();
+const me = vi.fn();
 
 vi.mock('@/lib/admin-api', () => ({
   adminApi: {
     getForm: (...a: unknown[]) => getForm(...a),
     listSubmissions: (...a: unknown[]) => listSubmissions(...a),
+    me: (...a: unknown[]) => me(...a),
   },
+  isAdminRole: (role: string) => role === 'owner' || role === 'admin',
   // Declared in the factory: `vi.mock` is hoisted above every top-level binding,
   // and the page imports this one eagerly.
   ApiError: class ApiError extends Error {
@@ -166,6 +169,7 @@ async function visit(opts: {
 
   getForm.mockResolvedValue({ id: FORM_ID, config: { version: 1, steps: [] } });
   listSubmissions.mockResolvedValue(page);
+  me.mockResolvedValue({ accountId: 'acc-1', role: 'owner', timezone: 'America/Bogota' });
 
   const shell = await SubmissionsRoute({
     params: Promise.resolve({ id: FORM_ID }),
@@ -314,5 +318,14 @@ describe('submissions pagination — offset past the last row', () => {
     expect(text).toContain('No submissions yet');
     // Still the filtered question — the empty state is not a fallback to `all`.
     expect(queries).toEqual([query({ status: 'completed', offset: 25 })]);
+  });
+});
+
+describe('workspace timezone', () => {
+  it('prints every timestamp in the workspace zone, not the server clock', async () => {
+    // completedAt 2024-05-01T10:05Z reads as 5:05 AM in Bogota (UTC-5).
+    const { text } = await visit({ total: 1, offset: 0, items: 1 });
+    expect(text.replace(/\u202f/g, ' ')).toContain('May 1, 2024, 5:05 AM');
+    expect(text).not.toContain('10:05');
   });
 });

--- a/apps/web/app/admin/forms/[id]/submissions/page.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.tsx
@@ -2,8 +2,9 @@ import { Suspense } from 'react';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import type { FormConfig, SubmissionsPage } from '@quill/types';
-import { getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
-import { adminApi, ApiError } from '@/lib/admin-api';
+import { formatDateTime, getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
+import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
+import { WorkspaceTimezoneField } from '@/app/admin/_components/workspace-timezone-field';
 import { getLocale } from '@/lib/locale';
 import { FormTabs } from '@/components/ui/form-tabs';
 import { Skeleton } from '@/components/skeleton';
@@ -34,6 +35,9 @@ export default async function SubmissionsPage({
   const status = parseStatus(sp.status);
   const offset = Math.max(0, Number(sp.offset ?? 0) || 0);
   const key = `${status}:${offset}`;
+  // The workspace zone every timestamp below is read in, and who may change it.
+  const me = await adminApi.me();
+  const timeZone = me.timezone ?? 'UTC';
 
   const exportQuery = status === 'all' ? '' : `?status=${status}`;
 
@@ -54,17 +58,37 @@ export default async function SubmissionsPage({
             {m.submissions.export}
           </a>
         </div>
-        <SubmissionsFilter
-          labels={{
-            all: m.submissions.statusAll,
-            completed: m.submissions.statusCompleted,
-            partial: m.submissions.statusPartial,
-          }}
-        />
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <SubmissionsFilter
+            labels={{
+              all: m.submissions.statusAll,
+              completed: m.submissions.statusCompleted,
+              partial: m.submissions.statusPartial,
+            }}
+          />
+          {/* The SHARED workspace zone, right where the timestamps are: an
+              admin can fix it here, a member sees which zone applies. */}
+          <WorkspaceTimezoneField
+            accountId={me.accountId}
+            value={me.timezone}
+            canEdit={isAdminRole(me.role)}
+            variant="inline"
+            locale={locale}
+            labels={{
+              label: m.submissions.timezoneLabel,
+              help: m.submissions.timezoneHint,
+              saved: m.settings.workspaceTimezoneSaved,
+              error: m.settings.workspaceTimezoneError,
+              unset: m.settings.workspaceTimezoneUnset,
+              utc: m.settings.workspaceTimezoneUtc,
+              readOnly: m.submissions.timezoneReadOnly,
+            }}
+          />
+        </div>
       </div>
 
       <Suspense key={key} fallback={<Skeleton className="h-80 w-full" />}>
-        <SubmissionsData id={id} status={status} offset={offset} locale={locale} m={m} />
+        <SubmissionsData id={id} status={status} offset={offset} locale={locale} timeZone={timeZone} m={m} />
       </Suspense>
     </div>
   );
@@ -83,12 +107,14 @@ async function SubmissionsData({
   status,
   offset,
   locale,
+  timeZone,
   m,
 }: {
   id: string;
   status: 'all' | 'completed' | 'partial';
   offset: number;
   locale: Locale;
+  timeZone: string;
   m: FormsMessages['admin'];
 }) {
   let form: Awaited<ReturnType<typeof adminApi.getForm>>;
@@ -163,7 +189,7 @@ async function SubmissionsData({
               return (
                 <tr key={row.id} className="border-b border-border last:border-b-0 align-top">
                   <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
-                    {new Date(when).toLocaleString(locale)}
+                    {formatDateTime(when, { locale, timeZone })}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3">
                     <span

--- a/apps/web/app/admin/forms/create-form.tsx
+++ b/apps/web/app/admin/forms/create-form.tsx
@@ -5,7 +5,9 @@ import { useFormStatus } from 'react-dom';
 import { Modal } from '@/components/modal';
 import { cn } from '@/lib/cn';
 import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
 import { createFormAction } from '@/app/admin/actions';
+import type { Folder } from '@/lib/admin-api';
 
 interface Labels {
   create: string;
@@ -21,6 +23,9 @@ interface Labels {
   layoutSlidesDesc: string;
   layoutVertical: string;
   layoutVerticalDesc: string;
+  /** Folder picker (only when the surface has folders). */
+  folderLabel?: string;
+  folderNone?: string;
 }
 
 function SubmitButton({ label }: { label: string }) {
@@ -45,17 +50,32 @@ function SubmitButton({ label }: { label: string }) {
 export function CreateForm({
   labels,
   variant = 'button',
+  size,
+  triggerLabel,
   cardTitle,
   cardDesc,
+  folders = [],
+  defaultFolderId = null,
+  locale = 'en',
 }: {
   labels: Labels;
   variant?: 'button' | 'outline' | 'card';
+  /** Button size override (a folder header uses `sm`). */
+  size?: 'sm' | 'default';
+  /** Trigger text override (the header says "New form", the dialog keeps its title). */
+  triggerLabel?: string;
   cardTitle?: string;
   cardDesc?: string;
+  /** The workspace's folders; with any, the dialog offers a folder picker. */
+  folders?: Folder[];
+  /** Preselected folder (a section's own "New form"). */
+  defaultFolderId?: string | null;
+  locale?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [nameError, setNameError] = useState(false);
   const [layout, setLayout] = useState<'slides' | 'vertical'>('slides');
+  const [folderId, setFolderId] = useState<string>(defaultFolderId ?? '');
 
   // Every open starts clean and every dismissal clears the error, so a Cancel
   // (or ESC, or overlay click) can't leave a stale "name required" on the next,
@@ -63,6 +83,7 @@ export function CreateForm({
   const openDialog = () => {
     setNameError(false);
     setLayout('slides');
+    setFolderId(defaultFolderId ?? '');
     setOpen(true);
   };
   const closeDialog = () => {
@@ -84,8 +105,8 @@ export function CreateForm({
         {cardDesc ? <span className="text-sm text-muted-foreground">{cardDesc}</span> : null}
       </button>
     ) : (
-      <Button variant={variant === 'outline' ? 'outline' : 'default'} onClick={openDialog}>
-        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {labels.create}
+      <Button variant={variant === 'outline' ? 'outline' : 'default'} size={size} onClick={openDialog}>
+        <i aria-hidden className="pi pi-plus" style={{ fontSize: 12 }} /> {triggerLabel ?? labels.create}
       </Button>
     );
 
@@ -135,6 +156,22 @@ export function CreateForm({
               </span>
             ) : null}
           </label>
+          {folders.length > 0 && labels.folderLabel ? (
+            <label className="flex flex-col gap-1.5 text-sm">
+              <span className="font-medium">{labels.folderLabel}</span>
+              <input type="hidden" name="folderId" value={folderId} />
+              <Select
+                ariaLabel={labels.folderLabel}
+                value={folderId}
+                locale={locale}
+                options={[
+                  { value: '', label: labels.folderNone ?? '' },
+                  ...folders.map((f) => ({ value: f.id, label: f.name })),
+                ]}
+                onChange={setFolderId}
+              />
+            </label>
+          ) : null}
 
           {/* Layout picker: two visual cards. Rides the form as a hidden input
               so the server action reads one flat FormData — no client fetch. */}

--- a/apps/web/app/admin/forms/folder-actions.ts
+++ b/apps/web/app/admin/forms/folder-actions.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { unstable_rethrow } from "next/navigation";
+import { adminApi, ApiError, type Folder } from "@/lib/admin-api";
+
+/** Every surface that lists forms by folder. */
+function revalidateForms(): void {
+  revalidatePath("/admin/forms");
+  revalidatePath("/admin");
+}
+
+export type FolderWriteState =
+  | { ok: true; folder: Folder }
+  | { ok: false; code: "NAME_TAKEN" | "INVALID" | "FAILED" };
+
+function failure(e: unknown): FolderWriteState {
+  unstable_rethrow(e);
+  if (e instanceof ApiError && e.status === 409)
+    return { ok: false, code: "NAME_TAKEN" };
+  if (e instanceof ApiError && e.status === 400)
+    return { ok: false, code: "INVALID" };
+  return { ok: false, code: "FAILED" };
+}
+
+export async function createFolderAction(
+  name: string,
+): Promise<FolderWriteState> {
+  try {
+    const folder = await adminApi.createFolder(name.trim());
+    revalidateForms();
+    return { ok: true, folder };
+  } catch (e) {
+    return failure(e);
+  }
+}
+
+export async function renameFolderAction(
+  id: string,
+  name: string,
+): Promise<FolderWriteState> {
+  try {
+    const folder = await adminApi.renameFolder(id, name.trim());
+    revalidateForms();
+    return { ok: true, folder };
+  } catch (e) {
+    return failure(e);
+  }
+}
+
+/** Delete a folder: its forms are unfiled, never deleted. */
+export async function deleteFolderAction(id: string): Promise<{ ok: boolean }> {
+  try {
+    await adminApi.deleteFolder(id);
+    revalidateForms();
+    return { ok: true };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}
+
+/** File a form in a folder (null unfiles). */
+export async function moveFormAction(
+  formId: string,
+  folderId: string | null,
+): Promise<{ ok: boolean }> {
+  try {
+    await adminApi.setFormFolder(formId, folderId);
+    revalidateForms();
+    return { ok: true };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}

--- a/apps/web/app/admin/forms/folder-dialog.tsx
+++ b/apps/web/app/admin/forms/folder-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useId, useState, useTransition } from "react";
+import { Modal } from "@/components/modal";
+import { Button } from "@/components/ui/button";
+import { callAction } from "@/lib/call-action";
+import {
+  createFolderAction,
+  renameFolderAction,
+  type FolderWriteState,
+} from "./folder-actions";
+
+export interface FolderDialogLabels {
+  newFolderTitle: string;
+  renameFolderTitle: string;
+  folderCreate: string;
+  folderSave: string;
+  folderNameLabel: string;
+  folderNamePlaceholder: string;
+  folderNameRequired: string;
+  folderNameTaken: string;
+  actionFailed: string;
+  cancel: string;
+}
+
+/**
+ * Create or rename a folder. One dialog for both: the only differences are the
+ * title, the submit label and which action runs. A duplicate name comes back
+ * as an inline error on the field (409 NAME_TAKEN), never as a toast the
+ * person has to hunt for while the dialog is still open.
+ */
+export function FolderDialog({
+  open,
+  onClose,
+  onDone,
+  mode,
+  initialName = "",
+  folderId,
+  labels,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onDone?: (state: Extract<FolderWriteState, { ok: true }>) => void;
+  mode: "create" | "rename";
+  initialName?: string;
+  /** Required for `rename`. */
+  folderId?: string;
+  labels: FolderDialogLabels;
+}) {
+  const [pending, start] = useTransition();
+  const [error, setError] = useState<"required" | "taken" | "failed" | null>(
+    null,
+  );
+  const [name, setName] = useState(initialName);
+  const errorId = useId();
+  const labelId = useId();
+
+  const close = () => {
+    setError(null);
+    onClose();
+  };
+
+  const submit = () => {
+    const value = name.trim();
+    if (!value) {
+      setError("required");
+      return;
+    }
+    start(async () => {
+      const res = await callAction(() =>
+        mode === "create"
+          ? createFolderAction(value)
+          : renameFolderAction(folderId ?? "", value),
+      );
+      if (res && "ok" in res && res.ok) {
+        setError(null);
+        onDone?.(res);
+        onClose();
+        return;
+      }
+      setError(
+        res && "code" in res && res.code === "NAME_TAKEN" ? "taken" : "failed",
+      );
+    });
+  };
+
+  const message =
+    error === "required"
+      ? labels.folderNameRequired
+      : error === "taken"
+        ? labels.folderNameTaken
+        : error === "failed"
+          ? labels.actionFailed
+          : null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={close}
+      title={
+        mode === "create" ? labels.newFolderTitle : labels.renameFolderTitle
+      }
+      labelId={labelId}
+    >
+      <form
+        data-testid="folder-dialog"
+        noValidate
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+        className="flex flex-col gap-4"
+      >
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium">{labels.folderNameLabel}</span>
+          <input
+            name="name"
+            value={name}
+            autoFocus
+            autoComplete="off"
+            maxLength={80}
+            placeholder={labels.folderNamePlaceholder}
+            aria-invalid={message ? true : undefined}
+            aria-describedby={message ? errorId : undefined}
+            data-testid="folder-name-input"
+            onChange={(e) => {
+              setName(e.target.value);
+              setError(null);
+            }}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          {message ? (
+            <span
+              id={errorId}
+              role="alert"
+              className="text-xs text-destructive"
+              data-testid="folder-name-error"
+            >
+              {message}
+            </span>
+          ) : null}
+        </label>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={close}
+            disabled={pending}
+          >
+            {labels.cancel}
+          </Button>
+          <Button
+            type="submit"
+            disabled={pending}
+            data-testid="folder-dialog-submit"
+            className="min-w-[120px]"
+          >
+            {mode === "create" ? labels.folderCreate : labels.folderSave}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/app/admin/forms/form-row-actions.tsx
+++ b/apps/web/app/admin/forms/form-row-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { getMessages } from '@quill/shared';
 import { duplicateFormAction, deleteFormAction } from '@/app/admin/actions';
 import { clientLocale } from '@/lib/client-locale';
@@ -63,6 +63,21 @@ export function FormRowActions({
     if (open) menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
   }, [open]);
 
+  // Arrows walk every item (Duplicate, the folder radios, Delete) so "Move to
+  // folder" is reachable from the keyboard, which is the whole point of it.
+  function onMenuKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"], [role="menuitemradio"]') ?? [],
+    );
+    if (items.length === 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const at = items.indexOf(document.activeElement as HTMLElement);
+    if (e.key === 'ArrowDown') items[at < 0 || at === items.length - 1 ? 0 : at + 1]?.focus();
+    else items[at <= 0 ? items.length - 1 : at - 1]?.focus();
+  }
+
   const itemClass =
     'flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:outline-none';
 
@@ -86,6 +101,7 @@ export function FormRowActions({
           ref={menuRef}
           role="menu"
           aria-label={labels.menu}
+          onKeyDown={onMenuKeyDown}
           className="absolute right-0 z-50 mt-2 w-52 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
         >
           <button
@@ -114,13 +130,12 @@ export function FormRowActions({
                     role="menuitemradio"
                     aria-checked={checked}
                     tabIndex={-1}
-                    disabled={pending || checked}
                     data-testid={`form-row-move-${folder.id ?? 'none'}`}
                     onClick={() => {
                       setOpen(false);
-                      onMove(folder.id);
+                      if (!checked) onMove(folder.id);
                     }}
-                    className={`${itemClass} disabled:opacity-60`}
+                    className={itemClass}
                   >
                     <i
                       aria-hidden

--- a/apps/web/app/admin/forms/form-row-actions.tsx
+++ b/apps/web/app/admin/forms/form-row-actions.tsx
@@ -6,6 +6,17 @@ import { duplicateFormAction, deleteFormAction } from '@/app/admin/actions';
 import { clientLocale } from '@/lib/client-locale';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import { callAction } from '@/lib/call-action';
+import type { Folder } from '@/lib/admin-api';
+
+export interface FormRowActionLabels {
+  menu: string;
+  duplicate: string;
+  delete: string;
+  deleteConfirm: string;
+  /** "Move to folder" group + the unfile choice; absent = no folders on this surface. */
+  moveTo?: string;
+  moveBack?: string;
+}
 
 /**
  * Overflow menu for a form row (WAI-ARIA menu-button). The cross-links
@@ -17,14 +28,16 @@ import { callAction } from '@/lib/call-action';
 export function FormRowActions({
   id,
   labels,
+  folders = [],
+  currentFolderId = null,
+  onMove,
 }: {
   id: string;
-  labels: {
-    menu: string;
-    duplicate: string;
-    delete: string;
-    deleteConfirm: string;
-  };
+  labels: FormRowActionLabels;
+  /** The workspace's folders, for the "Move to folder" radio group (keyboard fallback to drag). */
+  folders?: Folder[];
+  currentFolderId?: string | null;
+  onMove?: (folderId: string | null) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [pending, start] = useTransition();
@@ -89,6 +102,37 @@ export function FormRowActions({
             <i aria-hidden className="pi pi-copy text-muted-foreground" style={{ fontSize: 13 }} />
             {labels.duplicate}
           </button>
+          {onMove && labels.moveTo && folders.length > 0 ? (
+            <div role="group" aria-label={labels.moveTo} className="my-1 border-y border-border py-1">
+              <p className="px-2 pb-1 pt-0.5 text-2xs font-medium uppercase tracking-wide text-faint">{labels.moveTo}</p>
+              {[{ id: null as string | null, name: labels.moveBack ?? '' }, ...folders].map((folder) => {
+                const checked = (folder.id ?? null) === (currentFolderId ?? null);
+                return (
+                  <button
+                    key={folder.id ?? 'none'}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={checked}
+                    tabIndex={-1}
+                    disabled={pending || checked}
+                    data-testid={`form-row-move-${folder.id ?? 'none'}`}
+                    onClick={() => {
+                      setOpen(false);
+                      onMove(folder.id);
+                    }}
+                    className={`${itemClass} disabled:opacity-60`}
+                  >
+                    <i
+                      aria-hidden
+                      className={`pi ${checked ? 'pi-check' : 'pi-folder'} text-muted-foreground`}
+                      style={{ fontSize: 13 }}
+                    />
+                    <span className="truncate">{folder.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
           <button
             type="button"
             role="menuitem"

--- a/apps/web/app/admin/forms/form-row.tsx
+++ b/apps/web/app/admin/forms/form-row.tsx
@@ -20,7 +20,6 @@ const iconBtn =
   "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 export interface FormRowLabels {
-  updated: string;
   edit: string;
   submissions: string;
   analytics: string;

--- a/apps/web/app/admin/forms/form-row.tsx
+++ b/apps/web/app/admin/forms/form-row.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import Link from "next/link";
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@/lib/cn";
+import { CopyLinkIcon } from "@/components/copy-link";
+import type { Folder, FormSummary } from "@/lib/admin-api";
+import type { MatchRange } from "@/lib/forms-search";
+import { FormRowActions, type FormRowActionLabels } from "./form-row-actions";
+
+/** First-class row actions (user feedback: nothing hidden behind the kebab).
+ *  Secondary buttons collapse to icon-only below `md`; the aria-label/title
+ *  keep them nameable; the kebab holds Duplicate/Move/Delete. Tokens only. */
+const primaryBtn =
+  "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const secondaryBtn =
+  "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const iconBtn =
+  "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export interface FormRowLabels {
+  updated: string;
+  edit: string;
+  submissions: string;
+  analytics: string;
+  connect: string;
+  copy: string;
+  copied: string;
+  openForm: string;
+  dragHandle: string;
+}
+
+/** The name with the matched ranges wrapped in `<mark>`. */
+export function Highlight({
+  text,
+  ranges,
+}: {
+  text: string;
+  ranges: MatchRange[];
+}) {
+  if (ranges.length === 0) return <>{text}</>;
+  const parts: React.ReactNode[] = [];
+  let at = 0;
+  ranges.forEach(([start, end], i) => {
+    if (start > at) parts.push(text.slice(at, start));
+    parts.push(
+      <mark key={i} className="rounded-sm bg-primary/25 px-0.5 text-inherit">
+        {text.slice(start, end)}
+      </mark>,
+    );
+    at = end;
+  });
+  if (at < text.length) parts.push(text.slice(at));
+  return <>{parts}</>;
+}
+
+/**
+ * One form in the list. The markup (and every `data-testid`) is exactly what
+ * the flat list rendered before folders existed, so the e2e that pins the row
+ * still finds it; folders add a drag grip (listeners on the grip ONLY, so the
+ * links and buttons keep working as links and buttons) and a "Move to folder"
+ * entry in the kebab.
+ */
+export function FormRow({
+  form,
+  publicPath,
+  updatedLabel,
+  nameRanges,
+  folders,
+  labels,
+  actionLabels,
+  onMove,
+  draggable = true,
+}: {
+  form: FormSummary;
+  publicPath: string;
+  /** The already-formatted "Updated {when}" line. */
+  updatedLabel: string;
+  nameRanges: MatchRange[];
+  folders: Folder[];
+  labels: FormRowLabels;
+  actionLabels: FormRowActionLabels;
+  onMove: (formId: string, folderId: string | null) => void;
+  draggable?: boolean;
+}) {
+  const editHref = `/admin/forms/${form.id}/edit`;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: form.id,
+    data: { type: "form", name: form.name },
+    disabled: !draggable,
+  });
+  return (
+    <li
+      ref={setNodeRef}
+      data-testid="form-row"
+      data-form-id={form.id}
+      style={{
+        transform: transform
+          ? CSS.Translate.toString({ ...transform, x: 0, y: 0 })
+          : undefined,
+      }}
+      className={cn(
+        "flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card px-5 py-4 transition-colors hover:border-primary-edge/60",
+        isDragging && "opacity-40",
+      )}
+    >
+      {draggable ? (
+        <button
+          ref={setActivatorNodeRef}
+          type="button"
+          data-testid="form-row-grip"
+          aria-label={labels.dragHandle}
+          title={labels.dragHandle}
+          className="flex h-9 w-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-faint transition-colors hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          {...attributes}
+          {...listeners}
+        >
+          <i aria-hidden className="pi pi-bars" style={{ fontSize: 14 }} />
+        </button>
+      ) : null}
+      <div className="min-w-0 flex-1 basis-60">
+        <Link
+          href={editHref}
+          data-form-link
+          className="block w-fit max-w-full truncate text-base font-semibold tracking-tight transition-colors hover:text-primary"
+        >
+          <Highlight text={form.name} ranges={nameRanges} />
+        </Link>
+        {/* The row's two facts are not equally interesting. The public path is
+            what someone came here to copy, so it keeps the body tier; the
+            timestamp and the separator drop to `text-faint`. */}
+        <p className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
+          <span className="shrink-0 text-faint">{updatedLabel}</span>
+          <span aria-hidden className="shrink-0 text-faint">
+            ·
+          </span>
+          <span
+            className="min-w-0 truncate font-mono text-muted-foreground"
+            title={publicPath}
+          >
+            {publicPath}
+          </span>
+        </p>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+        <Link
+          data-testid="form-row-edit"
+          href={editHref}
+          className={primaryBtn}
+          title={labels.edit}
+        >
+          <i aria-hidden className="pi pi-pencil" style={{ fontSize: 13 }} />
+          {labels.edit}
+        </Link>
+        <Link
+          data-testid="form-row-submissions"
+          href={`/admin/forms/${form.id}/submissions`}
+          className={secondaryBtn}
+          aria-label={labels.submissions}
+          title={labels.submissions}
+        >
+          <i aria-hidden className="pi pi-inbox" style={{ fontSize: 13 }} />
+          <span className="hidden md:inline">{labels.submissions}</span>
+        </Link>
+        <Link
+          data-testid="form-row-analytics"
+          href={`/admin/forms/${form.id}/analytics`}
+          className={secondaryBtn}
+          aria-label={labels.analytics}
+          title={labels.analytics}
+        >
+          <i aria-hidden className="pi pi-chart-bar" style={{ fontSize: 13 }} />
+          <span className="hidden md:inline">{labels.analytics}</span>
+        </Link>
+        <Link
+          data-testid="form-row-connect"
+          href={`${editHref}?tab=connect`}
+          className={secondaryBtn}
+          aria-label={labels.connect}
+          title={labels.connect}
+        >
+          <i aria-hidden className="pi pi-link" style={{ fontSize: 13 }} />
+          <span className="hidden md:inline">{labels.connect}</span>
+        </Link>
+        <CopyLinkIcon
+          path={publicPath}
+          labels={{ copy: labels.copy, copied: labels.copied }}
+          testId="form-row-copy"
+          className={iconBtn}
+        />
+        <a
+          data-testid="form-row-open"
+          href={publicPath}
+          target="_blank"
+          rel="noreferrer"
+          className={iconBtn}
+          aria-label={labels.openForm}
+          title={labels.openForm}
+        >
+          <i
+            aria-hidden
+            className="pi pi-external-link"
+            style={{ fontSize: 14 }}
+          />
+        </a>
+        <FormRowActions
+          id={form.id}
+          labels={actionLabels}
+          folders={folders}
+          currentFolderId={form.folderId}
+          onMove={(folderId) => onMove(form.id, folderId)}
+        />
+      </div>
+    </li>
+  );
+}

--- a/apps/web/app/admin/forms/forms-explorer.spec.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.spec.tsx
@@ -1,0 +1,169 @@
+/**
+ * The explorer's static shape: Unfiled first, folders alphabetically as
+ * collapsible sections with counts, every row testid the flat list had, and
+ * the search box. Rendered through static markup in plain node (dnd-kit and
+ * the dialogs render their inert shells fine without a DOM).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => {}, push: () => {} }),
+}));
+vi.mock("@/components/toast", () => ({
+  useToast: () => ({ success: () => {}, error: () => {}, info: () => {} }),
+}));
+
+import { FormsExplorer, type FormsExplorerProps } from "./forms-explorer";
+
+const labels: FormsExplorerProps["labels"] = {
+  searchPlaceholder: "Search forms",
+  searchLabel: "Search forms by name or link",
+  searchClear: "Clear",
+  searchEmpty: "No forms match",
+  searchResults: "{count} forms match",
+  searchShortcut: "Ctrl K",
+  unfiled: "Unfiled",
+  folderCount: "{count} forms",
+  folderCountOne: "1 form",
+  renameFolder: "Rename",
+  deleteFolder: "Delete folder",
+  deleteFolderConfirm: "Delete {name}? {count}",
+  folderMenu: "Folder actions",
+  collapse: "Collapse",
+  expand: "Expand",
+  createIn: "New form",
+  moveFailed: "Could not move",
+  dropHere: "Drop here",
+  updated: "Updated {when}",
+};
+
+function render(overrides: Partial<FormsExplorerProps> = {}) {
+  const props: FormsExplorerProps = {
+    forms: [
+      {
+        id: "a",
+        name: "Lead Qualifier",
+        slug: "lead-qualifier",
+        brandAppliedAt: null,
+        folderId: "sales",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        id: "b",
+        name: "Survey",
+        slug: "survey",
+        brandAppliedAt: null,
+        folderId: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ],
+    folders: [{ id: "sales", name: "Sales", createdAt: 1, updatedAt: 1 }],
+    accountCode: "acme",
+    handle: "alex",
+    locale: "en",
+    updatedByForm: { a: "Updated today", b: "Updated today" },
+    labels,
+    rowLabels: {
+      updated: "Updated {when}",
+      edit: "Edit",
+      submissions: "Submissions",
+      analytics: "Analytics",
+      connect: "Connect",
+      copy: "Copy link",
+      copied: "Copied",
+      openForm: "Open form",
+      dragHandle: "Drag",
+    },
+    actionLabels: {
+      menu: "Actions",
+      duplicate: "Duplicate",
+      delete: "Delete",
+      deleteConfirm: "Sure?",
+      moveTo: "Move to folder",
+      moveBack: "No folder",
+    },
+    dialogLabels: {
+      newFolderTitle: "Create a folder",
+      renameFolderTitle: "Rename folder",
+      folderCreate: "Create",
+      folderSave: "Save",
+      folderNameLabel: "Folder name",
+      folderNamePlaceholder: "e.g. Sales",
+      folderNameRequired: "Required",
+      folderNameTaken: "Taken",
+      actionFailed: "Failed",
+      cancel: "Cancel",
+    },
+    createLabels: {
+      create: "Create form",
+      createTitle: "Create a new form",
+      nameLabel: "Name",
+      namePlaceholder: "e.g.",
+      nameRequired: "Required",
+      cancel: "Cancel",
+      layoutLabel: "Layout",
+      layoutSlides: "Slides",
+      layoutSlidesDesc: "",
+      layoutVertical: "One page",
+      layoutVerticalDesc: "",
+      folderLabel: "Folder",
+      folderNone: "No folder",
+    },
+    ...overrides,
+  };
+  return renderToStaticMarkup(<FormsExplorer {...props} />);
+}
+
+describe("FormsExplorer", () => {
+  it("renders Unfiled first, then folders, each as a collapsible section with a count", () => {
+    const html = render();
+    const unfiledAt = html.indexOf('data-testid="unfiled-section"');
+    const salesAt = html.indexOf('data-testid="folder-section"');
+    expect(unfiledAt).toBeGreaterThan(-1);
+    expect(salesAt).toBeGreaterThan(unfiledAt);
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain("1 form");
+    expect(html).toContain('data-folder-id="sales"');
+  });
+
+  it("keeps every row testid the flat list had, plus a grip and the search box", () => {
+    const html = render();
+    for (const id of [
+      "form-row",
+      "form-row-edit",
+      "form-row-submissions",
+      "form-row-analytics",
+      "form-row-connect",
+      "form-row-copy",
+      "form-row-open",
+      "form-row-menu",
+      "form-row-grip",
+    ])
+      expect(html).toContain(`data-testid="${id}"`);
+    expect(html).toContain('data-testid="forms-search"');
+    expect(html).toContain('href="/acme/alex/lead-qualifier"');
+  });
+
+  it("without folders it is the flat list: one section, no folder chrome", () => {
+    const html = render({
+      folders: [],
+      forms: [
+        {
+          id: "b",
+          name: "Survey",
+          slug: "survey",
+          brandAppliedAt: null,
+          folderId: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+    expect(html).not.toContain('data-testid="folder-section"');
+    expect(html).not.toContain('data-testid="folder-menu"');
+    expect((html.match(/data-testid="form-row"/g) ?? []).length).toBe(1);
+  });
+});

--- a/apps/web/app/admin/forms/forms-explorer.spec.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.spec.tsx
@@ -35,7 +35,6 @@ const labels: FormsExplorerProps["labels"] = {
   createIn: "New form",
   moveFailed: "Could not move",
   dropHere: "Drop here",
-  updated: "Updated {when}",
 };
 
 function render(overrides: Partial<FormsExplorerProps> = {}) {
@@ -67,7 +66,6 @@ function render(overrides: Partial<FormsExplorerProps> = {}) {
     updatedByForm: { a: "Updated today", b: "Updated today" },
     labels,
     rowLabels: {
-      updated: "Updated {when}",
       edit: "Edit",
       submissions: "Submissions",
       analytics: "Analytics",
@@ -164,6 +162,10 @@ describe("FormsExplorer", () => {
     });
     expect(html).not.toContain('data-testid="folder-section"');
     expect(html).not.toContain('data-testid="folder-menu"');
+
+    expect(html).not.toContain('data-testid="unfiled-section"');
+
+    expect(html).not.toContain('data-testid="form-row-grip"');
     expect((html.match(/data-testid="form-row"/g) ?? []).length).toBe(1);
   });
 });

--- a/apps/web/app/admin/forms/forms-explorer.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.tsx
@@ -69,7 +69,6 @@ export interface FormsExplorerLabels {
   createIn: string;
   moveFailed: string;
   dropHere: string;
-  updated: string;
 }
 
 export interface FormsExplorerProps {
@@ -123,8 +122,15 @@ export function FormsExplorer(props: FormsExplorerProps) {
     }
   }, []);
 
-  // Fresh server data supersedes any optimistic move still recorded here.
-  useEffect(() => setOverrides(new Map()), [forms]);
+  // Fresh server data supersedes an optimistic move once it SHOWS that move;
+  // one still in flight keeps its override, so two moves in a row do not
+  // snap the second back while the first refresh lands.
+  useEffect(() => {
+    setOverrides((prev) => {
+      const next = new Map([...prev].filter(([id, folderId]) => forms.find((f) => f.id === id)?.folderId !== folderId));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [forms]);
 
   const effectiveForms = useMemo(
     () =>
@@ -186,11 +192,15 @@ export function FormsExplorer(props: FormsExplorerProps) {
     }, []),
   );
 
-  // Roving focus over the row titles: arrows walk them, Enter opens (a link).
+  // Roving focus over the VISIBLE row titles: arrows walk them, Enter opens
+  // (a link). Keys inside a dialog, a menu or a listbox belong to that widget.
   function onListKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"], input, textarea, select'))
+      return;
     const items = Array.from(
-      listRef.current?.querySelectorAll<HTMLElement>("[data-form-link]") ?? [],
+      listRef.current?.querySelectorAll<HTMLElement>("ul:not([hidden]) [data-form-link]") ?? [],
     );
     if (items.length === 0) return;
     const active = document.activeElement as HTMLElement | null;
@@ -224,6 +234,12 @@ export function FormsExplorer(props: FormsExplorerProps) {
   };
 
   const searchId = useId();
+  // The chord's glyph follows the platform; read after mount (the server has no platform).
+  const [shortcutLabel, setShortcutLabel] = useState(labels.searchShortcut);
+  useEffect(() => {
+    if (/Mac|iPhone|iPad/.test(navigator.platform)) setShortcutLabel('\u2318 K');
+  }, []);
+  const flat = folders.length === 0;
   return (
     <DndContext
       id={dndId}
@@ -259,7 +275,7 @@ export function FormsExplorer(props: FormsExplorerProps) {
               if (e.key === "ArrowDown") {
                 e.preventDefault();
                 listRef.current
-                  ?.querySelector<HTMLElement>("[data-form-link]")
+                  ?.querySelector<HTMLElement>("ul:not([hidden]) [data-form-link]")
                   ?.focus();
               }
             }}
@@ -268,7 +284,7 @@ export function FormsExplorer(props: FormsExplorerProps) {
           <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 text-2xs text-faint">
             {query ? null : (
               <kbd className="rounded border border-border px-1.5 py-0.5 font-mono">
-                {labels.searchShortcut}
+                {shortcutLabel}
               </kbd>
             )}
           </span>
@@ -311,7 +327,26 @@ export function FormsExplorer(props: FormsExplorerProps) {
             {labels.searchEmpty}
           </p>
         ) : null}
-        {sections.map((section) => (
+        {flat && !searching && sections[0] ? (
+          /* No folders yet: the flat list this page always had, no section chrome, no grip. */
+          <ul role="list" className="flex flex-col gap-3">
+            {sections[0].forms.map((f) => (
+              <FormRow
+                key={f.id}
+                form={f}
+                publicPath={`/${props.accountCode}/${props.handle}/${f.slug}`}
+                updatedLabel={props.updatedByForm[f.id] ?? ''}
+                nameRanges={f.match.nameRanges}
+                folders={folders}
+                labels={props.rowLabels}
+                actionLabels={props.actionLabels}
+                onMove={move}
+                draggable={false}
+              />
+            ))}
+          </ul>
+        ) : null}
+        {(flat && !searching ? [] : sections).map((section) => (
           <FolderSection
             key={section.id ?? UNFILED}
             section={section}
@@ -399,7 +434,7 @@ function FolderSection({
     setMenuOpen(false);
     const ok = await confirmDialog({
       title: getMessages(clientLocale()).dialog.deleteFolderTitle,
-      message: t(labels.deleteFolderConfirm, { name, count: section.total }),
+      message: t(labels.deleteFolderConfirm, { name, forms: count }),
       confirmLabel: labels.deleteFolder,
       destructive: true,
     });

--- a/apps/web/app/admin/forms/forms-explorer.tsx
+++ b/apps/web/app/admin/forms/forms-explorer.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  rectIntersection,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { getMessages, t } from "@quill/shared";
+import { cn } from "@/lib/cn";
+import { callAction } from "@/lib/call-action";
+import { clientLocale } from "@/lib/client-locale";
+import {
+  groupBySections,
+  normalize,
+  type FormSection,
+} from "@/lib/forms-search";
+import { useGlobalShortcut } from "@/lib/use-global-shortcut";
+import type { Folder, FormSummary } from "@/lib/admin-api";
+import { useToast } from "@/components/toast";
+import { useConfirmDialog } from "@/components/ui/confirm-dialog";
+import { CreateForm } from "./create-form";
+import { FolderDialog, type FolderDialogLabels } from "./folder-dialog";
+import { FormRow, type FormRowLabels } from "./form-row";
+import type { FormRowActionLabels } from "./form-row-actions";
+import { deleteFolderAction, moveFormAction } from "./folder-actions";
+
+/** Per-viewer collapse state (never shared: how you fold your list is yours). */
+const COLLAPSED_KEY = "forms.folders.collapsed";
+
+/** dnd-kit droppable ids: the folder id, or this marker for Unfiled. */
+const UNFILED = "__unfiled__";
+
+export interface FormsExplorerLabels {
+  searchPlaceholder: string;
+  searchLabel: string;
+  searchClear: string;
+  searchEmpty: string;
+  searchResults: string;
+  searchShortcut: string;
+  unfiled: string;
+  folderCount: string;
+  folderCountOne: string;
+  renameFolder: string;
+  deleteFolder: string;
+  deleteFolderConfirm: string;
+  folderMenu: string;
+  collapse: string;
+  expand: string;
+  createIn: string;
+  moveFailed: string;
+  dropHere: string;
+  updated: string;
+}
+
+export interface FormsExplorerProps {
+  forms: FormSummary[];
+  folders: Folder[];
+  accountCode: string;
+  handle: string;
+  locale: string;
+  /** Already-formatted "Updated {when}" per form id (formatted on the server, one clock). */
+  updatedByForm: Record<string, string>;
+  labels: FormsExplorerLabels;
+  rowLabels: FormRowLabels;
+  actionLabels: FormRowActionLabels;
+  dialogLabels: FolderDialogLabels;
+  createLabels: React.ComponentProps<typeof CreateForm>["labels"];
+}
+
+/**
+ * The forms list with folders and search. ONE list: every folder is a
+ * collapsible section (Unfiled first), rows drag onto section headers, the
+ * kebab's "Move to folder" is the keyboard-only route to the same move, and
+ * the search box filters the loaded list by name or slug, expanding the
+ * sections with a hit and hiding the rest. Without folders it looks exactly
+ * like the flat list it replaces.
+ */
+export function FormsExplorer(props: FormsExplorerProps) {
+  const { forms, folders, labels } = props;
+  const router = useRouter();
+  const toast = useToast();
+  const [query, setQuery] = useState("");
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const [overrides, setOverrides] = useState<Map<string, string | null>>(
+    () => new Map(),
+  );
+  const [dragging, setDragging] = useState<{ id: string; name: string } | null>(
+    null,
+  );
+  const [, start] = useTransition();
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const dndId = useId();
+
+  // Collapse state is read AFTER mount: the server cannot know this viewer's
+  // localStorage, and reading it during render would hydrate to a mismatch.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(COLLAPSED_KEY);
+      if (raw) setCollapsed(new Set(JSON.parse(raw) as string[]));
+    } catch {
+      // No storage, or a stale value: everything starts expanded.
+    }
+  }, []);
+
+  // Fresh server data supersedes any optimistic move still recorded here.
+  useEffect(() => setOverrides(new Map()), [forms]);
+
+  const effectiveForms = useMemo(
+    () =>
+      forms.map((f) =>
+        overrides.has(f.id)
+          ? { ...f, folderId: overrides.get(f.id) ?? null }
+          : f,
+      ),
+    [forms, overrides],
+  );
+  const sections = useMemo(
+    () => groupBySections(effectiveForms, folders, query),
+    [effectiveForms, folders, query],
+  );
+  const searching = normalize(query).length > 0;
+  const matches = sections.reduce((n, s) => n + s.forms.length, 0);
+
+  const toggle = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      try {
+        localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...next]));
+      } catch {
+        // Best effort only.
+      }
+      return next;
+    });
+  };
+
+  const move = useCallback(
+    (formId: string, folderId: string | null) => {
+      const current =
+        effectiveForms.find((f) => f.id === formId)?.folderId ?? null;
+      if (current === folderId) return;
+      setOverrides((prev) => new Map(prev).set(formId, folderId));
+      start(async () => {
+        const res = await callAction(() => moveFormAction(formId, folderId));
+        if (res && "ok" in res && res.ok) {
+          router.refresh();
+        } else {
+          setOverrides((prev) => {
+            const next = new Map(prev);
+            next.delete(formId);
+            return next;
+          });
+          toast.error(labels.moveFailed);
+        }
+      });
+    },
+    [effectiveForms, router, toast, labels.moveFailed],
+  );
+
+  // Cmd/Ctrl+K and `/` focus the search box from anywhere on the page.
+  useGlobalShortcut(
+    useCallback((shortcut) => {
+      if (shortcut === "search") searchRef.current?.focus();
+    }, []),
+  );
+
+  // Roving focus over the row titles: arrows walk them, Enter opens (a link).
+  function onListKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>("[data-form-link]") ?? [],
+    );
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement | null;
+    const at = active ? items.indexOf(active) : -1;
+    e.preventDefault();
+    if (e.key === "ArrowDown")
+      items[at < 0 || at === items.length - 1 ? 0 : at + 1]?.focus();
+    else if (at <= 0) searchRef.current?.focus();
+    else items[at - 1]?.focus();
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor),
+  );
+  // Prefer the section the pointer is actually inside; a row dragged past every
+  // section edge still snaps to the nearest one rather than nowhere.
+  const collision: CollisionDetection = (args) => {
+    const within = pointerWithin(args);
+    return within.length > 0 ? within : rectIntersection(args);
+  };
+  const onDragStart = (e: DragStartEvent) => {
+    const data = e.active.data.current as { name?: string } | undefined;
+    setDragging({ id: String(e.active.id), name: data?.name ?? "" });
+  };
+  const onDragEnd = (e: DragEndEvent) => {
+    setDragging(null);
+    const over = e.over?.id;
+    if (over == null) return;
+    move(String(e.active.id), over === UNFILED ? null : String(over));
+  };
+
+  const searchId = useId();
+  return (
+    <DndContext
+      id={dndId}
+      sensors={sensors}
+      collisionDetection={collision}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragCancel={() => setDragging(null)}
+    >
+      <div className="mb-4">
+        <div className="relative max-w-md">
+          <i
+            aria-hidden
+            className="pi pi-search pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            style={{ fontSize: 13 }}
+          />
+          <input
+            ref={searchRef}
+            id={searchId}
+            type="search"
+            value={query}
+            data-testid="forms-search"
+            aria-label={labels.searchLabel}
+            placeholder={labels.searchPlaceholder}
+            autoComplete="off"
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                if (query) setQuery("");
+                else searchRef.current?.blur();
+              }
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                listRef.current
+                  ?.querySelector<HTMLElement>("[data-form-link]")
+                  ?.focus();
+              }
+            }}
+            className="h-10 w-full rounded-md border border-input bg-background pl-9 pr-24 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 text-2xs text-faint">
+            {query ? null : (
+              <kbd className="rounded border border-border px-1.5 py-0.5 font-mono">
+                {labels.searchShortcut}
+              </kbd>
+            )}
+          </span>
+          {query ? (
+            <button
+              type="button"
+              aria-label={labels.searchClear}
+              onClick={() => {
+                setQuery("");
+                searchRef.current?.focus();
+              }}
+              className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <i aria-hidden className="pi pi-times" style={{ fontSize: 12 }} />
+            </button>
+          ) : null}
+        </div>
+        <p
+          role="status"
+          aria-live="polite"
+          className={cn(
+            "mt-1 text-xs text-muted-foreground",
+            !searching && "sr-only",
+          )}
+        >
+          {searching ? t(labels.searchResults, { count: matches }) : ""}
+        </p>
+      </div>
+
+      <div
+        ref={listRef}
+        onKeyDown={onListKeyDown}
+        className="flex flex-col gap-6"
+      >
+        {searching && matches === 0 ? (
+          <p
+            data-testid="forms-search-empty"
+            className="rounded-xl border border-dashed border-border bg-card/40 p-8 text-center text-sm text-muted-foreground"
+          >
+            {labels.searchEmpty}
+          </p>
+        ) : null}
+        {sections.map((section) => (
+          <FolderSection
+            key={section.id ?? UNFILED}
+            section={section}
+            expanded={searching || !collapsed.has(section.id ?? UNFILED)}
+            onToggle={() => toggle(section.id ?? UNFILED)}
+            onMove={move}
+            dragging={dragging != null}
+            {...props}
+          />
+        ))}
+      </div>
+
+      <DragOverlay dropAnimation={null}>
+        {dragging ? (
+          <div className="rounded-xl border border-primary-edge bg-card px-5 py-3 text-sm font-semibold shadow-lg">
+            {dragging.name}
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+function FolderSection({
+  section,
+  expanded,
+  onToggle,
+  onMove,
+  dragging,
+  folders,
+  accountCode,
+  handle,
+  locale,
+  updatedByForm,
+  labels,
+  rowLabels,
+  actionLabels,
+  dialogLabels,
+  createLabels,
+}: FormsExplorerProps & {
+  section: FormSection<FormSummary>;
+  expanded: boolean;
+  onToggle: () => void;
+  onMove: (formId: string, folderId: string | null) => void;
+  dragging: boolean;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const { confirm: confirmDialog, dialog } = useConfirmDialog();
+  const [renaming, setRenaming] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [, start] = useTransition();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const headingId = useId();
+  const listId = useId();
+  const droppableId = section.id ?? UNFILED;
+  const { setNodeRef, isOver } = useDroppable({
+    id: droppableId,
+    data: { type: "folder" },
+  });
+  const isFolder = section.id != null;
+  const name = section.name ?? labels.unfiled;
+  const count =
+    section.total === 1
+      ? labels.folderCountOne
+      : t(labels.folderCount, { count: section.total });
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node))
+        setMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) =>
+      e.key === "Escape" && setMenuOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [menuOpen]);
+
+  const remove = async () => {
+    setMenuOpen(false);
+    const ok = await confirmDialog({
+      title: getMessages(clientLocale()).dialog.deleteFolderTitle,
+      message: t(labels.deleteFolderConfirm, { name, count: section.total }),
+      confirmLabel: labels.deleteFolder,
+      destructive: true,
+    });
+    if (!ok || !section.id) return;
+    const id = section.id;
+    start(async () => {
+      const res = await callAction(() => deleteFolderAction(id));
+      if (res && "ok" in res && res.ok) router.refresh();
+      else toast.error(dialogLabels.actionFailed);
+    });
+  };
+
+  const itemClass =
+    "flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:outline-none";
+
+  return (
+    <section
+      ref={setNodeRef}
+      aria-labelledby={headingId}
+      data-testid={isFolder ? "folder-section" : "unfiled-section"}
+      data-folder-id={section.id ?? ""}
+      className={cn(
+        "rounded-xl transition-colors",
+        dragging && "outline outline-1 outline-dashed outline-border",
+        isOver && "bg-primary/10 outline-primary-edge",
+      )}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 px-1 py-1">
+        <button
+          type="button"
+          id={headingId}
+          aria-expanded={expanded}
+          aria-controls={listId}
+          data-testid="folder-toggle"
+          onClick={onToggle}
+          title={expanded ? labels.collapse : labels.expand}
+          className="flex min-w-0 items-center gap-2 rounded-md py-1 pr-2 text-left text-sm font-semibold text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <i
+            aria-hidden
+            className={cn(
+              "pi text-muted-foreground",
+              expanded ? "pi-chevron-down" : "pi-chevron-right",
+            )}
+            style={{ fontSize: 11 }}
+          />
+          <i
+            aria-hidden
+            className={cn(
+              "pi text-muted-foreground",
+              isFolder ? "pi-folder" : "pi-inbox",
+            )}
+            style={{ fontSize: 14 }}
+          />
+          <span className="truncate">{name}</span>
+          <span
+            data-testid="folder-count"
+            className="rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-muted-foreground"
+          >
+            {count}
+          </span>
+          {isOver ? (
+            <span className="text-2xs text-primary">{labels.dropHere}</span>
+          ) : null}
+        </button>
+        <div className="flex items-center gap-1">
+          <CreateForm
+            labels={createLabels}
+            variant="outline"
+            size="sm"
+            triggerLabel={labels.createIn}
+            folders={folders}
+            defaultFolderId={section.id}
+            locale={locale}
+          />
+          {isFolder ? (
+            <div ref={menuRef} className="relative">
+              <button
+                type="button"
+                data-testid="folder-menu"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                aria-label={labels.folderMenu}
+                title={labels.folderMenu}
+                onClick={() => setMenuOpen((o) => !o)}
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <i
+                  aria-hidden
+                  className="pi pi-ellipsis-v"
+                  style={{ fontSize: 14 }}
+                />
+              </button>
+              {menuOpen ? (
+                <div
+                  role="menu"
+                  aria-label={labels.folderMenu}
+                  className="absolute right-0 z-50 mt-1 w-48 rounded-md border border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    data-testid="folder-rename"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setRenaming(true);
+                    }}
+                    className={itemClass}
+                  >
+                    <i
+                      aria-hidden
+                      className="pi pi-pencil text-muted-foreground"
+                      style={{ fontSize: 13 }}
+                    />
+                    {labels.renameFolder}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    data-testid="folder-delete"
+                    onClick={() => void remove()}
+                    className="flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none"
+                  >
+                    <i
+                      aria-hidden
+                      className="pi pi-trash"
+                      style={{ fontSize: 13 }}
+                    />
+                    {labels.deleteFolder}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <ul
+        id={listId}
+        role="list"
+        hidden={!expanded}
+        className="flex flex-col gap-3"
+      >
+        {section.forms.map((f) => (
+          <FormRow
+            key={f.id}
+            form={f}
+            publicPath={`/${accountCode}/${handle}/${f.slug}`}
+            updatedLabel={updatedByForm[f.id] ?? ""}
+            nameRanges={f.match.nameRanges}
+            folders={folders}
+            labels={rowLabels}
+            actionLabels={actionLabels}
+            onMove={onMove}
+          />
+        ))}
+      </ul>
+
+      {isFolder && section.id ? (
+        <FolderDialog
+          key={`${section.id}:${renaming ? "open" : "closed"}`}
+          open={renaming}
+          onClose={() => setRenaming(false)}
+          onDone={() => router.refresh()}
+          mode="rename"
+          folderId={section.id}
+          initialName={section.name ?? ""}
+          labels={dialogLabels}
+        />
+      ) : null}
+      {dialog}
+    </section>
+  );
+}

--- a/apps/web/app/admin/forms/new-folder-button.tsx
+++ b/apps/web/app/admin/forms/new-folder-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { FolderDialog, type FolderDialogLabels } from "./folder-dialog";
+
+/** The header's "New folder" trigger and its dialog. */
+export function NewFolderButton({
+  label,
+  labels,
+}: {
+  label: string;
+  labels: FolderDialogLabels;
+}) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  return (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => setOpen(true)}
+        data-testid="new-folder"
+      >
+        <i aria-hidden className="pi pi-folder-plus" style={{ fontSize: 12 }} />{" "}
+        {label}
+      </Button>
+      <FolderDialog
+        key={open ? "open" : "closed"}
+        open={open}
+        onClose={() => setOpen(false)}
+        onDone={() => router.refresh()}
+        mode="create"
+        labels={labels}
+      />
+    </>
+  );
+}

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -106,10 +106,8 @@ export default async function FormsList() {
             createIn: m.createIn,
             moveFailed: m.moveFailed,
             dropHere: m.dropHere,
-            updated: m.updated,
           }}
           rowLabels={{
-            updated: m.updated,
             edit: m.edit,
             submissions: messages.nav.submissions,
             analytics: messages.nav.analytics,

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -1,29 +1,24 @@
-import Link from 'next/link';
 import { getMessages, t } from '@quill/shared';
 import { adminApi } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
-import { CopyLinkIcon } from '@/components/copy-link';
 import { PageHeader } from '@/components/ui/page-header';
 import { CreateForm } from './create-form';
-import { FormRowActions } from './form-row-actions';
+import { FormsExplorer } from './forms-explorer';
+import { NewFolderButton } from './new-folder-button';
 
 export const dynamic = 'force-dynamic';
 
-/** First-class row actions (user feedback: nothing hidden behind the kebab).
- *  Secondary buttons collapse to icon-only below `md` — the aria-label/title
- *  keep them nameable; the kebab holds only Duplicate/Delete. Tokens only. */
-const primaryBtn =
-  'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-const secondaryBtn =
-  'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-const iconBtn =
-  'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-
+/**
+ * The forms list: one list, grouped by folder (Unfiled first), searchable by
+ * keyboard. Stays a server component: it fetches, formats the dates once on
+ * the server clock, and hands the explorer plain data; every interaction
+ * (search, collapse, drag, move, folder dialogs) lives in the client tree.
+ */
 export default async function FormsList() {
   const locale = await getLocale();
   const messages = getMessages(locale).admin;
   const m = messages.forms;
-  const [me, forms] = await Promise.all([adminApi.me(), adminApi.listForms()]);
+  const [me, forms, folders] = await Promise.all([adminApi.me(), adminApi.listForms(), adminApi.listFolders()]);
 
   const createLabels = {
     create: m.create,
@@ -37,23 +32,43 @@ export default async function FormsList() {
     layoutSlidesDesc: m.layoutSlidesDesc,
     layoutVertical: m.layoutVertical,
     layoutVerticalDesc: m.layoutVerticalDesc,
+    folderLabel: m.folderLabel,
+    folderNone: m.folderNone,
   };
-  const rowLabels = {
-    menu: m.actions,
-    duplicate: m.duplicate,
-    delete: m.delete,
-    deleteConfirm: m.deleteConfirm,
+  const dialogLabels = {
+    newFolderTitle: m.newFolderTitle,
+    renameFolderTitle: m.renameFolderTitle,
+    folderCreate: m.folderCreate,
+    folderSave: m.folderSave,
+    folderNameLabel: m.folderNameLabel,
+    folderNamePlaceholder: m.folderNamePlaceholder,
+    folderNameRequired: m.folderNameRequired,
+    folderNameTaken: m.folderNameTaken,
+    actionFailed: m.actionFailed,
+    cancel: m.cancel,
   };
+  // Formatted once on the server clock, the same way the flat list did; the
+  // workspace-timezone change switches this to the shared formatter.
+  const updatedByForm = Object.fromEntries(
+    forms.map((f) => [f.id, t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })]),
+  );
 
   return (
     <div className="mx-auto max-w-[1520px] px-6 py-10 sm:px-8">
       <PageHeader
         title={m.title}
         subtitle={m.subtitle}
-        action={forms.length > 0 ? <CreateForm labels={createLabels} /> : undefined}
+        action={
+          forms.length > 0 || folders.length > 0 ? (
+            <div className="flex items-center gap-2">
+              <NewFolderButton label={m.newFolder} labels={dialogLabels} />
+              <CreateForm labels={createLabels} folders={folders} locale={locale} />
+            </div>
+          ) : undefined
+        }
       />
 
-      {forms.length === 0 ? (
+      {forms.length === 0 && folders.length === 0 ? (
         <div className="flex flex-col items-center gap-4 rounded-xl border border-dashed border-border bg-card/40 p-12 text-center">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
             <i aria-hidden className="pi pi-file-edit" style={{ fontSize: 20 }} />
@@ -65,99 +80,56 @@ export default async function FormsList() {
           <CreateForm labels={createLabels} />
         </div>
       ) : (
-        <ul className="flex flex-col gap-3">
-          {forms.map((f) => {
-            const publicPath = `/${me.accountCode}/${me.handle ?? 'me'}/${f.slug}`;
-            const editHref = `/admin/forms/${f.id}/edit`;
-            return (
-              <li
-                key={f.id}
-                data-testid="form-row"
-                className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card px-5 py-4 transition-colors hover:border-primary-edge/60"
-              >
-                <div className="min-w-0 flex-1 basis-60">
-                  <Link
-                    href={editHref}
-                    className="block w-fit max-w-full truncate text-base font-semibold tracking-tight transition-colors hover:text-primary"
-                  >
-                    {f.name}
-                  </Link>
-                  {/* The row's two facts are not equally interesting. The public
-                      path is what someone came here to copy, so it keeps the body
-                      tier; the timestamp and the separator drop to `text-faint` —
-                      the quiet step exists exactly so metadata can sit beside a
-                      value without competing with it. */}
-                  <p className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
-                    <span className="shrink-0 text-faint">
-                      {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
-                    </span>
-                    <span aria-hidden className="shrink-0 text-faint">
-                      ·
-                    </span>
-                    <span className="min-w-0 truncate font-mono text-muted-foreground" title={publicPath}>
-                      {publicPath}
-                    </span>
-                  </p>
-                </div>
-
-                <div className="flex shrink-0 flex-wrap items-center gap-1.5">
-                  <Link data-testid="form-row-edit" href={editHref} className={primaryBtn} title={m.edit}>
-                    <i aria-hidden className="pi pi-pencil" style={{ fontSize: 13 }} />
-                    {m.edit}
-                  </Link>
-                  <Link
-                    data-testid="form-row-submissions"
-                    href={`/admin/forms/${f.id}/submissions`}
-                    className={secondaryBtn}
-                    aria-label={messages.nav.submissions}
-                    title={messages.nav.submissions}
-                  >
-                    <i aria-hidden className="pi pi-inbox" style={{ fontSize: 13 }} />
-                    <span className="hidden md:inline">{messages.nav.submissions}</span>
-                  </Link>
-                  <Link
-                    data-testid="form-row-analytics"
-                    href={`/admin/forms/${f.id}/analytics`}
-                    className={secondaryBtn}
-                    aria-label={messages.nav.analytics}
-                    title={messages.nav.analytics}
-                  >
-                    <i aria-hidden className="pi pi-chart-bar" style={{ fontSize: 13 }} />
-                    <span className="hidden md:inline">{messages.nav.analytics}</span>
-                  </Link>
-                  <Link
-                    data-testid="form-row-connect"
-                    href={`${editHref}?tab=connect`}
-                    className={secondaryBtn}
-                    aria-label={m.connect}
-                    title={m.connect}
-                  >
-                    <i aria-hidden className="pi pi-link" style={{ fontSize: 13 }} />
-                    <span className="hidden md:inline">{m.connect}</span>
-                  </Link>
-                  <CopyLinkIcon
-                    path={publicPath}
-                    labels={{ copy: m.copy, copied: m.copied }}
-                    testId="form-row-copy"
-                    className={iconBtn}
-                  />
-                  <a
-                    data-testid="form-row-open"
-                    href={publicPath}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={iconBtn}
-                    aria-label={m.openForm}
-                    title={m.openForm}
-                  >
-                    <i aria-hidden className="pi pi-external-link" style={{ fontSize: 14 }} />
-                  </a>
-                  <FormRowActions id={f.id} labels={rowLabels} />
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+        <FormsExplorer
+          forms={forms}
+          folders={folders}
+          accountCode={me.accountCode}
+          handle={me.handle ?? 'me'}
+          locale={locale}
+          updatedByForm={updatedByForm}
+          labels={{
+            searchPlaceholder: m.searchPlaceholder,
+            searchLabel: m.searchLabel,
+            searchClear: m.searchClear,
+            searchEmpty: m.searchEmpty,
+            searchResults: m.searchResults,
+            searchShortcut: m.searchShortcut,
+            unfiled: m.unfiled,
+            folderCount: m.folderCount,
+            folderCountOne: m.folderCountOne,
+            renameFolder: m.renameFolder,
+            deleteFolder: m.deleteFolder,
+            deleteFolderConfirm: m.deleteFolderConfirm,
+            folderMenu: m.folderMenu,
+            collapse: m.collapse,
+            expand: m.expand,
+            createIn: m.createIn,
+            moveFailed: m.moveFailed,
+            dropHere: m.dropHere,
+            updated: m.updated,
+          }}
+          rowLabels={{
+            updated: m.updated,
+            edit: m.edit,
+            submissions: messages.nav.submissions,
+            analytics: messages.nav.analytics,
+            connect: m.connect,
+            copy: m.copy,
+            copied: m.copied,
+            openForm: m.openForm,
+            dragHandle: m.dragHandle,
+          }}
+          actionLabels={{
+            menu: m.actions,
+            duplicate: m.duplicate,
+            delete: m.delete,
+            deleteConfirm: m.deleteConfirm,
+            moveTo: m.moveTo,
+            moveBack: m.moveBack,
+          }}
+          dialogLabels={dialogLabels}
+          createLabels={createLabels}
+        />
       )}
     </div>
   );

--- a/apps/web/app/admin/forms/page.tsx
+++ b/apps/web/app/admin/forms/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getMessages, t } from '@quill/shared';
+import { formatDate, getMessages, t } from '@quill/shared';
 import { adminApi } from '@/lib/admin-api';
 import { getLocale } from '@/lib/locale';
 import { CopyLinkIcon } from '@/components/copy-link';
@@ -89,7 +89,7 @@ export default async function FormsList() {
                       value without competing with it. */}
                   <p className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
                     <span className="shrink-0 text-faint">
-                      {t(m.updated, { when: new Date(f.updatedAt).toLocaleDateString(locale) })}
+                      {t(m.updated, { when: formatDate(f.updatedAt, { locale, timeZone: me.timezone ?? 'UTC' }) })}
                     </span>
                     <span aria-hidden className="shrink-0 text-faint">
                       ·

--- a/apps/web/app/admin/integrations/page.tsx
+++ b/apps/web/app/admin/integrations/page.tsx
@@ -23,6 +23,7 @@ export const dynamic = 'force-dynamic';
 export default async function ConnectionsPage() {
   const locale = await getLocale();
   const c = getMessages(locale).admin.connections;
+  const timeZone = (await adminApi.me()).timezone ?? 'UTC';
 
   let data: IntegrationsResponse = { encryptionAvailable: false, providers: [] };
   let loadError = false;
@@ -58,6 +59,7 @@ export default async function ConnectionsPage() {
       />
       <WebhooksSection
         items={webhooks}
+        timeZone={timeZone}
         loadError={webhooksLoadError}
         m={c.webhooks}
         locale={locale}

--- a/apps/web/app/admin/integrations/webhooks-section.spec.tsx
+++ b/apps/web/app/admin/integrations/webhooks-section.spec.tsx
@@ -37,7 +37,7 @@ const webhook = (over: Partial<AccountWebhook> = {}): AccountWebhook => ({
 
 const render = (items: AccountWebhook[], loadError = false): string =>
   renderToStaticMarkup(
-    <WebhooksSection items={items} loadError={loadError} m={m} locale="en" />,
+    <WebhooksSection items={items} loadError={loadError} m={m} locale="en" timeZone="UTC" />,
   );
 
 describe('WebhooksSection', () => {

--- a/apps/web/app/admin/integrations/webhooks-section.tsx
+++ b/apps/web/app/admin/integrations/webhooks-section.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { t, type FormsMessages, type Locale } from '@quill/shared';
+import { formatDateTime, t, type FormsMessages, type Locale } from '@quill/shared';
 import type { AccountWebhook } from '@/lib/admin-api';
 
 type Msgs = FormsMessages['admin']['connections']['webhooks'];
@@ -27,11 +27,14 @@ export function WebhooksSection({
   loadError,
   m,
   locale,
+  timeZone,
 }: {
   items: AccountWebhook[];
   loadError?: boolean;
   m: Msgs;
   locale: Locale;
+  /** The workspace zone the failure timestamp is read in. */
+  timeZone: string;
 }) {
   return (
     <section
@@ -52,7 +55,7 @@ export function WebhooksSection({
       ) : items.length === 0 ? (
         <EmptyState m={m} />
       ) : (
-        <WebhookTable items={items} m={m} locale={locale} />
+        <WebhookTable timeZone={timeZone} items={items} m={m} locale={locale} />
       )}
     </section>
   );
@@ -76,7 +79,17 @@ function EmptyState({ m }: { m: Msgs }) {
   );
 }
 
-function WebhookTable({ items, m, locale }: { items: AccountWebhook[]; m: Msgs; locale: Locale }) {
+function WebhookTable({
+  items,
+  m,
+  locale,
+  timeZone,
+}: {
+  items: AccountWebhook[];
+  m: Msgs;
+  locale: Locale;
+  timeZone: string;
+}) {
   return (
     <>
       {/* Horizontal scroll lives INSIDE this container: a long endpoint must not
@@ -170,7 +183,7 @@ function WebhookTable({ items, m, locale }: { items: AccountWebhook[]; m: Msgs; 
                       <span
                         data-testid="webhook-health"
                         title={`${t(m.lastFailure, {
-                          date: new Date(w.failures.lastAt).toLocaleString(locale),
+                          date: formatDateTime(w.failures.lastAt, { locale, timeZone }),
                         })}${w.failures.lastError ? `\n${w.failures.lastError}` : ''}`}
                         className="inline-flex items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive"
                       >

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -86,6 +86,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           bootstrap). Staff entering an estate workspace never seed it: the
           zone belongs to the team that works there, not to whoever looked. */}
       <WorkspaceTimezoneBootstrap
+        accountId={me.accountId}
         timezone={me.timezone}
         canClaim={isAdminRole(me.role) && me.accessGrant !== 'staff'}
         message={chrome.timezoneAutoSet}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from 'react';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getMessages } from '@quill/shared';
-import { adminApi, ApiError } from '@/lib/admin-api';
+import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
+import { WorkspaceTimeZoneProvider } from '@/components/workspace-timezone';
+import { WorkspaceTimezoneBootstrap } from './_components/workspace-timezone-bootstrap';
 import { AdminShell } from '@/components/admin-shell';
 import { getLocale } from '@/lib/locale';
 import { getThemePref } from '@/lib/theme.server';
@@ -79,6 +81,15 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           landingDistinctId: sanitizeLandingDistinctId(jar.get(PH_ID_COOKIE)?.value),
         }}
       />
+      {/* The workspace's zone for every client component that prints a date,
+          and the one-time seed from the first admin's browser (see the
+          bootstrap). Staff entering an estate workspace never seed it: the
+          zone belongs to the team that works there, not to whoever looked. */}
+      <WorkspaceTimezoneBootstrap
+        timezone={me.timezone}
+        canClaim={isAdminRole(me.role) && me.accessGrant !== 'staff'}
+        message={chrome.timezoneAutoSet}
+      />
       <AdminShell
         initialCollapsed={initialCollapsed}
         themePref={await getThemePref()}
@@ -89,7 +100,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
         staff={me.staff}
         user={{ displayName: me.displayName, email: me.email }}
       >
-        {children}
+        <WorkspaceTimeZoneProvider timeZone={me.timezone}>{children}</WorkspaceTimeZoneProvider>
       </AdminShell>
     </ToastProvider>
   );

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -167,3 +167,43 @@ export async function renameWorkspaceAction(
   revalidatePath('/admin', 'layout');
   return { ok: true };
 }
+
+/** Outcome of a timezone write, machine-readable so the client can localize. */
+export type WorkspaceTimezoneState = { ok: true; timezone: string | null } | { ok: false } | null;
+
+/**
+ * Set the workspace's timezone (admin/owner), for the settings page and the
+ * submissions dropdown. `accountId` names the workspace so Account settings
+ * can change any workspace the caller administers without switching into it.
+ */
+export async function setWorkspaceTimezoneAction(
+  accountId: string,
+  timezone: string | null,
+): Promise<WorkspaceTimezoneState> {
+  try {
+    const res = await adminApi.setWorkspaceTimezone({ timezone }, { workspace: accountId });
+    revalidatePath('/admin', 'layout');
+    return { ok: true, timezone: res.timezone };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { ok: false };
+  }
+}
+
+/**
+ * The write-once seed: the first admin's browser offers its zone, and the API
+ * keeps it only while the workspace has none. `applied` tells the caller
+ * whether THIS call was the one that set it (and so whether to say so).
+ */
+export async function claimWorkspaceTimezoneAction(
+  timezone: string,
+): Promise<{ applied: boolean; timezone: string | null }> {
+  try {
+    const res = await adminApi.setWorkspaceTimezone({ timezone, onlyIfUnset: true });
+    if (res.applied) revalidatePath('/admin', 'layout');
+    return { applied: res.applied, timezone: res.timezone };
+  } catch (e) {
+    unstable_rethrow(e);
+    return { applied: false, timezone: null };
+  }
+}

--- a/apps/web/app/admin/workspace-actions.ts
+++ b/apps/web/app/admin/workspace-actions.ts
@@ -169,7 +169,7 @@ export async function renameWorkspaceAction(
 }
 
 /** Outcome of a timezone write, machine-readable so the client can localize. */
-export type WorkspaceTimezoneState = { ok: true; timezone: string | null } | { ok: false } | null;
+export type WorkspaceTimezoneState = { ok: true; timezone: string | null } | { ok: false };
 
 /**
  * Set the workspace's timezone (admin/owner), for the settings page and the

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,16 +1,21 @@
 import Link from 'next/link';
+import { getMessages } from '@quill/shared';
 import { BrandMark } from '@/components/brand/brand';
+import { preferredLocale } from '@/lib/locale';
 
-export default function NotFound() {
+export default async function NotFound() {
+  // The persisted admin choice when there is one, else the browser: a dead
+  // public URL is usually reached by a visitor who never saw the switcher.
+  const m = getMessages(await preferredLocale()).renderer;
   return (
     <main className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center gap-4 px-6 text-center">
       {/* A dead URL is often someone's first impression of the product, so it
-          gets the mark too — decorative here, the heading carries the meaning. */}
+          gets the mark too: decorative here, the heading carries the meaning. */}
       <BrandMark className="h-8 w-auto text-muted-foreground" />
-      <h1 className="text-3xl font-semibold">Not found</h1>
-      <p className="text-muted-foreground">This page doesn’t exist.</p>
+      <h1 className="text-3xl font-semibold">{m.notFoundTitle}</h1>
+      <p className="text-muted-foreground">{m.notFoundBody}</p>
       <Link href="/" className="text-primary underline underline-offset-4">
-        Go home
+        {m.notFoundHome}
       </Link>
     </main>
   );

--- a/apps/web/app/preview/preview-document.tsx
+++ b/apps/web/app/preview/preview-document.tsx
@@ -64,7 +64,9 @@ export function PreviewDocument() {
       <style>{SCROLLBAR_RESET}</style>
       {/* Same wrapper depth as the public page (`page.tsx` renders the renderer
           inside one plain div), so nothing about the box tree differs. */}
-      <div data-testid="live-preview" data-preview-state={input ? 'ready' : 'waiting'}>
+      {/* `lang` mirrors the public page's wrapper: the FORM's language, not the
+          editor's, so the preview is announced the way the real page will be. */}
+      <div data-testid="live-preview" data-preview-state={input ? 'ready' : 'waiting'} lang={input?.locale}>
         {input ? (
           input.layout === 'vertical' ? (
             // One page scrolls — there is no screen to start at, so no `startAt`.

--- a/apps/web/app/preview/protocol.spec.ts
+++ b/apps/web/app/preview/protocol.spec.ts
@@ -171,3 +171,23 @@ describe('isBlockedPreviewRequest — the inertness matrix', () => {
     expect(isBlockedPreviewRequest('/v1/x', { method: 'get' }, BASE)).toBe(false);
   });
 });
+
+describe('config message: locale is narrowed to a shipped language', () => {
+  const post = (locale: unknown) =>
+    readPreviewMessage(
+      {
+        origin: ORIGIN,
+        source: parentWindow,
+        data: { channel: PREVIEW_CHANNEL, type: 'config', config: validConfig, locale },
+      } as unknown as MessageEvent,
+      parentWindow,
+      ORIGIN,
+    );
+
+  it('keeps en and es, and folds anything else to en', () => {
+    expect(post('es')).toMatchObject({ type: 'config', locale: 'es' });
+    expect(post('en')).toMatchObject({ type: 'config', locale: 'en' });
+    expect(post('fr')).toMatchObject({ type: 'config', locale: 'en' });
+    expect(post(undefined)).toMatchObject({ type: 'config', locale: 'en' });
+  });
+});

--- a/apps/web/app/preview/protocol.ts
+++ b/apps/web/app/preview/protocol.ts
@@ -55,7 +55,8 @@ export interface PreviewConfigMessage {
   config: FormConfig;
   /** Already resolved through `publicTitle` by the sender. */
   name: string;
-  locale: string;
+  /** The FORM's language (its `language`, else the editor's), never free text. */
+  locale: 'en' | 'es';
   layout: FormLayout;
   /**
    * Where the renderer should START: a runtime step index, or `'cover'` for the
@@ -120,7 +121,7 @@ export function readPreviewMessage(
       revision: typeof body.revision === 'number' ? body.revision : 0,
       config: config as FormConfig,
       name: typeof body.name === 'string' ? body.name : '',
-      locale: typeof body.locale === 'string' ? body.locale : 'en',
+      locale: body.locale === 'es' ? 'es' : 'en',
       layout: body.layout === 'vertical' ? 'vertical' : 'slides',
       screen,
     };

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -21,7 +21,7 @@ type ChromeMessages = FormsMessages['admin']['chrome'];
  *  a desktop collapse rail (cookie-persisted, no FOUC), and a <768px off-canvas
  *  drawer with a hamburger top bar. Tokens only; R22 press/hover; R27/R28. */
 
-type IconName = 'home' | 'forms' | 'submissions' | 'analytics' | 'integrations' | 'agents';
+type IconName = 'home' | 'forms' | 'submissions' | 'analytics' | 'integrations' | 'docs' | 'agents';
 
 interface NavItem {
   key: keyof ChromeMessages['nav'];
@@ -31,6 +31,11 @@ interface NavItem {
   match?: string[];
   /** Leaves the app: plain anchor in a new tab, never `aria-current`. */
   external?: true;
+  /**
+   * The href comes from the localized catalog instead of `href` (the docs
+   * site has one page per language). `NavLinks` resolves it from `docsHref`.
+   */
+  localizedHref?: 'docsHref';
 }
 
 // Forms information architecture: Home, Forms, Submissions, Analytics,
@@ -39,6 +44,10 @@ interface NavItem {
 // ACCOUNT (workspaces, brand kit, notifications, public page) lives behind the
 // profile button at the bottom of the rail, under /admin/account, the same
 // place Dapta's admin panel keeps it, so no rail item is active on those pages.
+//
+// Then "Docs": the product documentation, always present, in the reader's
+// language (the URL lives in the message catalog, see `docsHref`). External
+// like the platform door below, and tagged the same way.
 //
 // Last, and only on a deployment that has a platform: "Dapta Agents", the door
 // to the wider platform. It sits IN the nav rather than in a separate block so
@@ -53,6 +62,7 @@ const NAV: NavItem[] = [
   { key: 'submissions', href: '/admin/submissions', icon: 'submissions' },
   { key: 'analytics', href: '/admin/analytics', icon: 'analytics' },
   { key: 'integrations', href: '/admin/integrations', icon: 'integrations' },
+  { key: 'docs', href: '', icon: 'docs', external: true, localizedHref: 'docsHref' },
   ...(PLATFORM_URL
     ? [{ key: 'agents', href: suiteHref(PLATFORM_URL, 'sidebar'), icon: 'agents', external: true } as const]
     : []),
@@ -68,6 +78,7 @@ const PI_BY_NAME: Record<IconName, string> = {
   submissions: 'pi-inbox',
   analytics: 'pi-chart-bar',
   integrations: 'pi-link',
+  docs: 'pi-book',
   agents: 'pi-microchip-ai',
 };
 
@@ -84,11 +95,14 @@ function Icon({ name, className }: { name: IconName; className?: string }) {
 function NavLinks({
   collapsed,
   nav,
+  docsHref,
   newTab,
   onNavigate,
 }: {
   collapsed: boolean;
   nav: ChromeMessages['nav'];
+  /** The localized documentation URL, already UTM-tagged by the caller. */
+  docsHref: string;
   /** "(opens in a new tab)" — read out after an external item's label. */
   newTab: string;
   onNavigate?: () => void;
@@ -97,10 +111,11 @@ function NavLinks({
   return (
     <ul className="flex flex-col gap-1">
       {NAV.map((item) => {
+        const href = item.localizedHref ? docsHref : item.href;
         // An external item is never "here": its href is another origin, so the
         // prefix rule could not match anyway, but the intent should not depend
         // on that accident.
-        const active = !item.external && isNavItemActive(pathname, item.href, item.match);
+        const active = !item.external && isNavItemActive(pathname, href, item.match);
         const label = nav[item.key];
         const className = [
           'relative flex items-center gap-3 rounded-md text-sm transition-colors active:scale-[0.99]',
@@ -128,10 +143,10 @@ function NavLinks({
           </>
         );
         return (
-          <li key={item.href}>
+          <li key={item.key}>
             {item.external ? (
               <a
-                href={item.href}
+                href={href}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={onNavigate}
@@ -154,7 +169,7 @@ function NavLinks({
               </a>
             ) : (
               <Link
-                href={item.href}
+                href={href}
                 onClick={onNavigate}
                 title={collapsed ? label : undefined}
                 aria-current={active ? 'page' : undefined}
@@ -354,7 +369,12 @@ export function AdminShell({
           />
         ) : null}
         <nav aria-label="Primary">
-          <NavLinks collapsed={railCollapsed} nav={messages.nav} newTab={messages.switcher.opensNewTab} />
+          <NavLinks
+            collapsed={railCollapsed}
+            nav={messages.nav}
+            docsHref={suiteHref(messages.docsHref, 'sidebar')}
+            newTab={messages.switcher.opensNewTab}
+          />
         </nav>
         {renderFooter(railCollapsed)}
       </aside>
@@ -404,6 +424,7 @@ export function AdminShell({
           <NavLinks
             collapsed={false}
             nav={messages.nav}
+            docsHref={suiteHref(messages.docsHref, 'sidebar')}
             newTab={messages.switcher.opensNewTab}
             onNavigate={() => setDrawerOpen(false)}
           />

--- a/apps/web/components/admin-shell.tsx
+++ b/apps/web/components/admin-shell.tsx
@@ -218,6 +218,8 @@ export function AdminShell({
   staff?: boolean;
   children: ReactNode;
 }) {
+  // Tagged once for both rails (desktop and drawer), like the other suite doors.
+  const docsHref = suiteHref(messages.docsHref, 'sidebar');
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -372,7 +374,7 @@ export function AdminShell({
           <NavLinks
             collapsed={railCollapsed}
             nav={messages.nav}
-            docsHref={suiteHref(messages.docsHref, 'sidebar')}
+            docsHref={docsHref}
             newTab={messages.switcher.opensNewTab}
           />
         </nav>
@@ -424,7 +426,7 @@ export function AdminShell({
           <NavLinks
             collapsed={false}
             nav={messages.nav}
-            docsHref={suiteHref(messages.docsHref, 'sidebar')}
+            docsHref={docsHref}
             newTab={messages.switcher.opensNewTab}
             onNavigate={() => setDrawerOpen(false)}
           />

--- a/apps/web/components/notification-email-fields.spec.tsx
+++ b/apps/web/components/notification-email-fields.spec.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NotificationEmailFields } from "./notification-email-fields";
+
+const labels = {
+  enabledLabel: "Send",
+  enabledHint: "hint",
+  subjectLabel: "Subject",
+  bodyLabel: "Body",
+  tokensLabel: "Tokens",
+  tokensHint: "hint",
+  previewLabel: "Preview",
+  previewSubject: "Subject",
+  tokenLabels: { formName: "Form name", answers: "Answers" },
+};
+
+function render(notice?: string | null) {
+  return renderToStaticMarkup(
+    createElement(NotificationEmailFields, {
+      value: { enabled: true, subject: "S", body: "B" },
+      onChange: () => {},
+      tokens: ["formName", "answers"],
+      labels,
+      notice,
+    }),
+  );
+}
+
+describe("NotificationEmailFields notice", () => {
+  it("renders the notice as a status line above the token chips when given", () => {
+    const html = render("This email does not include the answers.");
+    expect(html).toContain('role="status"');
+    expect(html).toContain("This email does not include the answers.");
+    expect(html.indexOf('role="status"')).toBeLessThan(
+      html.indexOf("{{answers}}"),
+    );
+  });
+
+  it("renders nothing extra without a notice", () => {
+    expect(render(null)).not.toContain('role="status"');
+  });
+});

--- a/apps/web/components/notification-email-fields.tsx
+++ b/apps/web/components/notification-email-fields.tsx
@@ -39,6 +39,7 @@ export function NotificationEmailFields({
   tokens,
   labels,
   testIdPrefix,
+  notice,
 }: {
   value: NotificationEmailValue;
   onChange: (next: NotificationEmailValue) => void;
@@ -46,6 +47,11 @@ export function NotificationEmailFields({
   labels: NotificationFieldsLabels;
   /** Optional data-testid prefix for the subject/body controls. */
   testIdPrefix?: string;
+  /**
+   * A permanent, non-blocking warning about the current draft (e.g. the owner
+   * notice lacks `{{answers}}`), shown above the token chips. Null hides it.
+   */
+  notice?: string | null;
 }) {
   const subjectRef = useRef<HTMLInputElement>(null);
   const bodyRef = useRef<HTMLTextAreaElement>(null);
@@ -120,6 +126,17 @@ export function NotificationEmailFields({
           className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
         />
       </label>
+
+      {notice ? (
+        <p
+          role="status"
+          data-testid={testIdPrefix ? `${testIdPrefix}-notice` : undefined}
+          className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-foreground"
+        >
+          <i aria-hidden className="pi pi-exclamation-triangle mt-0.5 shrink-0" style={{ fontSize: 12 }} />
+          <span>{notice}</span>
+        </p>
+      ) : null}
 
       {/* Token chips */}
       <div className="mt-3">

--- a/apps/web/components/workspace-timezone.tsx
+++ b/apps/web/components/workspace-timezone.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * The workspace's timezone for CLIENT components that print a date. Server
+ * components read it from `/v1/me` directly; this carries the same value down
+ * to the client tree so both sides format the same instant the same way
+ * (null → UTC, deterministic, so hydration never disagrees).
+ */
+const WorkspaceTimeZoneContext = createContext<string>("UTC");
+
+export function WorkspaceTimeZoneProvider({
+  timeZone,
+  children,
+}: {
+  timeZone: string | null | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <WorkspaceTimeZoneContext.Provider value={timeZone || "UTC"}>
+      {children}
+    </WorkspaceTimeZoneContext.Provider>
+  );
+}
+
+/** The workspace zone, `'UTC'` when unset or outside the provider. */
+export function useWorkspaceTimeZone(): string {
+  return useContext(WorkspaceTimeZoneContext);
+}

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -211,6 +211,8 @@ export interface Me {
    * pages themselves read the cookie, not this.
    */
   locale: 'en' | 'es' | null;
+  /** The workspace's IANA timezone, or null while nobody has set one (UTC). */
+  timezone: string | null;
 }
 
 /**
@@ -602,7 +604,7 @@ export const adminApi = {
     req<{ reverted: string[] }>('POST', '/v1/branding/revert', { formIds }),
 
   // Analytics + submissions (this track)
-  getAnalytics: (id: string, range: { from?: number; to?: number } = {}) =>
+  getAnalytics: (id: string, range: { from?: number; to?: number; tz?: string } = {}) =>
     req<AnalyticsResponse>('GET', `/v1/forms/${id}/analytics${qs(range)}`),
   listSubmissions: (id: string, q: SubmissionsQuery = {}) =>
     req<SubmissionsPage>('GET', `/v1/forms/${id}/submissions${qs({ ...q })}`),
@@ -656,6 +658,14 @@ export const adminApi = {
   /** Rename the workspace the caller is acting in (admin/owner), or `opts.workspace`. */
   renameWorkspace: (name: string, opts?: ReqOptions) =>
     req<{ accountId: string; name: string }>('PATCH', '/v1/workspaces/current', { name }, opts),
+  /** Set (null = UTC) or, with `onlyIfUnset`, seed the workspace's timezone. */
+  setWorkspaceTimezone: (input: { timezone: string | null; onlyIfUnset?: boolean }, opts?: ReqOptions) =>
+    req<{ accountId: string; timezone: string | null; applied: boolean }>(
+      'PATCH',
+      '/v1/workspaces/current/timezone',
+      input,
+      opts,
+    ),
   /** Tell the API the caller is about to open this workspace (membership re-checked; remembered upstream). */
   enterWorkspace: (accountId: string) => req<{ ok: true }>('POST', `/v1/workspaces/${accountId}/enter`),
   /** Type-to-find: own workspaces filtered by name; staff also get the estate. */

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -260,6 +260,16 @@ export interface FormSummary {
   slug: string;
   /** Epoch-ms of the last brand-kit apply; null when never applied or reverted. */
   brandAppliedAt: number | null;
+  /** The folder the form is filed in; null = unfiled. */
+  folderId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** A form folder: flat, named only, unique per workspace without regard to case. */
+export interface Folder {
+  id: string;
+  name: string;
   createdAt: number;
   updatedAt: number;
 }
@@ -574,7 +584,7 @@ export const adminApi = {
   // Forms
   listForms: () => req<FormSummary[]>('GET', '/v1/forms'),
   getForm: (id: string) => req<FormDetail>('GET', `/v1/forms/${id}`),
-  createForm: (b: { name: string; slug?: string; config?: unknown }) =>
+  createForm: (b: { name: string; slug?: string; config?: unknown; folderId?: string | null }) =>
     req<FormDetail>('POST', '/v1/forms', b),
   updateForm: (id: string, b: { name?: string; config?: unknown }) =>
     req<FormDetail>('PUT', `/v1/forms/${id}`, b),
@@ -590,6 +600,15 @@ export const adminApi = {
   /** Publish the pending draft config (no-op when no draft is pending). */
   publishForm: (id: string) => req<FormDetail>('POST', `/v1/forms/${id}/publish`),
   deleteForm: (id: string) => req<void>('DELETE', `/v1/forms/${id}`),
+
+  // Form folders
+  listFolders: () => req<Folder[]>('GET', '/v1/folders'),
+  createFolder: (name: string) => req<Folder>('POST', '/v1/folders', { name }),
+  renameFolder: (id: string, name: string) => req<Folder>('PATCH', `/v1/folders/${id}`, { name }),
+  deleteFolder: (id: string) => req<void>('DELETE', `/v1/folders/${id}`),
+  /** File a form in a folder; null unfiles it. */
+  setFormFolder: (id: string, folderId: string | null) =>
+    req<{ id: string; folderId: string | null }>('PATCH', `/v1/forms/${id}/folder`, { folderId }),
 
   // Workspace brand kit (reads open to members; writes + apply/revert admin/owner)
   getBranding: () => req<BrandingResponse>('GET', '/v1/branding'),

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -53,7 +53,7 @@ export interface SubmitResult {
 export async function postSubmission(
   accountCode: string,
   slug: string,
-  body: { sessionId: string; data: Record<string, unknown>; partial?: boolean },
+  body: { sessionId: string; data: Record<string, unknown>; partial?: boolean; locale?: 'en' | 'es' },
 ): Promise<SubmitResult> {
   const res = await fetch(
     `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/submissions`,

--- a/apps/web/lib/client-locale.spec.ts
+++ b/apps/web/lib/client-locale.spec.ts
@@ -17,6 +17,10 @@ describe("publicClientLocale (the public error boundary has no request to read)"
 
     vi.stubGlobal("navigator", { language: "de-DE" });
     expect(publicClientLocale()).toBe("en");
+    // An unshipped ?lang is ignored, the browser still decides.
+    vi.stubGlobal("location", { search: "?lang=fr" });
+    vi.stubGlobal("navigator", { language: "es-CO" });
+    expect(publicClientLocale()).toBe("es");
   });
 
   it("is safe without a window (server render of the boundary shell)", () => {

--- a/apps/web/lib/client-locale.spec.ts
+++ b/apps/web/lib/client-locale.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { publicClientLocale } from "./client-locale";
+
+describe("publicClientLocale (the public error boundary has no request to read)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads ?lang first, then the browser language, then English", () => {
+    vi.stubGlobal("location", { search: "?lang=es" });
+    vi.stubGlobal("navigator", { language: "en-US" });
+    expect(publicClientLocale()).toBe("es");
+
+    vi.stubGlobal("location", { search: "" });
+    vi.stubGlobal("navigator", { language: "es-CO" });
+    expect(publicClientLocale()).toBe("es");
+
+    vi.stubGlobal("navigator", { language: "de-DE" });
+    expect(publicClientLocale()).toBe("en");
+  });
+
+  it("is safe without a window (server render of the boundary shell)", () => {
+    vi.stubGlobal("location", undefined);
+    vi.stubGlobal("navigator", undefined);
+    expect(publicClientLocale()).toBe("en");
+  });
+});

--- a/apps/web/lib/client-locale.ts
+++ b/apps/web/lib/client-locale.ts
@@ -5,6 +5,22 @@ import type { Locale } from '@quill/shared';
  * is server-only): the persisted admin locale from the document cookie.
  * Defaults to English so a bare fork renders with no cookie.
  */
+/**
+ * The locale of a PUBLIC surface that has no request to read (the error
+ * boundary is a client component): an explicit `?lang`, else the browser's
+ * language, else English. Same order as `resolveFormLocale`, minus the form
+ * language, which the boundary cannot know.
+ */
+export function publicClientLocale(): Locale {
+  const pick = (v: string): Locale => (v.trim().toLowerCase().startsWith('es') ? 'es' : 'en');
+  if (typeof location !== 'undefined' && location?.search) {
+    const lang = new URLSearchParams(location.search).get('lang');
+    if (lang) return pick(lang);
+  }
+  if (typeof navigator !== 'undefined' && navigator?.language) return pick(navigator.language);
+  return 'en';
+}
+
 export function clientLocale(): Locale {
   if (typeof document !== 'undefined' && /(?:^|;\s*)quill_locale=es\b/.test(document.cookie)) return 'es';
   return 'en';

--- a/apps/web/lib/client-locale.ts
+++ b/apps/web/lib/client-locale.ts
@@ -1,4 +1,5 @@
 import type { Locale } from '@quill/shared';
+import { shippedLocale } from './form-locale';
 
 /**
  * Client-side twin of lib/locale.ts#getLocale (that one reads next/headers and
@@ -14,8 +15,8 @@ import type { Locale } from '@quill/shared';
 export function publicClientLocale(): Locale {
   const pick = (v: string): Locale => (v.trim().toLowerCase().startsWith('es') ? 'es' : 'en');
   if (typeof location !== 'undefined' && location?.search) {
-    const lang = new URLSearchParams(location.search).get('lang');
-    if (lang) return pick(lang);
+    const asked = shippedLocale(new URLSearchParams(location.search).get('lang'));
+    if (asked) return asked;
   }
   if (typeof navigator !== 'undefined' && navigator?.language) return pick(navigator.language);
   return 'en';

--- a/apps/web/lib/form-locale.spec.ts
+++ b/apps/web/lib/form-locale.spec.ts
@@ -18,7 +18,9 @@ describe("resolveFormLocale: ?lang, then the form language, then the browser", (
       }),
     ).toBe("en");
     expect(resolveFormLocale({ lang: "ES-mx" })).toBe("es");
-    expect(resolveFormLocale({ lang: "fr", configLanguage: "es" })).toBe("en");
+    // A ?lang we do not ship is noise, not an ask: the author's language still wins.
+    expect(resolveFormLocale({ lang: "fr", configLanguage: "es" })).toBe("es");
+    expect(resolveFormLocale({ lang: "fr", acceptLanguage: "en-US" })).toBe("en");
   });
 
   it("the form language beats the browser", () => {

--- a/apps/web/lib/form-locale.spec.ts
+++ b/apps/web/lib/form-locale.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveFormLocale } from "./form-locale";
+
+describe("resolveFormLocale: ?lang, then the form language, then the browser", () => {
+  it("an explicit ?lang wins over everything, and only Spanish-ish values mean Spanish", () => {
+    expect(
+      resolveFormLocale({
+        lang: "es",
+        configLanguage: "en",
+        acceptLanguage: "en-US",
+      }),
+    ).toBe("es");
+    expect(
+      resolveFormLocale({
+        lang: "en",
+        configLanguage: "es",
+        acceptLanguage: "es-CO",
+      }),
+    ).toBe("en");
+    expect(resolveFormLocale({ lang: "ES-mx" })).toBe("es");
+    expect(resolveFormLocale({ lang: "fr", configLanguage: "es" })).toBe("en");
+  });
+
+  it("the form language beats the browser", () => {
+    expect(
+      resolveFormLocale({
+        configLanguage: "es",
+        acceptLanguage: "en-US,en;q=0.9",
+      }),
+    ).toBe("es");
+    expect(
+      resolveFormLocale({ configLanguage: "en", acceptLanguage: "es-CO" }),
+    ).toBe("en");
+  });
+
+  it("Auto (no form language) reads the browser, like before this field existed", () => {
+    expect(resolveFormLocale({ acceptLanguage: "es-CO,es;q=0.9" })).toBe("es");
+    expect(resolveFormLocale({ acceptLanguage: "en-GB" })).toBe("en");
+    expect(
+      resolveFormLocale({ configLanguage: null, acceptLanguage: "es" }),
+    ).toBe("es");
+  });
+
+  it("defaults to English with nothing at all", () => {
+    expect(resolveFormLocale({})).toBe("en");
+    expect(
+      resolveFormLocale({ lang: "", configLanguage: null, acceptLanguage: "" }),
+    ).toBe("en");
+  });
+});

--- a/apps/web/lib/form-locale.ts
+++ b/apps/web/lib/form-locale.ts
@@ -1,0 +1,27 @@
+import type { Locale } from "@quill/shared";
+
+/** Spanish-ish → es, anything else → en (the only two languages we ship). */
+function pick(value: string): Locale {
+  return value.trim().toLowerCase().startsWith("es") ? "es" : "en";
+}
+
+/**
+ * The language a public form renders in. Precedence, highest first:
+ *
+ *  1. `?lang=` on the URL, an explicit ask (a share link, an embed);
+ *  2. the form's own `language` (absent/null = Auto);
+ *  3. the visitor's `Accept-Language`;
+ *  4. English.
+ *
+ * Pure (no `next/headers`) so the matrix is testable in node; `publicLocale`
+ * in lib/locale.ts feeds it the request headers.
+ */
+export function resolveFormLocale(input: {
+  lang?: string | null;
+  configLanguage?: Locale | null;
+  acceptLanguage?: string | null;
+}): Locale {
+  if (input.lang) return pick(input.lang);
+  if (input.configLanguage) return input.configLanguage;
+  return pick(input.acceptLanguage ?? "");
+}

--- a/apps/web/lib/form-locale.ts
+++ b/apps/web/lib/form-locale.ts
@@ -8,7 +8,9 @@ function pick(value: string): Locale {
 /**
  * The language a public form renders in. Precedence, highest first:
  *
- *  1. `?lang=` on the URL, an explicit ask (a share link, an embed);
+ *  1. `?lang=` on the URL, an explicit ask (a share link, an embed), when it
+ *     names a language we ship: `?lang=fr` from a tracking tool is noise and
+ *     must not override the author's choice;
  *  2. the form's own `language` (absent/null = Auto);
  *  3. the visitor's `Accept-Language`;
  *  4. English.
@@ -16,12 +18,21 @@ function pick(value: string): Locale {
  * Pure (no `next/headers`) so the matrix is testable in node; `publicLocale`
  * in lib/locale.ts feeds it the request headers.
  */
+/** A `?lang` that names a language we ship, else null (a stray value must not beat the author). */
+export function shippedLocale(value: string | null | undefined): Locale | null {
+  const v = value?.trim().toLowerCase() ?? '';
+  if (v.startsWith('es')) return 'es';
+  if (v.startsWith('en')) return 'en';
+  return null;
+}
+
 export function resolveFormLocale(input: {
   lang?: string | null;
   configLanguage?: Locale | null;
   acceptLanguage?: string | null;
 }): Locale {
-  if (input.lang) return pick(input.lang);
+  const asked = shippedLocale(input.lang);
+  if (asked) return asked;
   if (input.configLanguage) return input.configLanguage;
   return pick(input.acceptLanguage ?? "");
 }

--- a/apps/web/lib/forms-search.spec.ts
+++ b/apps/web/lib/forms-search.spec.ts
@@ -47,6 +47,16 @@ describe("matchForm", () => {
     });
   });
 
+  it("keeps a decomposed accent inside the highlight and survives a no-break space", () => {
+    // "o" + combining acute, the NFD form some inputs produce.
+    const decomposed = { name: "Satisfaccio\u0301n total", slug: "x" };
+    expect(matchForm(decomposed, "satisfaccion")).toEqual({ matched: true, nameRanges: [[0, 13]] });
+    expect(matchForm({ name: "Lead\u00a0Qualifier", slug: "x" }, "qualifier")).toEqual({
+      matched: true,
+      nameRanges: [[5, 14]],
+    });
+  });
+
   it("an empty query matches everything with no ranges", () => {
     expect(matchForm(forms[2]!, "   ")).toEqual({
       matched: true,

--- a/apps/web/lib/forms-search.spec.ts
+++ b/apps/web/lib/forms-search.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { groupBySections, matchForm, normalize } from "./forms-search";
+
+const forms = [
+  {
+    id: "a",
+    name: "Lead Qualifier",
+    slug: "lead-qualifier",
+    folderId: "sales",
+  },
+  {
+    id: "b",
+    name: "Encuesta de satisfacción",
+    slug: "encuesta",
+    folderId: null,
+  },
+  { id: "c", name: "Demo request", slug: "demo-request", folderId: "sales" },
+  { id: "d", name: "Archived quiz", slug: "quiz", folderId: "old" },
+];
+const folders = [
+  { id: "old", name: "Archive" },
+  { id: "sales", name: "Sales" },
+];
+
+describe("normalize", () => {
+  it("lower-cases and strips accents so a query matches without them", () => {
+    expect(normalize("Satisfacción")).toBe("satisfaccion");
+    expect(normalize("  LEAD ")).toBe("lead");
+  });
+});
+
+describe("matchForm", () => {
+  it("matches the name or the slug, and reports the matched ranges on the name", () => {
+    expect(matchForm(forms[0]!, "lead")).toEqual({
+      matched: true,
+      nameRanges: [[0, 4]],
+    });
+    // Only the slug matches: no highlight ranges on the name, but still a hit.
+    expect(matchForm(forms[1]!, "encuesta")).toMatchObject({ matched: true });
+    expect(matchForm(forms[1]!, "satisfaccion")).toEqual({
+      matched: true,
+      nameRanges: [[12, 24]],
+    });
+    expect(matchForm(forms[0]!, "zzz")).toEqual({
+      matched: false,
+      nameRanges: [],
+    });
+  });
+
+  it("an empty query matches everything with no ranges", () => {
+    expect(matchForm(forms[2]!, "   ")).toEqual({
+      matched: true,
+      nameRanges: [],
+    });
+  });
+});
+
+describe("groupBySections", () => {
+  it("puts Unfiled first, then folders alphabetically, each with its forms in list order", () => {
+    const sections = groupBySections(forms, folders, "");
+    expect(sections.map((s) => s.id)).toEqual([null, "old", "sales"]);
+    expect(sections.map((s) => s.forms.map((f) => f.id))).toEqual([
+      ["b"],
+      ["d"],
+      ["a", "c"],
+    ]);
+    expect(sections.map((s) => s.total)).toEqual([1, 1, 2]);
+  });
+
+  it("keeps an empty folder as a section (so it can be a drop target) when there is no query", () => {
+    const sections = groupBySections(
+      forms,
+      [...folders, { id: "new", name: "New" }],
+      "",
+    );
+    expect(sections.find((s) => s.id === "new")).toMatchObject({
+      forms: [],
+      total: 0,
+    });
+  });
+
+  it("with a query, hides sections without a match and keeps the total for the count", () => {
+    const sections = groupBySections(forms, folders, "demo");
+    expect(sections.map((s) => s.id)).toEqual(["sales"]);
+    expect(sections[0]!.forms.map((f) => f.id)).toEqual(["c"]);
+    expect(sections[0]!.total).toBe(2);
+  });
+
+  it("a form whose folder no longer exists shows as unfiled rather than vanishing", () => {
+    const sections = groupBySections(
+      [{ id: "x", name: "Orphan", slug: "orphan", folderId: "gone" }],
+      folders,
+      "",
+    );
+    expect(sections[0]!.forms.map((f) => f.id)).toEqual(["x"]);
+  });
+});

--- a/apps/web/lib/forms-search.ts
+++ b/apps/web/lib/forms-search.ts
@@ -27,7 +27,11 @@ export interface FormMatch {
 
 /** Lower-case, accents stripped, trimmed. Same recipe as `slugify`'s first steps. */
 export function normalize(value: string): string {
-  return value.normalize("NFKD").replace(/[̀-ͯ]/g, "").toLowerCase().trim();
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
 }
 
 /**
@@ -43,7 +47,14 @@ function rangesOnOriginal(
   if (!normalizedQuery) return ranges;
   // Per-character normalized forms, so the map back is exact.
   const chars = [...original];
-  const normChars = chars.map((c) => normalize(c) || (c === " " ? " " : ""));
+  // Not `normalize` itself: that trims, and a space (or a no-break space) in
+  // the middle of a name must stay a character or every index after it drifts.
+  const normChars = chars.map((c) =>
+    c
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase(),
+  );
   const flat = normChars.join("");
   // Offsets: the original char index at which each normalized char starts.
   const origIndexAt: number[] = [];
@@ -55,7 +66,10 @@ function rangesOnOriginal(
     const at = flat.indexOf(normalizedQuery, from);
     if (at < 0) break;
     const startChar = origIndexAt[at]!;
-    const endChar = origIndexAt[at + normalizedQuery.length - 1]! + 1;
+    let endChar = origIndexAt[at + normalizedQuery.length - 1]! + 1;
+    // A decomposed accent (a base letter followed by a combining mark) has no
+    // normalized form of its own; keep it inside the highlight of its letter.
+    while (endChar < chars.length && normChars[endChar] === '') endChar += 1;
     // Convert char (code point) indexes to string indexes.
     const start = chars.slice(0, startChar).join("").length;
     const end = chars.slice(0, endChar).join("").length;

--- a/apps/web/lib/forms-search.ts
+++ b/apps/web/lib/forms-search.ts
@@ -1,0 +1,137 @@
+/**
+ * Client-side search and grouping for the forms list. Pure: the list is
+ * already loaded, so filtering by name or slug happens in the browser with no
+ * round trip. Matching ignores case and accents on both sides, the way the
+ * slugifier does, so "satisfaccion" finds "Satisfacción".
+ */
+
+export interface SearchableForm {
+  id: string;
+  name: string;
+  slug: string;
+  folderId: string | null;
+}
+
+export interface SearchableFolder {
+  id: string;
+  name: string;
+}
+
+/** A character range `[start, end)` on the ORIGINAL name, for highlighting. */
+export type MatchRange = [number, number];
+
+export interface FormMatch {
+  matched: boolean;
+  nameRanges: MatchRange[];
+}
+
+/** Lower-case, accents stripped, trimmed. Same recipe as `slugify`'s first steps. */
+export function normalize(value: string): string {
+  return value.normalize("NFKD").replace(/[̀-ͯ]/g, "").toLowerCase().trim();
+}
+
+/**
+ * Map an index in the normalized string back to the original. Accents are
+ * combining marks that `normalize` removed, so the original index only ever
+ * runs ahead of the normalized one; walk both in step.
+ */
+function rangesOnOriginal(
+  original: string,
+  normalizedQuery: string,
+): MatchRange[] {
+  const ranges: MatchRange[] = [];
+  if (!normalizedQuery) return ranges;
+  // Per-character normalized forms, so the map back is exact.
+  const chars = [...original];
+  const normChars = chars.map((c) => normalize(c) || (c === " " ? " " : ""));
+  const flat = normChars.join("");
+  // Offsets: the original char index at which each normalized char starts.
+  const origIndexAt: number[] = [];
+  chars.forEach((c, i) => {
+    for (let k = 0; k < normChars[i]!.length; k++) origIndexAt.push(i);
+  });
+  let from = 0;
+  for (;;) {
+    const at = flat.indexOf(normalizedQuery, from);
+    if (at < 0) break;
+    const startChar = origIndexAt[at]!;
+    const endChar = origIndexAt[at + normalizedQuery.length - 1]! + 1;
+    // Convert char (code point) indexes to string indexes.
+    const start = chars.slice(0, startChar).join("").length;
+    const end = chars.slice(0, endChar).join("").length;
+    ranges.push([start, end]);
+    from = at + normalizedQuery.length;
+  }
+  return ranges;
+}
+
+/** Whether `form` matches `query` by name or slug; ranges are on the name only. */
+export function matchForm(
+  form: Pick<SearchableForm, "name" | "slug">,
+  query: string,
+): FormMatch {
+  const q = normalize(query);
+  if (!q) return { matched: true, nameRanges: [] };
+  const nameRanges = rangesOnOriginal(form.name, q);
+  const matched = nameRanges.length > 0 || normalize(form.slug).includes(q);
+  return { matched, nameRanges: matched ? nameRanges : [] };
+}
+
+export interface FormSection<F extends SearchableForm = SearchableForm> {
+  /** The folder id, or null for the unfiled section. */
+  id: string | null;
+  /** The folder name; null for the unfiled section (the caller labels it). */
+  name: string | null;
+  /** The forms to show (filtered by the query), in list order. */
+  forms: Array<F & { match: FormMatch }>;
+  /** How many forms the folder holds regardless of the query (the header count). */
+  total: number;
+}
+
+/**
+ * Group forms into sections: Unfiled first, then every folder alphabetically
+ * (as the API lists them). Without a query every folder is a section, even an
+ * empty one, so it can receive a drop. With a query, sections without a match
+ * disappear and the ones left keep their full count.
+ */
+export function groupBySections<F extends SearchableForm>(
+  forms: F[],
+  folders: SearchableFolder[],
+  query: string,
+): FormSection<F>[] {
+  const known = new Set(folders.map((f) => f.id));
+  const byFolder = new Map<string | null, Array<F & { match: FormMatch }>>();
+  const totals = new Map<string | null, number>();
+  const keyOf = (f: F) =>
+    f.folderId && known.has(f.folderId) ? f.folderId : null;
+  for (const form of forms) {
+    const key = keyOf(form);
+    totals.set(key, (totals.get(key) ?? 0) + 1);
+    const match = matchForm(form, query);
+    if (!match.matched) continue;
+    const list = byFolder.get(key) ?? [];
+    list.push({ ...form, match });
+    byFolder.set(key, list);
+  }
+  const searching = normalize(query).length > 0;
+  const sections: FormSection<F>[] = [];
+  const unfiled = byFolder.get(null) ?? [];
+  if (!searching || unfiled.length > 0)
+    sections.push({
+      id: null,
+      name: null,
+      forms: unfiled,
+      total: totals.get(null) ?? 0,
+    });
+  for (const folder of folders) {
+    const list = byFolder.get(folder.id) ?? [];
+    if (searching && list.length === 0) continue;
+    sections.push({
+      id: folder.id,
+      name: folder.name,
+      forms: list,
+      total: totals.get(folder.id) ?? 0,
+    });
+  }
+  return sections;
+}

--- a/apps/web/lib/locale.ts
+++ b/apps/web/lib/locale.ts
@@ -1,5 +1,6 @@
 import { cookies, headers } from 'next/headers';
 import type { Locale } from '@quill/shared';
+import { resolveFormLocale } from './form-locale';
 
 /** Persisted admin-UI language choice (F8 parity with the old app's toggle). */
 export const LOCALE_COOKIE = 'quill_locale';
@@ -43,11 +44,14 @@ export async function preferredLocale(): Promise<Locale> {
 }
 
 /**
- * Public-surface locale (no admin cookie there): an explicit ?lang= wins,
- * otherwise the browser's Accept-Language decides. Defaults to English.
+ * Public-surface locale (no admin cookie there): an explicit ?lang= wins, then
+ * the form's own language, then the browser's Accept-Language. Defaults to
+ * English. See `resolveFormLocale` for the matrix.
  */
-export async function publicLocale(lang?: string): Promise<Locale> {
-  const pick = (v: string) => (v.trim().toLowerCase().startsWith('es') ? 'es' : 'en') as Locale;
-  if (lang) return pick(lang);
-  return pick((await headers()).get('accept-language') ?? '');
+export async function publicLocale(lang?: string, configLanguage?: Locale | null): Promise<Locale> {
+  return resolveFormLocale({
+    lang,
+    configLanguage,
+    acceptLanguage: (await headers()).get('accept-language'),
+  });
 }

--- a/apps/web/lib/notification-preview.spec.ts
+++ b/apps/web/lib/notification-preview.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { interpolate, NOTIFICATION_SAMPLE } from './notification-preview';
+import { hasToken, interpolate, NOTIFICATION_SAMPLE } from './notification-preview';
 
 describe('notification preview interpolate', () => {
   it('substitutes known {{tokens}} from the sample and tolerates whitespace', () => {
@@ -16,6 +16,11 @@ describe('notification preview interpolate', () => {
     expect(interpolate('{{formName}}', { formName: '{{score}}', score: '9' })).toBe('{{score}}');
   });
 
+  it('carries a multi-line answers sample so the preview shows the block as the email will', () => {
+    expect(NOTIFICATION_SAMPLE.answers).toContain('\n');
+    expect(NOTIFICATION_SAMPLE.answers!.split('\n').every((line) => /: /.test(line))).toBe(true);
+  });
+
   it('renders the default owner template with all five tokens filled', () => {
     const body = [
       'You have a new submission on "{{formName}}".',
@@ -30,8 +35,18 @@ describe('notification preview interpolate', () => {
         'From: lead@acme.io',
         'Score: 15',
         'Outcome: Qualified',
-        'View submissions: https://forms.example.com/acme/lead-qualifier',
+        'View submissions: https://forms.example.com/admin/forms/lead-qualifier/submissions',
       ].join('\n'),
     );
+  });
+});
+
+describe('hasToken', () => {
+  it('finds the token with or without inner whitespace, and not another token', () => {
+    expect(hasToken('A\n{{answers}}', 'answers')).toBe(true);
+    expect(hasToken('{{ answers }}', 'answers')).toBe(true);
+    expect(hasToken('{{answers }}', 'answers')).toBe(true);
+    expect(hasToken('{{formName}} answers', 'answers')).toBe(false);
+    expect(hasToken('', 'answers')).toBe(false);
   });
 });

--- a/apps/web/lib/notification-preview.ts
+++ b/apps/web/lib/notification-preview.ts
@@ -12,8 +12,16 @@ export const NOTIFICATION_SAMPLE: Record<string, string> = {
   respondentEmail: 'lead@acme.io',
   score: '15',
   outcomeLabel: 'Qualified',
-  formLink: 'https://forms.example.com/acme/lead-qualifier',
+  formLink: 'https://forms.example.com/admin/forms/lead-qualifier/submissions',
+  // Multi-line on purpose: the real token expands to one "Label: value" line
+  // per answered question, and the preview should show that shape.
+  answers: ['What best describes you?: Founder / Owner', 'How big is your team?: 20', 'Email: lead@acme.io'].join('\n'),
 };
+
+/** True when `template` references `{{name}}` (inner whitespace tolerated, like the server). */
+export function hasToken(template: string, name: string): boolean {
+  return new RegExp(`\\{\\{\\s*${name}\\s*\\}\\}`).test(template);
+}
 
 /** Substitute `{{token}}` markers in one pass; an unknown token stays literal. */
 export function interpolate(template: string, values: Record<string, string>): string {

--- a/apps/web/lib/suite.spec.ts
+++ b/apps/web/lib/suite.spec.ts
@@ -21,6 +21,13 @@ describe('suiteHref — the in-app doors to the suite', () => {
     expect(url.searchParams.get('utm_source')).toBe('forms');
   });
 
+  it('tags the documentation link without disturbing its path (the docs site routes on it)', () => {
+    const url = new URL(suiteHref('https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms', 'sidebar'));
+    expect(url.pathname).toBe('/dapta-docs-es/dapta-forms/forms');
+    expect(url.searchParams.get('utm_source')).toBe('forms');
+    expect(url.searchParams.get('utm_medium')).toBe('sidebar');
+  });
+
   it('returns an unparseable base verbatim rather than hiding it', () => {
     // A suite link that looks broken is a bug worth seeing; only the public
     // badge hides, because a fork may legitimately have no destination.

--- a/apps/web/lib/timezones.ts
+++ b/apps/web/lib/timezones.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser-side helpers for IANA timezone pickers. Advisory only: the SERVER's
+ * ICU data decides what a zone means; these keep the UI honest at the moment
+ * of typing and give a searchable list where the runtime can enumerate one.
+ */
+
+/** Whether this browser can resolve the IANA zone name. Blank is always fine (UTC). */
+export function isKnownTimezone(value: string): boolean {
+  const zone = value.trim();
+  if (!zone) return true;
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The IANA zones this browser can enumerate. Computed once: the list is static
+ * for the life of the page. A runtime without `Intl.supportedValuesOf` yields
+ * null, and callers fall back to a free-text input.
+ */
+let cachedTimezones: string[] | null | undefined;
+export function browserTimezones(): string[] | null {
+  if (cachedTimezones !== undefined) return cachedTimezones;
+  try {
+    const zones = Intl.supportedValuesOf("timeZone");
+    cachedTimezones = zones.length > 0 ? zones : null;
+  } catch {
+    cachedTimezones = null;
+  }
+  return cachedTimezones;
+}
+
+/** The zone this browser runs in, or null when the runtime will not say. */
+export function browserTimezone(): string | null {
+  try {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return zone && isKnownTimezone(zone) ? zone : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/use-global-shortcut.spec.ts
+++ b/apps/web/lib/use-global-shortcut.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { isEditableTarget, shortcutFor } from "./use-global-shortcut";
+
+function key(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    defaultPrevented: false,
+    ...init,
+  } as KeyboardEvent;
+}
+
+describe("shortcutFor", () => {
+  it("Cmd/Ctrl+K focuses search from anywhere, even inside an input", () => {
+    expect(
+      shortcutFor(key({ key: "k", metaKey: true }), {
+        editable: false,
+        dialogOpen: false,
+      }),
+    ).toBe("search");
+    expect(
+      shortcutFor(key({ key: "K", ctrlKey: true }), {
+        editable: true,
+        dialogOpen: false,
+      }),
+    ).toBe("search");
+  });
+
+  it("a bare slash focuses search only outside editable fields and with no dialog open", () => {
+    expect(
+      shortcutFor(key({ key: "/" }), { editable: false, dialogOpen: false }),
+    ).toBe("search");
+    expect(
+      shortcutFor(key({ key: "/" }), { editable: true, dialogOpen: false }),
+    ).toBeNull();
+    expect(
+      shortcutFor(key({ key: "/" }), { editable: false, dialogOpen: true }),
+    ).toBeNull();
+  });
+
+  it("ignores anything already handled, and unrelated keys", () => {
+    expect(
+      shortcutFor(key({ key: "/", defaultPrevented: true }), {
+        editable: false,
+        dialogOpen: false,
+      }),
+    ).toBeNull();
+    expect(
+      shortcutFor(key({ key: "k" }), { editable: false, dialogOpen: false }),
+    ).toBeNull();
+    expect(
+      shortcutFor(key({ key: "k", metaKey: true, altKey: true }), {
+        editable: false,
+        dialogOpen: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("isEditableTarget", () => {
+  const el = (tag: string, extra: Record<string, unknown> = {}) =>
+    ({
+      tagName: tag,
+      isContentEditable: false,
+      ...extra,
+    }) as unknown as EventTarget;
+  it("treats inputs, textareas, selects and contenteditable as editable", () => {
+    expect(isEditableTarget(el("INPUT"))).toBe(true);
+    expect(isEditableTarget(el("TEXTAREA"))).toBe(true);
+    expect(isEditableTarget(el("SELECT"))).toBe(true);
+    expect(isEditableTarget(el("DIV", { isContentEditable: true }))).toBe(true);
+    expect(isEditableTarget(el("DIV"))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});

--- a/apps/web/lib/use-global-shortcut.ts
+++ b/apps/web/lib/use-global-shortcut.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** Inputs, textareas, selects and anything contenteditable: a slash there is typing. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || typeof target !== "object") return false;
+  const el = target as { tagName?: string; isContentEditable?: boolean };
+  const tag = (el.tagName ?? "").toUpperCase();
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable === true
+  );
+}
+
+export type GlobalShortcut = "search";
+
+/**
+ * Which shortcut a keydown means, or null. Cmd/Ctrl+K works everywhere (it
+ * is the universal "find" chord and never types a character); a bare `/`
+ * only outside editable fields and while no dialog is open, because there it
+ * is a character someone is typing.
+ */
+export function shortcutFor(
+  e: Pick<
+    KeyboardEvent,
+    "key" | "metaKey" | "ctrlKey" | "altKey" | "defaultPrevented"
+  >,
+  ctx: { editable: boolean; dialogOpen: boolean },
+): GlobalShortcut | null {
+  if (e.defaultPrevented || e.altKey) return null;
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") return "search";
+  if (
+    !e.metaKey &&
+    !e.ctrlKey &&
+    e.key === "/" &&
+    !ctx.editable &&
+    !ctx.dialogOpen
+  )
+    return "search";
+  return null;
+}
+
+/** One document keydown listener that routes the page's shortcuts to `onShortcut`. */
+export function useGlobalShortcut(
+  onShortcut: (shortcut: GlobalShortcut, e: KeyboardEvent) => void,
+): void {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const shortcut = shortcutFor(e, {
+        editable: isEditableTarget(e.target),
+        dialogOpen: document.querySelector('[role="dialog"]') != null,
+      });
+      if (!shortcut) return;
+      e.preventDefault();
+      onShortcut(shortcut, e);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onShortcut]);
+}

--- a/apps/web/lib/use-global-shortcut.ts
+++ b/apps/web/lib/use-global-shortcut.ts
@@ -51,7 +51,7 @@ export function useGlobalShortcut(
     const onKeyDown = (e: KeyboardEvent) => {
       const shortcut = shortcutFor(e, {
         editable: isEditableTarget(e.target),
-        dialogOpen: document.querySelector('[role="dialog"]') != null,
+        dialogOpen: document.querySelector('[role="dialog"], [role="alertdialog"]') != null,
       });
       if (!shortcut) return;
       e.preventDefault();

--- a/packages/db/migrations/postgres/0019_owner_email_answers_token.sql
+++ b/packages/db/migrations/postgres/0019_owner_email_answers_token.sql
@@ -1,0 +1,14 @@
+-- The owner notice gained an `{{answers}}` token (the submission's answers as
+-- "Label: value" lines / a table), and the shipped default now carries it.
+-- An account or form that customized its owner-notice body BEFORE the token
+-- existed would otherwise keep receiving an email without the answers, which
+-- is the exact bug this release fixes. Append the token to every custom body
+-- that lacks it (with a blank spacer line, matching the default's layout).
+-- NULL bodies render the shipped default and need nothing. The respondent
+-- email is untouched: the answers there are opt-in. Reruns match nothing.
+UPDATE notification_setting
+SET body = body || chr(10) || chr(10) || '{{answers}}'
+WHERE email_key = 'submission_received'
+  AND body IS NOT NULL
+  AND body NOT LIKE '%{{answers}}%'
+  AND body NOT LIKE '%{{ answers }}%';

--- a/packages/db/migrations/postgres/0020_account_timezone.sql
+++ b/packages/db/migrations/postgres/0020_account_timezone.sql
@@ -1,0 +1,9 @@
+-- Workspace timezone: additive.
+--
+-- Every date the admin shows was rendered on the server clock (UTC) and the
+-- analytics day buckets were UTC days, so a team in Bogota read yesterday's
+-- evening submissions as today's. `account.timezone` is the IANA zone the
+-- whole workspace reads dates in: the submissions table, the analytics day
+-- cuts and the CSV's local columns. NULL means UTC, exactly as before, until
+-- the first admin's browser claims it (UPDATE ... WHERE timezone IS NULL).
+ALTER TABLE account ADD COLUMN IF NOT EXISTS timezone TEXT;

--- a/packages/db/migrations/postgres/0021_form_folders.sql
+++ b/packages/db/migrations/postgres/0021_form_folders.sql
@@ -1,0 +1,20 @@
+-- Form folders: additive.
+--
+-- A workspace with more than a screenful of forms had one flat list and no
+-- way to group it. `form_folder` is that grouping: flat (one level), named
+-- only, unique per account without regard to case (the expression index on
+-- lower(name)), and a form belongs to at most one (`form.folder_id`, NULL =
+-- unfiled, which is what every existing form is). Deleting a folder unfiles
+-- its forms (ON DELETE SET NULL, and the repo does it explicitly too) and
+-- never deletes them.
+CREATE TABLE IF NOT EXISTS form_folder (
+  id          TEXT PRIMARY KEY,
+  account_id  TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  created_at  BIGINT NOT NULL,
+  updated_at  BIGINT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS form_folder_account_name_uq ON form_folder (account_id, lower(name));
+
+ALTER TABLE form ADD COLUMN IF NOT EXISTS folder_id TEXT REFERENCES form_folder(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS form_account_folder_idx ON form (account_id, folder_id);

--- a/packages/db/migrations/sqlite/0019_owner_email_answers_token.sql
+++ b/packages/db/migrations/sqlite/0019_owner_email_answers_token.sql
@@ -1,0 +1,14 @@
+-- The owner notice gained an `{{answers}}` token (the submission's answers as
+-- "Label: value" lines / a table), and the shipped default now carries it.
+-- An account or form that customized its owner-notice body BEFORE the token
+-- existed would otherwise keep receiving an email without the answers, which
+-- is the exact bug this release fixes. Append the token to every custom body
+-- that lacks it (with a blank spacer line, matching the default's layout).
+-- NULL bodies render the shipped default and need nothing. The respondent
+-- email is untouched: the answers there are opt-in. Reruns match nothing.
+UPDATE notification_setting
+SET body = body || char(10) || char(10) || '{{answers}}'
+WHERE email_key = 'submission_received'
+  AND body IS NOT NULL
+  AND body NOT LIKE '%{{answers}}%'
+  AND body NOT LIKE '%{{ answers }}%';

--- a/packages/db/migrations/sqlite/0020_account_timezone.sql
+++ b/packages/db/migrations/sqlite/0020_account_timezone.sql
@@ -1,0 +1,2 @@
+-- Workspace timezone: additive. See the Postgres twin for the why.
+ALTER TABLE account ADD COLUMN timezone TEXT;

--- a/packages/db/migrations/sqlite/0021_form_folders.sql
+++ b/packages/db/migrations/sqlite/0021_form_folders.sql
@@ -1,0 +1,12 @@
+-- Form folders: additive. See the Postgres twin for the why.
+CREATE TABLE IF NOT EXISTS form_folder (
+  id          TEXT PRIMARY KEY,
+  account_id  TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS form_folder_account_name_uq ON form_folder (account_id, lower(name));
+
+ALTER TABLE form ADD COLUMN folder_id TEXT REFERENCES form_folder(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS form_account_folder_idx ON form (account_id, folder_id);

--- a/packages/db/src/account-timezone.spec.ts
+++ b/packages/db/src/account-timezone.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * The workspace timezone column (migration 0020): read, set, clear, and the
+ * write-once claim the dashboard uses to seed it from the first admin's
+ * browser. In-memory SQLite locally; DATABASE_URL for the Postgres parity job.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createDb, sql, type Db } from "./client";
+import { migrate } from "./migrate";
+import {
+  claimAccountTimezone,
+  getAccountTimezone,
+  setAccountTimezone,
+} from "./workspaces";
+import { getMe } from "./forms";
+
+let db: Db;
+let accountId: string;
+let memberId: string;
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? "file::memory:");
+  await migrate(db);
+  accountId = randomUUID();
+  memberId = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${accountId}, ${"t" + accountId.slice(0, 7)}, ${"Test"}, ${Date.now()})`,
+  );
+  await db.run(
+    sql`INSERT INTO member (id, account_id, email, role, status, created_at)
+        VALUES (${memberId}, ${accountId}, ${"o@x.com"}, ${"owner"}, ${"active"}, ${Date.now()})`,
+  );
+});
+
+afterEach(async () => {
+  await db.run(sql`DELETE FROM member WHERE account_id = ${accountId}`);
+  await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  await db.close();
+});
+
+describe("account timezone", () => {
+  it("starts unset, sets, and clears back to null", async () => {
+    expect(await getAccountTimezone(db, accountId)).toBeNull();
+    await setAccountTimezone(db, accountId, "America/Bogota");
+    expect(await getAccountTimezone(db, accountId)).toBe("America/Bogota");
+    await setAccountTimezone(db, accountId, null);
+    expect(await getAccountTimezone(db, accountId)).toBeNull();
+  });
+
+  it("claims only while unset: the first browser wins, later ones do not overwrite", async () => {
+    expect(await claimAccountTimezone(db, accountId, "America/Bogota")).toBe(
+      true,
+    );
+    expect(await claimAccountTimezone(db, accountId, "Europe/Madrid")).toBe(
+      false,
+    );
+    expect(await getAccountTimezone(db, accountId)).toBe("America/Bogota");
+  });
+
+  it("rides along on /me", async () => {
+    await setAccountTimezone(db, accountId, "Asia/Tokyo");
+    expect((await getMe(db, accountId, memberId))?.timezone).toBe("Asia/Tokyo");
+  });
+});

--- a/packages/db/src/analytics.spec.ts
+++ b/packages/db/src/analytics.spec.ts
@@ -311,7 +311,7 @@ describe('day buckets in a zone (offset segments)', () => {
     ],
   };
 
-  it('keeps 04:30Z and 08:30Z on the same New York day, while UTC splits them from 23:30Z', async () => {
+  it('splits 04:30Z (still Mar 7 in New York) from 08:30Z (Mar 8), where UTC puts both on Mar 8', async () => {
     // 04:30Z Mar 8 = 23:30 EST Mar 7; 08:30Z Mar 8 = 04:30 EDT Mar 8.
     await ev('a', 'view', Date.UTC(2026, 2, 8, 4, 30));
     await ev('b', 'view', Date.UTC(2026, 2, 8, 8, 30));

--- a/packages/db/src/analytics.spec.ts
+++ b/packages/db/src/analytics.spec.ts
@@ -299,3 +299,38 @@ describe('step-view attribution — by authored key vs legacy index', () => {
     expect((await stepViewCounts(db, formId)).byKey.get('q1')).toBe(2);
   });
 });
+
+describe('day buckets in a zone (offset segments)', () => {
+  // 2026-03-08: New York goes from -05:00 to -04:00 at 07:00Z.
+  const NY_SPRING = Date.UTC(2026, 2, 8, 7, 0, 0);
+  const HOUR = 3_600_000;
+  const bucketing = {
+    segments: [
+      { from: NY_SPRING - 3 * 86_400_000, offsetMs: -5 * HOUR },
+      { from: NY_SPRING, offsetMs: -4 * HOUR },
+    ],
+  };
+
+  it('keeps 04:30Z and 08:30Z on the same New York day, while UTC splits them from 23:30Z', async () => {
+    // 04:30Z Mar 8 = 23:30 EST Mar 7; 08:30Z Mar 8 = 04:30 EDT Mar 8.
+    await ev('a', 'view', Date.UTC(2026, 2, 8, 4, 30));
+    await ev('b', 'view', Date.UTC(2026, 2, 8, 8, 30));
+    await ev('c', 'view', Date.UTC(2026, 2, 7, 23, 30));
+    const utc = await dailyViewSessions(db, formId);
+    expect(utc.map((d) => d.n)).toEqual([1, 2]); // Mar 7 (c), Mar 8 (a, b)
+    const ny = await dailyViewSessions(db, formId, undefined, bucketing);
+    expect(ny.map((d) => d.n)).toEqual([2, 1]); // Mar 7 (c, a), Mar 8 (b)
+    const mar7 = Math.floor((Date.UTC(2026, 2, 7) - 5 * HOUR + 5 * HOUR) / 86_400_000);
+    expect(ny[0]!.day).toBe(mar7);
+  });
+
+  it('a single segment is a plain shifted bucket, and completed submissions bucket the same way', async () => {
+    const bogota = { segments: [{ from: 0, offsetMs: -5 * HOUR }] };
+    // 2026-09-04T03:30Z is Sep 3 in Bogota.
+    await sub('s1', { startedAt: Date.UTC(2026, 8, 4, 3, 0), completedAt: Date.UTC(2026, 8, 4, 3, 30) });
+    const utc = await completedSubmissions(db, formId);
+    const bog = await completedSubmissions(db, formId, undefined, bogota);
+    expect(utc[0]!.day).toBe(Math.floor(Date.UTC(2026, 8, 4) / 86_400_000));
+    expect(bog[0]!.day).toBe(Math.floor(Date.UTC(2026, 8, 3) / 86_400_000));
+  });
+});

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -491,10 +491,17 @@ export async function deleteSubmissionForAccount(
   return exists ? 'forbidden' : 'absent';
 }
 
-/** The earliest `form_event` of a form (epoch-ms), or null with no events yet. */
+/**
+ * The earliest activity of a form (epoch-ms): its first `form_event` or its
+ * first submission, whichever is older (a submission can predate every event
+ * when the beacons were lost). Null with nothing yet. Bounds the offset
+ * segments of an unbounded analytics range, so every row falls inside one.
+ */
 export async function firstEventAt(db: Db, formId: string): Promise<number | null> {
-  const row = await db.get<{ t: number | string | null }>(
-    sql`SELECT MIN(created_at) AS t FROM form_event WHERE form_id = ${formId}`,
+  const row = await db.get<{ e: number | string | null; s: number | string | null }>(
+    sql`SELECT (SELECT MIN(created_at) FROM form_event WHERE form_id = ${formId}) AS e,
+               (SELECT MIN(started_at) FROM submission WHERE form_id = ${formId}) AS s`,
   );
-  return row?.t == null ? null : Number(row.t);
+  const candidates = [row?.e, row?.s].filter((v): v is number | string => v != null).map(Number);
+  return candidates.length ? Math.min(...candidates) : null;
 }

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -18,6 +18,40 @@ export interface DateRange {
 }
 
 /**
+ * How to name the CALENDAR DAY an epoch-ms instant falls on. Absent = UTC
+ * days, byte-for-byte the SQL this module always ran. Otherwise the UTC
+ * offset of the workspace's zone across the queried window, as segments that
+ * start where the offset changes (`utcOffsetSegments` in @quill/shared): one
+ * for a fixed-offset zone, two or three across a DST year. The day expression
+ * becomes `(col + offset) / 86400000` with the offset picked by a CASE over
+ * the segment starts, so bucketing stays inside SQL (COUNT DISTINCT needs it
+ * there) and stays dialect-neutral.
+ */
+export interface DayBucketing {
+  segments: Array<{ from: number; offsetMs: number }>;
+}
+
+/** The whole-day index of `col` under `bucketing` (UTC days when absent). */
+function localDayExpr(col: SQL, bucketing?: DayBucketing): SQL {
+  const segments = bucketing?.segments ?? [];
+  // 86400000 is a SQL literal (not a bound param) so both engines do INTEGER
+  // division and bucket to a whole day.
+  if (segments.length === 0) return sql`(${col} / 86400000)`;
+  // Offsets and boundaries are inlined as INTEGER literals, like the day
+  // length: a bound number reaches SQLite as a REAL and the division stops
+  // truncating, which splits one day into fractional buckets. They are
+  // computed integers (whole minutes of offset, epoch-ms instants), never
+  // caller input, so inlining is safe.
+  const int = (n: number) => sql.raw(String(Math.trunc(n)));
+  if (segments.length === 1) return sql`((${col} + ${int(segments[0]!.offsetMs)}) / 86400000)`;
+  const branches = segments
+    .slice(0, -1)
+    .map((seg, i) => sql`WHEN ${col} < ${int(segments[i + 1]!.from)} THEN ${int(seg.offsetMs)}`);
+  const last = segments[segments.length - 1]!;
+  return sql`((${col} + (CASE ${sql.join(branches, sql` `)} ELSE ${int(last.offsetMs)} END)) / 86400000)`;
+}
+
+/**
  * Build the `AND col >= from AND col <= to` fragment for an optional range.
  * Each bound is independent; an empty range contributes no SQL. `col` is a
  * fixed internal identifier fragment (never user input).
@@ -257,6 +291,7 @@ export async function completedSubmissions(
   db: Db,
   formId: string,
   range?: DateRange,
+  bucketing?: DayBucketing,
 ): Promise<CompletedSubmission[]> {
   const rows = await db.all<{
     day: number | string;
@@ -268,7 +303,7 @@ export async function completedSubmissions(
     // do INTEGER division and bucket to a whole day. The open timestamp comes
     // back RAW (not COALESCEd in SQL) so the caller can tell "no open signal"
     // apart from "opened and completed instantly" — see below.
-    sql`SELECT (${submissionAnchor()} / 86400000) AS day,
+    sql`SELECT ${localDayExpr(submissionAnchor(), bucketing)} AS day,
                s.completed_at AS completed_at,
                s.started_at AS started_at,
                (SELECT MIN(e.created_at) FROM form_event e
@@ -303,8 +338,9 @@ export async function completedSubmissions(
  * lands in exactly one bucket, in every metric, instead of splitting its views
  * into one day and its start into another.
  */
-function dailySessionsQuery(formId: string, eventFilter: SQL, range?: DateRange): SQL {
-  return sql`SELECT (a.anchor / 86400000) AS day, COUNT(DISTINCT a.session_id) AS n
+function dailySessionsQuery(formId: string, eventFilter: SQL, range?: DateRange, bucketing?: DayBucketing): SQL {
+  const day = localDayExpr(sql`a.anchor`, bucketing);
+  return sql`SELECT ${day} AS day, COUNT(DISTINCT a.session_id) AS n
       FROM (
         SELECT session_id, MIN(created_at) AS anchor FROM form_event
         WHERE form_id = ${formId} GROUP BY session_id
@@ -313,7 +349,7 @@ function dailySessionsQuery(formId: string, eventFilter: SQL, range?: DateRange)
         SELECT session_id FROM form_event WHERE form_id = ${formId} AND ${eventFilter}
       )
       ${andRange(sql`a.anchor`, range)}
-      GROUP BY (a.anchor / 86400000)`;
+      GROUP BY ${day}`;
 }
 
 /** Per-day unique sessions that viewed the form (trend series for Views). */
@@ -321,9 +357,10 @@ export async function dailyViewSessions(
   db: Db,
   formId: string,
   range?: DateRange,
+  bucketing?: DayBucketing,
 ): Promise<{ day: number; n: number }[]> {
   const rows = await db.all<{ day: number | string; n: number | string }>(
-    dailySessionsQuery(formId, sql`type = 'view'`, range),
+    dailySessionsQuery(formId, sql`type = 'view'`, range, bucketing),
   );
   return rows.map((r) => ({ day: Number(r.day), n: Number(r.n) }));
 }
@@ -334,9 +371,10 @@ export async function dailyStartSessions(
   db: Db,
   formId: string,
   range?: DateRange,
+  bucketing?: DayBucketing,
 ): Promise<{ day: number; n: number }[]> {
   const rows = await db.all<{ day: number | string; n: number | string }>(
-    dailySessionsQuery(formId, sql`type IN ('start', 'step_complete')`, range),
+    dailySessionsQuery(formId, sql`type IN ('start', 'step_complete')`, range, bucketing),
   );
   return rows.map((r) => ({ day: Number(r.day), n: Number(r.n) }));
 }
@@ -451,4 +489,12 @@ export async function deleteSubmissionForAccount(
     sql`SELECT id FROM submission WHERE id = ${submissionId} LIMIT 1`,
   );
   return exists ? 'forbidden' : 'absent';
+}
+
+/** The earliest `form_event` of a form (epoch-ms), or null with no events yet. */
+export async function firstEventAt(db: Db, formId: string): Promise<number | null> {
+  const row = await db.get<{ t: number | string | null }>(
+    sql`SELECT MIN(created_at) AS t FROM form_event WHERE form_id = ${formId}`,
+  );
+  return row?.t == null ? null : Number(row.t);
 }

--- a/packages/db/src/crud.ts
+++ b/packages/db/src/crud.ts
@@ -7,6 +7,13 @@ export type CrudResult<T> =
   | { ok: true; value: T }
   | {
       ok: false;
-      reason: 'NOT_FOUND' | 'SLUG_TAKEN' | 'SLUG_INVALID' | 'CONFLICT' | 'LAST_OWNER' | 'EMAIL_TAKEN';
+      reason:
+        | 'NOT_FOUND'
+        | 'SLUG_TAKEN'
+        | 'SLUG_INVALID'
+        | 'CONFLICT'
+        | 'LAST_OWNER'
+        | 'EMAIL_TAKEN'
+        | 'NAME_TAKEN';
       message?: string;
     };

--- a/packages/db/src/folders.spec.ts
+++ b/packages/db/src/folders.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Form folders (migration 0021): flat, one level, one folder per form, a name
+ * unique per account without regard to case. Deleting a folder unfiles its
+ * forms and never deletes them. In-memory SQLite locally; DATABASE_URL for the
+ * Postgres parity job (the expression index is the part worth proving there).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createDb, sql, type Db } from "./client";
+import { migrate } from "./migrate";
+import { createForm, duplicateForm, getFormById, listForms } from "./forms";
+import {
+  createFolder,
+  deleteFolder,
+  getFolderById,
+  listFolders,
+  renameFolder,
+  setFormFolder,
+} from "./folders";
+
+let db: Db;
+let accountId: string;
+let otherAccountId: string;
+
+async function insertAccount(): Promise<string> {
+  const id = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${id}, ${"t" + id.slice(0, 7)}, ${"Test"}, ${Date.now()})`,
+  );
+  return id;
+}
+
+async function form(name: string, folderId?: string | null): Promise<string> {
+  const r = await createForm(db, accountId, {
+    name,
+    ...(folderId ? { folderId } : {}),
+  });
+  if (!r.ok) throw new Error(r.reason);
+  return r.value.id;
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? "file::memory:");
+  await migrate(db);
+  accountId = await insertAccount();
+  otherAccountId = await insertAccount();
+});
+
+afterEach(async () => {
+  for (const id of [accountId, otherAccountId]) {
+    await db.run(sql`DELETE FROM form WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM form_folder WHERE account_id = ${id}`);
+    await db.run(sql`DELETE FROM account WHERE id = ${id}`);
+  }
+  await db.close();
+});
+
+describe("folders", () => {
+  it("lists alphabetically without regard to case", async () => {
+    await createFolder(db, accountId, "sales");
+    await createFolder(db, accountId, "Archive");
+    await createFolder(db, accountId, "marketing");
+    expect((await listFolders(db, accountId)).map((f) => f.name)).toEqual([
+      "Archive",
+      "marketing",
+      "sales",
+    ]);
+  });
+
+  it("a name is unique per account without regard to case, and free in another account", async () => {
+    const first = await createFolder(db, accountId, "Sales");
+    expect(first.ok).toBe(true);
+    const dup = await createFolder(db, accountId, " sales ");
+    expect(dup).toEqual({ ok: false, reason: "NAME_TAKEN" });
+    expect((await createFolder(db, otherAccountId, "sales")).ok).toBe(true);
+  });
+
+  it("renames, refusing another folder’s name and allowing a case change of its own", async () => {
+    const a = await createFolder(db, accountId, "Sales");
+    await createFolder(db, accountId, "Marketing");
+    if (!a.ok) throw new Error("setup");
+    expect(await renameFolder(db, accountId, a.value.id, "marketing")).toEqual({
+      ok: false,
+      reason: "NAME_TAKEN",
+    });
+    const renamed = await renameFolder(db, accountId, a.value.id, "SALES");
+    expect(renamed.ok && renamed.value.name).toBe("SALES");
+    expect(await renameFolder(db, otherAccountId, a.value.id, "x")).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+
+  it("a form moves into a folder, out of it, and shows its folder in the list", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    if (!f.ok) throw new Error("setup");
+    const id = await form("Quiz");
+    expect(await setFormFolder(db, accountId, id, f.value.id)).toEqual({
+      ok: true,
+      value: { id, folderId: f.value.id },
+    });
+    expect(
+      (await listForms(db, accountId)).find((x) => x.id === id)?.folderId,
+    ).toBe(f.value.id);
+    expect((await getFormById(db, accountId, id))?.folderId).toBe(f.value.id);
+    expect(await setFormFolder(db, accountId, id, null)).toEqual({
+      ok: true,
+      value: { id, folderId: null },
+    });
+    expect(
+      (await listForms(db, accountId)).find((x) => x.id === id)?.folderId,
+    ).toBeNull();
+  });
+
+  it("moving does not touch updated_at, and refuses a folder or form of another account", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    const foreign = await createFolder(db, otherAccountId, "Theirs");
+    if (!f.ok || !foreign.ok) throw new Error("setup");
+    const id = await form("Quiz");
+    const before = (await getFormById(db, accountId, id))!.updatedAt;
+    await setFormFolder(db, accountId, id, f.value.id);
+    expect((await getFormById(db, accountId, id))!.updatedAt).toBe(before);
+    expect(await setFormFolder(db, accountId, id, foreign.value.id)).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+    expect(await setFormFolder(db, otherAccountId, id, null)).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+
+  it("deleting a folder unfiles its forms and keeps them; a second delete is a no-op", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    if (!f.ok) throw new Error("setup");
+    const id = await form("Quiz", f.value.id);
+    expect((await getFormById(db, accountId, id))?.folderId).toBe(f.value.id);
+    expect(await deleteFolder(db, accountId, f.value.id)).toBe(true);
+    expect((await getFormById(db, accountId, id))?.folderId).toBeNull();
+    expect(await getFolderById(db, accountId, f.value.id)).toBeNull();
+    expect(await deleteFolder(db, accountId, f.value.id)).toBe(false);
+    expect(await deleteFolder(db, otherAccountId, f.value.id)).toBe(false);
+  });
+
+  it("a form is created inside a folder, and a duplicate inherits it", async () => {
+    const f = await createFolder(db, accountId, "Sales");
+    if (!f.ok) throw new Error("setup");
+    const id = await form("Quiz", f.value.id);
+    const copy = await duplicateForm(db, accountId, id);
+    expect(copy.ok && copy.value.folderId).toBe(f.value.id);
+    // A folder of another account cannot be named at creation either.
+    const foreign = await createFolder(db, otherAccountId, "Theirs");
+    if (!foreign.ok) throw new Error("setup");
+    expect(
+      await createForm(db, accountId, {
+        name: "X",
+        folderId: foreign.value.id,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+});

--- a/packages/db/src/folders.ts
+++ b/packages/db/src/folders.ts
@@ -1,0 +1,208 @@
+/**
+ * Form folders (see 0021): flat, one level, named only. A folder is unique per
+ * account without regard to case; a form is filed in at most one. Deleting a
+ * folder unfiles its forms and never deletes them. Moving a form never touches
+ * its `updated_at`: filing is organisation, not authoring.
+ */
+import { randomUUID } from "node:crypto";
+import { sql, type Db } from "./client";
+import type { CrudResult } from "./crud";
+
+export interface FormFolder {
+  id: string;
+  accountId: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface DatabaseError {
+  code?: string;
+  constraint?: string;
+  constraint_name?: string;
+  message?: string;
+  cause?: unknown;
+  driverError?: unknown;
+}
+
+/** True only for the (account_id, lower(name)) unique index, on either engine. */
+function isFolderNameUniqueViolation(error: unknown): boolean {
+  const e =
+    error && typeof error === "object" ? (error as DatabaseError) : undefined;
+  if (!e) return false;
+  if (
+    e.code === "23505" &&
+    (e.constraint === "form_folder_account_name_uq" ||
+      e.constraint_name === "form_folder_account_name_uq")
+  )
+    return true;
+  // SQLite names an EXPRESSION index by the index, not by its columns.
+  return (
+    e.code === "SQLITE_CONSTRAINT_UNIQUE" &&
+    typeof e.message === "string" &&
+    e.message.includes("form_folder_account_name_uq")
+  );
+}
+
+function isFolderNameConflict(error: unknown): boolean {
+  const e =
+    error && typeof error === "object" ? (error as DatabaseError) : undefined;
+  return (
+    isFolderNameUniqueViolation(error) ||
+    isFolderNameUniqueViolation(e?.cause) ||
+    isFolderNameUniqueViolation(e?.driverError)
+  );
+}
+
+function mapFolder(r: Record<string, unknown>): FormFolder {
+  return {
+    id: String(r.id),
+    accountId: String(r.account_id),
+    name: String(r.name),
+    createdAt: Number(r.created_at),
+    updatedAt: Number(r.updated_at),
+  };
+}
+
+/** The account's folders, alphabetically without regard to case. */
+export async function listFolders(
+  db: Db,
+  accountId: string,
+): Promise<FormFolder[]> {
+  const rows = await db.all<Record<string, unknown>>(
+    sql`SELECT id, account_id, name, created_at, updated_at FROM form_folder
+        WHERE account_id = ${accountId} ORDER BY lower(name) ASC, created_at ASC`,
+  );
+  return rows.map(mapFolder);
+}
+
+export async function getFolderById(
+  db: Db,
+  accountId: string,
+  id: string,
+): Promise<FormFolder | null> {
+  const row = await db.get<Record<string, unknown>>(
+    sql`SELECT id, account_id, name, created_at, updated_at FROM form_folder
+        WHERE account_id = ${accountId} AND id = ${id} LIMIT 1`,
+  );
+  return row ? mapFolder(row) : null;
+}
+
+/** Another folder of the account already using `name` (case-insensitively), excluding `exceptId`. */
+async function nameTaken(
+  db: Db,
+  accountId: string,
+  name: string,
+  exceptId?: string,
+): Promise<boolean> {
+  const row = await db.get<{ id: string }>(
+    sql`SELECT id FROM form_folder
+        WHERE account_id = ${accountId} AND lower(name) = lower(${name})
+          ${exceptId ? sql`AND id <> ${exceptId}` : sql``}
+        LIMIT 1`,
+  );
+  return Boolean(row);
+}
+
+/**
+ * Create a folder. The pre-check gives the common case a clean NAME_TAKEN; the
+ * unique index (and the catch below) closes the race two writers could open.
+ */
+export async function createFolder(
+  db: Db,
+  accountId: string,
+  rawName: string,
+): Promise<CrudResult<FormFolder>> {
+  const name = rawName.trim();
+  if (!name)
+    return { ok: false, reason: "CONFLICT", message: "A name is required." };
+  if (await nameTaken(db, accountId, name))
+    return { ok: false, reason: "NAME_TAKEN" };
+  const id = randomUUID();
+  const now = Date.now();
+  try {
+    await db.run(
+      sql`INSERT INTO form_folder (id, account_id, name, created_at, updated_at)
+          VALUES (${id}, ${accountId}, ${name}, ${now}, ${now})`,
+    );
+  } catch (error) {
+    if (isFolderNameConflict(error)) return { ok: false, reason: "NAME_TAKEN" };
+    throw error;
+  }
+  const created = await getFolderById(db, accountId, id);
+  return created
+    ? { ok: true, value: created }
+    : { ok: false, reason: "CONFLICT" };
+}
+
+export async function renameFolder(
+  db: Db,
+  accountId: string,
+  id: string,
+  rawName: string,
+): Promise<CrudResult<FormFolder>> {
+  const name = rawName.trim();
+  if (!name)
+    return { ok: false, reason: "CONFLICT", message: "A name is required." };
+  const existing = await getFolderById(db, accountId, id);
+  if (!existing) return { ok: false, reason: "NOT_FOUND" };
+  if (await nameTaken(db, accountId, name, id))
+    return { ok: false, reason: "NAME_TAKEN" };
+  try {
+    await db.run(
+      sql`UPDATE form_folder SET name = ${name}, updated_at = ${Date.now()}
+          WHERE account_id = ${accountId} AND id = ${id}`,
+    );
+  } catch (error) {
+    if (isFolderNameConflict(error)) return { ok: false, reason: "NAME_TAKEN" };
+    throw error;
+  }
+  const renamed = await getFolderById(db, accountId, id);
+  return renamed
+    ? { ok: true, value: renamed }
+    : { ok: false, reason: "NOT_FOUND" };
+}
+
+/**
+ * Delete a folder: its forms are unfiled first (explicitly, so the result does
+ * not depend on the engine enforcing the foreign key), then the row goes.
+ * Returns whether a folder was actually deleted; a repeat is false, not an error.
+ */
+export async function deleteFolder(
+  db: Db,
+  accountId: string,
+  id: string,
+): Promise<boolean> {
+  const existing = await getFolderById(db, accountId, id);
+  if (!existing) return false;
+  await db.run(
+    sql`UPDATE form SET folder_id = NULL WHERE account_id = ${accountId} AND folder_id = ${id}`,
+  );
+  await db.run(
+    sql`DELETE FROM form_folder WHERE account_id = ${accountId} AND id = ${id}`,
+  );
+  return true;
+}
+
+/**
+ * File a form in a folder of the same account, or unfile it with null.
+ * `updated_at` is deliberately untouched: the form did not change, its
+ * shelf did.
+ */
+export async function setFormFolder(
+  db: Db,
+  accountId: string,
+  formId: string,
+  folderId: string | null,
+): Promise<CrudResult<{ id: string; folderId: string | null }>> {
+  const form = await db.get<{ id: string }>(
+    sql`SELECT id FROM form WHERE account_id = ${accountId} AND id = ${formId} LIMIT 1`,
+  );
+  if (!form) return { ok: false, reason: "NOT_FOUND" };
+  if (folderId != null && !(await getFolderById(db, accountId, folderId)))
+    return { ok: false, reason: "NOT_FOUND" };
+  await db.run(
+    sql`UPDATE form SET folder_id = ${folderId} WHERE account_id = ${accountId} AND id = ${formId}`,
+  );
+  return { ok: true, value: { id: formId, folderId } };
+}

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -191,6 +191,8 @@ export interface FormRow {
    * `accountId`, never by this.
    */
   createdBy: string | null;
+  /** The folder this form is filed in (0021); null = unfiled. */
+  folderId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -201,6 +203,8 @@ export interface FormSummary {
   slug: string;
   /** Epoch-ms of the last brand-kit apply; null when never applied or reverted. */
   brandAppliedAt: number | null;
+  /** The folder this form is filed in (0021); null = unfiled. */
+  folderId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -216,6 +220,7 @@ function mapForm(r: Record<string, unknown>): FormRow {
     publishedAt: r.published_at == null ? null : Number(r.published_at),
     brandAppliedAt: r.brand_applied_at == null ? null : Number(r.brand_applied_at),
     createdBy: r.created_by == null ? null : String(r.created_by),
+    folderId: r.folder_id == null ? null : String(r.folder_id),
     createdAt: Number(r.created_at),
     updatedAt: Number(r.updated_at),
   };
@@ -328,7 +333,7 @@ function isFormAccountSlugConflict(error: unknown): boolean {
 
 export async function listForms(db: Db, accountId: string): Promise<FormSummary[]> {
   const rows = await db.all<Record<string, unknown>>(
-    sql`SELECT id, name, slug, brand_applied_at, created_at, updated_at FROM form
+    sql`SELECT id, name, slug, brand_applied_at, folder_id, created_at, updated_at FROM form
         WHERE account_id = ${accountId} ORDER BY updated_at DESC, created_at DESC`,
   );
   return rows.map((r) => ({
@@ -336,6 +341,7 @@ export async function listForms(db: Db, accountId: string): Promise<FormSummary[
     name: String(r.name),
     slug: String(r.slug),
     brandAppliedAt: r.brand_applied_at == null ? null : Number(r.brand_applied_at),
+    folderId: r.folder_id == null ? null : String(r.folder_id),
     createdAt: Number(r.created_at),
     updatedAt: Number(r.updated_at),
   }));
@@ -430,7 +436,7 @@ export async function getFormById(db: Db, accountId: string, id: string): Promis
 export async function createForm(
   db: Db,
   accountId: string,
-  input: { name: string; slug?: string; config?: unknown },
+  input: { name: string; slug?: string; config?: unknown; folderId?: string | null },
   /**
    * `member.id` of the author, for per-user analytics (migration 0010).
    * MUST come from the resolved principal, never from request input — this is
@@ -440,6 +446,15 @@ export async function createForm(
   createdBy?: string | null,
 ): Promise<CrudResult<FormRow>> {
   const config = input.config ?? { version: 1, steps: [] };
+  // A folder is named by id and must be this account's: filing a form into a
+  // stranger's folder would leak its existence and misfile the form.
+  const folderId = input.folderId ?? null;
+  if (folderId != null) {
+    const folder = await db.get<{ id: string }>(
+      sql`SELECT id FROM form_folder WHERE account_id = ${accountId} AND id = ${folderId} LIMIT 1`,
+    );
+    if (!folder) return { ok: false, reason: 'NOT_FOUND', message: 'No such folder.' };
+  }
 
   for (let attempt = 0; attempt < FORM_SLUG_INSERT_ATTEMPTS; attempt++) {
     const slug = await uniqueFormSlug(db, accountId, input.slug ?? input.name);
@@ -447,9 +462,9 @@ export async function createForm(
     const now = Date.now();
     try {
       await db.run(
-        sql`INSERT INTO form (id, account_id, name, slug, config, created_by, created_at, updated_at)
+        sql`INSERT INTO form (id, account_id, name, slug, config, created_by, folder_id, created_at, updated_at)
             VALUES (${id}, ${accountId}, ${input.name}, ${slug}, ${jsonParam(config)},
-                    ${createdBy ?? null}, ${now}, ${now})`,
+                    ${createdBy ?? null}, ${folderId}, ${now}, ${now})`,
       );
     } catch (error) {
       if (attempt + 1 < FORM_SLUG_INSERT_ATTEMPTS && isFormAccountSlugConflict(error)) continue;
@@ -814,6 +829,8 @@ export async function duplicateForm(
     {
       name: `${src.name} (copy)`,
       slug: src.slug,
+      // The copy lands on the same shelf as the original.
+      folderId: src.folderId,
       // NOT verbatim: the HubSpot mirror-form pointer is the original's, and a
       // copy that inherits it delivers its submissions AS the original.
       config: withoutOwnedMirrorState(src.config),

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -101,6 +101,8 @@ export interface MeView {
    * un-sliceable by campaign, which is most of the reason to measure it.
    */
   attribution: Attribution | null;
+  /** The workspace's IANA timezone (0020), or null for UTC. */
+  timezone: string | null;
   /** `'staff'` when the caller is in this workspace by access grant, not by membership (0016). */
   accessGrant: 'staff' | null;
   /**
@@ -129,8 +131,9 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     attribution: unknown;
     access_grant: string | null;
     locale: string | null;
+    timezone: string | null;
   }>(
-    sql`SELECT a.code, a.name, a.vanity_slug, a.onboarding_completed_at, a.attribution,
+    sql`SELECT a.code, a.name, a.vanity_slug, a.onboarding_completed_at, a.attribution, a.timezone,
                m.handle, m.display_name, m.email, m.role, m.status, m.access_grant, m.locale
         FROM account a JOIN member m ON m.account_id = a.id
         WHERE a.id = ${accountId} AND m.id = ${memberId} LIMIT 1`,
@@ -157,6 +160,7 @@ export async function getMe(db: Db, accountId: string, memberId: string): Promis
     // dashboard page. Unreadable tags degrade to "not known", never to a 500.
     attribution: parseAttributionColumn(row.attribution),
     accessGrant: row.access_grant === 'staff' ? 'staff' : null,
+    timezone: row.timezone ?? null,
     // Narrowed here, not trusted: the column is plain text and predates this
     // field, so an unrecognised value reads as "never chose" instead of
     // reaching a catalog that has no such locale.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,6 +6,7 @@
 export * from './client';
 export * from './crud';
 export * from './forms';
+export * from './folders';
 export * from './bookings';
 export * from './account-integrations';
 export * from './account-branding';

--- a/packages/db/src/migration-0019.spec.ts
+++ b/packages/db/src/migration-0019.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Migration 0019 appends the `{{answers}}` token to every CUSTOM owner-notice
+ * body that lacks it, so accounts that edited their template before the token
+ * existed still get the answers in the email. Exercised by running the script
+ * directly against a migrated database (in-memory SQLite locally, the shared
+ * Postgres in parity mode), because the migrator has already applied it by the
+ * time the rows exist. Must be idempotent: a second run changes nothing.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { sql } from "drizzle-orm";
+import { createDb, type Db } from "./client";
+import { migrate } from "./migrate";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FILE = "0019_owner_email_answers_token.sql";
+
+let db: Db;
+/** One account per row: the account scope allows a single row per email key. */
+const accounts: string[] = [];
+
+async function insertAccount(): Promise<string> {
+  const id = randomUUID();
+  await db.run(
+    sql`INSERT INTO account (id, code, name, created_at)
+        VALUES (${id}, ${"t" + id.slice(0, 7)}, ${"Test"}, ${Date.now()})`,
+  );
+  accounts.push(id);
+  return id;
+}
+
+async function insertSetting(
+  emailKey: string,
+  body: string | null,
+  formId: string | null = null,
+): Promise<string> {
+  const id = randomUUID();
+  const accountId = await insertAccount();
+  await db.run(
+    sql`INSERT INTO notification_setting
+          (id, account_id, email_key, form_id, enabled, subject, body, created_at, updated_at)
+        VALUES (${id}, ${accountId}, ${emailKey}, ${formId}, 1, ${null}, ${body}, 1, 1)`,
+  );
+  return id;
+}
+
+async function bodyOf(id: string): Promise<string | null> {
+  const r = await db.get<{ body: string | null }>(
+    sql`SELECT body FROM notification_setting WHERE id = ${id}`,
+  );
+  return r?.body ?? null;
+}
+
+async function runScript(): Promise<void> {
+  await db.execRaw(
+    readFileSync(join(HERE, "..", "migrations", db.dialect, FILE), "utf8"),
+  );
+}
+
+beforeEach(async () => {
+  db = await createDb(process.env.DATABASE_URL ?? "file::memory:");
+  await migrate(db);
+});
+
+afterEach(async () => {
+  // Postgres parity mode shares a database: leave no rows behind.
+  for (const accountId of accounts.splice(0)) {
+    await db.run(
+      sql`DELETE FROM notification_setting WHERE account_id = ${accountId}`,
+    );
+    await db.run(sql`DELETE FROM account WHERE id = ${accountId}`);
+  }
+  await db.close();
+});
+
+describe(FILE, () => {
+  it("appends {{answers}} to a custom owner body that lacks it, account and form rows alike", async () => {
+    const account = await insertSetting(
+      "submission_received",
+      "Lead on {{formName}}\nScore {{score}}",
+    );
+    const form = await insertSetting(
+      "submission_received",
+      "Form copy",
+      randomUUID(),
+    );
+    await runScript();
+    expect(await bodyOf(account)).toBe(
+      "Lead on {{formName}}\nScore {{score}}\n\n{{answers}}",
+    );
+    expect(await bodyOf(form)).toBe("Form copy\n\n{{answers}}");
+  });
+
+  it("leaves alone bodies that already carry the token (spaced or not), NULL bodies and the respondent email", async () => {
+    const has = await insertSetting("submission_received", "A\n{{answers}}");
+    const spaced = await insertSetting(
+      "submission_received",
+      "A\n{{ answers }}",
+    );
+    const stock = await insertSetting("submission_received", null);
+    const confirmed = await insertSetting(
+      "submission_confirmed",
+      "Thanks {{formName}}",
+    );
+    await runScript();
+    expect(await bodyOf(has)).toBe("A\n{{answers}}");
+    expect(await bodyOf(spaced)).toBe("A\n{{ answers }}");
+    expect(await bodyOf(stock)).toBeNull();
+    expect(await bodyOf(confirmed)).toBe("Thanks {{formName}}");
+  });
+
+  it("is idempotent: a second run changes nothing", async () => {
+    const id = await insertSetting("submission_received", "Custom");
+    await runScript();
+    const once = await bodyOf(id);
+    await runScript();
+    expect(await bodyOf(id)).toBe(once);
+    expect(once).toBe("Custom\n\n{{answers}}");
+  });
+});

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -170,6 +170,26 @@ export const notificationSetting = pgTable(
 
 // --- Forms domain ------------------------------------------------------------
 
+/**
+ * A form folder (see 0021): flat, one level, named only, unique per account
+ * without regard to case (the lower(name) expression index lives in the
+ * migration, since Drizzle's index builder cannot express it). Declared before
+ * `form`, which points at it.
+ */
+export const formFolder = pgTable(
+  'form_folder',
+  {
+    id: text('id').primaryKey(),
+    accountId: text('account_id').notNull(),
+    name: text('name').notNull(),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (t) => ({
+    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
+  }),
+);
+
 export const form = pgTable(
   'form',
   {
@@ -188,6 +208,8 @@ export const form = pgTable(
     brandAppliedAt: bigint('brand_applied_at', { mode: 'number' }),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled. */
+    folderId: text('folder_id'),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },
@@ -320,6 +342,7 @@ export const pgSchema = {
   outbox,
   notificationSetting,
   form,
+  formFolder,
   formAlias,
   submission,
   formEvent,

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -24,6 +24,12 @@ export const account = pgTable('account', {
   /** Milestone CLAIM: epoch-ms of the first form view. Same write-once discipline. */
   firstViewedAt: bigint('first_viewed_at', { mode: 'number' }),
   /**
+   * The workspace's IANA timezone (0020): the zone every date in the admin,
+   * the analytics day buckets and the CSV local columns are read in. NULL =
+   * UTC until the first admin's browser claims it (`claimAccountTimezone`).
+   */
+  timezone: text('timezone'),
+  /**
    * Onboarding wizard state AND result (see 0011) — `accountOnboardingSchema` in
    * @quill/types. Written on every step advance, so a row with a `lastStep` and
    * no `onboardingCompletedAt` IS the drop-off record.

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -185,9 +185,9 @@ export const formFolder = pgTable(
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },
-  (t) => ({
-    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
-  }),
+  // The (account_id, lower(name)) unique index lives in the migration only:
+  // Drizzle cannot express an expression index, and this file declares what
+  // the migration creates, nothing more.
 );
 
 export const form = pgTable(
@@ -208,13 +208,14 @@ export const form = pgTable(
     brandAppliedAt: bigint('brand_applied_at', { mode: 'number' }),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
-    /** The folder this form is filed in (see 0021); NULL = unfiled. */
-    folderId: text('folder_id'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled, and a deleted folder unfiles. */
+    folderId: text('folder_id').references(() => formFolder.id, { onDelete: 'set null' }),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },
   (t) => ({
     formAccountSlugUq: uniqueIndex('form_account_slug_uq').on(t.accountId, t.slug),
+    formAccountFolderIdx: index('form_account_folder_idx').on(t.accountId, t.folderId),
   }),
 );
 

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -181,9 +181,9 @@ export const formFolder = sqliteTable(
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
-  (t) => ({
-    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
-  }),
+  // The (account_id, lower(name)) unique index lives in the migration only:
+  // Drizzle cannot express an expression index, and this file declares what
+  // the migration creates, nothing more.
 );
 
 export const form = sqliteTable(
@@ -206,13 +206,14 @@ export const form = sqliteTable(
     brandAppliedAt: integer('brand_applied_at'),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
-    /** The folder this form is filed in (see 0021); NULL = unfiled. */
-    folderId: text('folder_id'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled, and a deleted folder unfiles. */
+    folderId: text('folder_id').references(() => formFolder.id, { onDelete: 'set null' }),
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
   (t) => ({
     formAccountSlugUq: uniqueIndex('form_account_slug_uq').on(t.accountId, t.slug),
+    formAccountFolderIdx: index('form_account_folder_idx').on(t.accountId, t.folderId),
   }),
 );
 

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -166,6 +166,26 @@ export const notificationSetting = sqliteTable(
 // --- Forms domain ------------------------------------------------------------
 
 /** A form: one versioned JSON `config` blob drives the whole public flow. */
+/**
+ * A form folder (see 0021): flat, one level, named only, unique per account
+ * without regard to case (the lower(name) expression index lives in the
+ * migration, since Drizzle's index builder cannot express it). Declared before
+ * `form`, which points at it.
+ */
+export const formFolder = sqliteTable(
+  'form_folder',
+  {
+    id: text('id').primaryKey(),
+    accountId: text('account_id').notNull(),
+    name: text('name').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (t) => ({
+    formFolderAccountIdx: index('form_folder_account_idx').on(t.accountId),
+  }),
+);
+
 export const form = sqliteTable(
   'form',
   {
@@ -186,6 +206,8 @@ export const form = sqliteTable(
     brandAppliedAt: integer('brand_applied_at'),
     /** member.id of the author; NULL for pre-0010 forms and API-key creates. Authorship, never authorization. */
     createdBy: text('created_by'),
+    /** The folder this form is filed in (see 0021); NULL = unfiled. */
+    folderId: text('folder_id'),
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
@@ -321,6 +343,7 @@ export const sqliteSchema = {
   outbox,
   notificationSetting,
   form,
+  formFolder,
   formAlias,
   submission,
   formEvent,

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -32,6 +32,8 @@ export const account = sqliteTable('account', {
   activatedAt: integer('activated_at'),
   /** Milestone CLAIM: epoch-ms of the first form view. Same write-once discipline. */
   firstViewedAt: integer('first_viewed_at'),
+  /** The workspace's IANA timezone (0020); NULL = UTC. See the Postgres twin. */
+  timezone: text('timezone'),
   /**
    * Onboarding wizard state AND result (TEXT JSON, see 0011) —
    * `accountOnboardingSchema` in @quill/types. Written on every step advance, so

--- a/packages/db/src/workspaces.ts
+++ b/packages/db/src/workspaces.ts
@@ -611,3 +611,33 @@ export async function getMemberUpstreamRef(
   if (!r) return null;
   return { externalId: r.external_id ?? null, workspaceUserId: r.iam_workspace_user_id ?? null, email: r.email ?? null };
 }
+
+// --- Workspace timezone (0020) ---------------------------------------------
+
+/** The workspace's IANA zone, or null (= UTC) when nobody has set one. */
+export async function getAccountTimezone(db: Db, accountId: string): Promise<string | null> {
+  const row = await db.get<{ timezone: string | null }>(
+    sql`SELECT timezone FROM account WHERE id = ${accountId} LIMIT 1`,
+  );
+  return row?.timezone ?? null;
+}
+
+/** Set (or clear, with null) the workspace's zone. Validation is the API's job. */
+export async function setAccountTimezone(db: Db, accountId: string, timezone: string | null): Promise<void> {
+  await db.run(sql`UPDATE account SET timezone = ${timezone} WHERE id = ${accountId}`);
+}
+
+/**
+ * Write-once seed: the first admin to load the dashboard offers their
+ * browser's zone, and it sticks only while the column is still NULL, so two
+ * teammates in different zones cannot flip it back and forth. Same
+ * UPDATE ... WHERE IS NULL discipline as the milestone claims.
+ */
+export async function claimAccountTimezone(db: Db, accountId: string, timezone: string): Promise<boolean> {
+  const claimed = await db.get<{ id: string }>(
+    sql`UPDATE account SET timezone = ${timezone}
+        WHERE id = ${accountId} AND timezone IS NULL
+        RETURNING id`,
+  );
+  return Boolean(claimed);
+}

--- a/packages/engine/src/answer-summary.spec.ts
+++ b/packages/engine/src/answer-summary.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { summarizeAnswers } from "./answer-summary";
+import type { FormConfig, FormStep } from "./form-logic";
+
+const step = (
+  partial: Partial<FormStep> & Pick<FormStep, "key" | "type">,
+): FormStep => partial;
+
+const config: FormConfig = {
+  version: 1,
+  steps: [
+    step({ key: "intro", type: "message", question: "Welcome" }),
+    step({ key: "name", type: "name", question: "Your name?" }),
+    step({
+      key: "role",
+      type: "multiple_choice",
+      question: "What is your role?",
+      options: [
+        { label: "Founder / CEO", value: "founder" },
+        { label: "Marketing", value: "marketing" },
+      ],
+    }),
+    step({
+      key: "tools",
+      type: "dropdown",
+      question: "Which tools do you use?",
+      options: [
+        { label: "HubSpot", value: "hubspot" },
+        { label: "Salesforce", value: "salesforce" },
+      ],
+    }),
+    step({ key: "team_size", type: "slider", question: "Team size" }),
+    step({ key: "email", type: "email", question: "Email" }),
+    step({ key: "processing", type: "reveal" }),
+    step({
+      key: "why",
+      type: "textarea",
+      question: "Why, [firstname]?",
+    }),
+    step({ key: "call", type: "scheduler", question: "Book a call" }),
+    step({ key: "nolabel", type: "text" }),
+  ],
+};
+
+describe("summarizeAnswers", () => {
+  it("walks the steps in order, skipping inputless steps and unanswered ones", () => {
+    const rows = summarizeAnswers(config, {
+      firstname: "Ana",
+      lastname: "Ruiz",
+      role: "founder",
+      team_size: 20,
+      email: "ana@acme.io",
+    });
+    expect(rows).toEqual([
+      { label: "Your name?", value: "Ana Ruiz" },
+      { label: "What is your role?", value: "Founder / CEO" },
+      { label: "Team size", value: "20" },
+      { label: "Email", value: "ana@acme.io" },
+    ]);
+  });
+
+  it("maps option values to their labels and joins multi-selects with a comma", () => {
+    const rows = summarizeAnswers(config, { tools: ["hubspot", "salesforce"] });
+    expect(rows).toEqual([
+      { label: "Which tools do you use?", value: "HubSpot, Salesforce" },
+    ]);
+  });
+
+  it('keeps a value that matches no option verbatim (an "other" answer is still an answer)', () => {
+    const rows = summarizeAnswers(config, { role: "student" });
+    expect(rows).toEqual([{ label: "What is your role?", value: "student" }]);
+  });
+
+  it("resolves the question the respondent actually saw ([field] interpolation)", () => {
+    const rows = summarizeAnswers(config, { firstname: "Ana", why: "Speed" });
+    expect(rows).toEqual([
+      { label: "Your name?", value: "Ana" },
+      { label: "Why, Ana?", value: "Speed" },
+    ]);
+  });
+
+  it("formats a scheduler booking as a readable UTC timestamp", () => {
+    expect(
+      summarizeAnswers(config, { call: "2026-09-03T14:30:00.000Z" }),
+    ).toEqual([{ label: "Book a call", value: "2026-09-03 14:30 UTC" }]);
+    // The renderer falls back to the literal "booked" when the provider sent no time.
+    expect(summarizeAnswers(config, { call: "booked" })).toEqual([
+      { label: "Book a call", value: "booked" },
+    ]);
+  });
+
+  it("falls back to the step key when a step has no question", () => {
+    expect(summarizeAnswers(config, { nolabel: "x" })).toEqual([
+      { label: "nolabel", value: "x" },
+    ]);
+  });
+
+  it("drops blank strings, empty arrays and nulls; keeps 0 and false", () => {
+    const cfg: FormConfig = {
+      version: 1,
+      steps: [
+        step({ key: "a", type: "text", question: "A" }),
+        step({ key: "b", type: "multiple_choice", question: "B", options: [] }),
+        step({ key: "c", type: "text", question: "C" }),
+        step({ key: "d", type: "slider", question: "D" }),
+        step({ key: "e", type: "text", question: "E" }),
+      ],
+    };
+    expect(
+      summarizeAnswers(cfg, { a: "   ", b: [], c: null, d: 0, e: false }),
+    ).toEqual([
+      { label: "D", value: "0" },
+      { label: "E", value: "false" },
+    ]);
+  });
+
+  it("caps a value at 2000 characters", () => {
+    const rows = summarizeAnswers(config, { why: "x".repeat(2500) });
+    expect(rows[0]!.value).toHaveLength(2000);
+  });
+
+  it("ignores answers with no matching step (hidden fields, UTM params)", () => {
+    expect(summarizeAnswers(config, { utm_source: "linkedin" })).toEqual([]);
+  });
+});

--- a/packages/engine/src/answer-summary.ts
+++ b/packages/engine/src/answer-summary.ts
@@ -1,0 +1,98 @@
+/**
+ * A submission's answers as the owner reads them: one `{label, value}` row per
+ * answered question, in step order, with option values mapped back to their
+ * labels and the question text resolved exactly as the respondent saw it.
+ *
+ * Pure and framework-free so the API can build it and hand plain rows to the
+ * notifications package (which stays independent of the engine). Nothing here
+ * escapes HTML: the email renderer owns that boundary.
+ */
+import {
+  isInputlessStep,
+  nameFields,
+  resolveQuestion,
+  type Answers,
+  type AnswerValue,
+  type FormConfig,
+  type FormStep,
+} from "./form-logic";
+
+/** One answered question, ready to print. */
+export interface AnswerSummaryRow {
+  label: string;
+  value: string;
+}
+
+/** Longest value an email row carries; a pasted essay must not become the email. */
+export const ANSWER_VALUE_MAX = 2000;
+
+function isBlank(value: AnswerValue): boolean {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
+/** Map one raw token to its option label (an unknown token stays as typed). */
+function optionLabel(step: FormStep, token: string): string {
+  const match = (step.options ?? []).find((o) => o.value === token);
+  return match ? match.label : token;
+}
+
+/** `2026-09-03T14:30:00.000Z` → `2026-09-03 14:30 UTC`; anything else verbatim. */
+function formatBooking(value: string): string {
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return value;
+  const iso = new Date(ms).toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}
+
+function formatValue(step: FormStep, value: AnswerValue): string {
+  if (Array.isArray(value))
+    return value.map((v) => optionLabel(step, v)).join(", ");
+  if (typeof value === "string") {
+    if (step.type === "scheduler") return formatBooking(value.trim());
+    if (step.type === "multiple_choice" || step.type === "dropdown")
+      return optionLabel(step, value.trim());
+    return value.trim();
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value)
+      .filter((v) => typeof v === "string" && v.trim())
+      .join(" ");
+  }
+  return String(value);
+}
+
+/** The answered rows of `answers`, in step order. Unanswered steps are omitted. */
+export function summarizeAnswers(
+  config: FormConfig,
+  answers: Answers,
+): AnswerSummaryRow[] {
+  const rows: AnswerSummaryRow[] = [];
+  for (const step of config.steps) {
+    if (isInputlessStep(step)) continue;
+    let value: string;
+    if (step.type === "name") {
+      value = nameFields(step)
+        .map((field) => answers[field])
+        .filter(
+          (v): v is string => typeof v === "string" && v.trim().length > 0,
+        )
+        .map((v) => v.trim())
+        .join(" ");
+      if (!value) continue;
+    } else {
+      const raw = answers[step.key];
+      if (isBlank(raw)) continue;
+      value = formatValue(step, raw);
+      if (!value) continue;
+    }
+    const question = resolveQuestion(step, answers).trim();
+    rows.push({
+      label: question || step.key,
+      value: value.slice(0, ANSWER_VALUE_MAX),
+    });
+  }
+  return rows;
+}

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -570,6 +570,16 @@ export function publicTitle(config: { title?: string | null } | null | undefined
   return t ? t : name;
 }
 
+/** The languages the public form ships. Mirrors @quill/shared `Locale`. */
+export type FormLanguage = 'en' | 'es';
+
+/** Form-level overrides for the renderer's navigation buttons. */
+export interface FormLabels {
+  back?: string | null;
+  next?: string | null;
+  submit?: string | null;
+}
+
 export interface FormConfig {
   version: 1;
   /**
@@ -584,6 +594,10 @@ export interface FormConfig {
   cover?: FormCover | null;
   /** Presentation layout for the public form. Absent = `'slides'` (back-compat). */
   layout?: FormLayout;
+  /** Public chrome language. Absent/null = Auto (the visitor's browser). */
+  language?: FormLanguage | null;
+  /** Form-level button copy; a step's `buttonText` still wins for that step. */
+  labels?: FormLabels | null;
   steps: FormStep[];
   scoring?: { enabled?: boolean } | null;
   outcomes?: FormOutcome[];

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,6 +3,7 @@
  * Fully unit-tested; portable across SQLite and Postgres deployments.
  */
 export * from './form-logic';
+export * from './answer-summary';
 export * from './form-config';
 export * from './form-design';
 export * from './short-links';

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -15,10 +15,15 @@ export {
   isSubmissionEmailKey,
   NOTIFICATION_TOKENS,
   notificationTokenValues,
+  htmlTokenValues,
   interpolateTokens,
+  renderBodyLines,
+  renderSubmissionEmail,
   applyCopyOverride,
   defaultSubmissionTemplate,
   type NotificationLocale,
+  type RenderedBodyLines,
+  type RenderedSubmissionEmail,
   type ReceivedCopyVars,
   type ConfirmedCopyVars,
   type MemberInvitedCopyVars,
@@ -26,6 +31,7 @@ export {
   type SubmissionEmailKey,
   type NotificationToken,
 } from './templates';
+export { answersTableHtml, emailDocument, type AnswerRow } from './render-html';
 export { LogOnlyEmailProvider } from './adapters/log-only';
 export { NoopEmailProvider } from './adapters/noop';
 export { SmtpEmailProvider, type SmtpOptions } from './adapters/smtp';

--- a/packages/notifications/src/render-html.spec.ts
+++ b/packages/notifications/src/render-html.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { answersTableHtml, emailDocument } from "./render-html";
+
+describe("answersTableHtml", () => {
+  it("renders one row per answer with the label and value HTML-escaped", () => {
+    const html = answersTableHtml([
+      { label: "Role", value: "Founder" },
+      { label: "<b>Why</b>", value: '<script>alert(1)</script> & "quotes"' },
+    ]);
+    expect(html).toContain("<table");
+    expect(html).toContain('role="presentation"');
+    expect(html).toContain("Role");
+    expect(html).toContain("Founder");
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<b>Why</b>");
+    expect(html).toContain("&lt;b&gt;Why&lt;/b&gt;");
+    expect(html).toContain(
+      "&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quotes&quot;",
+    );
+  });
+
+  it("renders an empty string when there are no rows", () => {
+    expect(answersTableHtml([])).toBe("");
+  });
+
+  it("breaks long values so a URL cannot stretch the email", () => {
+    expect(answersTableHtml([{ label: "Site", value: "https://x" }])).toContain(
+      "word-break",
+    );
+  });
+});
+
+describe("emailDocument", () => {
+  it("wraps the lines in a complete, responsive HTML document", () => {
+    const html = emailDocument({ lang: "es", lines: ["Hola", "Segunda"] });
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain('<html lang="es">');
+    expect(html).toContain('name="viewport"');
+    expect(html).toContain("max-width:600px");
+    expect(html).toContain("Hola<br/>Segunda");
+    // dapta-email splices its support footer before the closing body tag.
+    expect(html.trimEnd().endsWith("</body></html>")).toBe(true);
+  });
+
+  it("does NOT escape the lines (the caller escapes text and passes trusted markup)", () => {
+    const html = emailDocument({ lang: "en", lines: ["<table></table>"] });
+    expect(html).toContain("<table></table>");
+  });
+
+  it("puts the lines inside a div, never a paragraph (a table inside <p> is invalid HTML)", () => {
+    const html = emailDocument({ lang: "en", lines: ["x"] });
+    expect(html).not.toContain("<p>");
+  });
+
+  it("lets a long link line wrap so it cannot push the card past a phone screen", () => {
+    const html = emailDocument({ lang: "en", lines: ["View: https://x"] });
+    expect(html).toMatch(
+      /<div style="[^"]*overflow-wrap:anywhere[^"]*">View: https:\/\/x<\/div>/,
+    );
+  });
+});

--- a/packages/notifications/src/render-html.ts
+++ b/packages/notifications/src/render-html.ts
@@ -1,0 +1,70 @@
+/**
+ * The HTML side of a notification email. The text body is the source of truth
+ * (every line is plain text); this module turns those lines into a complete,
+ * responsive document and renders the answers block as a real table.
+ *
+ * Escaping contract: `answersTableHtml` escapes its inputs. `emailDocument`
+ * does NOT escape `lines`: the caller passes lines that are already escaped
+ * text or trusted markup (the answers table), never raw user input.
+ */
+import { escapeHtml } from "./util";
+
+/** One answered question, already resolved to plain text by the caller. */
+export interface AnswerRow {
+  label: string;
+  value: string;
+}
+
+const FONT_STACK =
+  "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif";
+
+/**
+ * The answers as a two-column table: muted label on the left, value on the
+ * right. `role="presentation"` because it is layout, not data, to a screen
+ * reader; `word-break` so a long URL or a pasted paragraph wraps instead of
+ * forcing the email wider than a phone.
+ */
+export function answersTableHtml(rows: AnswerRow[]): string {
+  if (rows.length === 0) return "";
+  const body = rows
+    .map(
+      (row) =>
+        `<tr>` +
+        `<td style="padding:8px 12px 8px 0;vertical-align:top;width:40%;color:#6b7280;font-size:13px;line-height:1.4;word-break:break-word;">${escapeHtml(row.label)}</td>` +
+        `<td style="padding:8px 0;vertical-align:top;color:#111827;font-size:14px;line-height:1.4;word-break:break-word;white-space:pre-wrap;">${escapeHtml(row.value)}</td>` +
+        `</tr>`,
+    )
+    .join("");
+  return (
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;margin:12px 0;">` +
+    `<tbody>${body}</tbody></table>`
+  );
+}
+
+/**
+ * A complete email document around the rendered lines: doctype, viewport meta,
+ * a full-width outer table and a 600px white card, system font stack. The
+ * lines are joined with `<br/>` inside a `<div>` (a `<p>` cannot legally
+ * contain the answers table). Emits a real `</body></html>` because the
+ * transactional service appends its footer right before `</body>`.
+ */
+export function emailDocument(input: {
+  lang: "en" | "es";
+  lines: string[];
+}): string {
+  const content = input.lines.join("<br/>");
+  return (
+    `<!DOCTYPE html>` +
+    `<html lang="${input.lang}">` +
+    `<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/></head>` +
+    `<body style="margin:0;padding:0;background:#f3f4f6;">` +
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;background:#f3f4f6;">` +
+    `<tr><td align="center" style="padding:24px 12px;">` +
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse;max-width:600px;background:#ffffff;border-radius:8px;">` +
+    `<tr><td style="padding:24px;font-family:${FONT_STACK};font-size:15px;line-height:1.5;color:#111827;">` +
+    `<div style="word-break:break-word;overflow-wrap:anywhere;">${content}</div>` +
+    `</td></tr></table>` +
+    `</td></tr></table>` +
+    `</body></html>`
+  );
+}

--- a/packages/notifications/src/submission-notifier.spec.ts
+++ b/packages/notifications/src/submission-notifier.spec.ts
@@ -97,7 +97,104 @@ describe('SubmissionNotifier', () => {
     const m = provider.sent[0]!;
     expect(m.subject).toBe('New lead on Lead Qualifier (15)');
     expect(m.text).toBe('lead@acme.io scored 15\nForm: Lead Qualifier');
-    expect(m.html).toBe('<p>lead@acme.io scored 15<br/>Form: Lead Qualifier</p>');
+    expect(m.html).toContain('lead@acme.io scored 15<br/>Form: Lead Qualifier');
+  });
+
+  it('sends a complete HTML document (doctype, lang, viewport, closing body)', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-doc',
+      formName: 'Survey',
+      to: ['owner@example.com'],
+      locale: 'es',
+    });
+    const html = provider.sent[0]!.html!;
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('<html lang="es">');
+    expect(html).toContain('name="viewport"');
+    expect(html.trimEnd().endsWith('</body></html>')).toBe(true);
+  });
+
+  it('puts the answers in the owner notice: "Label: value" in text, a table in HTML, escaped', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-ans',
+      formName: 'Lead Qualifier',
+      to: ['owner@example.com'],
+      score: 15,
+      outcomeLabel: 'Qualified',
+      formLink: 'https://forms.example.com/admin/forms/f1/submissions',
+      answers: [
+        { label: 'Role', value: 'Founder' },
+        { label: 'Why', value: '<script>alert(1)</script>' },
+      ],
+    });
+    const m = provider.sent[0]!;
+    expect(m.text).toBe(
+      [
+        'You have a new submission on "Lead Qualifier".',
+        'Score: 15',
+        'Outcome: Qualified',
+        '',
+        'Role: Founder',
+        'Why: <script>alert(1)</script>',
+        '',
+        'View submissions: https://forms.example.com/admin/forms/f1/submissions',
+      ].join('\n'),
+    );
+    expect(m.html).toContain('<table');
+    expect(m.html).toContain('Founder');
+    expect(m.html).not.toContain('<script>');
+    expect(m.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(m.html).toContain('View submissions: https://forms.example.com/admin/forms/f1/submissions');
+  });
+
+  it('a custom body can place {{answers}} anywhere, in both emails', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    const answers = [{ label: 'Role', value: 'Founder' }];
+    await notifier.sendSubmissionReceived({
+      accountId: 'acc-1',
+      submissionId: 'sub-c1',
+      formName: 'Survey',
+      to: ['owner@example.com'],
+      bodyTemplate: 'Top\n{{answers}}\nBottom',
+      answers,
+    });
+    await notifier.sendSubmissionConfirmed({
+      accountId: 'acc-1',
+      submissionId: 'sub-c2',
+      formName: 'Survey',
+      to: [],
+      respondentEmail: 'lead@acme.io',
+      bodyTemplate: 'Your answers:\n{{answers}}',
+      answers,
+    });
+    expect(provider.sent[0]!.text).toBe('Top\nRole: Founder\nBottom');
+    expect(provider.sent[0]!.html).toContain('Top<br/><table');
+    expect(provider.sent[1]!.text).toBe('Your answers:\nRole: Founder');
+    expect(provider.sent[1]!.html).toContain('<table');
+  });
+
+  it('the invitation email is a complete HTML document too', async () => {
+    const provider = new CaptureProvider();
+    const notifier = new SubmissionNotifier(provider);
+    await notifier.sendMemberInvited({
+      accountId: 'acc-1',
+      memberId: 'm-1',
+      to: 'new@example.com',
+      accountName: '<Acme>',
+      signInLink: 'https://forms.example.com/login',
+    });
+    const m = provider.sent[0]!;
+    expect(m.html!.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(m.html).toContain('&lt;Acme&gt;');
+    expect(m.html).not.toContain('<Acme>');
+    expect(m.text).toContain('Sign in: https://forms.example.com/login');
   });
 
   it('ESCAPES interpolated values in a custom body (E8 — the boundary holds)', async () => {

--- a/packages/notifications/src/submission-notifier.ts
+++ b/packages/notifications/src/submission-notifier.ts
@@ -1,18 +1,12 @@
 import type { EmailProvider, EmailResult } from './email.port';
 import { escapeHtml } from './util';
+import { emailDocument, type AnswerRow } from './render-html';
 import {
-  applyCopyOverride,
   normalizeLocale,
   renderMemberInvited,
-  renderSubmissionConfirmed,
-  renderSubmissionReceived,
+  renderSubmissionEmail,
   type NotificationLocale,
 } from './templates';
-
-/** Render plaintext lines to a safe HTML body — every line HTML-escaped (E8). */
-function htmlBody(lines: string[]): string {
-  return `<p>${lines.filter(Boolean).map(escapeHtml).join('<br/>')}</p>`;
-}
 
 /** Everything a submission notification needs to render, provider-agnostic. */
 /** Everything the invitation email needs, resolved before it is enqueued. */
@@ -46,8 +40,13 @@ export interface SubmissionNotification {
   respondentEmail?: string | null;
   score?: number | null;
   outcomeLabel?: string | null;
-  /** A public link back to the form (book-again style). */
+  /** Where the owner reads the answers (the admin submissions page). Never set on the receipt. */
   formLink?: string | null;
+  /**
+   * The answers, resolved to `{label, value}` rows in step order by the caller
+   * (the API, via the engine). Printed by the `{{answers}}` token.
+   */
+  answers?: AnswerRow[] | null;
   /**
    * Language for the rendered copy. Accepts a bare `en`/`es` or any locale-ish
    * value (e.g. `es-CO`, an Accept-Language fragment) — normalized to one of the
@@ -66,9 +65,10 @@ export interface SubmissionNotification {
 }
 
 /**
- * Renders and sends submission emails through the EmailProvider port — plain
- * text + escaped HTML, no attachments. The app only ever calls these methods;
- * the transport is whatever adapter is wired (log-only by default). Copy is
+ * Renders and sends submission emails through the EmailProvider port — a plain
+ * text body plus a complete HTML document (escaped line by line, the answers as
+ * a table), no attachments. The app only ever calls these methods; the
+ * transport is whatever adapter is wired (log-only by default). Copy is
  * bilingual (EN/ES) via the templates module; the caller supplies `locale`.
  */
 export class SubmissionNotifier {
@@ -76,19 +76,19 @@ export class SubmissionNotifier {
 
   /** Internal notice to the account: a new submission landed. */
   sendSubmissionReceived(n: SubmissionNotification): Promise<EmailResult> {
-    const base = renderSubmissionReceived(normalizeLocale(n.locale), n);
-    const { subject, lines } = applyCopyOverride(
-      base,
+    const locale = normalizeLocale(n.locale);
+    const { subject, text, html } = renderSubmissionEmail(
+      'submission_received',
+      locale,
       { subject: n.subjectTemplate, body: n.bodyTemplate },
       n,
     );
-    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.to,
       subject,
-      text: body.join('\n'),
-      html: htmlBody(body),
+      text: text.join('\n'),
+      html: emailDocument({ lang: locale, lines: html }),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:received`,
     });
@@ -99,14 +99,16 @@ export class SubmissionNotifier {
    * copy, not the per-account submission templates an owner can edit.
    */
   sendMemberInvited(n: MemberInvitedNotification): Promise<EmailResult> {
-    const { subject, lines } = renderMemberInvited(normalizeLocale(n.locale), n);
+    const locale = normalizeLocale(n.locale);
+    const { subject, lines } = renderMemberInvited(locale, n);
     const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: [n.to],
       subject,
       text: body.join('\n'),
-      html: htmlBody(body),
+      // Platform copy with interpolated names: escape every line (E8).
+      html: emailDocument({ lang: locale, lines: body.map(escapeHtml) }),
       // One invite per member row — a retried delivery must not read as a second
       // invitation to a managed service that de-duplicates on this key.
       idempotencyKey: `member:${n.memberId}:invited`,
@@ -115,19 +117,19 @@ export class SubmissionNotifier {
 
   /** Confirmation to the respondent that their answers were recorded. */
   sendSubmissionConfirmed(n: SubmissionNotification): Promise<EmailResult> {
-    const base = renderSubmissionConfirmed(normalizeLocale(n.locale), n);
-    const { subject, lines } = applyCopyOverride(
-      base,
+    const locale = normalizeLocale(n.locale);
+    const { subject, text, html } = renderSubmissionEmail(
+      'submission_confirmed',
+      locale,
       { subject: n.subjectTemplate, body: n.bodyTemplate },
       n,
     );
-    const body = lines.filter(Boolean);
     return this.email.send({
       accountId: n.accountId,
       to: n.respondentEmail ? [n.respondentEmail] : n.to,
       subject,
-      text: body.join('\n'),
-      html: htmlBody(body),
+      text: text.join('\n'),
+      html: emailDocument({ lang: locale, lines: html }),
       headers: { 'X-Submission-Id': n.submissionId },
       idempotencyKey: `submission:${n.submissionId}:confirmed`,
     });

--- a/packages/notifications/src/templates.spec.ts
+++ b/packages/notifications/src/templates.spec.ts
@@ -6,6 +6,8 @@ import {
   isSubmissionEmailKey,
   normalizeLocale,
   notificationTokenValues,
+  NOTIFICATION_TOKENS,
+  renderBodyLines,
   renderSubmissionConfirmed,
   renderSubmissionReceived,
   SUBMISSION_EMAIL_KEYS,
@@ -60,6 +62,29 @@ describe('renderSubmissionReceived', () => {
     const { lines } = renderSubmissionReceived('en', { formName: 'Survey' });
     expect(lines.filter(Boolean)).toHaveLength(1);
   });
+
+  it('prints the answers as "Label: value" lines between the outcome and the link', () => {
+    const { lines } = renderSubmissionReceived('en', {
+      formName: 'Survey',
+      outcomeLabel: 'Hot',
+      formLink: 'https://forms.example.com/admin/forms/f1/submissions',
+      answers: [
+        { label: 'Role', value: 'Founder' },
+        { label: 'Team size', value: '20' },
+      ],
+    });
+    expect(lines.join('\n')).toBe(
+      [
+        'You have a new submission on "Survey".',
+        'Outcome: Hot',
+        '',
+        'Role: Founder',
+        'Team size: 20',
+        '',
+        'View submissions: https://forms.example.com/admin/forms/f1/submissions',
+      ].join('\n'),
+    );
+  });
 });
 
 describe('renderSubmissionConfirmed', () => {
@@ -98,7 +123,62 @@ describe('notificationTokenValues', () => {
       score: '0',
       outcomeLabel: '',
       formLink: '',
+      answers: '',
     });
+  });
+
+  it('renders the answers as one "Label: value" line each', () => {
+    expect(
+      notificationTokenValues({
+        formName: 'F',
+        answers: [
+          { label: 'Role', value: 'Founder' },
+          { label: 'Why', value: 'Speed' },
+        ],
+      }).answers,
+    ).toBe('Role: Founder\nWhy: Speed');
+  });
+
+  it('offers {{answers}} as a token', () => {
+    expect(NOTIFICATION_TOKENS).toContain('answers');
+  });
+});
+
+describe('renderBodyLines', () => {
+  const text = { formName: 'Survey', score: '', outcomeLabel: '', answers: 'Role: Founder' };
+  const html = { formName: 'Survey', score: '', outcomeLabel: '', answers: '<table></table>' };
+
+  it('keeps a line with no tokens, even a blank one', () => {
+    const out = renderBodyLines('Hello', text, html);
+    expect(out.text).toEqual(['Hello']);
+    expect(out.html).toEqual(['Hello']);
+  });
+
+  it('drops a line only when it has tokens and every token resolved empty', () => {
+    const out = renderBodyLines('Score: {{score}}\nName: {{formName}}\n{{score}} / {{outcomeLabel}}', text, html);
+    expect(out.text).toEqual(['Name: Survey']);
+  });
+
+  it('keeps a line where at least one token resolved', () => {
+    const out = renderBodyLines('{{score}} on {{formName}}', text, html);
+    expect(out.text).toEqual([' on Survey']);
+  });
+
+  it('keeps an unknown token literal and does not count it as empty', () => {
+    const out = renderBodyLines('{{nope}}', text, html);
+    expect(out.text).toEqual(['{{nope}}']);
+  });
+
+  it('escapes the template text on the html side but substitutes html token values raw', () => {
+    const out = renderBodyLines('<b>{{formName}}</b>\n{{answers}}', { ...text, formName: 'A & B' }, { ...html, formName: 'A &amp; B' });
+    expect(out.text).toEqual(['<b>A & B</b>', 'Role: Founder']);
+    expect(out.html).toEqual(['&lt;b&gt;A &amp; B&lt;/b&gt;', '<table></table>']);
+  });
+
+  it('collapses runs of blank lines left behind and trims blank ends', () => {
+    const out = renderBodyLines('\nA\n\n{{score}}\n\nB\n', text, html);
+    expect(out.text).toEqual(['A', '', 'B']);
+    expect(out.html).toEqual(['A', '', 'B']);
   });
 });
 
@@ -140,7 +220,15 @@ describe('defaultSubmissionTemplate (stays in sync with the code templates)', ()
     score: 15,
     outcomeLabel: 'Qualified',
     formLink: 'https://forms.example.com/x',
+    answers: [{ label: 'Role', value: 'Founder' }],
   };
+
+  it('the owner default carries {{answers}}; the respondent default does not', () => {
+    for (const locale of ['en', 'es'] as const) {
+      expect(defaultSubmissionTemplate('submission_received', locale).body).toContain('{{answers}}');
+      expect(defaultSubmissionTemplate('submission_confirmed', locale).body).not.toContain('{{answers}}');
+    }
+  });
 
   it('SUBMISSION_EMAIL_KEYS are exactly the two customizable emails', () => {
     expect([...SUBMISSION_EMAIL_KEYS]).toEqual(['submission_received', 'submission_confirmed']);
@@ -153,9 +241,7 @@ describe('defaultSubmissionTemplate (stays in sync with the code templates)', ()
       const def = defaultSubmissionTemplate('submission_received', locale);
       const stock = renderSubmissionReceived(locale, full);
       expect(interpolateTokens(def.subject, notificationTokenValues(full))).toBe(stock.subject);
-      expect(interpolateTokens(def.body, notificationTokenValues(full)).split('\n')).toEqual(
-        stock.lines.filter(Boolean),
-      );
+      expect(interpolateTokens(def.body, notificationTokenValues(full))).toBe(stock.lines.join('\n'));
     }
   });
 
@@ -164,9 +250,7 @@ describe('defaultSubmissionTemplate (stays in sync with the code templates)', ()
       const def = defaultSubmissionTemplate('submission_confirmed', locale);
       const stock = renderSubmissionConfirmed(locale, full);
       expect(interpolateTokens(def.subject, notificationTokenValues(full))).toBe(stock.subject);
-      expect(interpolateTokens(def.body, notificationTokenValues(full)).split('\n')).toEqual(
-        stock.lines.filter(Boolean),
-      );
+      expect(interpolateTokens(def.body, notificationTokenValues(full))).toBe(stock.lines.join('\n'));
     }
   });
 });

--- a/packages/notifications/src/templates.ts
+++ b/packages/notifications/src/templates.ts
@@ -11,6 +11,9 @@
  * text bodies read naturally while the HTML path stays XSS-safe (E8).
  */
 
+import { answersTableHtml, type AnswerRow } from './render-html';
+import { escapeHtml } from './util';
+
 /** The two supported notification languages. Mirrors @quill/shared `Locale`. */
 export type NotificationLocale = 'en' | 'es';
 
@@ -30,15 +33,23 @@ export interface ReceivedCopyVars {
   respondentEmail?: string | null;
   score?: number | null;
   outcomeLabel?: string | null;
-  /** A link back to the submissions view (owner) — optional. */
+  /** A link to the admin submissions page (owner notice only). */
   formLink?: string | null;
+  /**
+   * The answers as the owner reads them (label + value, in step order), already
+   * resolved by the caller. Rendered by the `{{answers}}` token: one
+   * `Label: value` line each in text, a two-column table in HTML.
+   */
+  answers?: AnswerRow[] | null;
 }
 
 /** Everything the "we got your responses" (respondent) copy can interpolate. */
 export interface ConfirmedCopyVars {
   formName: string;
-  /** A public link back to the form (view/edit) — optional. */
+  /** Reserved: no producer sets it on the receipt today, so the stock line drops. */
   formLink?: string | null;
+  /** The respondent's own answers, for a custom template that wants to echo them. */
+  answers?: AnswerRow[] | null;
 }
 
 /** A rendered email: a plain subject + the body lines (blank entries dropped). */
@@ -51,33 +62,15 @@ export interface RenderedCopy {
  * The internal notice to the account owner: "a new submission landed on your
  * form." This is the primary Forms notification — the equivalent of the
  * host-notification email a Calendly/Bookings flow emits when someone books.
+ * Rendered from the same token-bearing default an owner sees in Settings, so
+ * the stock email and the editable default can never drift.
  */
 export function renderSubmissionReceived(
   locale: NotificationLocale,
   v: ReceivedCopyVars,
 ): RenderedCopy {
-  if (locale === 'es') {
-    return {
-      subject: `Nueva respuesta: ${v.formName}`,
-      lines: [
-        `Recibiste una nueva respuesta en "${v.formName}".`,
-        v.respondentEmail ? `De: ${v.respondentEmail}` : '',
-        v.score != null ? `Puntuación: ${v.score}` : '',
-        v.outcomeLabel ? `Resultado: ${v.outcomeLabel}` : '',
-        v.formLink ? `Ver las respuestas: ${v.formLink}` : '',
-      ],
-    };
-  }
-  return {
-    subject: `New submission: ${v.formName}`,
-    lines: [
-      `You have a new submission on "${v.formName}".`,
-      v.respondentEmail ? `From: ${v.respondentEmail}` : '',
-      v.score != null ? `Score: ${v.score}` : '',
-      v.outcomeLabel ? `Outcome: ${v.outcomeLabel}` : '',
-      v.formLink ? `View submissions: ${v.formLink}` : '',
-    ],
-  };
+  const { subject, text } = renderSubmissionEmail('submission_received', locale, {}, v);
+  return { subject, lines: text };
 }
 
 /**
@@ -89,22 +82,8 @@ export function renderSubmissionConfirmed(
   locale: NotificationLocale,
   v: ConfirmedCopyVars,
 ): RenderedCopy {
-  if (locale === 'es') {
-    return {
-      subject: `Recibimos tus respuestas: ${v.formName}`,
-      lines: [
-        `Gracias: registramos tus respuestas de "${v.formName}".`,
-        v.formLink ? `Ver o editar: ${v.formLink}` : '',
-      ],
-    };
-  }
-  return {
-    subject: `We got your responses: ${v.formName}`,
-    lines: [
-      `Thanks: we've recorded your responses to "${v.formName}".`,
-      v.formLink ? `View or edit: ${v.formLink}` : '',
-    ],
-  };
+  const { subject, text } = renderSubmissionEmail('submission_confirmed', locale, {}, v);
+  return { subject, lines: text };
 }
 
 /** What an invitation email needs to say. */
@@ -185,6 +164,7 @@ export const NOTIFICATION_TOKENS = [
   'score',
   'outcomeLabel',
   'formLink',
+  'answers',
 ] as const;
 export type NotificationToken = (typeof NOTIFICATION_TOKENS)[number];
 
@@ -196,8 +176,29 @@ export function notificationTokenValues(v: ReceivedCopyVars): Record<Notificatio
     score: v.score != null ? String(v.score) : '',
     outcomeLabel: v.outcomeLabel ?? '',
     formLink: v.formLink ?? '',
+    answers: (v.answers ?? []).map((row) => `${row.label}: ${row.value}`).join('\n'),
   };
 }
+
+/**
+ * The same map for the HTML body: every value escaped, except `answers`, which
+ * is the already-escaped table (see render-html.ts). This is the ONLY place a
+ * token value reaches HTML unescaped, and only because the table escaped its
+ * cells itself.
+ */
+export function htmlTokenValues(v: ReceivedCopyVars): Record<NotificationToken, string> {
+  const text = notificationTokenValues(v);
+  return {
+    formName: escapeHtml(text.formName),
+    respondentEmail: escapeHtml(text.respondentEmail),
+    score: escapeHtml(text.score),
+    outcomeLabel: escapeHtml(text.outcomeLabel),
+    formLink: escapeHtml(text.formLink),
+    answers: answersTableHtml(v.answers ?? []),
+  };
+}
+
+const TOKEN_RE = /\{\{\s*([a-zA-Z][A-Za-z0-9_]*)\s*\}\}/g;
 
 /**
  * Substitute `{{token}}` markers in ONE pass. Single-pass matters: a value that
@@ -207,10 +208,78 @@ export function notificationTokenValues(v: ReceivedCopyVars): Record<Notificatio
  * inside the braces is tolerated (`{{ formName }}`).
  */
 export function interpolateTokens(template: string, values: Record<string, string>): string {
-  return template.replace(/\{\{\s*([a-zA-Z][A-Za-z0-9_]*)\s*\}\}/g, (whole, name: string) => {
+  return template.replace(TOKEN_RE, (whole, name: string) => {
     const value = values[name];
     return value === undefined ? whole : value;
   });
+}
+
+/** A rendered body: the text lines and their HTML twins, index for index. */
+export interface RenderedBodyLines {
+  text: string[];
+  html: string[];
+}
+
+/**
+ * Render a body template line by line, for the text and the HTML body at once.
+ * ONE rule for stock and custom copy alike: a line is dropped only when it
+ * carries tokens and every one of them resolved to nothing (`Score: {{score}}`
+ * with no score), so an absent optional never leaves a dangling label, while a
+ * line with no tokens (a blank spacer, a sign-off) is always kept. Runs of
+ * blank lines left behind collapse to one and blank ends are trimmed.
+ *
+ * The HTML twin escapes the TEMPLATE text first (the owner's own copy is plain
+ * text) and then substitutes `htmlValues`, which the caller has escaped per
+ * token; `escapeHtml` never touches `{{`, so the markers survive the escape.
+ * An unknown token stays literal on both sides and counts as visible content.
+ */
+export function renderBodyLines(
+  template: string,
+  textValues: Record<string, string>,
+  htmlValues: Record<string, string>,
+): RenderedBodyLines {
+  const text: string[] = [];
+  const html: string[] = [];
+  for (const line of template.replace(/\r\n?/g, '\n').split('\n')) {
+    const names = [...line.matchAll(TOKEN_RE)].map((m) => m[1]!);
+    if (names.length > 0 && names.every((name) => textValues[name] === '')) continue;
+    const rendered = interpolateTokens(line, textValues);
+    // A blank spacer stays; a run of blanks (from dropped lines) collapses.
+    if (rendered.trim() === '' && (text.length === 0 || text[text.length - 1]!.trim() === '')) continue;
+    text.push(rendered);
+    html.push(interpolateTokens(escapeHtml(line), htmlValues));
+  }
+  while (text.length > 0 && text[text.length - 1]!.trim() === '') {
+    text.pop();
+    html.pop();
+  }
+  return { text, html };
+}
+
+/** A fully rendered submission email: the subject plus text and HTML lines. */
+export interface RenderedSubmissionEmail extends RenderedBodyLines {
+  subject: string;
+}
+
+/**
+ * Render one submission email from its effective template: the account/form
+ * override where set, the shipped default otherwise, each field independent.
+ * The subject collapses any newlines to spaces (a header is single-line; this
+ * closes off subject header-injection).
+ */
+export function renderSubmissionEmail(
+  key: SubmissionEmailKey,
+  locale: NotificationLocale,
+  override: { subject?: string | null; body?: string | null },
+  vars: ReceivedCopyVars,
+): RenderedSubmissionEmail {
+  const def = defaultSubmissionTemplate(key, locale);
+  const values = notificationTokenValues(vars);
+  const subject = interpolateTokens(override.subject ?? def.subject, values)
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
+  const body = renderBodyLines(override.body ?? def.body, values, htmlTokenValues(vars));
+  return { subject, ...body };
 }
 
 /**
@@ -218,8 +287,8 @@ export function interpolateTokens(template: string, values: Record<string, strin
  * is independent: a non-null override replaces it (interpolated), a null/absent
  * override keeps the stock text. The subject collapses any newlines to spaces
  * (a header is single-line — closes off subject header-injection). The returned
- * lines are RAW (unescaped) exactly like the stock render, so the notifier's
- * `htmlBody` remains the single escaping boundary.
+ * lines are the TEXT lines (unescaped), exactly like the stock render; the HTML
+ * twin comes from `renderSubmissionEmail`.
  */
 export function applyCopyOverride(
   base: RenderedCopy,
@@ -232,7 +301,9 @@ export function applyCopyOverride(
       ? interpolateTokens(override.subject, values).replace(/[\r\n]+/g, ' ').trim()
       : base.subject;
   const lines =
-    override.body != null ? interpolateTokens(override.body, values).split('\n') : base.lines;
+    override.body != null
+      ? renderBodyLines(override.body, values, htmlTokenValues(vars)).text
+      : base.lines;
   return { subject, lines };
 }
 
@@ -255,6 +326,9 @@ export function defaultSubmissionTemplate(
             'De: {{respondentEmail}}',
             'Puntuación: {{score}}',
             'Resultado: {{outcomeLabel}}',
+            '',
+            '{{answers}}',
+            '',
             'Ver las respuestas: {{formLink}}',
           ].join('\n'),
         }
@@ -265,6 +339,9 @@ export function defaultSubmissionTemplate(
             'From: {{respondentEmail}}',
             'Score: {{score}}',
             'Outcome: {{outcomeLabel}}',
+            '',
+            '{{answers}}',
+            '',
             'View submissions: {{formLink}}',
           ].join('\n'),
         };

--- a/packages/shared/src/datetime.spec.ts
+++ b/packages/shared/src/datetime.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  dayBoundsInZone,
+  formatDate,
+  formatDateTime,
+  formatIsoWithOffset,
+  isValidTimeZone,
+  isoDateInZone,
+  localDayIndex,
+  resolveTimeZone,
+  tzOffsetMs,
+  utcOffsetSegments,
+  zonedMidnightMs,
+} from "./datetime";
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+// New York springs forward on 2026-03-08 at 07:00Z (02:00 EST -> 03:00 EDT).
+const NY_SPRING = Date.UTC(2026, 2, 8, 7, 0, 0);
+
+describe("zone validation", () => {
+  it("accepts IANA names the runtime knows and rejects the rest", () => {
+    expect(isValidTimeZone("America/Bogota")).toBe(true);
+    expect(isValidTimeZone("UTC")).toBe(true);
+    expect(isValidTimeZone("Mars/Olympus")).toBe(false);
+    expect(isValidTimeZone("")).toBe(false);
+  });
+
+  it("resolveTimeZone falls back to UTC with a warning instead of throwing", () => {
+    const warnings: string[] = [];
+    expect(resolveTimeZone("Mars/Olympus", (m) => warnings.push(m))).toBe(
+      "UTC",
+    );
+    expect(warnings).toHaveLength(1);
+    expect(resolveTimeZone(null)).toBe("UTC");
+    expect(resolveTimeZone("America/Bogota")).toBe("America/Bogota");
+  });
+});
+
+describe("offsets and day math", () => {
+  it("knows the offset on both sides of a DST change", () => {
+    expect(tzOffsetMs(NY_SPRING - 1, "America/New_York")).toBe(-5 * HOUR);
+    expect(tzOffsetMs(NY_SPRING, "America/New_York")).toBe(-4 * HOUR);
+    expect(tzOffsetMs(NY_SPRING, "America/Bogota")).toBe(-5 * HOUR);
+    expect(tzOffsetMs(NY_SPRING, "UTC")).toBe(0);
+  });
+
+  it("buckets an instant into the calendar day of the zone", () => {
+    // 2026-09-04T03:30Z is still Sep 3 in Bogota.
+    const t = Date.UTC(2026, 8, 4, 3, 30);
+    expect(localDayIndex(t, "UTC")).toBe(Math.floor(t / DAY));
+    expect(localDayIndex(t, "America/Bogota")).toBe(Math.floor(t / DAY) - 1);
+    expect(isoDateInZone(t, "America/Bogota")).toBe("2026-09-03");
+    expect(isoDateInZone(t, "UTC")).toBe("2026-09-04");
+  });
+
+  it("finds local midnight, including on the day the clocks jump", () => {
+    expect(zonedMidnightMs("2026-09-03", "America/Bogota")).toBe(
+      Date.UTC(2026, 8, 3, 5),
+    );
+    expect(zonedMidnightMs("2026-03-08", "America/New_York")).toBe(
+      Date.UTC(2026, 2, 8, 5),
+    );
+    // A zone where midnight itself is skipped lands on the first instant that exists.
+    expect(zonedMidnightMs("2026-09-06", "America/Santiago")).toBe(
+      Date.UTC(2026, 8, 6, 4),
+    );
+  });
+
+  it("dayBoundsInZone spans exactly the local day, 23 hours on the spring-forward day", () => {
+    const b = dayBoundsInZone("2026-09-03", "America/Bogota");
+    expect(b).toEqual({
+      from: Date.UTC(2026, 8, 3, 5),
+      to: Date.UTC(2026, 8, 4, 5) - 1,
+    });
+    const ny = dayBoundsInZone("2026-03-08", "America/New_York");
+    expect(ny.to - ny.from + 1).toBe(23 * HOUR);
+  });
+});
+
+describe("utcOffsetSegments", () => {
+  it("is one segment for a fixed-offset zone and for UTC", () => {
+    expect(
+      utcOffsetSegments(
+        Date.UTC(2026, 0, 1),
+        Date.UTC(2026, 11, 31),
+        "America/Bogota",
+      ),
+    ).toEqual([{ from: Date.UTC(2026, 0, 1), offsetMs: -5 * HOUR }]);
+    expect(utcOffsetSegments(0, DAY, "UTC")).toEqual([
+      { from: 0, offsetMs: 0 },
+    ]);
+  });
+
+  it("splits at the exact minute of a DST change", () => {
+    const segments = utcOffsetSegments(
+      NY_SPRING - 3 * DAY,
+      NY_SPRING + 3 * DAY,
+      "America/New_York",
+    );
+    expect(segments).toEqual([
+      { from: NY_SPRING - 3 * DAY, offsetMs: -5 * HOUR },
+      { from: NY_SPRING, offsetMs: -4 * HOUR },
+    ]);
+  });
+});
+
+describe("formatting", () => {
+  it("formats a date-time in the zone and locale", () => {
+    const t = Date.UTC(2026, 8, 3, 23, 30);
+    // Newer ICU prints a narrow no-break space before AM/PM; the assertion is about the zone.
+    const plain = (s: string) => s.replace(/\u202f/g, " ");
+    expect(
+      plain(formatDateTime(t, { locale: "en", timeZone: "America/Bogota" })),
+    ).toBe("Sep 3, 2026, 6:30 PM");
+    expect(plain(formatDateTime(t, { locale: "en", timeZone: "UTC" }))).toBe(
+      "Sep 3, 2026, 11:30 PM",
+    );
+    expect(formatDate(t, { locale: "en", timeZone: "Asia/Tokyo" })).toBe(
+      "Sep 4, 2026",
+    );
+  });
+
+  it("writes an ISO timestamp with the zone offset, UTC as +00:00", () => {
+    const t = Date.UTC(2026, 8, 3, 23, 30, 15);
+    expect(formatIsoWithOffset(t, "America/Bogota")).toBe(
+      "2026-09-03T18:30:15-05:00",
+    );
+    expect(formatIsoWithOffset(t, "UTC")).toBe("2026-09-03T23:30:15+00:00");
+    expect(formatIsoWithOffset(t, "Asia/Kolkata")).toBe(
+      "2026-09-04T05:00:15+05:30",
+    );
+  });
+
+  it("never throws on an invalid zone: everything resolves in UTC", () => {
+    const t = Date.UTC(2026, 8, 3, 23, 30);
+    expect(formatIsoWithOffset(t, "Mars/Olympus")).toBe(
+      "2026-09-03T23:30:00+00:00",
+    );
+    expect(isoDateInZone(t, "Mars/Olympus")).toBe("2026-09-03");
+  });
+});

--- a/packages/shared/src/datetime.ts
+++ b/packages/shared/src/datetime.ts
@@ -1,0 +1,267 @@
+/**
+ * Timezone-aware date math on top of `Intl` alone (this repo carries no date
+ * library). Isomorphic: the same code names calendar days on the server (day
+ * buckets, CSV export) and formats timestamps in the browser.
+ *
+ * Every function tolerates an unknown zone by resolving it as UTC (with an
+ * optional warning), never by throwing: a mistyped zone in a setting must not
+ * take a page or a query down with it.
+ */
+
+export const DAY_MS = 86_400_000;
+const MINUTE_MS = 60_000;
+
+/** Whether this runtime's ICU data knows `zone` as an IANA name. */
+export function isValidTimeZone(zone: string | null | undefined): boolean {
+  const name = zone?.trim();
+  if (!name) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: name });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `zone` when the runtime knows it, else `'UTC'` (warning the caller). */
+export function resolveTimeZone(
+  zone: string | null | undefined,
+  warn?: (message: string) => void,
+): string {
+  const name = zone?.trim();
+  if (!name) return "UTC";
+  if (isValidTimeZone(name)) return name;
+  warn?.(`timezone: unknown zone ${JSON.stringify(name)}, using UTC instead`);
+  return "UTC";
+}
+
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+/** A cached parts formatter for one zone; `hourCycle: 'h23'` keeps midnight as 0. */
+function partsFormatter(zone: string): Intl.DateTimeFormat {
+  let f = formatters.get(zone);
+  if (!f) {
+    f = new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    formatters.set(zone, f);
+  }
+  return f;
+}
+
+interface WallClock {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+/** The wall-clock reading of `epochMs` in a (resolved) zone. */
+function wallClock(epochMs: number, zone: string): WallClock {
+  // Read BY PART TYPE, never by parsing a formatted string: the order of a
+  // formatted date depends on ICU data, the part types do not.
+  const parts = partsFormatter(zone).formatToParts(new Date(epochMs));
+  const at = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? NaN);
+  const hour = at("hour");
+  return {
+    year: at("year"),
+    month: at("month"),
+    day: at("day"),
+    // Some ICU builds print midnight as 24 even under h23.
+    hour: hour === 24 ? 0 : hour,
+    minute: at("minute"),
+    second: at("second"),
+  };
+}
+
+/** The zone's UTC offset at `epochMs`, in ms (negative west of Greenwich). */
+export function tzOffsetMs(epochMs: number, zone: string): number {
+  const name = resolveTimeZone(zone);
+  if (name === "UTC") return 0;
+  const w = wallClock(epochMs, name);
+  const asUtc = Date.UTC(
+    w.year,
+    w.month - 1,
+    w.day,
+    w.hour,
+    w.minute,
+    w.second,
+  );
+  // Offsets are whole minutes; rounding drops the sub-second part of `epochMs`.
+  return Math.round((asUtc - epochMs) / MINUTE_MS) * MINUTE_MS;
+}
+
+/**
+ * The calendar day `epochMs` falls on in `zone`, as a day index (days since
+ * the epoch of that LOCAL day). The JS twin of the SQL bucketing expression
+ * `(col + offset) / 86400000`, so trends built here and buckets built there
+ * agree by construction.
+ */
+export function localDayIndex(epochMs: number, zone: string): number {
+  return Math.floor((epochMs + tzOffsetMs(epochMs, zone)) / DAY_MS);
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** `YYYY-MM-DD` of the calendar day `epochMs` falls on in `zone`. */
+export function isoDateInZone(epochMs: number, zone: string): string {
+  const w = wallClock(epochMs, resolveTimeZone(zone));
+  return `${String(w.year).padStart(4, "0")}-${pad2(w.month)}-${pad2(w.day)}`;
+}
+
+function parseIso(isoDate: string): {
+  year: number;
+  month: number;
+  day: number;
+} {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!m)
+    throw new Error(`expected YYYY-MM-DD, got ${JSON.stringify(isoDate)}`);
+  return { year: Number(m[1]), month: Number(m[2]), day: Number(m[3]) };
+}
+
+/**
+ * The instant local midnight of `isoDate` happens in `zone`. Two passes over
+ * the offset (the offset AT the guessed instant may differ from the offset at
+ * the naive one around a DST change). When midnight itself does not exist
+ * (the clocks jump from 23:59 to 01:00), the first instant of that local day
+ * is returned instead.
+ */
+export function zonedMidnightMs(isoDate: string, zone: string): number {
+  const name = resolveTimeZone(zone);
+  const { year, month, day } = parseIso(isoDate);
+  const naive = Date.UTC(year, month - 1, day);
+  if (name === "UTC") return naive;
+  let candidate = naive - tzOffsetMs(naive, name);
+  const second = tzOffsetMs(candidate, name);
+  candidate = naive - second;
+  const target = `${String(year).padStart(4, "0")}-${pad2(month)}-${pad2(day)}`;
+  const w = wallClock(candidate, name);
+  if (
+    isoDateInZone(candidate, name) === target &&
+    w.hour === 0 &&
+    w.minute === 0
+  )
+    return candidate;
+  // A skipped midnight: walk forward minute by minute (a DST gap is an hour or
+  // two) to the first instant that reads as the wanted day.
+  let t = candidate;
+  for (let i = 0; i < 3 * 60; i++) {
+    if (isoDateInZone(t, name) === target) return t;
+    t += MINUTE_MS;
+  }
+  return candidate;
+}
+
+function addDaysIso(isoDate: string, days: number): string {
+  const { year, month, day } = parseIso(isoDate);
+  return new Date(Date.UTC(year, month - 1, day + days))
+    .toISOString()
+    .slice(0, 10);
+}
+
+/** The epoch-ms window `[from, to]` of the whole local day `isoDate` in `zone`. */
+export function dayBoundsInZone(
+  isoDate: string,
+  zone: string,
+): { from: number; to: number } {
+  const from = zonedMidnightMs(isoDate, zone);
+  const next = zonedMidnightMs(addDaysIso(isoDate, 1), zone);
+  return { from, to: next - 1 };
+}
+
+/** One stretch of constant UTC offset; `from` is inclusive, the next segment ends it. */
+export interface OffsetSegment {
+  from: number;
+  offsetMs: number;
+}
+
+/**
+ * The UTC offset of `zone` across `[from, to]`, as segments that start where
+ * the offset changes (to the minute). Walks in daily steps and bisects each
+ * change, so a year of a DST zone is two or three segments and a fixed-offset
+ * zone (or UTC) is always exactly one. This is what lets SQL bucket days in
+ * a zone with a CASE over a handful of boundaries instead of per-row math.
+ */
+export function utcOffsetSegments(
+  from: number,
+  to: number,
+  zone: string,
+): OffsetSegment[] {
+  const name = resolveTimeZone(zone);
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  const off = (t: number) => tzOffsetMs(t, name);
+  const segments: OffsetSegment[] = [{ from: start, offsetMs: off(start) }];
+  if (name === "UTC") return segments;
+  let t = start;
+  while (t < end) {
+    const next = Math.min(t + DAY_MS, end);
+    const before = off(t);
+    if (off(next) !== before) {
+      // Bisect on the minute grid for the first minute with the new offset.
+      let lo = Math.floor(t / MINUTE_MS);
+      let hi = Math.ceil(next / MINUTE_MS);
+      while (hi - lo > 1) {
+        const mid = lo + Math.floor((hi - lo) / 2);
+        if (off(mid * MINUTE_MS) === before) lo = mid;
+        else hi = mid;
+      }
+      const at = hi * MINUTE_MS;
+      segments.push({ from: at, offsetMs: off(at) });
+    }
+    t = next;
+  }
+  return segments;
+}
+
+export interface FormatOptions {
+  locale: string;
+  timeZone: string;
+}
+
+/** `Sep 3, 2026, 6:30 PM` in the locale, read in the zone. */
+export function formatDateTime(
+  epochMs: number,
+  options: FormatOptions,
+): string {
+  return new Intl.DateTimeFormat(options.locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: resolveTimeZone(options.timeZone),
+  }).format(new Date(epochMs));
+}
+
+/** `Sep 3, 2026` in the locale, read in the zone. */
+export function formatDate(epochMs: number, options: FormatOptions): string {
+  return new Intl.DateTimeFormat(options.locale, {
+    dateStyle: "medium",
+    timeZone: resolveTimeZone(options.timeZone),
+  }).format(new Date(epochMs));
+}
+
+/** `2026-09-03T18:30:15-05:00`: the wall-clock reading plus the zone's offset (UTC = `+00:00`). */
+export function formatIsoWithOffset(epochMs: number, zone: string): string {
+  const name = resolveTimeZone(zone);
+  const w = wallClock(epochMs, name);
+  const offset = tzOffsetMs(epochMs, name);
+  const sign = offset < 0 ? "-" : "+";
+  const abs = Math.abs(offset) / MINUTE_MS;
+  return (
+    `${String(w.year).padStart(4, "0")}-${pad2(w.month)}-${pad2(w.day)}` +
+    `T${pad2(w.hour)}:${pad2(w.minute)}:${pad2(w.second)}` +
+    `${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`
+  );
+}

--- a/packages/shared/src/form-labels.spec.ts
+++ b/packages/shared/src/form-labels.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { resolveFormLabels } from "./form-labels";
+
+describe("resolveFormLabels", () => {
+  it("falls back to the stock renderer copy of the locale", () => {
+    expect(resolveFormLabels({}, "en")).toEqual({
+      back: "Back",
+      next: "Next",
+      submit: "Submit",
+      start: "Start",
+    });
+    expect(resolveFormLabels({}, "es")).toEqual({
+      back: "Atrás",
+      next: "Siguiente",
+      submit: "Enviar",
+      start: "Comenzar",
+    });
+  });
+
+  it("a form-level override wins over the stock copy, trimmed", () => {
+    const labels = resolveFormLabels(
+      { labels: { next: "  Continue  ", submit: "Send it" } },
+      "es",
+    );
+    expect(labels.next).toBe("Continue");
+    expect(labels.submit).toBe("Send it");
+    expect(labels.back).toBe("Atrás");
+  });
+
+  it("a blank or null override is no override", () => {
+    expect(
+      resolveFormLabels({ labels: { next: "   ", back: null } }, "en").next,
+    ).toBe("Next");
+    expect(resolveFormLabels({ labels: null }, "en").back).toBe("Back");
+  });
+
+  it("the cover CTA keeps its own field", () => {
+    expect(resolveFormLabels({ cover: { ctaText: "Go" } }, "en").start).toBe(
+      "Go",
+    );
+    expect(resolveFormLabels({ cover: { ctaText: "  " } }, "es").start).toBe(
+      "Comenzar",
+    );
+  });
+});

--- a/packages/shared/src/form-labels.ts
+++ b/packages/shared/src/form-labels.ts
@@ -1,0 +1,43 @@
+import { getMessages, type Locale } from "./i18n";
+
+/** What the renderer prints on its navigation buttons. */
+export interface ResolvedFormLabels {
+  back: string;
+  next: string;
+  submit: string;
+  /** The cover CTA: `cover.ctaText`, else the stock "Start". */
+  start: string;
+}
+
+/** The slice of a form config this resolver reads (engine and types both fit). */
+export interface FormLabelSource {
+  labels?: {
+    back?: string | null;
+    next?: string | null;
+    submit?: string | null;
+  } | null;
+  cover?: { ctaText?: string | null } | null;
+}
+
+function pick(override: string | null | undefined, fallback: string): string {
+  const trimmed = override?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+/**
+ * The button copy for a form in a locale: the author's form-level override
+ * where set (trimmed), the stock renderer copy otherwise. One resolver for
+ * both renderers and the builder preview, so they can never disagree.
+ */
+export function resolveFormLabels(
+  config: FormLabelSource,
+  locale: Locale,
+): ResolvedFormLabels {
+  const m = getMessages(locale).renderer;
+  return {
+    back: pick(config.labels?.back, m.back),
+    next: pick(config.labels?.next, m.next),
+    submit: pick(config.labels?.submit, m.submit),
+    start: pick(config.cover?.ctaText, m.start),
+  };
+}

--- a/packages/shared/src/i18n/chrome.spec.ts
+++ b/packages/shared/src/i18n/chrome.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getMessages } from './index';
+
+describe('admin.chrome docs link', () => {
+  it('points each language at its own documentation site', () => {
+    expect(getMessages('en').admin.chrome.docsHref).toBe('https://docs.dapta.ai/dapta-forms/forms');
+    expect(getMessages('es').admin.chrome.docsHref).toBe('https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms');
+  });
+
+  it('carries absolute URLs (the rail opens them in a new tab, so a relative path would 404 in the app)', () => {
+    for (const locale of ['en', 'es'] as const) {
+      const url = new URL(getMessages(locale).admin.chrome.docsHref);
+      expect(url.protocol).toBe('https:');
+      expect(url.hostname).toBe('docs.dapta.ai');
+    }
+  });
+
+  it('labels the nav item in both languages', () => {
+    expect(getMessages('en').admin.chrome.nav.docs).toBe('Docs');
+    expect(getMessages('es').admin.chrome.nav.docs).toBe('Documentación');
+  });
+});

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -510,6 +510,44 @@ export interface FormsMessages {
       open: string;
       connect: string;
       openForm: string;
+      /** Search box over the loaded list (name or slug, no case, no accents). */
+      searchPlaceholder: string;
+      searchLabel: string;
+      searchClear: string;
+      searchEmpty: string;
+      /** "{count} results" live announcement. */
+      searchResults: string;
+      /** The keyboard hint shown inside the search box. */
+      searchShortcut: string;
+      /** Folders: sections of the list. */
+      unfiled: string;
+      folderCount: string; // {count}
+      folderCountOne: string;
+      newFolder: string;
+      newFolderTitle: string;
+      folderCreate: string;
+      renameFolder: string;
+      renameFolderTitle: string;
+      folderSave: string;
+      folderNameLabel: string;
+      folderNamePlaceholder: string;
+      folderNameRequired: string;
+      folderNameTaken: string;
+      deleteFolder: string;
+      deleteFolderConfirm: string; // {name} {count}
+      folderMenu: string;
+      collapse: string;
+      expand: string;
+      /** "New form" on a folder header, creating straight into it. */
+      createIn: string;
+      folderLabel: string;
+      folderNone: string;
+      moveTo: string;
+      moveBack: string;
+      moveFailed: string;
+      dragHandle: string;
+      dropHere: string;
+      actionFailed: string;
     };
     /** The form editor (builder). */
     editor: {
@@ -1653,6 +1691,7 @@ export interface FormsMessages {
     cancel: string;
     /** Per-surface dialog titles (the body reuses each surface's *Confirm copy). */
     deleteFormTitle: string;
+    deleteFolderTitle: string;
     deleteQuestionTitle: string;
     deleteSubmissionTitle: string;
     removeMemberTitle: string;
@@ -2078,6 +2117,39 @@ export const en: FormsMessages = {
       open: 'Open',
       connect: 'Connect',
       openForm: 'Open form',
+      searchPlaceholder: 'Search forms',
+      searchLabel: 'Search forms by name or link',
+      searchClear: 'Clear search',
+      searchEmpty: 'No forms match your search.',
+      searchResults: '{count} forms match',
+      searchShortcut: 'Ctrl K',
+      unfiled: 'Unfiled',
+      folderCount: '{count} forms',
+      folderCountOne: '1 form',
+      newFolder: 'New folder',
+      newFolderTitle: 'Create a folder',
+      folderCreate: 'Create folder',
+      renameFolder: 'Rename',
+      renameFolderTitle: 'Rename folder',
+      folderSave: 'Save',
+      folderNameLabel: 'Folder name',
+      folderNamePlaceholder: 'e.g. Sales',
+      folderNameRequired: 'Give the folder a name.',
+      folderNameTaken: 'A folder with that name already exists.',
+      deleteFolder: 'Delete folder',
+      deleteFolderConfirm: 'Delete “{name}”? Its {count} forms are kept and move to Unfiled.',
+      folderMenu: 'Folder actions',
+      collapse: 'Collapse',
+      expand: 'Expand',
+      createIn: 'New form',
+      folderLabel: 'Folder',
+      folderNone: 'No folder',
+      moveTo: 'Move to folder',
+      moveBack: 'No folder',
+      moveFailed: 'Could not move the form. Please try again.',
+      dragHandle: 'Drag to a folder',
+      dropHere: 'Drop to move here',
+      actionFailed: 'Something went wrong. Please try again.',
     },
     editor: {
       back: 'Back to forms',
@@ -3133,6 +3205,7 @@ export const en: FormsMessages = {
     confirm: 'Confirm',
     cancel: 'Cancel',
     deleteFormTitle: 'Delete form',
+    deleteFolderTitle: 'Delete folder',
     deleteQuestionTitle: 'Delete question',
     deleteSubmissionTitle: 'Delete submission',
     removeMemberTitle: 'Remove member',
@@ -3560,6 +3633,39 @@ export const es: FormsMessages = {
       open: 'Abrir',
       connect: 'Conectar',
       openForm: 'Abrir formulario',
+      searchPlaceholder: 'Buscar formularios',
+      searchLabel: 'Buscar formularios por nombre o enlace',
+      searchClear: 'Limpiar búsqueda',
+      searchEmpty: 'Ningún formulario coincide con tu búsqueda.',
+      searchResults: '{count} formularios coinciden',
+      searchShortcut: 'Ctrl K',
+      unfiled: 'Sin carpeta',
+      folderCount: '{count} formularios',
+      folderCountOne: '1 formulario',
+      newFolder: 'Nueva carpeta',
+      newFolderTitle: 'Crear una carpeta',
+      folderCreate: 'Crear carpeta',
+      renameFolder: 'Renombrar',
+      renameFolderTitle: 'Renombrar carpeta',
+      folderSave: 'Guardar',
+      folderNameLabel: 'Nombre de la carpeta',
+      folderNamePlaceholder: 'p. ej. Ventas',
+      folderNameRequired: 'Ponle un nombre a la carpeta.',
+      folderNameTaken: 'Ya existe una carpeta con ese nombre.',
+      deleteFolder: 'Eliminar carpeta',
+      deleteFolderConfirm: '¿Eliminar “{name}”? Sus {count} formularios se conservan y pasan a Sin carpeta.',
+      folderMenu: 'Acciones de la carpeta',
+      collapse: 'Contraer',
+      expand: 'Expandir',
+      createIn: 'Nuevo formulario',
+      folderLabel: 'Carpeta',
+      folderNone: 'Sin carpeta',
+      moveTo: 'Mover a carpeta',
+      moveBack: 'Sin carpeta',
+      moveFailed: 'No se pudo mover el formulario. Inténtalo de nuevo.',
+      dragHandle: 'Arrastra a una carpeta',
+      dropHere: 'Suelta para mover aquí',
+      actionFailed: 'Algo salió mal. Inténtalo de nuevo.',
     },
     editor: {
       back: 'Volver a formularios',
@@ -4622,6 +4728,7 @@ export const es: FormsMessages = {
     confirm: 'Confirmar',
     cancel: 'Cancelar',
     deleteFormTitle: 'Eliminar formulario',
+    deleteFolderTitle: 'Eliminar carpeta',
     deleteQuestionTitle: 'Eliminar pregunta',
     deleteSubmissionTitle: 'Eliminar respuesta',
     removeMemberTitle: 'Quitar miembro',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -464,6 +464,9 @@ export interface FormsMessages {
       tokenScore: string;
       tokenOutcomeLabel: string;
       tokenFormLink: string;
+      tokenAnswers: string;
+      /** Permanent warning when the owner notice body lacks `{{answers}}`. */
+      answersMissing: string;
       /** Muted pointer: forms can override these from their Connect tab. */
       formOverrideNote: string;
     };
@@ -2033,7 +2036,10 @@ export const en: FormsMessages = {
       tokenRespondentEmail: 'Respondent email',
       tokenScore: 'Score',
       tokenOutcomeLabel: 'Outcome',
-      tokenFormLink: 'Form link',
+      tokenFormLink: 'Submissions link',
+      tokenAnswers: 'Answers',
+      answersMissing:
+        'This email does not include {{answers}}, so the answers will not be in it. Insert the Answers variable to add them.',
       formOverrideNote: 'Each form can override these emails from its Connect tab in the editor.',
     },
     login: {
@@ -3514,7 +3520,10 @@ export const es: FormsMessages = {
       tokenRespondentEmail: 'Correo del encuestado',
       tokenScore: 'Puntuación',
       tokenOutcomeLabel: 'Resultado',
-      tokenFormLink: 'Enlace del formulario',
+      tokenFormLink: 'Enlace a las respuestas',
+      tokenAnswers: 'Respuestas',
+      answersMissing:
+        'Este correo no incluye {{answers}}, así que las respuestas no aparecerán en él. Inserta la variable Respuestas para agregarlas.',
       formOverrideNote:
         'Cada formulario puede personalizar estos correos desde su pestaña Conectar en el editor.',
     },

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -534,7 +534,7 @@ export interface FormsMessages {
       folderNameRequired: string;
       folderNameTaken: string;
       deleteFolder: string;
-      deleteFolderConfirm: string; // {name} {count}
+      deleteFolderConfirm: string; // {name} {forms} (the already-pluralised count label)
       folderMenu: string;
       collapse: string;
       expand: string;
@@ -2137,7 +2137,7 @@ export const en: FormsMessages = {
       folderNameRequired: 'Give the folder a name.',
       folderNameTaken: 'A folder with that name already exists.',
       deleteFolder: 'Delete folder',
-      deleteFolderConfirm: 'Delete “{name}”? Its {count} forms are kept and move to Unfiled.',
+      deleteFolderConfirm: 'Delete “{name}”? The forms inside ({forms}) are kept and move to Unfiled.',
       folderMenu: 'Folder actions',
       collapse: 'Collapse',
       expand: 'Expand',
@@ -3653,7 +3653,7 @@ export const es: FormsMessages = {
       folderNameRequired: 'Ponle un nombre a la carpeta.',
       folderNameTaken: 'Ya existe una carpeta con ese nombre.',
       deleteFolder: 'Eliminar carpeta',
-      deleteFolderConfirm: '¿Eliminar “{name}”? Sus {count} formularios se conservan y pasan a Sin carpeta.',
+      deleteFolderConfirm: '¿Eliminar “{name}”? Los formularios que contiene ({forms}) se conservan y pasan a Sin carpeta.',
       folderMenu: 'Acciones de la carpeta',
       collapse: 'Contraer',
       expand: 'Expandir',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -134,6 +134,12 @@ export interface FormsMessages {
         light: string;
         next: string;
       };
+      /**
+       * Where the "Docs" nav item goes: the Forms documentation in THIS
+       * language. Lives in the catalog because the shell only receives the
+       * localized messages, never the locale itself. Always an absolute URL.
+       */
+      docsHref: string;
       /** Left-nav item labels (icon + label). */
       nav: {
         home: string;
@@ -141,6 +147,8 @@ export interface FormsMessages {
         submissions: string;
         analytics: string;
         integrations: string;
+        /** The product documentation, an EXTERNAL link (see `docsHref`). */
+        docs: string;
         /**
          * The door to the wider platform (agents), an EXTERNAL link. Rendered
          * only when the deployment configures a platform URL, so a fork's rail
@@ -1752,12 +1760,14 @@ export const en: FormsMessages = {
         light: 'Light',
         next: 'Switch to',
       },
+      docsHref: 'https://docs.dapta.ai/dapta-forms/forms',
       nav: {
         home: 'Home',
         forms: 'Forms',
         submissions: 'Submissions',
         analytics: 'Analytics',
         integrations: 'Integrations',
+        docs: 'Docs',
         agents: 'Dapta Agents',
       },
       profileMenu: {
@@ -3232,12 +3242,14 @@ export const es: FormsMessages = {
         light: 'Claro',
         next: 'Cambiar a',
       },
+      docsHref: 'https://docs.dapta.ai/dapta-docs-es/dapta-forms/forms',
       nav: {
         home: 'Inicio',
         forms: 'Formularios',
         submissions: 'Respuestas',
         analytics: 'Analíticas',
         integrations: 'Integraciones',
+        docs: 'Documentación',
         agents: 'Dapta Agents',
       },
       profileMenu: {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -58,6 +58,13 @@ export interface FormsMessages {
     dropdownEmpty: string;
     trustedBy: string;
     newTab: string;
+    /** The public error boundary and the 404, in the visitor's language. */
+    errorTitle: string;
+    errorBody: string;
+    errorRetry: string;
+    notFoundTitle: string;
+    notFoundBody: string;
+    notFoundHome: string;
     /** Scheduler step (V6): copy for an unconfigured embed + the optional skip. */
     schedulerUnconfigured: string;
     schedulerSkip: string;
@@ -937,6 +944,17 @@ export interface FormsMessages {
       };
       /** The Design tab: everything about how the form looks. */
       design: {
+        /** Form language (Auto / English / Spanish) and the button copy overrides. */
+        languageTitle: string;
+        languageHint: string;
+        languageAuto: string;
+        languageEn: string;
+        languageEs: string;
+        labelsTitle: string;
+        labelsHint: string;
+        labelBack: string;
+        labelNext: string;
+        labelSubmit: string;
         publicTitle: string;
         publicTitleHint: string;
         presetsTitle: string;
@@ -1693,6 +1711,12 @@ export const en: FormsMessages = {
     dropdownEmpty: 'No results found',
     trustedBy: 'Trusted by',
     newTab: '(opens in a new tab)',
+    errorTitle: 'This page didn\u2019t load',
+    errorBody: 'Something went wrong reaching the forms service.',
+    errorRetry: 'Try again',
+    notFoundTitle: 'Not found',
+    notFoundBody: 'This page doesn\u2019t exist.',
+    notFoundHome: 'Go home',
     schedulerUnconfigured: 'This scheduler has not been set up yet.',
     schedulerSkip: 'Skip for now',
     booking: {
@@ -2461,6 +2485,17 @@ export const en: FormsMessages = {
         next: 'Next screen',
       },
       design: {
+        languageTitle: 'Language',
+        languageHint:
+          'The language of the buttons, progress and thank-you copy visitors see. Auto follows each visitor\u2019s browser. A ?lang= link still wins.',
+        languageAuto: 'Auto (visitor\u2019s browser)',
+        languageEn: 'English',
+        languageEs: 'Spanish',
+        labelsTitle: 'Button text',
+        labelsHint: 'Replace the default button copy for this form. Leave empty to keep the default for the language. A question\u2019s own button text still wins on that question.',
+        labelBack: 'Back',
+        labelNext: 'Next',
+        labelSubmit: 'Submit',
         publicTitle: 'Form title',
         publicTitleHint:
           'What visitors see. The browser tab, share previews, and the cover heading. Leave empty to use the form\u2019s internal name.',
@@ -3173,6 +3208,12 @@ export const es: FormsMessages = {
     dropdownEmpty: 'No se encontraron resultados',
     trustedBy: 'Confían en nosotros',
     newTab: '(se abre en una pestaña nueva)',
+    errorTitle: 'Esta página no cargó',
+    errorBody: 'Algo falló al conectar con el servicio de formularios.',
+    errorRetry: 'Intentar de nuevo',
+    notFoundTitle: 'No encontrado',
+    notFoundBody: 'Esta página no existe.',
+    notFoundHome: 'Ir al inicio',
     schedulerUnconfigured: 'Este agendador aún no está configurado.',
     schedulerSkip: 'Omitir por ahora',
     booking: {
@@ -3943,6 +3984,17 @@ export const es: FormsMessages = {
         next: 'Pantalla siguiente',
       },
       design: {
+        languageTitle: 'Idioma',
+        languageHint:
+          'El idioma de los botones, el progreso y el mensaje de gracias que ven los visitantes. Auto sigue el navegador de cada visitante. Un enlace con ?lang= sigue ganando.',
+        languageAuto: 'Auto (navegador del visitante)',
+        languageEn: 'Inglés',
+        languageEs: 'Español',
+        labelsTitle: 'Texto de los botones',
+        labelsHint: 'Reemplaza el texto predeterminado de los botones de este formulario. Déjalo vacío para usar el predeterminado del idioma. El texto propio de una pregunta sigue ganando en esa pregunta.',
+        labelBack: 'Atrás',
+        labelNext: 'Siguiente',
+        labelSubmit: 'Enviar',
         publicTitle: 'Título del formulario',
         publicTitleHint:
           'Lo que ven los visitantes: la pestaña del navegador, las vistas previas al compartir y el encabezado de portada. Déjalo vacío para usar el nombre interno del formulario.',

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -126,6 +126,8 @@ export interface FormsMessages {
       collapse: string;
       expand: string;
       openNav: string;
+      /** Toast when the first admin's browser seeds the workspace zone. // {zone} */
+      timezoneAutoSet: string;
       /** The colour-scheme toggle. `next` names what one more click will do, so an
        *  icon-only control still announces its effect rather than only its state. */
       theme: {
@@ -288,6 +290,13 @@ export interface FormsMessages {
       subtitle: string;
       /** The renameable workspace name (admin/owner). */
       workspaceName: string;
+      /** The shared IANA zone every date in this workspace is read in. */
+      workspaceTimezone: string;
+      workspaceTimezoneHelp: string;
+      workspaceTimezoneSaved: string;
+      workspaceTimezoneError: string;
+      workspaceTimezoneUnset: string;
+      workspaceTimezoneUtc: string;
       workspaceNameSave: string;
       workspaceNameSaved: string;
       workspaceNameError: string;
@@ -1087,6 +1096,8 @@ export interface FormsMessages {
       rangeFrom: string;
       rangeTo: string;
       rangeApply: string;
+      /** Under the trends chart: which zone the days are cut in. // {zone} */
+      timezoneNote: string;
       /** Trends chart (per-day series, metric switchable). */
       trendsTitle: string;
       trendsSubtitle: string;
@@ -1114,6 +1125,10 @@ export interface FormsMessages {
       title: string;
       subtitle: string;
       statusAll: string;
+      /** The shared workspace zone, editable from the table by admins. */
+      timezoneLabel: string;
+      timezoneHint: string;
+      timezoneReadOnly: string;
       statusCompleted: string;
       statusPartial: string;
       badgeCompleted: string;
@@ -1744,6 +1759,7 @@ export const en: FormsMessages = {
     },
     chrome: {
       collapse: 'Collapse sidebar',
+      timezoneAutoSet: 'Workspace timezone set to {zone}. Change it in Account settings or on the submissions page.',
       expand: 'Expand sidebar',
       openNav: 'Open navigation',
       theme: {
@@ -1883,6 +1899,13 @@ export const en: FormsMessages = {
       title: 'Settings',
       subtitle: 'Your workspace and team.',
       workspaceName: 'Workspace name',
+      workspaceTimezone: 'Workspace timezone',
+      workspaceTimezoneHelp:
+        'Shared by everyone in this workspace. Every date in the dashboard, the analytics day cuts and the local columns of the CSV export are read in this zone.',
+      workspaceTimezoneSaved: 'Workspace timezone saved.',
+      workspaceTimezoneError: 'Could not save the timezone. Please try again.',
+      workspaceTimezoneUnset: 'Not set (UTC)',
+      workspaceTimezoneUtc: 'UTC',
       workspaceNameSave: 'Save',
       workspaceNameSaved: 'Workspace renamed.',
       workspaceNameError: 'Could not rename the workspace.',
@@ -2609,6 +2632,7 @@ export const en: FormsMessages = {
       rangeFrom: 'From',
       rangeTo: 'To',
       rangeApply: 'Apply',
+      timezoneNote: 'Days in {zone}',
       trendsTitle: 'Trends',
       trendsSubtitle: 'Daily movement over the selected range.',
       trendsMetricLabel: 'Metric',
@@ -2634,6 +2658,9 @@ export const en: FormsMessages = {
       title: 'Submissions',
       subtitle: 'Every response to this form.',
       statusAll: 'All',
+      timezoneLabel: 'Workspace timezone',
+      timezoneHint: 'Dates below are read in this zone. It is shared by the whole workspace.',
+      timezoneReadOnly: 'Only an admin can change it.',
       statusCompleted: 'Completed',
       statusPartial: 'Partial',
       badgeCompleted: 'Completed',
@@ -3224,6 +3251,7 @@ export const es: FormsMessages = {
     },
     chrome: {
       collapse: 'Contraer barra lateral',
+      timezoneAutoSet: 'Zona horaria del workspace fijada en {zone}. Cámbiala en Ajustes de cuenta o en la página de respuestas.',
       expand: 'Expandir barra lateral',
       openNav: 'Abrir navegación',
       theme: {
@@ -3364,6 +3392,13 @@ export const es: FormsMessages = {
       title: 'Ajustes',
       subtitle: 'Tu espacio de trabajo y tu equipo.',
       workspaceName: 'Nombre del workspace',
+      workspaceTimezone: 'Zona horaria del workspace',
+      workspaceTimezoneHelp:
+        'La comparten todos en este workspace. Cada fecha del panel, los cortes por día de las analíticas y las columnas locales del CSV se leen en esta zona.',
+      workspaceTimezoneSaved: 'Zona horaria del workspace guardada.',
+      workspaceTimezoneError: 'No se pudo guardar la zona horaria. Inténtalo de nuevo.',
+      workspaceTimezoneUnset: 'Sin definir (UTC)',
+      workspaceTimezoneUtc: 'UTC',
       workspaceNameSave: 'Guardar',
       workspaceNameSaved: 'Workspace renombrado.',
       workspaceNameError: 'No se pudo renombrar el workspace.',
@@ -4093,6 +4128,7 @@ export const es: FormsMessages = {
       rangeFrom: 'Desde',
       rangeTo: 'Hasta',
       rangeApply: 'Aplicar',
+      timezoneNote: 'Días en {zone}',
       trendsTitle: 'Tendencias',
       trendsSubtitle: 'Movimiento diario en el rango seleccionado.',
       trendsMetricLabel: 'Métrica',
@@ -4118,6 +4154,9 @@ export const es: FormsMessages = {
       title: 'Respuestas',
       subtitle: 'Todas las respuestas a este formulario.',
       statusAll: 'Todas',
+      timezoneLabel: 'Zona horaria del workspace',
+      timezoneHint: 'Las fechas de abajo se leen en esta zona. La comparte todo el workspace.',
+      timezoneReadOnly: 'Solo un administrador puede cambiarla.',
       statusCompleted: 'Completadas',
       statusPartial: 'Parciales',
       badgeCompleted: 'Completada',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './growth';
 export * from './nav';
 export * from './countries';
 export * from './i18n';
+export * from './form-labels';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './growth';
 export * from './nav';
 export * from './countries';
 export * from './i18n';
+export * from './datetime';

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -9,7 +9,7 @@
  * has somewhere obvious to prove the same thing.
  */
 import { describe, expect, it } from 'vitest';
-import { formConfigSchema, hasExtraHubspotDestination } from './index';
+import { formConfigSchema, hasExtraHubspotDestination, workspaceTimezoneSchema } from './index';
 
 /** The smallest config the schema accepts — one step, nothing configured. */
 function baseConfig() {
@@ -195,5 +195,18 @@ describe('hasExtraHubspotDestination', () => {
     it('still ignores webhooks on both sides', () => {
       expect(hasExtraHubspotDestination([webhook, webhook, hubspot], [hubspot])).toBe(false);
     });
+  });
+});
+
+describe('workspace timezone input', () => {
+  it('accepts a known IANA zone or null, rejects garbage and an unknown zone', () => {
+    expect(workspaceTimezoneSchema.parse({ timezone: 'America/Bogota' })).toEqual({ timezone: 'America/Bogota' });
+    expect(workspaceTimezoneSchema.parse({ timezone: null, onlyIfUnset: true })).toEqual({
+      timezone: null,
+      onlyIfUnset: true,
+    });
+    expect(() => workspaceTimezoneSchema.parse({ timezone: 'Mars/Olympus' })).toThrow();
+    expect(() => workspaceTimezoneSchema.parse({ timezone: 'drop table' })).toThrow();
+    expect(() => workspaceTimezoneSchema.parse({})).toThrow();
   });
 });

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -198,7 +198,7 @@ describe('hasExtraHubspotDestination', () => {
   });
 });
 
-describe('formConfigSchema — form language and button labels (additive)', () => {
+describe('formConfigSchema: form language and button labels (additive)', () => {
   it('a legacy config parses with neither field set (Auto language, stock labels)', () => {
     const parsed = formConfigSchema.parse(baseConfig());
     expect(parsed.language).toBeUndefined();
@@ -227,7 +227,7 @@ describe('formConfigSchema — form language and button labels (additive)', () =
   });
 });
 
-describe('submissionSchema — the locale the respondent saw (additive)', () => {
+describe('submissionSchema: the locale the respondent saw (additive)', () => {
   it('carries an optional locale and rejects an unknown one', () => {
     expect(submissionSchema.parse({ sessionId: 's', data: {} }).locale).toBeUndefined();
     expect(submissionSchema.parse({ sessionId: 's', data: {}, locale: 'es' }).locale).toBe('es');

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -9,7 +9,14 @@
  * has somewhere obvious to prove the same thing.
  */
 import { describe, expect, it } from 'vitest';
-import { formConfigSchema, hasExtraHubspotDestination } from './index';
+import {
+  folderInputSchema,
+  folderViewSchema,
+  formConfigSchema,
+  formCreateInputSchema,
+  formFolderPatchSchema,
+  hasExtraHubspotDestination,
+} from './index';
 
 /** The smallest config the schema accepts — one step, nothing configured. */
 function baseConfig() {
@@ -195,5 +202,22 @@ describe('hasExtraHubspotDestination', () => {
     it('still ignores webhooks on both sides', () => {
       expect(hasExtraHubspotDestination([webhook, webhook, hubspot], [hubspot])).toBe(false);
     });
+  });
+});
+
+describe('folder schemas', () => {
+  it('trims and bounds a folder name, and the move patch requires the key', () => {
+    expect(folderInputSchema.parse({ name: '  Sales  ' })).toEqual({ name: 'Sales' });
+    expect(() => folderInputSchema.parse({ name: '   ' })).toThrow();
+    expect(() => folderInputSchema.parse({ name: 'x'.repeat(81) })).toThrow();
+    expect(formFolderPatchSchema.parse({ folderId: null })).toEqual({ folderId: null });
+    expect(formFolderPatchSchema.parse({ folderId: 'f1' })).toEqual({ folderId: 'f1' });
+    expect(() => formFolderPatchSchema.parse({})).toThrow();
+  });
+
+  it('create input carries an optional folderId; the view carries it too', () => {
+    expect(formCreateInputSchema.parse({ name: 'Quiz', folderId: 'f1' }).folderId).toBe('f1');
+    expect(formCreateInputSchema.parse({ name: 'Quiz' }).folderId).toBeUndefined();
+    expect(folderViewSchema.parse({ id: 'f1', name: 'Sales', createdAt: 1, updatedAt: 1 }).name).toBe('Sales');
   });
 });

--- a/packages/types/src/form-config.spec.ts
+++ b/packages/types/src/form-config.spec.ts
@@ -9,7 +9,7 @@
  * has somewhere obvious to prove the same thing.
  */
 import { describe, expect, it } from 'vitest';
-import { formConfigSchema, hasExtraHubspotDestination } from './index';
+import { formConfigSchema, hasExtraHubspotDestination, submissionSchema } from './index';
 
 /** The smallest config the schema accepts — one step, nothing configured. */
 function baseConfig() {
@@ -195,5 +195,42 @@ describe('hasExtraHubspotDestination', () => {
     it('still ignores webhooks on both sides', () => {
       expect(hasExtraHubspotDestination([webhook, webhook, hubspot], [hubspot])).toBe(false);
     });
+  });
+});
+
+describe('formConfigSchema — form language and button labels (additive)', () => {
+  it('a legacy config parses with neither field set (Auto language, stock labels)', () => {
+    const parsed = formConfigSchema.parse(baseConfig());
+    expect(parsed.language).toBeUndefined();
+    expect(parsed.labels).toBeUndefined();
+  });
+
+  it('keeps an explicit language and partial labels', () => {
+    const parsed = formConfigSchema.parse({
+      ...baseConfig(),
+      language: 'es',
+      labels: { next: 'Siguiente' },
+    });
+    expect(parsed.language).toBe('es');
+    expect(parsed.labels).toEqual({ next: 'Siguiente' });
+  });
+
+  it('accepts null for both (the editor clears back to Auto / stock this way)', () => {
+    const parsed = formConfigSchema.parse({ ...baseConfig(), language: null, labels: null });
+    expect(parsed.language).toBeNull();
+    expect(parsed.labels).toBeNull();
+  });
+
+  it('rejects a language the product does not ship and a label over 80 characters', () => {
+    expect(() => formConfigSchema.parse({ ...baseConfig(), language: 'fr' })).toThrow();
+    expect(() => formConfigSchema.parse({ ...baseConfig(), labels: { submit: 'x'.repeat(81) } })).toThrow();
+  });
+});
+
+describe('submissionSchema — the locale the respondent saw (additive)', () => {
+  it('carries an optional locale and rejects an unknown one', () => {
+    expect(submissionSchema.parse({ sessionId: 's', data: {} }).locale).toBeUndefined();
+    expect(submissionSchema.parse({ sessionId: 's', data: {}, locale: 'es' }).locale).toBe('es');
+    expect(() => submissionSchema.parse({ sessionId: 's', data: {}, locale: 'fr' })).toThrow();
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1406,7 +1406,7 @@ export const timeZoneSchema = z
   .trim()
   .min(1)
   .max(64)
-  .regex(/^[A-Za-z0-9_+\-]+(?:\/[A-Za-z0-9_+\-]+)*$/, 'Not a timezone name.')
+  .regex(/^[A-Za-z0-9_+-]+(?:\/[A-Za-z0-9_+-]+)*$/, 'Not a timezone name.')
   .refine(
     (zone) => {
       try {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1089,6 +1089,26 @@ export const formConfigSchema = z.object({
    * config, which then renders as `'slides'`, exactly as it always has).
    */
   layout: z.enum(FORM_LAYOUTS).optional(),
+  /**
+   * The language the public form renders its chrome in: buttons, progress,
+   * thank-you copy, the confirmation email. ADDITIVE: absent or null = Auto,
+   * the visitor's browser decides, exactly as before this field existed. An
+   * explicit `?lang` on the URL still wins over both.
+   */
+  language: localeSchema.nullable().optional(),
+  /**
+   * Form-level button copy overriding the localized defaults (ADDITIVE).
+   * A step's own `buttonText` still wins for that step; the cover CTA keeps
+   * `cover.ctaText`. Blank or null = the stock label for the language.
+   */
+  labels: z
+    .object({
+      back: z.string().max(80).nullable().optional(),
+      next: z.string().max(80).nullable().optional(),
+      submit: z.string().max(80).nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   steps: z.array(formStepSchema).default([]),
   scoring: z.object({ enabled: z.boolean().optional() }).nullable().optional(),
   outcomes: z.array(formOutcomeSchema).optional(),
@@ -1203,6 +1223,12 @@ export const submissionSchema = z.object({
   data: submissionAnswersSchema,
   /** True for an intermediate (partial) save; false/absent = final submit. */
   partial: z.boolean().optional(),
+  /**
+   * The language the respondent actually saw (the page resolved `?lang`, the
+   * form language and the browser; the API knows none of those). Drives the
+   * confirmation email. Absent = the form language, then English.
+   */
+  locale: localeSchema.optional(),
 });
 export type SubmissionInput = z.infer<typeof submissionSchema>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1298,7 +1298,10 @@ export type DropoffRow = z.infer<typeof dropoffRowSchema>;
  * (a missing day would draw a misleading straight line across it).
  */
 export const trendPointSchema = z.object({
-  /** Epoch ms at the START of the day bucket (UTC). */
+  /**
+   * Epoch ms of UTC midnight of the CALENDAR DAY this bucket names, in the
+   * zone the response was resolved in (`range.timeZone`). Render it in UTC.
+   */
   t: z.number().int(),
   /** Unique sessions that viewed the form that day. */
   views: z.number().int(),
@@ -1353,7 +1356,12 @@ export const analyticsResponseSchema = z.object({
   /** Gap-filled per-day series for the Trends chart (oldest → newest). */
   trends: z.array(trendPointSchema),
   /** Echoes the resolved range (epoch ms) so the client can render it. */
-  range: z.object({ from: z.number().nullable(), to: z.number().nullable() }),
+  range: z.object({
+    from: z.number().nullable(),
+    to: z.number().nullable(),
+    /** The zone the day buckets were named in (absent on older responses = UTC). */
+    timeZone: z.string().optional(),
+  }),
 });
 export type AnalyticsResponse = z.infer<typeof analyticsResponseSchema>;
 
@@ -1386,6 +1394,38 @@ export const workspaceRenameSchema = z.object({
   name: z.string().trim().min(1, 'A name is required.').max(80),
 });
 export type WorkspaceRenameInput = z.infer<typeof workspaceRenameSchema>;
+
+/**
+ * An IANA timezone name the runtime knows (`America/Bogota`, `UTC`). The
+ * regex keeps the shape honest before `Intl` is asked, and `Intl` is the
+ * source of truth: a zone this server cannot resolve is rejected here rather
+ * than silently read as UTC everywhere later.
+ */
+export const timeZoneSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9_+\-]+(?:\/[A-Za-z0-9_+\-]+)*$/, 'Not a timezone name.')
+  .refine(
+    (zone) => {
+      try {
+        new Intl.DateTimeFormat('en-US', { timeZone: zone });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Unknown timezone.' },
+  );
+
+/** PATCH /v1/workspaces/current/timezone: set, clear (null), or seed only while unset. */
+export const workspaceTimezoneSchema = z.object({
+  timezone: timeZoneSchema.nullable(),
+  /** True = a write-once claim from the browser's zone; false/absent = an explicit choice. */
+  onlyIfUnset: z.boolean().optional(),
+});
+export type WorkspaceTimezoneInput = z.infer<typeof workspaceTimezoneSchema>;
 
 export const memberInviteSchema = z.object({
   email: z.string().email().max(320),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1140,6 +1140,32 @@ export const formInputSchema = z.object({
 });
 export type FormInput = z.infer<typeof formInputSchema>;
 
+// --- Form folders (0021) -------------------------------------------------------
+
+/** A folder name: trimmed, 1 to 80 characters. Unique per account without regard to case (the API answers 409 NAME_TAKEN). */
+export const folderNameSchema = z.string().trim().min(1).max(80);
+/** Body of POST /v1/folders and PATCH /v1/folders/:id. */
+export const folderInputSchema = z.object({ name: folderNameSchema });
+export type FolderInput = z.infer<typeof folderInputSchema>;
+
+export const folderViewSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+export type FolderView = z.infer<typeof folderViewSchema>;
+
+/** Body of PATCH /v1/forms/:id/folder: the key is required, null unfiles. */
+export const formFolderPatchSchema = z.object({ folderId: z.string().min(1).nullable() });
+export type FormFolderPatch = z.infer<typeof formFolderPatchSchema>;
+
+/** POST /v1/forms may file the new form straight into a folder (PUT /v1/forms/:id never moves it). */
+export const formCreateInputSchema = formInputSchema.extend({
+  folderId: z.string().min(1).nullable().optional(),
+});
+export type FormCreateInput = z.infer<typeof formCreateInputSchema>;
+
 /**
  * Body of PUT /v1/forms/:id/slug: the form's new public URL segment.
  *
@@ -1163,6 +1189,8 @@ export const formViewSchema = z.object({
   draftConfig: formConfigSchema.nullable().optional(),
   /** Epoch-ms of the last publish (ADDITIVE; null when never published). */
   publishedAt: z.number().nullable().optional(),
+  /** The folder the form is filed in (ADDITIVE, 0021; null = unfiled). */
+  folderId: z.string().nullable().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/qa/e2e/v15-form-folders.spec.ts
+++ b/qa/e2e/v15-form-folders.spec.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * Folders + keyboard search on the forms list (V15).
+ *
+ * Seeded through the API (folders and forms alike) so the assertions are
+ * about the list, not about the create dialog. Names carry a random tag: the
+ * QA database survives between runs and folder names are unique per
+ * workspace without regard to case, so a fixed name would 409 on the second
+ * run. Every test cleans up its own folder and forms.
+ */
+
+const API = "http://localhost:4400";
+
+function tag() {
+  return randomUUID().slice(0, 8);
+}
+
+async function createFolder(request: APIRequestContext, name: string) {
+  const res = await request.post(`${API}/v1/folders`, { data: { name } });
+  expect(res.status(), "POST /v1/folders should create the folder").toBe(201);
+  return (await res.json()) as { id: string; name: string };
+}
+
+async function createForm(
+  request: APIRequestContext,
+  name: string,
+  folderId?: string,
+) {
+  const res = await request.post(`${API}/v1/forms`, {
+    data: {
+      name,
+      config: { version: 1, steps: [] },
+      ...(folderId ? { folderId } : {}),
+    },
+  });
+  expect(res.status(), "POST /v1/forms should create the form").toBe(201);
+  return (await res.json()) as {
+    id: string;
+    slug: string;
+    folderId: string | null;
+  };
+}
+
+async function folderOf(
+  request: APIRequestContext,
+  formId: string,
+): Promise<string | null> {
+  const res = await request.get(`${API}/v1/forms`);
+  const rows = (await res.json()) as Array<{
+    id: string;
+    folderId: string | null;
+  }>;
+  return rows.find((r) => r.id === formId)?.folderId ?? null;
+}
+
+async function cleanup(
+  request: APIRequestContext,
+  ids: { forms: string[]; folders: string[] },
+) {
+  for (const id of ids.forms) await request.delete(`${API}/v1/forms/${id}`);
+  for (const id of ids.folders) await request.delete(`${API}/v1/folders/${id}`);
+}
+
+function section(page: Page, folderId: string) {
+  return page.locator(
+    `[data-testid="folder-section"][data-folder-id="${folderId}"]`,
+  );
+}
+
+test.describe("forms list: folders and search", () => {
+  test("sections: Unfiled first, folders alphabetically, counts, and the fold survives a reload", async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const beta = await createFolder(request, `qa-${t}-Beta`);
+    const alpha = await createFolder(request, `qa-${t}-alpha`);
+    const inBeta = await createForm(request, `qa-${t}-in-beta`, beta.id);
+    const loose = await createForm(request, `qa-${t}-loose`);
+    try {
+      await page.goto("/admin/forms");
+      const unfiled = page.getByTestId("unfiled-section");
+      await expect(unfiled).toBeVisible();
+      // Unfiled comes first in DOM order, then the folders alphabetically (case-insensitive).
+      const order = await page
+        .locator(
+          '[data-testid="unfiled-section"], [data-testid="folder-section"]',
+        )
+        .evaluateAll((els) =>
+          els.map((el) => el.getAttribute("data-folder-id")),
+        );
+      expect(order[0]).toBe("");
+      expect(order.indexOf(alpha.id)).toBeLessThan(order.indexOf(beta.id));
+      await expect(
+        section(page, beta.id).getByTestId("folder-count"),
+      ).toHaveText(/1 form/);
+      await expect(
+        section(page, beta.id).locator(`[data-form-id="${inBeta.id}"]`),
+      ).toBeVisible();
+      await expect(
+        unfiled.locator(`[data-form-id="${loose.id}"]`),
+      ).toBeVisible();
+
+      // Collapse Beta, reload: still collapsed (per-browser memory).
+      await section(page, beta.id).getByTestId("folder-toggle").click();
+      await expect(
+        section(page, beta.id).getByTestId("folder-toggle"),
+      ).toHaveAttribute("aria-expanded", "false");
+      await page.reload();
+      await expect(
+        section(page, beta.id).getByTestId("folder-toggle"),
+      ).toHaveAttribute("aria-expanded", "false");
+      await expect(
+        section(page, beta.id).locator(`[data-form-id="${inBeta.id}"]`),
+      ).toBeHidden();
+    } finally {
+      await cleanup(request, {
+        forms: [inBeta.id, loose.id],
+        folders: [alpha.id, beta.id],
+      });
+    }
+  });
+
+  test("search: Ctrl+K focuses, matches without accents, highlights, hides empty sections, Escape clears", async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const folder = await createFolder(request, `qa-${t}-Ventas`);
+    const hit = await createForm(request, `qa-${t}-Satisfacción`, folder.id);
+    const miss = await createForm(request, `qa-${t}-Other`);
+    try {
+      await page.goto("/admin/forms");
+      await page.keyboard.press("Control+K");
+      await expect(page.getByTestId("forms-search")).toBeFocused();
+      await page.keyboard.type("satisfaccion");
+      await expect(page.locator(`[data-form-id="${hit.id}"] mark`)).toHaveText(
+        "Satisfacción",
+      );
+      await expect(page.locator(`[data-form-id="${miss.id}"]`)).toHaveCount(0);
+      await expect(
+        section(page, folder.id).getByTestId("folder-toggle"),
+      ).toHaveAttribute("aria-expanded", "true");
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("forms-search")).toHaveValue("");
+      await expect(page.locator(`[data-form-id="${miss.id}"]`)).toBeVisible();
+      // Arrow down from the box lands on the first row title; Enter opens the editor.
+      await page.getByTestId("forms-search").focus();
+      await page.keyboard.press("ArrowDown");
+      await expect(page.locator("[data-form-link]").first()).toBeFocused();
+    } finally {
+      await cleanup(request, {
+        forms: [hit.id, miss.id],
+        folders: [folder.id],
+      });
+    }
+  });
+
+  test('move: kebab "Move to folder", drag by the grip, and deleting a folder keeps its forms', async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const folder = await createFolder(request, `qa-${t}-Sales`);
+    const form = await createForm(request, `qa-${t}-mover`);
+    try {
+      await page.goto("/admin/forms");
+      const row = page.locator(`[data-form-id="${form.id}"]`);
+      await row.getByTestId("form-row-menu").click();
+      await page.getByTestId(`form-row-move-${folder.id}`).click();
+      await expect(
+        section(page, folder.id).locator(`[data-form-id="${form.id}"]`),
+      ).toBeVisible();
+      await expect.poll(() => folderOf(request, form.id)).toBe(folder.id);
+
+      // Drag it back to Unfiled by the grip (pointer sensor needs > 6px of travel).
+      const grip = section(page, folder.id)
+        .locator(`[data-form-id="${form.id}"]`)
+        .getByTestId("form-row-grip");
+      const target = page
+        .getByTestId("unfiled-section")
+        .getByTestId("folder-toggle");
+      const from = (await grip.boundingBox())!;
+      const to = (await target.boundingBox())!;
+      await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(
+        from.x + from.width / 2 + 12,
+        from.y + from.height / 2 + 12,
+        { steps: 4 },
+      );
+      await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, {
+        steps: 12,
+      });
+      await page.mouse.up();
+      await expect(
+        page
+          .getByTestId("unfiled-section")
+          .locator(`[data-form-id="${form.id}"]`),
+      ).toBeVisible();
+      await expect.poll(() => folderOf(request, form.id)).toBeNull();
+
+      // Back into the folder, then delete the folder: the form survives, unfiled.
+      await row.getByTestId("form-row-menu").click();
+      await page.getByTestId(`form-row-move-${folder.id}`).click();
+      await expect.poll(() => folderOf(request, form.id)).toBe(folder.id);
+      await section(page, folder.id).getByTestId("folder-menu").click();
+      await page.getByTestId("folder-delete").click();
+      await page
+        .getByRole("dialog")
+        .getByRole("button", { name: /delete folder|eliminar carpeta/i })
+        .click();
+      await expect(section(page, folder.id)).toHaveCount(0);
+      await expect(
+        page
+          .getByTestId("unfiled-section")
+          .locator(`[data-form-id="${form.id}"]`),
+      ).toBeVisible();
+      await expect.poll(() => folderOf(request, form.id)).toBeNull();
+    } finally {
+      await cleanup(request, { forms: [form.id], folders: [folder.id] });
+    }
+  });
+
+  test("folder names are unique per workspace without regard to case: the dialog says so inline", async ({
+    page,
+    request,
+  }) => {
+    const t = tag();
+    const folder = await createFolder(request, `qa-${t}-Marketing`);
+    try {
+      await page.goto("/admin/forms");
+      await page.getByTestId("new-folder").click();
+      await page.getByTestId("folder-name-input").fill(`qa-${t}-MARKETING`);
+      await page.getByTestId("folder-dialog-submit").click();
+      await expect(page.getByTestId("folder-name-error")).toBeVisible();
+      // Renaming the folder to its own name in another case is fine.
+      await page.keyboard.press("Escape");
+      await section(page, folder.id).getByTestId("folder-menu").click();
+      await page.getByTestId("folder-rename").click();
+      await page.getByTestId("folder-name-input").fill(`qa-${t}-marketing`);
+      await page.getByTestId("folder-dialog-submit").click();
+      await expect(
+        section(page, folder.id).getByTestId("folder-toggle"),
+      ).toContainText(`qa-${t}-marketing`);
+    } finally {
+      await cleanup(request, { forms: [], folders: [folder.id] });
+    }
+  });
+});

--- a/scripts/publish-gate.sh
+++ b/scripts/publish-gate.sh
@@ -28,7 +28,11 @@ echo "== publish-gate: internal-token scan =="
 # that must never reach public history. Extend as needed.
 # Matched case-insensitively (grep -i) so "Aurora"/"aurora" both trip it.
 PATTERN='[a-z0-9-]+\.dapta\.(ai|dev|com)|daptatech|amazonaws|aurora|\bdapta_forms\b|\bforms_ms\b|dapta_lab|dapta-iam|integration\.app|apps-configs-flux2|DO[ -]NOT[ -]MERGE|(client|org)_01[0-9a-z]{22,}|AKIA[0-9A-Z]{16}|(sk|rk)_(live|test)_[0-9a-z]{16,}'
-PUBLIC_HOST_ALLOW='^\./(README\.md|\.env\.example|apps/web/lib/growth\.ts|packages/shared/src/growth\.(ts|spec\.ts))\b.*\b(app|www)\.dapta\.ai'
+# Public hosts the product legitimately links to, pinned to the files that may
+# carry them: the marketing site in the growth helpers, and the documentation
+# site (docs.dapta.ai, a public page in either language, the rail's "Docs"
+# item) in the message catalog and the two specs that pin those URLs.
+PUBLIC_HOST_ALLOW='^\./(README\.md|\.env\.example|apps/web/lib/growth\.ts|packages/shared/src/growth\.(ts|spec\.ts))\b.*\b(app|www)\.dapta\.ai|^\./(packages/shared/src/i18n/(index|chrome\.spec)\.ts|apps/web/lib/suite\.spec\.ts)\b.*\bdocs\.dapta\.ai'
 
 # Scan tracked/working files, excluding vendored/build/self paths. The deploy/
 # overlay is gitignored (never in public history) so it is not scanned here.


### PR DESCRIPTION
## What ships

Five features and one CI fix, all planned in one sprint and merged to develop as #150 to #155.

### #150: the owner notification finally carries the answers

The "new submission" email told the owner that someone answered and nothing else. Three defects stacked up: the answers were never passed to the template, the `{{formLink}}` token had no producer (so the "View submissions" line always dropped and custom templates looked half rendered), and the HTML body was a bare paragraph with line breaks, which most clients showed as plain text.

- `summarizeAnswers` in the engine resolves a submission to label and value rows in step order: the question the respondent actually saw, option values mapped back to their labels, multi-selects joined with commas, bookings as a UTC timestamp, values capped at 2000 characters.
- A new `{{answers}}` token, available in both submission emails and included by default in the owner notice only. In text it renders one `Label: value` line per answer; in HTML a two-column table with every cell escaped.
- `{{formLink}}` now points the owner at `PUBLIC_APP_URL/admin/forms/:id/submissions`.
- Every email is a complete responsive HTML document, with a real closing body tag so the transactional service can splice its footer.
- An owner with no email no longer enqueues a row that fails five times; rows already queued with no recipient are skipped once instead of retried.

### #151: a Docs item in the rail

A permanent "Docs" entry above "Dapta Agents", opening the documentation in the reader's language (English and Spanish sites), tagged like the other suite doors.

### #152: form language and button copy

The public form's chrome followed each visitor's browser, with no way for the author to decide.

- `config.language` (absent means Auto). Precedence: an explicit `?lang` that names a shipped language, then the form's language, then the browser, then English. The page description, the social card, the `lang` attribute and the respondent's confirmation email all follow the same resolution.
- `config.labels` for Back, Next and Submit at the form level. A step's own button text still wins for that step.
- A Language selector and Button text fields at the top of the Design tab. The live preview and the Preview modal render in the form's language, not the editor's.
- New forms are stamped with their author's language. Existing forms stay on Auto.

### #153: one shared workspace timezone

Every admin date was rendered on the server clock and the analytics day buckets were UTC days, so a team in Bogota read yesterday evening's submissions as today's.

- `account.timezone` (migration 0020). The first admin to load the dashboard seeds it from their browser, write-once; it is editable in Account settings and from a dropdown on the submissions page (owner and admin write, a member sees it locked).
- Every admin date goes through one shared formatter. Analytics day cuts and buckets are computed in the workspace zone, in SQL, through offset segments so a DST change splits correctly.
- The CSV keeps its UTC columns and adds `started_at_local` and `completed_at_local` with the zone offset.
- An unknown zone resolves as UTC with a warning, never an error.

### #154: folders and keyboard search on the forms list

Flat folders, one level, a form in at most one folder. The list stays one page with each folder as a collapsible section, Unfiled first. Drag a row onto a folder header, or use the row menu. Search focuses with Cmd/Ctrl+K or `/`, filters by name and slug without case or accents, expands the sections that match, and highlights the hit. Without folders the list looks exactly as it did (migration 0021).

### #155: the publish gate stopped failing on a public link

The gate's internal-token layer denylists every `*.dapta.ai` host so an internal hostname cannot reach public history. The documentation link added by #151 is a public page, and it turned the gate red on develop and on every branch that merged it. The gate now allows that one host in the three files that may name it. gitleaks and trufflehog were clean throughout; only the grep layer was involved.

## Migrations

Three, each additive and in both dialects. They run themselves on deploy.

| Migration | Effect |
|---|---|
| 0019 | Appends `{{answers}}` to custom owner-notice bodies that lack it, so templates edited before the token existed also get the answers. Idempotent. |
| 0020 | Adds the nullable `account.timezone` column. NULL reads as UTC, exactly as before. |
| 0021 | Adds the `form_folder` table and the nullable `form.folder_id` column. |

0019 is the only one that rewrites author-written content. It touches account-level and per-form notification bodies for the owner notice only, appends a blank line and the token, and matches nothing on a rerun.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (16 of 16 tasks, 144 test files), `pnpm build` and the publish gate all pass on develop.
- `dash-check.sh origin/main` is clean, so the release adds no em dashes.
- Each feature was verified in a worktree with build and start: the owner email delivered through the outbox worker with the answers and the link and was read at 375px and 1000px; the Docs item resolved to each language's URL; a Spanish form rendered its own language and custom Submit label for an English browser and its receipt carried the locale; the timezone dropdown, the day cuts and the CSV local columns were checked against Bogota and a New York DST boundary; the folders list, drag, search and shortcuts were exercised by hand.
- Every PR went through a two-axis review (repo standards and the sprint spec) and the findings were closed in a follow-up commit on each branch.

Still to do by hand, not blocking this merge: a real send through the transactional service in dev, and the new end-to-end spec `qa/e2e/v15-form-folders.spec.ts`, which is written but has not been run against the QA instance.

## Deploy notes

- No new environment variables, no compose or self-hosting changes.
- prd remains a manual gate: merging this PR ships nothing by itself.
- After this merges, the release workflow bumps versions on main but cannot open its own PR, so `changeset-release/main` still has to be opened by hand.

⚠️ Merge with a merge commit, never squash (release history rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
