### PR TITLE
feat(uploads): object storage, presigned uploads and submit-time verification

### DIFF
--- a/.changeset/file-upload-storage.md
+++ b/.changeset/file-upload-storage.md
@@ -1,0 +1,57 @@
+---
+'@quill/engine': minor
+'@quill/types': minor
+'@quill/shared': minor
+'@quill/config': minor
+---
+
+Groundwork for a "file" question type: object storage, presigned uploads, and
+server-side verification.
+
+This is the backend half. The type exists in the engine and the API, but no
+builder gallery entry and no public input render it yet, so no form can ask for
+a file until the renderer lands.
+
+The file never travels through the app. The browser asks the API for permission
+(`POST /v1/public/forms/:accountCode/:slug/uploads`, behind the same per-IP rate
+limit as the rest of the public surface), gets a presigned PUT that can write one
+key for a few minutes with one exact content type, and uploads straight to the
+bucket. That is what lets a 10 MB file exist at all: the current path caps the
+request body at 1 MB in the server action and 100 kb in the API.
+
+Two prefixes carry the difference between "a stranger wrote this" and "we
+checked it":
+
+- `incoming/{accountId}/{formId}/{sessionId}/{uuid}.{ext}` is the only place a
+  browser may write. A bucket lifecycle rule expires it, so a visitor who
+  uploads and abandons the form costs nothing.
+- `uploads/` is written by the API alone, after verification, and is the only
+  prefix a stored submission ever points at.
+
+On submit, every file answer is checked before anything is persisted or scored:
+the object exists, its REAL size is within the limit (the size the client
+claimed is not evidence), its key is under this session's own staging prefix, and
+its first bytes match the extension it arrived under. A format with no signature
+to check, such as .txt or .csv, is accepted only under an extension that is
+genuinely signature-free. Executables and active documents (html, svg) are
+refused whatever the form owner configured. Verification is idempotent, so a
+partial save followed by a complete submit promotes the file once.
+
+Nothing in the bucket is public. Downloads are minted per click as short-lived
+signed URLs and always as an attachment, so an uploaded page cannot execute on
+an origin of ours. Deletion removes every VERSION of an object, because a
+versioned bucket turns an ordinary delete into a recoverable delete marker.
+
+Configuration is one variable in the normal case. `STORAGE_BUCKET` turns the
+feature on and the AWS SDK finds the pod's own role, so there is no key to
+configure; `STORAGE_PROVIDER=none` is an explicit off switch for a deployment
+that has a bucket but does not want the feature. Unset, which is the default and
+every bare fork, means the question type does not exist and the deployment boots
+and runs exactly as before. `UPLOAD_MAX_FILE_MB` (10 by default) is a ceiling a
+form owner can lower but never raise, and `STORAGE_REGION`, `STORAGE_ENDPOINT`
+and `STORAGE_FORCE_PATH_STYLE` cover S3-compatible storage.
+
+An answer rides in the existing answers JSON as `{ key, name, size, mime }`, so
+there is no migration and no new column. `parseFileAnswer` is the only reader of
+that shape; answer summaries print the respondent's own filename and never the
+object key, which keeps it out of notification emails and CSV exports.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1129.0",
+    "@aws-sdk/s3-request-presigner": "^3.1129.0",
     "@nestjs/common": "^10.4.15",
     "@nestjs/core": "^10.4.15",
     "@nestjs/platform-express": "^10.4.15",
@@ -25,6 +27,7 @@
     "@quill/notifications": "workspace:*",
     "@quill/shared": "workspace:*",
     "@quill/types": "workspace:*",
+    "file-type": "^22.0.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "tsx": "^4.19.2",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import {
   ONBOARDING_ENABLED,
   PREMIUM_MODE,
   RATE_LIMITER,
+  STORAGE,
   WORKSPACE_PROJECTION,
 } from './tokens';
 import { SubmissionService } from './submission.service';
@@ -27,6 +28,8 @@ import { DaptaSyncEffects } from './dapta-sync-effects';
 import { DaptaSyncDelivery } from './dapta-sync';
 import { OutboxWorker } from './outbox.worker';
 import { RateLimitGuard, createRateLimiter } from './rate-limit';
+import { createObjectStorage } from './storage';
+import { UploadService } from './upload.service';
 import { resolveEntitlementsProvider } from './entitlements.provider';
 import { createAuthProvider, type SignupObserver } from './auth.provider';
 import { WorkspaceProjection } from './workspace-projection';
@@ -156,6 +159,11 @@ function signupObserver(productAnalytics: AnalyticsEffects): SignupObserver {
     // when RATE_LIMIT_ENABLED=false; swappable for a distributed limiter.
     { provide: RATE_LIMITER, useFactory: (env: ServerEnv) => createRateLimiter(env), inject: [ENV] },
     RateLimitGuard,
+    // Object storage for the `file` question type. With STORAGE_BUCKET unset,
+    // the default and every bare fork, this is the noop adapter and the
+    // question type reports itself unavailable rather than half-working.
+    { provide: STORAGE, useFactory: (env: ServerEnv) => createObjectStorage(env), inject: [ENV] },
+    UploadService,
     SubmissionService,
     AnalyticsService,
     AdminService,

--- a/apps/api/src/public.controller.ts
+++ b/apps/api/src/public.controller.ts
@@ -12,8 +12,10 @@ import {
 } from '@nestjs/common';
 import { ZodError } from 'zod';
 import { SubmissionService } from './submission.service';
+import { UploadService } from './upload.service';
 import { unwrap } from './http';
 import { RateLimitGuard } from './rate-limit';
+import { uploadPresignSchema } from '@quill/types';
 
 function badReq(err: unknown): never {
   if (err instanceof ZodError)
@@ -29,7 +31,10 @@ function badReq(err: unknown): never {
 @UseGuards(RateLimitGuard)
 @Controller('v1/public')
 export class PublicController {
-  constructor(@Inject(SubmissionService) private readonly svc: SubmissionService) {}
+  constructor(
+    @Inject(SubmissionService) private readonly svc: SubmissionService,
+    @Inject(UploadService) private readonly uploads: UploadService,
+  ) {}
 
   /** The published form config for the public renderer. */
   @Get('forms/:accountCode/:slug')
@@ -45,6 +50,30 @@ export class PublicController {
     const p = await this.svc.publicProfile(accountCode, handle);
     if (!p) throw new NotFoundException({ error: 'NOT_FOUND', message: 'Page not found.' });
     return p;
+  }
+
+  /**
+   * Authorize one file upload: returns a presigned PUT the browser uses to send
+   * the file straight to the bucket.
+   *
+   * Behind the same per-IP rate limit as the rest of this controller, which is
+   * what keeps an anonymous client from minting signatures in a loop. The URL
+   * it hands back can write exactly one key, for minutes, with one content
+   * type; the object is checked again when the submission arrives.
+   */
+  @Post('forms/:accountCode/:slug/uploads')
+  @HttpCode(200)
+  async presignUpload(
+    @Param('accountCode') accountCode: string,
+    @Param('slug') slug: string,
+    @Body() body: unknown,
+  ) {
+    try {
+      const input = uploadPresignSchema.parse(body);
+      return unwrap(await this.uploads.presign(accountCode, slug, input));
+    } catch (err) {
+      badReq(err);
+    }
   }
 
   /** Persist a submission (partial or complete); the score is recomputed server-side. */

--- a/apps/api/src/storage.spec.ts
+++ b/apps/api/src/storage.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * The pure half of object storage: how a key is built, and what is safe to put
+ * in a Content-Disposition header. Both are security boundaries: the key is
+ * what proves an upload belongs to a session, and the header is a place an
+ * attacker-supplied filename gets interpolated.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createObjectStorage,
+  extensionOf,
+  headerSafeFilename,
+  incomingKey,
+  storedBasename,
+  uploadsPrefixFor,
+} from './storage';
+import type { ServerEnv } from '@quill/config/env';
+
+describe('incomingKey', () => {
+  const args = { accountId: 'acct1', formId: 'form1', sessionId: 'sess1', originalName: 'My CV.pdf' };
+
+  it('scopes the key to account, form and session', () => {
+    expect(incomingKey(args).startsWith('incoming/acct1/form1/sess1/')).toBe(true);
+  });
+
+  it('keeps the extension but NOT the original filename', () => {
+    const key = incomingKey(args);
+    expect(key.endsWith('.pdf')).toBe(true);
+    // A filename routinely carries a person's name; it belongs in the answer.
+    expect(key.toLowerCase()).not.toContain('my cv');
+    expect(key.toLowerCase()).not.toContain('my%20cv');
+  });
+
+  it('never repeats a key for the same file uploaded twice', () => {
+    expect(incomingKey(args)).not.toBe(incomingKey(args));
+  });
+
+  it('cannot be walked out of its prefix by a hostile id or filename', () => {
+    const key = incomingKey({
+      accountId: '../../etc',
+      formId: 'a/b',
+      sessionId: '../../..',
+      originalName: '../../../evil.pdf',
+    });
+    expect(key.startsWith('incoming/')).toBe(true);
+    expect(key).not.toContain('..');
+    expect(key.split('/')).toHaveLength(5);
+  });
+});
+
+describe('uploadsPrefixFor', () => {
+  it('is the prefix a deletion sweeps', () => {
+    expect(uploadsPrefixFor({ accountId: 'a', formId: 'f', submissionId: 's' })).toBe('uploads/a/f/s');
+  });
+});
+
+describe('storedBasename', () => {
+  it('lowercases the extension so .PDF and .pdf land the same', () => {
+    expect(storedBasename('Report.PDF').endsWith('.pdf')).toBe(true);
+  });
+  it('drops an extension that is not one', () => {
+    expect(storedBasename('archive.tar.thisisnotanextension')).not.toContain('.');
+  });
+  it('survives a file with no extension', () => {
+    expect(storedBasename('README')).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe('extensionOf', () => {
+  it('reads the last extension, lowercased, without the dot', () => {
+    expect(extensionOf('a.tar.GZ')).toBe('gz');
+    expect(extensionOf('resume.pdf')).toBe('pdf');
+  });
+  it('is empty when there is none', () => {
+    expect(extensionOf('resume')).toBe('');
+    expect(extensionOf('.gitignore')).toBe('gitignore');
+  });
+});
+
+describe('headerSafeFilename', () => {
+  it('strips CR/LF so a filename cannot inject a header', () => {
+    expect(headerSafeFilename('a.pdf\r\nX-Evil: 1')).toBe('a.pdfX-Evil: 1');
+  });
+  it('strips quotes and backslashes that would break out of the quoted string', () => {
+    expect(headerSafeFilename('a".pdf')).toBe('a.pdf');
+    expect(headerSafeFilename('a\\".pdf')).toBe('a.pdf');
+  });
+  it('flattens path separators', () => {
+    expect(headerSafeFilename('../../etc/passwd')).toBe('.._.._etc_passwd');
+  });
+  it('never returns empty', () => {
+    expect(headerSafeFilename('""')).toBe('download');
+  });
+  it('bounds the length', () => {
+    expect(headerSafeFilename('x'.repeat(500))).toHaveLength(120);
+  });
+});
+
+describe('createObjectStorage', () => {
+  const env = (over: Partial<ServerEnv>) =>
+    ({
+      STORAGE_REGION: 'us-east-2',
+      STORAGE_FORCE_PATH_STYLE: false,
+      UPLOAD_PRESIGN_TTL_SEC: 600,
+      UPLOAD_DOWNLOAD_TTL_SEC: 300,
+      ...over,
+    }) as ServerEnv;
+
+  it('is disabled with no bucket, which is every bare fork', () => {
+    expect(createObjectStorage(env({})).enabled).toBe(false);
+  });
+
+  it('turns on from the bucket alone, with no provider set', () => {
+    expect(createObjectStorage(env({ STORAGE_BUCKET: 'b' })).enabled).toBe(true);
+  });
+
+  it('honors the explicit kill switch even with a bucket configured', () => {
+    expect(createObjectStorage(env({ STORAGE_BUCKET: 'b', STORAGE_PROVIDER: 'none' })).enabled).toBe(
+      false,
+    );
+  });
+
+  it('refuses to mint a URL when disabled rather than returning a broken one', async () => {
+    await expect(createObjectStorage(env({})).presignPut('k', 'text/plain')).rejects.toThrow(
+      /not configured/i,
+    );
+  });
+});

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -1,0 +1,317 @@
+/**
+ * Object storage for the `file` question type.
+ *
+ * The file never passes through this process. The browser PUTs straight to the
+ * bucket with a short-lived presigned URL minted here, and on submit the API
+ * verifies the object it was told about (it exists, it is small enough, its key
+ * belongs to that session) before copying it out of the staging prefix. That
+ * shape is what keeps a 10 MB upload from having to fit through the 1 MB server
+ * action and the 100 kb body parser in front of this service.
+ *
+ * Two prefixes, and the difference matters:
+ *
+ * - `incoming/` is where the browser is allowed to write. Anything here is
+ *   unverified and may be abandoned; a bucket lifecycle rule expires it after
+ *   two days, which is what keeps the visitor who uploads and walks away from
+ *   costing us storage forever.
+ * - `uploads/` is written by this service only, after verification, and is the
+ *   only prefix a submission ever points at.
+ *
+ * Nothing in the bucket is public. Reads happen through `presignGet`, which the
+ * caller mints per click after checking the submission belongs to the account.
+ */
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import {
+  CopyObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectVersionsCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { isStorageEnabled, type ServerEnv } from '@quill/config/env';
+
+/** Staging prefix the browser may write to; expired by bucket lifecycle. */
+export const INCOMING_PREFIX = 'incoming';
+/** Verified files. Written by this service only. */
+export const UPLOADS_PREFIX = 'uploads';
+
+export interface StoredObject {
+  size: number;
+  contentType: string | null;
+}
+
+export interface ObjectStorage {
+  /** False on a deployment with no bucket: the whole question type is off. */
+  readonly enabled: boolean;
+  /** Upload URL, valid for the configured TTL. `contentType` is SIGNED: the client must send it back exactly. */
+  presignPut(key: string, contentType: string): Promise<string>;
+  /** Download URL, always as an attachment so an HTML or SVG upload cannot execute on our origin. */
+  presignGet(key: string, filename: string): Promise<string>;
+  /** Object metadata, or null when the key does not exist. */
+  head(key: string): Promise<StoredObject | null>;
+  /** The first `bytes` of the object, for magic-byte sniffing. Null when absent. */
+  readHead(key: string, bytes: number): Promise<Uint8Array | null>;
+  copy(fromKey: string, toKey: string): Promise<void>;
+  /** Delete everything under a prefix, ALL VERSIONS. Returns how many objects went. */
+  deletePrefix(prefix: string): Promise<number>;
+}
+
+function disabled(): never {
+  throw new Error('Object storage is not configured on this deployment (STORAGE_BUCKET is unset).');
+}
+
+/**
+ * What every deployment without a bucket gets. Reads answer "nothing there"
+ * rather than throwing, because asking about a file that cannot exist is a fair
+ * question; minting a URL is not, and stays loud.
+ */
+export class NoopStorage implements ObjectStorage {
+  readonly enabled = false;
+  async presignPut(): Promise<string> {
+    return disabled();
+  }
+  async presignGet(): Promise<string> {
+    return disabled();
+  }
+  async head(): Promise<StoredObject | null> {
+    return null;
+  }
+  async readHead(): Promise<Uint8Array | null> {
+    return null;
+  }
+  async copy(): Promise<void> {
+    return disabled();
+  }
+  async deletePrefix(): Promise<number> {
+    return 0;
+  }
+}
+
+/** S3 and anything that speaks its API (R2, MinIO) behind one adapter. */
+export class S3Storage implements ObjectStorage {
+  readonly enabled = true;
+  private readonly log = new Logger('S3Storage');
+  private readonly client: S3Client;
+
+  constructor(
+    private readonly bucket: string,
+    private readonly opts: {
+      region: string;
+      endpoint?: string;
+      forcePathStyle?: boolean;
+      accessKeyId?: string;
+      secretAccessKey?: string;
+      putTtlSec: number;
+      getTtlSec: number;
+    },
+  ) {
+    this.client = new S3Client({
+      region: opts.region,
+      ...(opts.endpoint ? { endpoint: opts.endpoint } : {}),
+      ...(opts.forcePathStyle ? { forcePathStyle: true } : {}),
+      // Both or neither. With neither, which is the deployed shape, the SDK
+      // walks its own credential chain and finds the pod's role. That is why a
+      // normal deployment configures no key at all.
+      ...(opts.accessKeyId && opts.secretAccessKey
+        ? { credentials: { accessKeyId: opts.accessKeyId, secretAccessKey: opts.secretAccessKey } }
+        : {}),
+    });
+  }
+
+  presignPut(key: string, contentType: string): Promise<string> {
+    return getSignedUrl(
+      this.client,
+      new PutObjectCommand({ Bucket: this.bucket, Key: key, ContentType: contentType }),
+      {
+        expiresIn: this.opts.putTtlSec,
+        // Pin the content type into the signature. Without this the client can
+        // sign for a PDF and upload anything; with it, a mismatched header is
+        // rejected by S3 before a byte lands.
+        signableHeaders: new Set(['content-type']),
+      },
+    );
+  }
+
+  presignGet(key: string, filename: string): Promise<string> {
+    return getSignedUrl(
+      this.client,
+      new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        // Never inline. An uploaded .html or .svg served inline from a domain
+        // we control would execute in that origin; as an attachment it cannot.
+        ResponseContentDisposition: `attachment; filename="${headerSafeFilename(filename)}"`,
+      }),
+      { expiresIn: this.opts.getTtlSec },
+    );
+  }
+
+  async head(key: string): Promise<StoredObject | null> {
+    try {
+      const r = await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+      return { size: r.ContentLength ?? 0, contentType: r.ContentType ?? null };
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  async readHead(key: string, bytes: number): Promise<Uint8Array | null> {
+    try {
+      const r = await this.client.send(
+        new GetObjectCommand({ Bucket: this.bucket, Key: key, Range: `bytes=0-${bytes - 1}` }),
+      );
+      const body = r.Body as { transformToByteArray?: () => Promise<Uint8Array> } | undefined;
+      if (!body?.transformToByteArray) return null;
+      return await body.transformToByteArray();
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  async copy(fromKey: string, toKey: string): Promise<void> {
+    await this.client.send(
+      new CopyObjectCommand({
+        Bucket: this.bucket,
+        Key: toKey,
+        // CopySource is a path, so the key has to be encoded even though the
+        // key itself is already URL-safe by construction.
+        CopySource: `${this.bucket}/${encodeURIComponent(fromKey).replace(/%2F/g, '/')}`,
+      }),
+    );
+  }
+
+  /**
+   * Delete every object under `prefix`, every version of each.
+   *
+   * The plain DeleteObject that looks right here is wrong on a versioned
+   * bucket, and our buckets are versioned because cross-region replication
+   * requires it: a delete without a version id writes a delete marker and
+   * leaves the bytes recoverable. An erasure request has to actually erase, so
+   * this enumerates versions and delete markers and removes them by id.
+   */
+  async deletePrefix(prefix: string): Promise<number> {
+    let keyMarker: string | undefined;
+    let versionIdMarker: string | undefined;
+    let removed = 0;
+
+    do {
+      const page = await this.client.send(
+        new ListObjectVersionsCommand({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          KeyMarker: keyMarker,
+          VersionIdMarker: versionIdMarker,
+        }),
+      );
+      const targets = [...(page.Versions ?? []), ...(page.DeleteMarkers ?? [])]
+        .filter((v): v is { Key: string; VersionId: string } => Boolean(v.Key && v.VersionId))
+        .map((v) => ({ Key: v.Key, VersionId: v.VersionId }));
+
+      // DeleteObjects takes 1000 keys per call, and a long-lived object with
+      // many versions can exceed that on a single page.
+      for (let i = 0; i < targets.length; i += 1000) {
+        const batch = targets.slice(i, i + 1000);
+        const r = await this.client.send(
+          new DeleteObjectsCommand({ Bucket: this.bucket, Delete: { Objects: batch, Quiet: true } }),
+        );
+        removed += batch.length - (r.Errors?.length ?? 0);
+        for (const e of r.Errors ?? []) {
+          this.log.error(`failed to delete ${e.Key}@${e.VersionId}: ${e.Code} ${e.Message}`);
+        }
+      }
+
+      keyMarker = page.IsTruncated ? page.NextKeyMarker : undefined;
+      versionIdMarker = page.IsTruncated ? page.NextVersionIdMarker : undefined;
+    } while (keyMarker || versionIdMarker);
+
+    return removed;
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return e?.name === 'NotFound' || e?.name === 'NoSuchKey' || e?.$metadata?.httpStatusCode === 404;
+}
+
+/**
+ * A filename safe to interpolate into a Content-Disposition header: no quotes,
+ * no CR/LF (header injection), no path separators, and short enough that the
+ * header stays sane.
+ */
+export function headerSafeFilename(name: string): string {
+  const cleaned = name
+    .replace(/[\r\n"\\]/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[/\\]/g, '_')
+    .trim();
+  return (cleaned || 'download').slice(0, 120);
+}
+
+/**
+ * The stored basename. The original name goes in the answer, not the key: a
+ * filename is user data and routinely carries a person's name, so the key gets
+ * a uuid and keeps only the extension, which is what the download needs to
+ * behave. Extensions are bounded and lowercased so `.PDF` and `.pdf` land the
+ * same, and anything strange collapses to no extension rather than travelling.
+ */
+export function storedBasename(originalName: string): string {
+  const ext = /\.([A-Za-z0-9]{1,12})$/.exec(originalName.trim())?.[1]?.toLowerCase();
+  return ext ? `${randomUUID()}.${ext}` : randomUUID();
+}
+
+/** The extension a filename claims, lowercased and without the dot; '' when it claims none. */
+export function extensionOf(name: string): string {
+  return /\.([A-Za-z0-9]{1,12})$/.exec(name.trim())?.[1]?.toLowerCase() ?? '';
+}
+
+/**
+ * Staging key for one upload. `sessionId` is in the path on purpose: it is what
+ * lets the submit handler prove the key it was handed belongs to the session
+ * that is submitting, rather than to somebody else's form.
+ */
+export function incomingKey(a: {
+  accountId: string;
+  formId: string;
+  sessionId: string;
+  originalName: string;
+}): string {
+  return [
+    INCOMING_PREFIX,
+    safeSegment(a.accountId),
+    safeSegment(a.formId),
+    safeSegment(a.sessionId),
+    storedBasename(a.originalName),
+  ].join('/');
+}
+
+/** Where a verified file lives. Deleting a submission deletes this prefix. */
+export function uploadsPrefixFor(a: { accountId: string; formId: string; submissionId: string }): string {
+  return [UPLOADS_PREFIX, safeSegment(a.accountId), safeSegment(a.formId), safeSegment(a.submissionId)].join(
+    '/',
+  );
+}
+
+/** Ids are ours and already tame, but a key is a security boundary, so pin it anyway. */
+function safeSegment(v: string): string {
+  return v.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 64) || '_';
+}
+
+export function createObjectStorage(env: ServerEnv): ObjectStorage {
+  if (!isStorageEnabled(env) || !env.STORAGE_BUCKET) return new NoopStorage();
+  return new S3Storage(env.STORAGE_BUCKET, {
+    region: env.STORAGE_REGION,
+    endpoint: env.STORAGE_ENDPOINT,
+    forcePathStyle: env.STORAGE_FORCE_PATH_STYLE,
+    accessKeyId: env.STORAGE_ACCESS_KEY_ID,
+    secretAccessKey: env.STORAGE_SECRET_ACCESS_KEY,
+    putTtlSec: env.UPLOAD_PRESIGN_TTL_SEC,
+    getTtlSec: env.UPLOAD_DOWNLOAD_TTL_SEC,
+  });
+}

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -26,6 +26,7 @@ import { EmailEffects } from './email-effects';
 import { DestinationEffects } from './destination-effects';
 import { BookingEffects } from './booking-effects';
 import { AnalyticsEffects } from './analytics-effects';
+import { UploadService } from './upload.service';
 import { DB } from './tokens';
 
 export type ServiceError = { error: string; message: string; status: number };
@@ -49,6 +50,9 @@ export class SubmissionService {
     @Optional() @Inject(BookingEffects) private readonly bookings?: BookingEffects,
     // Product analytics about the form OWNER (activation), not the respondent.
     @Optional() @Inject(AnalyticsEffects) private readonly productAnalytics?: AnalyticsEffects,
+    // Verifies + promotes `file` answers. Optional for the same reason as the
+    // rest: a form with no file question never reaches it.
+    @Optional() @Inject(UploadService) private readonly uploads?: UploadService,
   ) {}
 
   /**
@@ -125,15 +129,27 @@ export class SubmissionService {
     if (!form) return { error: 'NOT_FOUND', message: 'Form not found.', status: 404 };
 
     const config = form.config as FormConfig;
-    const score = computeScore(config, input.data);
+
+    // File answers are checked against the bucket BEFORE anything is persisted
+    // or scored: an unverified answer must never reach the row, the score, or
+    // an outbound effect. What comes back has its keys rewritten out of the
+    // staging prefix, which lifecycle deletes.
+    let data = input.data;
+    if (this.uploads) {
+      const verified = await this.uploads.verifyAnswers(form, input.sessionId, data);
+      if ('error' in verified) return verified;
+      data = verified.answers;
+    }
+
+    const score = computeScore(config, data);
     // Pass the answers so answer-forced outcome overrides resolve identically
     // to the client renderer (a score-only resolution would disagree with the
     // redirect the visitor actually saw).
-    const outcome = resolveOutcome(config, score, input.data);
+    const outcome = resolveOutcome(config, score, data);
     const row = await upsertSubmission(this.db, {
       formId: form.id,
       sessionId: input.sessionId,
-      data: input.data,
+      data,
       score,
       partial: input.partial,
     });
@@ -148,12 +164,12 @@ export class SubmissionService {
     const reCompleted = !input.partial && row.wasCompletedBefore;
 
     if (!input.partial && !reCompleted) {
-      const respondentEmail = pickEmail(input.data);
+      const respondentEmail = pickEmail(data);
       // The answers as the owner reads them (labels, option labels, step
       // order): resolved once here, printed by the `{{answers}}` token in
       // either email. The respondent copy carries them too so a custom receipt
       // can echo what was submitted.
-      const answers = summarizeAnswers(config, input.data);
+      const answers = summarizeAnswers(config, data);
       // form.id lets the effect apply any per-form template override
       // (precedence form → account → stock, resolved inside the effect).
       void this.email.enqueueSubmissionReceived(
@@ -207,7 +223,7 @@ export class SubmissionService {
       outcomeLabel: outcome?.label ?? null,
       phase: input.partial ? 'partial' : 'complete',
       submittedAt: Date.now(),
-      data: input.data,
+      data,
       config,
     });
 

--- a/apps/api/src/tokens.ts
+++ b/apps/api/src/tokens.ts
@@ -9,3 +9,4 @@ export const ENTITLEMENTS = Symbol('ENTITLEMENTS');
 export const PREMIUM_MODE = Symbol('PREMIUM_MODE');
 export const ONBOARDING_ENABLED = Symbol('ONBOARDING_ENABLED');
 export const WORKSPACE_PROJECTION = Symbol('WORKSPACE_PROJECTION');
+export const STORAGE = Symbol('STORAGE');

--- a/apps/api/src/upload.service.spec.ts
+++ b/apps/api/src/upload.service.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * The `file` question type, server side.
+ *
+ * Two boundaries are under test and they are not the same boundary. `presign`
+ * decides whether to hand an ANONYMOUS client a write token, using only what
+ * that client claims. `verifyAnswers` decides whether the object it later
+ * points at is real, small enough, its own, and actually the kind of file its
+ * name says. The claims are worth nothing by then.
+ *
+ * The storage adapter is a fake, so these tests pin OUR rules rather than the
+ * SDK's behaviour. `storage.spec.ts` covers the key and header helpers.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDb, migrate, seed, sql, type Db } from '@quill/db';
+import { UploadService } from './upload.service';
+import type { ObjectStorage, StoredObject } from './storage';
+import type { ServerEnv } from '@quill/config/env';
+
+const PDF_MAGIC = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]); // "%PDF-1.7"
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PLAIN_TEXT = new TextEncoder().encode('name,email\nada,ada@example.com\n');
+
+/** Records what it was asked to do and answers from a map of planted objects. */
+class FakeStorage implements ObjectStorage {
+  objects = new Map<string, { size: number; head: Uint8Array; contentType?: string }>();
+  copies: Array<{ from: string; to: string }> = [];
+  signed: Array<{ key: string; contentType: string }> = [];
+
+  constructor(readonly enabled = true) {}
+
+  async presignPut(key: string, contentType: string): Promise<string> {
+    this.signed.push({ key, contentType });
+    return `https://bucket.example/${key}?sig=test`;
+  }
+  async presignGet(key: string): Promise<string> {
+    return `https://bucket.example/${key}?sig=get`;
+  }
+  async head(key: string): Promise<StoredObject | null> {
+    const o = this.objects.get(key);
+    return o ? { size: o.size, contentType: o.contentType ?? null } : null;
+  }
+  async readHead(key: string, bytes: number): Promise<Uint8Array | null> {
+    const o = this.objects.get(key);
+    return o ? o.head.slice(0, bytes) : null;
+  }
+  async copy(from: string, to: string): Promise<void> {
+    this.copies.push({ from, to });
+    const o = this.objects.get(from);
+    if (o) this.objects.set(to, o);
+  }
+  async deletePrefix(): Promise<number> {
+    return 0;
+  }
+}
+
+const ENV = {
+  UPLOAD_MAX_FILE_MB: 10,
+  UPLOAD_PRESIGN_TTL_SEC: 600,
+  UPLOAD_DOWNLOAD_TTL_SEC: 300,
+} as unknown as ServerEnv;
+
+const FILE_STEP = {
+  key: 'cv',
+  type: 'file',
+  question: 'Upload your CV',
+  required: true,
+  allowedTypes: ['pdf', 'png'],
+};
+
+const CONFIG = {
+  version: 1,
+  steps: [{ key: 'work_email', type: 'email', question: 'Work email?' }, FILE_STEP],
+};
+
+let db: Db;
+let storage: FakeStorage;
+let svc: UploadService;
+let form: { id: string; accountId: string; config: unknown };
+
+beforeEach(async () => {
+  db = await createDb('file::memory:');
+  await migrate(db);
+  await seed(db); // account "acme" + form "lead-qualifier"
+  await db.run(sql`UPDATE form SET config = ${JSON.stringify(CONFIG)} WHERE slug = 'lead-qualifier'`);
+  const row = await db.get<{ id: string; account_id: string }>(
+    sql`SELECT id, account_id FROM form WHERE slug = 'lead-qualifier' LIMIT 1`,
+  );
+  form = { id: row!.id, accountId: row!.account_id, config: CONFIG };
+  storage = new FakeStorage();
+  svc = new UploadService(db, ENV, storage);
+});
+
+describe('presign', () => {
+  const ask = (over: Partial<Record<string, unknown>> = {}) =>
+    svc.presign('acme', 'lead-qualifier', {
+      sessionId: 'sess-1',
+      stepKey: 'cv',
+      name: 'resume.pdf',
+      size: 1_000_000,
+      mime: 'application/pdf',
+      ...over,
+    } as never);
+
+  it('signs a key scoped to the account, form and SESSION', async () => {
+    const r = await ask();
+    expect('error' in r).toBe(false);
+    const ok = r as { key: string; url: string; contentType: string; expiresInSec: number };
+    expect(ok.key.startsWith(`incoming/${form.accountId}/${form.id}/sess-1/`)).toBe(true);
+    expect(ok.contentType).toBe('application/pdf');
+    expect(ok.expiresInSec).toBe(600);
+    // The original filename is user data and must not be in the key.
+    expect(ok.key).not.toContain('resume');
+    expect(ok.key.endsWith('.pdf')).toBe(true);
+  });
+
+  it('pins the content type into the signature', async () => {
+    await ask();
+    expect(storage.signed[0]?.contentType).toBe('application/pdf');
+  });
+
+  it('404s on a deployment with no bucket', async () => {
+    const off = new UploadService(db, ENV, new FakeStorage(false));
+    expect(await off.presign('acme', 'lead-qualifier', { sessionId: 's', stepKey: 'cv', name: 'a.pdf', size: 1, mime: 'application/pdf' } as never)).toMatchObject({ status: 404 });
+  });
+
+  it('refuses a step that does not take a file', async () => {
+    expect(await ask({ stepKey: 'work_email' })).toMatchObject({ status: 400 });
+  });
+
+  it('refuses a step that does not exist', async () => {
+    expect(await ask({ stepKey: 'nope' })).toMatchObject({ status: 400 });
+  });
+
+  it('refuses an extension the owner did not allow', async () => {
+    expect(await ask({ name: 'sheet.xlsx' })).toMatchObject({ error: 'FILE_TYPE_NOT_ALLOWED' });
+  });
+
+  it('refuses executables and active content even when the owner allowed them', async () => {
+    const wide = { ...form, config: { version: 1, steps: [{ ...FILE_STEP, allowedTypes: ['exe', 'svg', 'html'] }] } };
+    await db.run(sql`UPDATE form SET config = ${JSON.stringify(wide.config)} WHERE slug = 'lead-qualifier'`);
+    for (const name of ['payload.exe', 'logo.svg', 'page.html']) {
+      expect(await ask({ name })).toMatchObject({ error: 'FILE_TYPE_NOT_ALLOWED' });
+    }
+  });
+
+  it('refuses a file with no extension at all', async () => {
+    expect(await ask({ name: 'resume' })).toMatchObject({ error: 'FILE_TYPE_NOT_ALLOWED' });
+  });
+
+  it('refuses a claimed size over the deployment ceiling', async () => {
+    expect(await ask({ size: 11_000_000 })).toMatchObject({ error: 'FILE_TOO_LARGE' });
+  });
+
+  it("clamps to the owner's own lower limit, and never above the ceiling", async () => {
+    const tight = { version: 1, steps: [{ ...FILE_STEP, maxSizeMb: 2 }] };
+    await db.run(sql`UPDATE form SET config = ${JSON.stringify(tight)} WHERE slug = 'lead-qualifier'`);
+    expect(await ask({ size: 3_000_000 })).toMatchObject({ error: 'FILE_TOO_LARGE' });
+
+    const greedy = { version: 1, steps: [{ ...FILE_STEP, maxSizeMb: 500 }] };
+    await db.run(sql`UPDATE form SET config = ${JSON.stringify(greedy)} WHERE slug = 'lead-qualifier'`);
+    expect(await ask({ size: 11_000_000 })).toMatchObject({ error: 'FILE_TOO_LARGE' });
+  });
+
+  it('normalizes a junk mime instead of signing it', async () => {
+    const r = (await ask({ mime: 'text/html\r\nX-Evil: 1' })) as { contentType: string };
+    expect(r.contentType).toBe('application/octet-stream');
+  });
+});
+
+describe('verifyAnswers', () => {
+  const stagingKey = (name = 'abc.pdf', session = 'sess-1') =>
+    `incoming/${form.accountId}/${form.id}/${session}/${name}`;
+
+  const answer = (key: string, name = 'resume.pdf') => ({
+    cv: { key, name, size: '1000', mime: 'application/pdf' },
+  });
+
+  it('promotes a verified file out of staging and rewrites the key', async () => {
+    const key = stagingKey();
+    storage.objects.set(key, { size: 1000, head: PDF_MAGIC });
+
+    const r = await svc.verifyAnswers(form, 'sess-1', answer(key));
+    expect('error' in r).toBe(false);
+    const cv = (r as { answers: Record<string, { key: string; name: string }> }).answers.cv!;
+    expect(cv.key.startsWith(`uploads/${form.accountId}/${form.id}/sess-1/`)).toBe(true);
+    expect(cv.name).toBe('resume.pdf');
+    expect(storage.copies).toHaveLength(1);
+  });
+
+  it('refuses a key belonging to a DIFFERENT session', async () => {
+    const key = stagingKey('abc.pdf', 'someone-else');
+    storage.objects.set(key, { size: 1000, head: PDF_MAGIC });
+    expect(await svc.verifyAnswers(form, 'sess-1', answer(key))).toMatchObject({ status: 400 });
+    expect(storage.copies).toHaveLength(0);
+  });
+
+  it('refuses a key that points outside the staging prefix entirely', async () => {
+    const key = `uploads/${form.accountId}/${form.id}/other-session/abc.pdf`;
+    storage.objects.set(key, { size: 1000, head: PDF_MAGIC });
+    expect(await svc.verifyAnswers(form, 'sess-1', answer(key))).toMatchObject({ status: 400 });
+  });
+
+  it('refuses an object that was never uploaded (or already expired)', async () => {
+    expect(await svc.verifyAnswers(form, 'sess-1', answer(stagingKey()))).toMatchObject({ status: 400 });
+  });
+
+  it('uses the REAL size, not the claimed one', async () => {
+    const key = stagingKey();
+    // The answer says 1000 bytes; the object is 40 MB.
+    storage.objects.set(key, { size: 40_000_000, head: PDF_MAGIC });
+    expect(await svc.verifyAnswers(form, 'sess-1', answer(key))).toMatchObject({ error: 'FILE_TOO_LARGE' });
+  });
+
+  it('refuses bytes that disagree with the extension', async () => {
+    const key = stagingKey();
+    // A PNG wearing a .pdf name.
+    storage.objects.set(key, { size: 1000, head: PNG_MAGIC });
+    expect(await svc.verifyAnswers(form, 'sess-1', answer(key))).toMatchObject({
+      error: 'FILE_TYPE_MISMATCH',
+    });
+  });
+
+  it('accepts a format that HAS no signature, but only under a text extension', async () => {
+    const textish = { version: 1, steps: [{ ...FILE_STEP, allowedTypes: ['csv', 'pdf'] }] };
+    const csvForm = { ...form, config: textish };
+    const key = stagingKey('abc.csv');
+    storage.objects.set(key, { size: 30, head: PLAIN_TEXT });
+
+    const ok = await svc.verifyAnswers(csvForm, 'sess-1', {
+      cv: { key, name: 'leads.csv', size: '30', mime: 'text/csv' },
+    });
+    expect('error' in ok).toBe(false);
+
+    // The same undetectable bytes under a binary extension are refused.
+    const lying = stagingKey('def.pdf');
+    storage.objects.set(lying, { size: 30, head: PLAIN_TEXT });
+    expect(await svc.verifyAnswers(csvForm, 'sess-1', answer(lying))).toMatchObject({
+      error: 'FILE_TYPE_MISMATCH',
+    });
+  });
+
+  it('is idempotent: a second save of an already promoted key copies nothing', async () => {
+    const key = stagingKey();
+    storage.objects.set(key, { size: 1000, head: PDF_MAGIC });
+    const first = (await svc.verifyAnswers(form, 'sess-1', answer(key))) as {
+      answers: Record<string, { key: string }>;
+    };
+
+    const second = await svc.verifyAnswers(form, 'sess-1', first.answers);
+    expect('error' in second).toBe(false);
+    // One copy total: the partial save's. The complete submit left it alone.
+    expect(storage.copies).toHaveLength(1);
+    expect((second as { answers: Record<string, { key: string }> }).answers.cv!.key).toBe(
+      first.answers.cv!.key,
+    );
+  });
+
+  it('passes through a form with no file question, touching storage not at all', async () => {
+    const plain = { id: form.id, accountId: form.accountId, config: { version: 1, steps: [{ key: 'e', type: 'email' }] } };
+    const r = await svc.verifyAnswers(plain, 'sess-1', { e: 'ada@example.com' });
+    expect(r).toEqual({ answers: { e: 'ada@example.com' } });
+    expect(storage.copies).toHaveLength(0);
+  });
+
+  it('leaves an unanswered optional file question alone', async () => {
+    const r = await svc.verifyAnswers(form, 'sess-1', { work_email: 'ada@example.com' });
+    expect(r).toEqual({ answers: { work_email: 'ada@example.com' } });
+  });
+
+  it('refuses a malformed file answer rather than storing it', async () => {
+    expect(await svc.verifyAnswers(form, 'sess-1', { cv: 'just-a-string' })).toMatchObject({
+      status: 400,
+    });
+    expect(await svc.verifyAnswers(form, 'sess-1', { cv: { name: 'x.pdf' } })).toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/apps/api/src/upload.service.ts
+++ b/apps/api/src/upload.service.ts
@@ -1,0 +1,298 @@
+/**
+ * The `file` question type, server side: mint an upload URL, then prove on
+ * submit that the thing the client points at is what it said it was.
+ *
+ * The split matters. `presign` runs before any bytes exist and can only check
+ * CLAIMS: a name, a size, a mime the browser typed. `verify` runs after the
+ * upload and checks the object itself. Neither is sufficient alone: signing
+ * without checking hands an anonymous client a write token for arbitrary
+ * content, and checking without signing means the file had to travel through
+ * this process to get here, which is the thing the presigned flow exists to
+ * avoid.
+ *
+ * Everything here fails closed. With no bucket configured the deployment has no
+ * file question at all, and both entry points say so rather than half-working.
+ */
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { fileTypeFromBuffer } from 'file-type';
+import type { Db } from '@quill/db';
+import { getPublishedForm } from '@quill/db';
+import { parseFileAnswer, type FormConfig, type FormStep } from '@quill/engine';
+import type { SubmissionAnswers, UploadPresignInput, UploadPresignResult } from '@quill/types';
+import { type ServerEnv } from '@quill/config/env';
+import {
+  extensionOf,
+  incomingKey,
+  storedBasename,
+  uploadsPrefixFor,
+  type ObjectStorage,
+} from './storage';
+import { DB, ENV, STORAGE } from './tokens';
+
+export type UploadError = { error: string; message: string; status: number };
+
+/**
+ * Extensions no form may accept, whatever its owner configured.
+ *
+ * Two families. Executables and scripts, because a bucket of them is a malware
+ * host with our name on it. And active documents (html, svg, xhtml), because
+ * they run script in whatever origin serves them. We always serve as an
+ * attachment, which defuses that, but a deployment that ever changes its mind
+ * about `Content-Disposition` should not silently become an XSS surface.
+ */
+const DENIED_EXTENSIONS = new Set([
+  'exe',
+  'dll',
+  'msi',
+  'bat',
+  'cmd',
+  'com',
+  'scr',
+  'cpl',
+  'jar',
+  'app',
+  'dmg',
+  'pkg',
+  'deb',
+  'rpm',
+  'sh',
+  'bash',
+  'ps1',
+  'vbs',
+  'js',
+  'mjs',
+  'jse',
+  'wsf',
+  'hta',
+  'html',
+  'htm',
+  'xhtml',
+  'svg',
+]);
+
+/**
+ * Extensions whose bytes carry no signature to check.
+ *
+ * `file-type` is explicit that it detects binary formats only, so a .txt or a
+ * .csv will never be identified no matter how legitimate it is. Rejecting on
+ * "not detected" would therefore reject every plain-text upload; accepting on
+ * "not detected" would let any bytes through under a .txt name. So the rule is:
+ * undetectable is fine ONLY for extensions that are genuinely undetectable, and
+ * everything else must produce a signature that agrees with its name.
+ */
+const SIGNATURELESS_EXTENSIONS = new Set(['txt', 'csv', 'tsv', 'md', 'log', 'json', 'xml', 'yml', 'yaml']);
+
+/** Extensions that are really one format wearing several names. */
+const EXTENSION_ALIASES: Record<string, string> = {
+  jpeg: 'jpg',
+  tif: 'tiff',
+  htm: 'html',
+  yaml: 'yml',
+};
+
+function canonicalExt(ext: string): string {
+  return EXTENSION_ALIASES[ext] ?? ext;
+}
+
+const MAGIC_BYTES_SAMPLE = 4100;
+
+@Injectable()
+export class UploadService {
+  private readonly log = new Logger('UploadService');
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(ENV) private readonly env: ServerEnv,
+    @Inject(STORAGE) private readonly storage: ObjectStorage,
+  ) {}
+
+  /** False on a deployment with no bucket: the question type does not exist here. */
+  get enabled(): boolean {
+    return this.storage.enabled;
+  }
+
+  /**
+   * Authorize one upload: check the claim against the published form, then hand
+   * back a URL that can only write one key, for a few minutes, with one exact
+   * content type.
+   */
+  async presign(
+    accountCode: string,
+    slug: string,
+    input: UploadPresignInput,
+  ): Promise<UploadPresignResult | UploadError> {
+    if (!this.storage.enabled) {
+      return { error: 'NOT_FOUND', message: 'File uploads are not enabled.', status: 404 };
+    }
+
+    const form = await getPublishedForm(this.db, accountCode, slug);
+    if (!form) return { error: 'NOT_FOUND', message: 'Form not found.', status: 404 };
+
+    const step = (form.config as FormConfig).steps.find((s) => s.key === input.stepKey);
+    if (!step || step.type !== 'file') {
+      return { error: 'BAD_REQUEST', message: 'That question does not take a file.', status: 400 };
+    }
+
+    const ext = extensionOf(input.name);
+    const denied = this.checkExtension(step, ext);
+    if (denied) return denied;
+
+    const maxBytes = this.maxBytesFor(step);
+    if (input.size > maxBytes) {
+      return {
+        error: 'FILE_TOO_LARGE',
+        message: `That file is larger than the ${Math.floor(maxBytes / 1_000_000)} MB limit.`,
+        status: 400,
+      };
+    }
+
+    const key = incomingKey({
+      accountId: form.accountId,
+      formId: form.id,
+      sessionId: input.sessionId,
+      originalName: input.name,
+    });
+    const contentType = sanitizeMime(input.mime);
+    const url = await this.storage.presignPut(key, contentType);
+    return { url, key, contentType, expiresInSec: this.env.UPLOAD_PRESIGN_TTL_SEC };
+  }
+
+  /**
+   * Check every file answer against the bucket and move the good ones out of
+   * staging. Returns the answers with their keys rewritten, or an error that
+   * fails the whole submission.
+   *
+   * Rewriting rather than mutating is deliberate: the caller persists what
+   * comes back, so a submission can never be stored pointing at a staging key
+   * that lifecycle is about to delete.
+   *
+   * Idempotent by key shape. A partial save verifies and promotes the file; the
+   * complete submit that follows sees a key already under `uploads/` for this
+   * same session and leaves it alone, instead of copying a second time or
+   * failing because the staging object is gone.
+   */
+  async verifyAnswers(
+    form: { id: string; accountId: string; config: unknown },
+    sessionId: string,
+    answers: SubmissionAnswers,
+  ): Promise<{ answers: SubmissionAnswers } | UploadError> {
+    const steps = (form.config as FormConfig).steps.filter((s) => s.type === 'file');
+    if (steps.length === 0) return { answers };
+
+    const out: SubmissionAnswers = { ...answers };
+    const stagingRoot = incomingRootFor(form, sessionId);
+    const promotedRoot = uploadsPrefixFor({
+      accountId: form.accountId,
+      formId: form.id,
+      // The session, not the submission id: the row does not exist yet on the
+      // first save, and one session is one submission anyway. Deleting a
+      // submission deletes this prefix.
+      submissionId: sessionId,
+    });
+
+    for (const step of steps) {
+      const raw = out[step.key];
+      if (raw == null || raw === '') continue;
+
+      const file = parseFileAnswer(raw as never);
+      if (!file) {
+        return { error: 'BAD_REQUEST', message: 'That file answer is malformed.', status: 400 };
+      }
+
+      // Already promoted by an earlier save from this same session.
+      if (file.key.startsWith(`${promotedRoot}/`)) continue;
+
+      // The session is in the key, so this is what stops one visitor from
+      // claiming another visitor's upload by pasting their key.
+      if (!file.key.startsWith(`${stagingRoot}/`)) {
+        return { error: 'BAD_REQUEST', message: 'That file does not belong to this session.', status: 400 };
+      }
+
+      const failed = await this.verifyObject(step, file.key, file.name);
+      if (failed) return failed;
+
+      const target = `${promotedRoot}/${storedBasename(file.name)}`;
+      await this.storage.copy(file.key, target);
+      out[step.key] = { key: target, name: file.name, size: file.size, mime: file.mime };
+    }
+
+    return { answers: out };
+  }
+
+  /** The object exists, is within the limit, and its bytes match the name it arrived under. */
+  private async verifyObject(step: FormStep, key: string, name: string): Promise<UploadError | null> {
+    const head = await this.storage.head(key);
+    if (!head) {
+      return { error: 'BAD_REQUEST', message: 'That file was not uploaded, or has expired.', status: 400 };
+    }
+    if (head.size > this.maxBytesFor(step)) {
+      // The presign call believed a claimed size; this is the real one.
+      return { error: 'FILE_TOO_LARGE', message: 'That file is over the size limit.', status: 400 };
+    }
+
+    const ext = canonicalExt(extensionOf(name));
+    const denied = this.checkExtension(step, ext);
+    if (denied) return denied;
+
+    const sample = await this.storage.readHead(key, MAGIC_BYTES_SAMPLE);
+    const sniffed = sample ? await fileTypeFromBuffer(sample) : undefined;
+
+    if (!sniffed) {
+      if (SIGNATURELESS_EXTENSIONS.has(ext)) return null;
+      return {
+        error: 'FILE_TYPE_MISMATCH',
+        message: 'That file does not look like its file type.',
+        status: 400,
+      };
+    }
+    if (canonicalExt(sniffed.ext) !== ext) {
+      this.log.warn(`upload rejected: ${key} claims .${ext}, bytes say .${sniffed.ext}`);
+      return {
+        error: 'FILE_TYPE_MISMATCH',
+        message: 'That file does not look like its file type.',
+        status: 400,
+      };
+    }
+    return null;
+  }
+
+  /** The owner's list narrows the deployment's; the denylist overrides both. */
+  private checkExtension(step: FormStep, ext: string): UploadError | null {
+    if (!ext) {
+      return { error: 'FILE_TYPE_NOT_ALLOWED', message: 'That file has no extension.', status: 400 };
+    }
+    if (DENIED_EXTENSIONS.has(ext)) {
+      return { error: 'FILE_TYPE_NOT_ALLOWED', message: 'That file type is not accepted.', status: 400 };
+    }
+    const allowed = step.allowedTypes?.map((t) => canonicalExt(t.trim().toLowerCase().replace(/^\./, '')));
+    if (allowed && allowed.length > 0 && !allowed.includes(canonicalExt(ext))) {
+      return { error: 'FILE_TYPE_NOT_ALLOWED', message: 'That file type is not accepted.', status: 400 };
+    }
+    return null;
+  }
+
+  /** The owner may ask for less than the deployment allows, never for more. */
+  private maxBytesFor(step: FormStep): number {
+    const ceiling = this.env.UPLOAD_MAX_FILE_MB;
+    const asked = step.maxSizeMb && step.maxSizeMb > 0 ? step.maxSizeMb : ceiling;
+    return Math.min(asked, ceiling) * 1_000_000;
+  }
+}
+
+function incomingRootFor(form: { id: string; accountId: string }, sessionId: string): string {
+  // Built through the same helper the presign uses, minus the basename, so the
+  // two can never drift into disagreeing about what a valid key looks like.
+  const sample = incomingKey({
+    accountId: form.accountId,
+    formId: form.id,
+    sessionId,
+    originalName: 'x.bin',
+  });
+  return sample.slice(0, sample.lastIndexOf('/'));
+}
+
+/** A content type safe to sign and to store: one token, no header injection. */
+function sanitizeMime(mime: string): string {
+  const m = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,80}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,80}$/i.exec(mime.trim());
+  return m ? m[0].toLowerCase() : 'application/octet-stream';
+}

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -240,9 +240,62 @@ export const serverEnvSchema = z.object({
   IAM_API_KEY: z.string().optional(),
   DAPTA_SYNC_FLOW_URL: z.string().url().optional(),
   DAPTA_SYNC_FLOW_KEY: z.string().optional(),
+
+  // Object storage for the `file` question type. Uploads NEVER pass through
+  // this process: the browser PUTs straight to the bucket with a short-lived
+  // presigned URL the API mints, and the API verifies the object on submit.
+  //
+  // STORAGE_BUCKET is the switch. Unset, which is the default and every bare
+  // fork, means the feature does not exist: it is refused at publish time and
+  // the presign endpoint 404s, so a clone with no bucket boots and runs end to
+  // end. Set it and storage turns on with the pod's own AWS credentials; there
+  // is no key to configure in the normal case.
+  //
+  // STORAGE_PROVIDER exists only as an explicit kill switch (`none`) for a
+  // deployment that wants the bucket configured but the feature off. It is NOT
+  // how you turn storage ON. The bucket is.
+  STORAGE_PROVIDER: z.enum(['none', 's3']).optional(),
+  STORAGE_BUCKET: z.string().optional(),
+  // Defaults to the region our own clusters run in, so a deployment whose
+  // bucket lives beside its pods needs one variable, not two. Any other
+  // deployment sets it; a mismatch fails the request, it does not misroute.
+  STORAGE_REGION: z.string().default('us-east-2'),
+  // Unset = AWS. Set for an S3-compatible endpoint (R2, MinIO), which also
+  // needs STORAGE_FORCE_PATH_STYLE=true on most self-hosted servers.
+  STORAGE_ENDPOINT: z.string().url().optional(),
+  STORAGE_FORCE_PATH_STYLE: boolish.default('false'),
+  // Unset on a pod with an instance/IRSA role, whose credentials the SDK's
+  // default chain finds. These exist for a deployment with no role to attach.
+  STORAGE_ACCESS_KEY_ID: z.string().optional(),
+  STORAGE_SECRET_ACCESS_KEY: z.string().optional(),
+
+  // Hard ceiling per file, in MB. A form owner may lower the limit on their own
+  // question but never raise it past this; the presign call and the post-upload
+  // HeadObject both enforce it, so a client that lies about `size` still fails.
+  UPLOAD_MAX_FILE_MB: z.coerce.number().int().positive().max(1024).default(10),
+  // Life of the upload URL. Long enough for a slow connection to finish a
+  // 10 MB PUT, short enough that a leaked URL is worthless by the time it
+  // travels. Note that with role credentials the URL also dies with the role
+  // session, whichever comes first.
+  UPLOAD_PRESIGN_TTL_SEC: z.coerce.number().int().positive().max(3600).default(600),
+  // Life of the owner's download URL. Minted per click, never stored, never
+  // mailed. A link with a longer life than this is a bug, not a feature.
+  UPLOAD_DOWNLOAD_TTL_SEC: z.coerce.number().int().positive().max(3600).default(300),
 });
 
 export type ServerEnv = z.infer<typeof serverEnvSchema>;
+
+/**
+ * True when the `file` question type is available on this deployment.
+ *
+ * The bucket is the switch (see STORAGE_BUCKET); `STORAGE_PROVIDER=none` is an
+ * explicit override that keeps a configured bucket but turns the feature off.
+ * Every caller asks this, and nothing branches on the raw variables, so a
+ * fork with no bucket takes exactly one path.
+ */
+export function isStorageEnabled(env: Pick<ServerEnv, 'STORAGE_BUCKET' | 'STORAGE_PROVIDER'>): boolean {
+  return Boolean(env.STORAGE_BUCKET) && env.STORAGE_PROVIDER !== 'none';
+}
 
 export const clientEnvSchema = z.object({
   NEXT_PUBLIC_API_URL: z.string().url().default('http://localhost:4000'),

--- a/packages/engine/src/answer-summary.ts
+++ b/packages/engine/src/answer-summary.ts
@@ -10,6 +10,7 @@
 import {
   isInputlessStep,
   nameFields,
+  parseFileAnswer,
   resolveQuestion,
   type Answers,
   type AnswerValue,
@@ -57,6 +58,12 @@ function formatValue(step: FormStep, value: AnswerValue): string {
     return value.trim();
   }
   if (typeof value === "object" && value !== null) {
+    // An uploaded file prints as its name and nothing else. The generic object
+    // branch below would join every field, which would put the object key into
+    // the owner's email and into the CSV. The key is not secret, but a link
+    // built from it would be, and a summary row is the wrong place for either.
+    const file = parseFileAnswer(value);
+    if (file) return file.name;
     return Object.values(value)
       .filter((v) => typeof v === "string" && v.trim())
       .join(" ");

--- a/packages/engine/src/file-answer.spec.ts
+++ b/packages/engine/src/file-answer.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * The `file` answer inside the engine: what counts as one, what the validator
+ * says about it, and how it prints when the owner reads their answers.
+ *
+ * The answers record is a free-form map shared by every question type, so
+ * `parseFileAnswer` is the single place that decides the shape. Anything that
+ * renders answers goes through it instead of duck-typing the object, which is
+ * what keeps an object key out of an email.
+ */
+import { describe, it, expect } from "vitest";
+import { parseFileAnswer, validateAnswer, validateAnswerCode } from "./form-logic";
+import { summarizeAnswers } from "./answer-summary";
+import type { FormConfig, FormStep } from "./form-logic";
+
+const FILE: FormStep = {
+  key: "cv",
+  type: "file",
+  question: "Upload your CV",
+  required: true,
+};
+
+const GOOD = {
+  key: "uploads/a/f/s/9f3c.pdf",
+  name: "Ada Lovelace CV.pdf",
+  size: "40211",
+  mime: "application/pdf",
+};
+
+describe("parseFileAnswer", () => {
+  it("reads a well-formed answer", () => {
+    expect(parseFileAnswer(GOOD)).toEqual(GOOD);
+  });
+
+  it("fills in the fields that only affect presentation", () => {
+    const r = parseFileAnswer({ key: "k", name: "n.pdf" } as never);
+    expect(r).toEqual({ key: "k", name: "n.pdf", size: "0", mime: "application/octet-stream" });
+  });
+
+  it("rejects anything without a real key or name", () => {
+    expect(parseFileAnswer({ ...GOOD, key: "" })).toBeNull();
+    expect(parseFileAnswer({ ...GOOD, key: "   " })).toBeNull();
+    expect(parseFileAnswer({ ...GOOD, name: "" })).toBeNull();
+    expect(parseFileAnswer({ name: "n.pdf" } as never)).toBeNull();
+  });
+
+  it("is not fooled by the other things an answer can be", () => {
+    expect(parseFileAnswer("a string")).toBeNull();
+    expect(parseFileAnswer(["a", "b"])).toBeNull();
+    expect(parseFileAnswer(42)).toBeNull();
+    expect(parseFileAnswer(null)).toBeNull();
+    // The reserved `utm` blob is a string map too, and must never read as a file.
+    expect(parseFileAnswer({ utm_source: "linkedin", utm_medium: "post" })).toBeNull();
+  });
+});
+
+describe("validation", () => {
+  it("requires an answer when the step is required", () => {
+    expect(validateAnswerCode(FILE, null)).toEqual({ ok: false, code: "required" });
+    expect(validateAnswer(FILE, null).ok).toBe(false);
+  });
+
+  it("lets an optional file question go unanswered", () => {
+    expect(validateAnswerCode({ ...FILE, required: false }, null)).toEqual({ ok: true });
+  });
+
+  it("accepts a well-formed answer", () => {
+    expect(validateAnswerCode(FILE, GOOD)).toEqual({ ok: true });
+    expect(validateAnswer(FILE, GOOD).ok).toBe(true);
+  });
+
+  it("rejects a value of the wrong shape with a code of its own", () => {
+    expect(validateAnswerCode(FILE, "uploads/a/f/s/9f3c.pdf")).toEqual({ ok: false, code: "file" });
+    expect(validateAnswer(FILE, "uploads/a/f/s/9f3c.pdf").ok).toBe(false);
+  });
+});
+
+describe("summarizeAnswers", () => {
+  const config = {
+    version: 1,
+    steps: [FILE],
+  } as unknown as FormConfig;
+
+  it("prints the respondent's own filename and nothing else", () => {
+    const rows = summarizeAnswers(config, { cv: GOOD });
+    expect(rows).toEqual([{ label: "Upload your CV", value: "Ada Lovelace CV.pdf" }]);
+  });
+
+  it("keeps the object key out of the row", () => {
+    const [row] = summarizeAnswers(config, { cv: GOOD });
+    expect(row.value).not.toContain("uploads/");
+    expect(row.value).not.toContain("9f3c");
+  });
+
+  it("omits the question entirely when no file was uploaded", () => {
+    expect(summarizeAnswers(config, {})).toEqual([]);
+  });
+});

--- a/packages/engine/src/form-config.ts
+++ b/packages/engine/src/form-config.ts
@@ -75,6 +75,13 @@ export function createEmptyStep(
   if (type === 'multiple_choice') {
     base.selectionMode = 'single';
   }
+  if (type === 'file') {
+    // Documents by default: the common case is a CV or a signed form, and a
+    // narrow list is the safer starting point than "anything". The size stays
+    // unset so the step inherits the deployment ceiling rather than pinning a
+    // number the deployment may not allow.
+    base.allowedTypes = ['pdf', 'doc', 'docx', 'jpg', 'png'];
+  }
   if (type === 'slider') {
     base.min = 0;
     base.max = 100;

--- a/packages/engine/src/form-logic.ts
+++ b/packages/engine/src/form-logic.ts
@@ -41,6 +41,7 @@ export const FORM_FIELD_TYPES = [
   'message',
   'reveal',
   'scheduler',
+  'file',
 ] as const;
 export type FormFieldType = (typeof FORM_FIELD_TYPES)[number];
 
@@ -162,6 +163,20 @@ export interface FormStep {
   corporateEmailOnly?: boolean;
   /** Phone validation: minimum digit count. */
   phoneMinDigits?: number;
+  /**
+   * `file` step: the extensions the owner accepts, lowercase and without the
+   * dot. Absent means "whatever the deployment allows", which is how a form
+   * saved before this setting existed keeps working. The ceiling is enforced
+   * server-side either way, so this is the owner's preference, not the
+   * security boundary.
+   */
+  allowedTypes?: string[];
+  /**
+   * `file` step: the owner's own size limit in MB. Clamped down to the
+   * deployment's UPLOAD_MAX_FILE_MB, never up. An owner can ask for less than
+   * the deployment allows but never for more.
+   */
+  maxSizeMb?: number;
   // --- Builder + runtime extensions (all optional; back-compat) -------------
   /** `name` step: the two fields collected on one slide (default firstname+lastname). */
   fields?: string[];
@@ -1347,6 +1362,10 @@ export function validateAnswer(step: FormStep, value: AnswerValue): ValidationRe
     return step.required ? { ok: false, error: 'This field is required.' } : { ok: true };
   }
 
+  if (step.type === 'file' && !parseFileAnswer(value)) {
+    return { ok: false, error: 'Upload a file to continue.' };
+  }
+
   switch (step.type) {
     case 'email': {
       const email = String(value).trim().toLowerCase();
@@ -1896,7 +1915,8 @@ export type ValidationCode =
   | 'number'
   | 'too_low'
   | 'too_high'
-  | 'option';
+  | 'option'
+  | 'file';
 
 export type ValidationCodeResult = { ok: true } | { ok: false; code: ValidationCode };
 
@@ -1956,9 +1976,49 @@ export function validateAnswerCode(
       if (tokens(value).some((t) => !allowed.has(t))) return { ok: false, code: 'option' };
       return { ok: true };
     }
+    case 'file': {
+      // Shape only. Whether the object actually exists in the bucket, and
+      // whether its bytes are what the name claims, is decided server-side on
+      // submit. A check here would be advisory, because this same function
+      // runs in the browser where the answer comes from.
+      if (!parseFileAnswer(value)) return { ok: false, code: 'file' };
+      return { ok: true };
+    }
     default:
       return { ok: true };
   }
+}
+
+/** One uploaded file, as it is stored inside the answers JSON. */
+export interface FileAnswer {
+  /** Object key in the bucket. Never shown to anyone; the download is minted from it. */
+  key: string;
+  /** The name the respondent's own file had, which is the only name worth showing. */
+  name: string;
+  /** Size in bytes, as a string because the answers map holds string values. */
+  size: string;
+  mime: string;
+}
+
+/**
+ * Read a `file` answer, or null when the value is not one.
+ *
+ * The answers map is a free-form record shared by every question type, so this
+ * is the single place that decides what counts as a file answer. Callers that
+ * render answers (CSV, email, webhook) go through it rather than duck-typing
+ * the object themselves.
+ */
+export function parseFileAnswer(value: AnswerValue): FileAnswer | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const v = value as Record<string, string>;
+  if (typeof v.key !== 'string' || v.key.trim() === '') return null;
+  if (typeof v.name !== 'string' || v.name.trim() === '') return null;
+  return {
+    key: v.key,
+    name: v.name,
+    size: typeof v.size === 'string' ? v.size : '0',
+    mime: typeof v.mime === 'string' ? v.mime : 'application/octet-stream',
+  };
 }
 
 /** The sub-fields a `name` step collects (default firstname + lastname). */

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -88,6 +88,7 @@ export interface FormsMessages {
       too_low: string;
       too_high: string;
       option: string;
+      file: string;
       submit: string;
     };
     /** The phone step's country-code picker (searchable dial-code selector). */
@@ -1802,6 +1803,7 @@ export const en: FormsMessages = {
       too_low: 'Value is too low.',
       too_high: 'Value is too high.',
       option: 'Choose one of the available options.',
+      file: 'Upload a file to continue.',
       submit: 'Could not submit. Please try again.',
     },
     phonePicker: {
@@ -3350,6 +3352,7 @@ export const es: FormsMessages = {
       too_low: 'El valor es muy bajo.',
       too_high: 'El valor es muy alto.',
       option: 'Elige una de las opciones disponibles.',
+      file: 'Sube un archivo para continuar.',
       submit: 'No se pudo enviar. Inténtalo de nuevo.',
     },
     phonePicker: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -240,6 +240,10 @@ export const formStepSchema = z.object({
   flowGroup: z.enum(['qualification', 'lead_capture']).optional(),
   corporateEmailOnly: z.boolean().optional(),
   phoneMinDigits: z.number().int().positive().optional(),
+  /** `file` step: extensions the owner accepts, lowercase, no dot. Absent = the deployment's own list. */
+  allowedTypes: z.array(z.string().min(1).max(12)).max(40).optional(),
+  /** `file` step: the owner's size limit in MB, clamped down to UPLOAD_MAX_FILE_MB server-side. */
+  maxSizeMb: z.number().int().positive().max(1024).optional(),
   // --- Builder + runtime extensions (all optional; back-compat) -------------
   /** Dynamic question: pick the text from the answer to this earlier field. */
   questionField: z.string().min(1).max(64).nullable().optional(),
@@ -1231,6 +1235,11 @@ export type PublicForm = z.infer<typeof publicFormSchema>;
  * string[] for multi-select); the reserved `utm` key carries a flat string map
  * of the URL's `utm_*` params (additive — captured from the public URL, never a
  * new column: it rides inside the free-form answers JSON).
+ *
+ * A `file` answer rides in that same string map as
+ * `{ key, name, size, mime }`. `size` is a string because this record holds
+ * strings, which is exactly why the shape needed no migration and no column.
+ * `parseFileAnswer` in @quill/engine is the only thing that should read it.
  */
 export const submissionAnswersSchema = z.record(
   z.string(),
@@ -1244,6 +1253,37 @@ export const submissionAnswersSchema = z.record(
   ]),
 );
 export type SubmissionAnswers = z.infer<typeof submissionAnswersSchema>;
+
+/**
+ * Body of POST /v1/public/forms/:accountCode/:slug/uploads: the browser asking
+ * for permission to upload one file.
+ *
+ * Everything here is a CLAIM by an anonymous client, including `size` and
+ * `mime`. The API checks the claim against the published config before signing
+ * anything, and checks the object itself again on submit. A client that lies
+ * gets a signature it cannot use.
+ */
+export const uploadPresignSchema = z.object({
+  /** Same per-session id the submission will carry; it scopes the object key. */
+  sessionId: z.string().min(1).max(200),
+  /** Which question this file answers. Must be a `file` step on the published form. */
+  stepKey: z.string().min(1).max(64),
+  /** The respondent's own filename. Stored in the answer, never in the key. */
+  name: z.string().min(1).max(255),
+  size: z.number().int().positive(),
+  mime: z.string().min(1).max(200),
+});
+export type UploadPresignInput = z.infer<typeof uploadPresignSchema>;
+
+/** What the browser gets back: where to PUT, and what the answer must carry. */
+export const uploadPresignResultSchema = z.object({
+  url: z.string(),
+  key: z.string(),
+  /** Header the PUT must send verbatim; it is inside the signature. */
+  contentType: z.string(),
+  expiresInSec: z.number().int().positive(),
+});
+export type UploadPresignResult = z.infer<typeof uploadPresignResultSchema>;
 
 export const submissionSchema = z.object({
   /** Per-session id (sessionStorage) tying events + the submission together. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1129.0
+        version: 3.1129.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1129.0
+        version: 3.1129.0
       '@nestjs/common':
         specifier: ^10.4.15
         version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -65,6 +71,9 @@ importers:
       '@quill/types':
         specifier: workspace:*
         version: link:../../packages/types
+      file-type:
+        specifier: ^22.0.2
+        version: 22.0.2
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -333,6 +342,82 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aws-sdk/checksums@3.1001.0':
+    resolution: {integrity: sha512-6uTniZc87q+B5eXouGTl+7Tmc482rEeCcvxpsvREP8EfF0gvloRZ41UOA9sbSJlyy8TbqIBXb3kKfKarEArUQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1129.0':
+    resolution: {integrity: sha512-TwbRTrAGwtFFUQ/jozsj9Jyjy+UjIsfSKaNs/tQfggIWFbk1Mim+IWjZ//IOz97Wc5Q/z/6G4cb5znYUXHKxHg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.978.0':
+    resolution: {integrity: sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.71':
+    resolution: {integrity: sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.73':
+    resolution: {integrity: sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    resolution: {integrity: sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.78':
+    resolution: {integrity: sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.83':
+    resolution: {integrity: sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.71':
+    resolution: {integrity: sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    resolution: {integrity: sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    resolution: {integrity: sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.76':
+    resolution: {integrity: sha512-NfnTkVUTBKTBuBgqaapFK9r3YdkKt1b2oRvgLzZq91bwNKh6ZS0S7sEcheguttREaL4iyfs/xQnqD7Z7AsWSsA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.45':
+    resolution: {integrity: sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1129.0':
+    resolution: {integrity: sha512-4nm7ZcBJdGNGea/y/VQGE075luT7VNcBa16o7bj5Rqr3RHvkiPrO8IVXRu1fM4h3hTd1diwX/AHbi+3Yn1tLJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1129.0':
+    resolution: {integrity: sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1256,6 +1341,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.8.0':
+    resolution: {integrity: sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.12.1':
+    resolution: {integrity: sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.18.0':
+    resolution: {integrity: sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==}
+    engines: {node: '>=18.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1349,6 +1458,10 @@ packages:
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
 
   '@tokenizer/token@0.3.0':
@@ -1594,6 +1707,9 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
@@ -1999,6 +2115,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2094,6 +2211,10 @@ packages:
   file-type@20.4.1:
     resolution: {integrity: sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==}
     engines: {node: '>=18'}
+
+  file-type@22.0.2:
+    resolution: {integrity: sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==}
+    engines: {node: '>=22'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -3274,6 +3395,180 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@aws-sdk/checksums@3.1001.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1129.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1001.0
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-node': 3.972.83
+      '@aws-sdk/middleware-sdk-s3': 3.972.76
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.978.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-login': 3.972.78
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.78':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.83':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-ini': 3.973.16
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/token-providers': 3.1129.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.45':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1129.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1129.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -4083,6 +4378,39 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.8.0':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.12.1':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.18.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -4160,6 +4488,13 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fflate: 0.8.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4454,6 +4789,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.16:
     dependencies:
@@ -4916,6 +5253,15 @@ snapshots:
   file-type@20.4.1:
     dependencies:
       '@tokenizer/inflate': 0.2.7
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  file-type@22.0.2:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0


### PR DESCRIPTION
Backend groundwork for a `file` question type. A customer asked for document
upload as a condition of staying on Dapta Forms; this is the first of three PRs.

**Not user-reachable yet.** The type exists in the engine and the API, but no
builder gallery entry and no public input render it, so no form can ask for a
file until the renderer PR lands. Nothing in the product changes on merge.

## The shape

The file never travels through the app. The browser asks the API for permission
(`POST /v1/public/forms/:accountCode/:slug/uploads`, behind the same per-IP rate
limit as the rest of the public surface), gets a presigned PUT that can write one
key for a few minutes with one exact content type, and uploads straight to the
bucket.

That is not an optimization, it is the only way a 10 MB file exists at all: the
current submit path caps the body at 1 MB in the Next server action and 100 kb in
the API's Express parser, and neither limit is raised here.

Two prefixes carry the difference between "a stranger wrote this" and "we checked
it":

- `incoming/{accountId}/{formId}/{sessionId}/{uuid}.{ext}` is the only place a
  browser may write. Bucket lifecycle expires it, so a visitor who uploads and
  abandons the form costs nothing.
- `uploads/` is written by the API alone, after verification, and is the only
  prefix a stored submission ever points at.

## What is checked, and when

`presign` runs before any bytes exist, so it can only check claims: the step is a
file step on the published form, the extension is one the owner allows and not
one the deployment denies, the claimed size fits.

`verifyAnswers` runs on submit, before anything is persisted or scored, and checks
the object itself:

- it exists, and its REAL size is within the limit (the claimed size is not
  evidence)
- its key is under this session's own staging prefix, which is what stops one
  visitor from claiming another's upload by pasting a key
- its first bytes match the extension it arrived under. A format with no signature
  to check, such as .txt or .csv, is accepted only under an extension that is
  genuinely signature-free
- executables and active documents (html, svg) are refused whatever the owner
  configured

Verification is idempotent by key shape, so a partial save followed by a complete
submit promotes the file once rather than copying twice or failing on the second
pass.

## Reads and deletes

Nothing in the bucket is public. Downloads are minted per click as short-lived
signed URLs, always with `Content-Disposition: attachment`, so an uploaded page
cannot execute on an origin of ours.

`deletePrefix` removes every VERSION of an object. Our buckets are versioned
because cross-region replication requires it, and on a versioned bucket an
ordinary delete writes a recoverable delete marker. An erasure request has to
actually erase. The outbox wiring that calls this on form and submission deletion
is the third PR.

## Configuration

One variable in the normal case. `STORAGE_BUCKET` turns the feature on and the
AWS SDK finds the pod's own role, so there is no key to configure.
`STORAGE_PROVIDER=none` is an explicit off switch for a deployment that has a
bucket but does not want the feature.

Unset, which is the default and every bare fork, means the question type does not
exist: the deployment boots and runs exactly as before, and both entry points say
so rather than half-working. `UPLOAD_MAX_FILE_MB` (10) is a ceiling an owner can
lower but never raise.

## Storage of the answer

`{ key, name, size, mime }` inside the existing answers JSON, so no migration and
no new column (invariant 4: the config contract is extended, never broken).
`parseFileAnswer` is the only reader of that shape. Answer summaries print the
respondent's own filename and never the object key, which keeps it out of
notification emails and CSV exports.

## Checks

- `pnpm typecheck`, `pnpm lint`, `pnpm build`: green (the two lint warnings are
  pre-existing, in `hubspot-mirror.spec.ts` and `packages/db`)
- `pnpm test`: 2029 tests green, 52 of them new
- `bash scripts/dash-check.sh origin/develop`: clean
- `bash scripts/publish-gate.sh`: passes once the local `.next` build output is
  out of the way (its findings are Next's own generated encryption keys in
  untracked files, not tracked source)

## Next

1. Builder gallery entry, settings and preview; public input with progress.
2. Deletion through the outbox on form and submission delete, plus the owner's
   download button in the submissions table.