### PR TITLE
fix(web): redirect embedded forms at the top level, not inside the iframe

### DIFF
--- a/.changeset/embed-top-level-redirect.md
+++ b/.changeset/embed-top-level-redirect.md
@@ -1,0 +1,27 @@
+---
+'@quill/shared': patch
+---
+
+An embedded form's redirect now leaves at the top level instead of inside the iframe.
+
+A form that ends in a redirect used to assign `window.location.href`. Embedded
+on someone else's site that navigates the FRAME, so the destination had to
+survive being framed by a third party. Checkout pages refuse to: a Stripe
+Payment Link answers "Stripe Checkout is not able to run in an iFrame" and hangs
+on its own skeleton forever, so the visitor submitted the form and went nowhere.
+
+All six redirect sites (immediate, delayed, and post-booking, in both the paged
+and the vertical renderer) now go through `navigateTop`, which asks the host
+page to navigate itself via `embed.js` and falls back to navigating the top
+directly when no acknowledgement comes back. Exactly one of the two ever runs:
+starting both races two navigations of the same document, and WebKit resolves
+that race by cancelling both.
+
+`embed.js` gained the matching handler. It is served with `max-age=0`, so an
+embedded page picks it up on its next load with no change to the snippet. A host
+still serving an older copy is covered by the direct fallback, as is a bare
+iframe pasted with no script at all.
+
+Framing is detected from the window, not from `?embed=1`, so an iframe pasted
+without the flag is fixed too. Unframed forms are untouched: one
+`window.location.href`, and nothing posted to anyone.

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -44,6 +44,7 @@ import { MadeWithBadge } from '@/components/made-with-badge';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
 import { callAction, callActionWithRetry, isTransportError } from '@/lib/call-action';
+import { navigateTop } from '@/lib/top-navigate';
 import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
 import {
   useSessionId,
@@ -154,7 +155,7 @@ export function FormRenderer({
     const url = ending.redirectUrl;
     const timer = setTimeout(() => {
       redirected.current = true;
-      window.location.href = url;
+      navigateTop(url);
     }, ending.redirectDelayMs);
     return () => clearTimeout(timer);
   }, [phase, done, engineConfig, answers]);
@@ -307,7 +308,7 @@ export function FormRenderer({
             setPhase('done');
             return;
           }
-          window.location.href = ending.redirectUrl;
+          navigateTop(ending.redirectUrl);
           return;
         }
         console.warn('[forms] ignored non-http(s) redirectUrl');
@@ -340,7 +341,7 @@ export function FormRenderer({
       );
       if (isTransportError(rec)) console.warn('[forms] post-submit booking record failed');
       if (outcome?.redirectUrl && isSafeHttpUrl(outcome.redirectUrl)) {
-        window.location.href = outcome.redirectUrl;
+        navigateTop(outcome.redirectUrl);
         return;
       }
       setPhase('done'); // `done` state was set in finalize

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -58,6 +58,7 @@ import { formDesignProps } from '@/lib/form-design';
 import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-embed';
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
 import { callAction, callActionWithRetry, isTransportError } from '@/lib/call-action';
+import { navigateTop } from '@/lib/top-navigate';
 import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
 import {
   useSessionId,
@@ -355,7 +356,7 @@ export function VerticalFormRenderer({
             setPhase('done');
             return;
           }
-          window.location.href = ending.redirectUrl;
+          navigateTop(ending.redirectUrl);
           return;
         }
         console.warn('[forms] ignored non-http(s) redirectUrl');
@@ -378,7 +379,7 @@ export function VerticalFormRenderer({
     const url = ending.redirectUrl;
     const timer = setTimeout(() => {
       redirected.current = true;
-      window.location.href = url;
+      navigateTop(url);
     }, ending.redirectDelayMs);
     return () => clearTimeout(timer);
   }, [phase, done, engineConfig]);
@@ -524,7 +525,7 @@ export function VerticalFormRenderer({
       );
       if (isTransportError(rec)) console.warn('[forms] post-submit booking record failed');
       if (outcome?.redirectUrl && isSafeHttpUrl(outcome.redirectUrl)) {
-        window.location.href = outcome.redirectUrl;
+        navigateTop(outcome.redirectUrl);
         return;
       }
       setPhase('done'); // `done` state was set in finalize

--- a/apps/web/lib/top-navigate.spec.ts
+++ b/apps/web/lib/top-navigate.spec.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isEmbedded,
+  navigateTop,
+  EMBED_REDIRECT_MESSAGE,
+  EMBED_REDIRECT_ACK,
+  EMBED_ACK_TIMEOUT_MS,
+} from './top-navigate';
+
+type Posted = { message: unknown; targetOrigin: string };
+
+/**
+ * A fake window. `framed` decides whether `top` is a different object from
+ * `self`, which is the only thing `isEmbedded` looks at. `onTopNav` stands in
+ * for a sandbox refusing the frame access to its top.
+ */
+function stubWindow(opts: { framed: boolean; onPost?: () => void; onTopNav?: () => void }) {
+  const posted: Posted[] = [];
+  const listeners: Array<(e: MessageEvent) => void> = [];
+  const self: Record<string, unknown> = {};
+  const location = { href: '' };
+  const topLocation = { href: '' };
+
+  const top = opts.framed
+    ? {
+        get location() {
+          if (opts.onTopNav) opts.onTopNav();
+          return topLocation;
+        },
+      }
+    : self;
+
+  const parent = {
+    postMessage: (message: unknown, targetOrigin: string) => {
+      if (opts.onPost) opts.onPost();
+      posted.push({ message, targetOrigin });
+    },
+  };
+
+  Object.assign(self, {
+    self,
+    top,
+    parent,
+    location,
+    addEventListener: (type: string, fn: (e: MessageEvent) => void) => {
+      if (type === 'message') listeners.push(fn);
+    },
+    removeEventListener: (type: string, fn: (e: MessageEvent) => void) => {
+      if (type !== 'message') return;
+      const i = listeners.indexOf(fn);
+      if (i >= 0) listeners.splice(i, 1);
+    },
+  });
+
+  vi.stubGlobal('window', self);
+
+  /** Deliver a message to whatever `navigateTop` is listening with. */
+  const deliver = (data: unknown, source: unknown = parent) => {
+    for (const fn of [...listeners]) fn({ data, source } as unknown as MessageEvent);
+  };
+
+  return { posted, location, topLocation, deliver, listeners };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('isEmbedded', () => {
+  it('is false at the top level and true inside a frame', () => {
+    stubWindow({ framed: false });
+    expect(isEmbedded()).toBe(false);
+
+    stubWindow({ framed: true });
+    expect(isEmbedded()).toBe(true);
+  });
+
+  it('treats a window whose `top` cannot be read as framed', () => {
+    const self: Record<string, unknown> = {};
+    self.self = self;
+    // Defined, not assigned: `Object.assign` would invoke the getter while
+    // copying and throw during setup instead of inside `isEmbedded`.
+    Object.defineProperty(self, 'top', {
+      get() {
+        throw new Error('cross-origin');
+      },
+    });
+    vi.stubGlobal('window', self);
+    expect(isEmbedded()).toBe(true);
+  });
+});
+
+describe('navigateTop, not embedded', () => {
+  it('navigates the page exactly as a plain assignment did, and posts nothing', () => {
+    const w = stubWindow({ framed: false });
+    navigateTop('https://buy.stripe.com/abc');
+    expect(w.location.href).toBe('https://buy.stripe.com/abc');
+    expect(w.posted).toEqual([]);
+    expect(w.listeners).toHaveLength(0); // nothing left listening
+  });
+});
+
+describe('navigateTop, embedded', () => {
+  it('asks the host page first and carries only the URL across', () => {
+    const w = stubWindow({ framed: true });
+    navigateTop('https://buy.stripe.com/abc');
+    expect(w.posted).toEqual([
+      {
+        message: { type: EMBED_REDIRECT_MESSAGE, url: 'https://buy.stripe.com/abc' },
+        targetOrigin: '*',
+      },
+    ]);
+    // Nothing has moved yet — the host is still being given its chance.
+    expect(w.topLocation.href).toBe('');
+    expect(w.location.href).toBe('');
+  });
+
+  it('stands down when the host acknowledges, so the two never race', () => {
+    const w = stubWindow({ framed: true });
+    navigateTop('https://buy.stripe.com/abc');
+    w.deliver({ type: EMBED_REDIRECT_ACK });
+    vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS * 4);
+    expect(w.topLocation.href).toBe(''); // the host page is handling it
+    expect(w.location.href).toBe('');
+    expect(w.listeners).toHaveLength(0);
+  });
+
+  it('navigates the top itself when no acknowledgement arrives', () => {
+    const w = stubWindow({ framed: true });
+    navigateTop('https://buy.stripe.com/abc');
+    vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS);
+    expect(w.topLocation.href).toBe('https://buy.stripe.com/abc');
+    // The frame itself is never navigated: that is the bug being fixed.
+    expect(w.location.href).toBe('');
+    expect(w.listeners).toHaveLength(0);
+  });
+
+  it('ignores an acknowledgement that did not come from the parent', () => {
+    const w = stubWindow({ framed: true });
+    navigateTop('https://buy.stripe.com/abc');
+    w.deliver({ type: EMBED_REDIRECT_ACK }, { some: 'other frame' });
+    vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS);
+    expect(w.topLocation.href).toBe('https://buy.stripe.com/abc');
+  });
+
+  it('ignores unrelated messages from the parent', () => {
+    const w = stubWindow({ framed: true });
+    navigateTop('https://buy.stripe.com/abc');
+    w.deliver({ type: 'dapta-forms:resize', height: 700 });
+    w.deliver(null);
+    vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS);
+    expect(w.topLocation.href).toBe('https://buy.stripe.com/abc');
+  });
+
+  it('still navigates the top when the host refuses the message', () => {
+    const w = stubWindow({
+      framed: true,
+      onPost: () => {
+        throw new Error('blocked');
+      },
+    });
+    navigateTop('https://buy.stripe.com/abc');
+    vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS);
+    expect(w.topLocation.href).toBe('https://buy.stripe.com/abc');
+  });
+
+  it('survives a sandbox that blocks the top navigation outright', () => {
+    const w = stubWindow({
+      framed: true,
+      onTopNav: () => {
+        throw new Error('sandboxed: allow-top-navigation not set');
+      },
+    });
+    navigateTop('https://buy.stripe.com/abc');
+    expect(w.posted).toHaveLength(1); // the host page was still asked
+    expect(() => vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS)).not.toThrow();
+    expect(w.topLocation.href).toBe('');
+  });
+});
+
+describe('navigateTop protocol allowlist', () => {
+  it('goes nowhere and posts nothing for a non-http(s) URL', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (const url of ['javascript:alert(1)', 'data:text/html,<script>', '/relative']) {
+      const w = stubWindow({ framed: true });
+      navigateTop(url);
+      vi.advanceTimersByTime(EMBED_ACK_TIMEOUT_MS);
+      expect(w.posted).toEqual([]);
+      expect(w.topLocation.href).toBe('');
+      expect(w.location.href).toBe('');
+    }
+  });
+});

--- a/apps/web/lib/top-navigate.ts
+++ b/apps/web/lib/top-navigate.ts
@@ -1,0 +1,121 @@
+import { isSafeHttpUrl } from '@quill/engine';
+
+/**
+ * Leaving an EMBEDDED form at the top level.
+ *
+ * The public renderer's ending/outcome redirect used to be a plain
+ * `window.location.href = url`. Inside an iframe embed that navigates the
+ * FRAME, not the tab the visitor is looking at, so the destination now has to
+ * survive being framed by a third-party site. Checkout pages deliberately do
+ * not: a Stripe Payment Link loads and then hangs on its own skeleton forever,
+ * because its session bootstrap refuses to run cross-site. To the visitor the
+ * form submitted into nothing.
+ *
+ * Two routes can take them out at the top level, and EXACTLY ONE of them must
+ * run — firing both starts two navigations of the same top-level document, and
+ * WebKit resolves that race by cancelling both, stranding the visitor on the
+ * form. So the host is asked first and answers for itself:
+ *
+ *  1. `postMessage` to the host page, where our `public/embed.js` navigates and
+ *     acknowledges. This is the only route that works when the host SANDBOXES
+ *     the iframe: a `sandbox` attribute without `allow-top-navigation` makes
+ *     route 2 a silent no-op (the browser refuses it with a console warning),
+ *     while `embed.js` runs in the host page, outside that sandbox.
+ *
+ *  2. A direct write to `window.top.location`, taken only when no
+ *     acknowledgement arrives — the host is serving an OLD cached `embed.js`,
+ *     or the iframe was pasted bare with no script at all. A plain cross-origin
+ *     frame may navigate its top, with or without user activation.
+ *
+ * A host that is BOTH sandboxed and running no `embed.js` cannot be redirected
+ * by anything the frame does; nothing inside the sandbox can reach past it.
+ *
+ * Framing is detected from the window itself, never from `?embed=1` — an
+ * iframe pasted without the flag is just as framed, and broke the same way.
+ *
+ * NOT embedded — the ordinary case — is left exactly as it was: one
+ * `window.location.href`, and nothing is posted to anyone.
+ *
+ * Security posture of route 1: `redirectUrl` is a static string from the
+ * PUBLISHED form config (`resolveEnding` returns it verbatim — it is never
+ * interpolated with answers), so the message is exactly as public as the form
+ * document any visitor can already fetch. It carries no answers, no keys and
+ * no identifiers, which is why `targetOrigin: '*'` is acceptable here, the same
+ * reasoning the height reporter runs on: the embedding site is by definition
+ * unknown to us, and `window.parent` delivers to that host page and nowhere
+ * else. The protocol is re-checked below because the value leaves our origin.
+ * The acknowledgement is accepted only from `window.parent`, so a frame beside
+ * ours cannot forge one to suppress route 2 and strand the visitor.
+ */
+
+/** The message `public/embed.js` listens for to navigate the host page. */
+export const EMBED_REDIRECT_MESSAGE = 'dapta-forms:redirect';
+
+/** The reply `public/embed.js` sends back: "I have this, do not navigate." */
+export const EMBED_REDIRECT_ACK = 'dapta-forms:redirect-ack';
+
+/**
+ * How long to wait for that reply. A `postMessage` round trip inside one tab is
+ * a pair of tasks, so this is far more than enough; it is only ever spent in
+ * full on a host with no current `embed.js`, which then redirects itself.
+ */
+export const EMBED_ACK_TIMEOUT_MS = 150;
+
+/** True when this document is rendered inside a frame of any kind. */
+export function isEmbedded(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.top !== window.self;
+  } catch {
+    // A cross-origin `window.top` comparison can throw in older engines. If we
+    // are not even allowed to look, we are certainly framed.
+    return true;
+  }
+}
+
+/**
+ * Navigate the visitor to `url` at the top level, embedded or not.
+ *
+ * Callers already gate on `isSafeHttpUrl` so they can fall through to the
+ * thank-you screen on a bad URL; the re-check here is belt-and-braces for the
+ * value that crosses the origin boundary, and never changes their control flow.
+ */
+export function navigateTop(url: string): void {
+  if (typeof window === 'undefined') return;
+  if (!isSafeHttpUrl(url)) {
+    console.warn('[forms] ignored non-http(s) redirectUrl');
+    return;
+  }
+
+  if (!isEmbedded()) {
+    window.location.href = url;
+    return;
+  }
+
+  let settled = false;
+  const onAck = (event: MessageEvent) => {
+    if (event.source !== window.parent) return;
+    if (!event.data || (event.data as { type?: unknown }).type !== EMBED_REDIRECT_ACK) return;
+    settled = true; // the host page is navigating itself — stay out of its way
+    window.removeEventListener('message', onAck);
+  };
+  window.addEventListener('message', onAck);
+
+  // Route 1 — ask the host page to navigate itself.
+  try {
+    window.parent.postMessage({ type: EMBED_REDIRECT_MESSAGE, url }, '*');
+  } catch {
+    /* a host that refuses messages will never ack, so route 2 takes over */
+  }
+
+  // Route 2 — no answer, so navigate the top ourselves.
+  setTimeout(() => {
+    window.removeEventListener('message', onAck);
+    if (settled) return;
+    try {
+      if (window.top) window.top.location.href = url;
+    } catch {
+      /* sandboxed frame with no embed.js on the page — nothing can reach out */
+    }
+  }, EMBED_ACK_TIMEOUT_MS);
+}

--- a/apps/web/public/embed.js
+++ b/apps/web/public/embed.js
@@ -1,5 +1,6 @@
 /**
- * Dapta Forms embed helper — auto-resizes embedded form iframes.
+ * Dapta Forms embed helper — auto-resizes embedded form iframes and carries
+ * their end-of-form redirect up to the host page.
  *
  * Drop next to any iframe carrying the `data-dapta-forms` attribute:
  *
@@ -8,33 +9,83 @@
  *           style="width:100%;border:0;min-height:480px;"></iframe>
  *   <script src="https://your-host/embed.js" async></script>
  *
- * The embedded page (opened with ?embed=1) posts its content height whenever
- * it changes; this script sets the matching iframe's height so the form never
- * shows an inner scrollbar. Frames are matched by `event.source`, never by
- * URL, so several forms can share one page and a message can only ever size
- * the frame it came from. Only a number crosses the boundary — no answers, no
- * identifiers — and the listener ignores anything that isn't that message.
+ * Two messages cross the boundary, both matched to a frame by `event.source`
+ * and never by URL, so several forms can share one page and a message can only
+ * ever act on the frame it came from:
+ *
+ *   dapta-forms:resize   {height}  — the embedded page (opened with ?embed=1)
+ *     posts its content height whenever it changes; this script sets the
+ *     matching iframe's height so the form never shows an inner scrollbar.
+ *     Only a number crosses — no answers, no identifiers.
+ *
+ *   dapta-forms:redirect {url}     — the form finished and its configured
+ *     destination has to be opened at the TOP level, not inside the frame.
+ *     Checkout pages (Stripe Payment Links above all) refuse to run framed by
+ *     another site and hang on their own skeleton, so a form that redirects to
+ *     one submits into nothing unless the host page navigates itself. The URL
+ *     is the form's published `redirectUrl` — a static string, never built from
+ *     what the visitor typed. It is allowlisted to http(s) before use, exactly
+ *     as the renderer does before assigning `window.location`. This script
+ *     replies `dapta-forms:redirect-ack` so the frame knows not to navigate
+ *     the top as well: two navigations of one document race, and WebKit
+ *     resolves that race by cancelling both.
+ *
+ * Anything that is not one of those two messages, in that shape, is ignored.
+ *
+ * WHY THE REDIRECT HANDLER EXISTS: a plain cross-origin iframe can navigate
+ * its own top, so most embeds never need this message. An iframe given a
+ * `sandbox` attribute that omits `allow-top-navigation` cannot — the browser
+ * refuses it with nothing but a console warning, and the visitor is stranded
+ * on a form that went nowhere. This script runs in the host page, outside that
+ * sandbox, so it can still navigate. Keep it on the page.
  */
 (function () {
   'use strict';
 
   var MAX_HEIGHT = 20000; // sanity cap — a runaway report can't blow up the host page
+  var HTTP_ONLY = /^https?:\/\//i; // same allowlist the renderer applies
+  var leaving = false; // one redirect per page — a second message is a no-op
 
-  window.addEventListener('message', function (event) {
-    var data = event && event.data;
-    if (!data || data.type !== 'dapta-forms:resize' || typeof data.height !== 'number') return;
-    if (!isFinite(data.height) || data.height <= 0) return;
-
+  /** True when `source` is the contentWindow of one of OUR embedded frames. */
+  function isOurFrame(source) {
     var frames = document.querySelectorAll('iframe[data-dapta-forms]');
     for (var i = 0; i < frames.length; i++) {
-      var frame = frames[i];
       try {
-        if (event.source === frame.contentWindow) {
-          frame.style.height = Math.min(Math.ceil(data.height), MAX_HEIGHT) + 'px';
-        }
+        if (source === frames[i].contentWindow) return frames[i];
       } catch (_) {
         /* cross-origin contentWindow access can throw — skip that frame */
       }
+    }
+    return null;
+  }
+
+  window.addEventListener('message', function (event) {
+    var data = event && event.data;
+    if (!data) return;
+
+    if (data.type === 'dapta-forms:resize') {
+      if (typeof data.height !== 'number') return;
+      if (!isFinite(data.height) || data.height <= 0) return;
+      var frame = isOurFrame(event.source);
+      if (!frame) return;
+      frame.style.height = Math.min(Math.ceil(data.height), MAX_HEIGHT) + 'px';
+      return;
+    }
+
+    if (data.type === 'dapta-forms:redirect') {
+      if (leaving) return;
+      if (typeof data.url !== 'string' || !HTTP_ONLY.test(data.url.trim())) return;
+      if (!isOurFrame(event.source)) return;
+      leaving = true;
+      // Answer BEFORE navigating. The frame falls back to navigating the top
+      // itself when no answer arrives, and two navigations of one top-level
+      // document race — WebKit cancels both and the visitor goes nowhere.
+      try {
+        event.source.postMessage({ type: 'dapta-forms:redirect-ack' }, '*');
+      } catch (_) {
+        /* the frame is gone; nothing left to tell */
+      }
+      window.location.href = data.url.trim();
     }
   });
 })();


### PR DESCRIPTION
## The bug

`https://dapta.ai/free-trial-case-study/` embeds `jwmq4e/alec/free-trial-meta-es?embed=1` with the standard snippet. The form ends in a redirect to a Stripe Payment Link. On submit the visitor got Stripe's loading skeleton and nothing else, forever.

The redirect was a plain `window.location.href`. Inside an embed that navigates the **frame**, so the destination has to survive being framed by a third party. Stripe does not, and says so:

```
Stripe Checkout is not able to run in an iFrame. Please redirect to Checkout at the top level.
```

Confirmed against the live page and the published config: `redirectUrl` is the Payment Link, `redirectDelayMs` is 0, and neither renderer had any notion of being framed.

## The change

All six redirect sites move to a new `navigateTop` helper: immediate, delayed and post-booking, in **both** the paged and the vertical renderer. Fixing one renderer would have left the other broken.

It asks the host page to navigate itself through `embed.js`, and falls back to navigating the top directly when no acknowledgement comes back.

**Exactly one of the two routes ever runs.** Firing both starts two navigations of the same top-level document, and WebKit resolves that race by cancelling both, which strands the visitor on the form. That was caught in testing, not in review. The acknowledgement is what keeps the routes mutually exclusive, and it is accepted only from `window.parent` so a neighbouring frame cannot forge one to suppress the fallback.

`embed.js` gained the matching handler, guarded exactly the way the height reporter is: matched to one of our own frames by `event.source`, never by URL, and allowlisted to http(s). The URL that crosses the boundary is the published `redirectUrl`, a static string that is never interpolated with answers, so the message is as public as the form document itself.

Framing is detected from the window, not from `?embed=1`, so a bare iframe pasted without the flag is fixed too. Unframed forms are untouched: one `window.location.href`, and nothing posted to anyone.

## Rollout

`embed.js` is served with `max-age=0`, so embedded pages pick it up on their next load. **No change to the snippet and nothing to do on the WordPress side.** A host still serving an older copy is covered by the direct fallback, as is an iframe pasted with no script at all.

## Verification

Nine-case matrix in a real cross-origin iframe, both engines, all as expected:

| | Chromium | WebKit |
|---|---|---|
| plain iframe, with and without `embed.js` | 6/6 | 6/6 |
| sandboxed iframe, with `embed.js` | 2/2 | 2/2 |
| sandboxed iframe, no `embed.js` (cannot work) | 1/1 | 1/1 |

Each covers redirecting on a user gesture, on a timer past the activation window, and with no gesture at all (the booking path). The resize path was re-tested in both engines and is unchanged, including that a forged report from a non-frame window is still ignored.

`1385` unit tests pass, `11` of them new. Typecheck and lint clean. Publish gate passes.

## Known limitation

A host that both sandboxes the iframe **and** serves no `embed.js` cannot be redirected by anything the frame does. Nothing inside a sandbox can reach past it. Documented in the helper.

## Follow-up, not in this PR

Whether an embedded redirect should stay in the frame, take the tab, or open a new one is an author decision, and it cannot be detected automatically: a destination that refuses framing looks identical to one that accepts it from inside the browser, and Stripe sends no framing headers at all, so a server-side probe would not catch this case either. A three-mode selector next to the redirect URL is tracked separately.