### PR TITLE
feat(web): the file question in the builder, the public form and the table

### DIFF
--- a/.changeset/file-upload-ui.md
+++ b/.changeset/file-upload-ui.md
@@ -1,0 +1,53 @@
+---
+'@quill/shared': minor
+'@quill/types': minor
+'@quill/db': minor
+---
+
+The file question, end to end: build it, answer it, download it.
+
+The storage groundwork shipped separately; this is the half a person can see.
+A form owner adds a "File upload" question from the builder gallery, a visitor
+picks a file and watches it upload, and the owner opens it from the submissions
+table.
+
+**Builder.** The gallery gets a File upload tile in the Text group. Its settings
+are four preset groups (documents, images, spreadsheets, archives) over a plain
+extension field, because "pdf, doc, docx, odt, rtf" is not a decision a form
+author wants to make and a bare text box is how a question nobody can answer
+gets published. Ticking a preset writes its extensions into the same list the
+field edits, so the two never disagree. The size field caps at the deployment's
+own ceiling, which the API reports rather than the dashboard assuming. An empty
+type list is called out, since it is almost never what the author meant.
+
+The canvas preview draws the real drop zone rather than a text placeholder: the
+canvas is the only place an author checks their work before publishing, and a
+question that previewed as an empty input would be lying about what it is.
+
+**Public form.** The upload starts the moment a file is chosen, not on Continue,
+so a visitor with a 9 MB document is watching a progress bar instead of a frozen
+button. It uses XMLHttpRequest because fetch still cannot report upload
+progress, and a progress bar is the whole difference between this feeling broken
+and feeling normal on a slow connection. Size and extension are checked in the
+browser first as a courtesy, and again on the server as the actual rule. Both
+layouts carry it, slides and vertical.
+
+The bytes go straight from the browser to the bucket. The presign request goes
+through a server action so the visitor's own address still reaches the API's
+rate limiter, and so no embed origin ever needs adding to an allowlist.
+
+**Submissions table.** A file answer renders as its filename with a download
+control instead of `[object Object]`, which is what the generic cell formatter
+produced. The signed URL is fetched on click rather than rendered into the page:
+a table of fifty rows would otherwise carry fifty short-lived credentials in its
+HTML, most of them expired before anyone clicked one. The endpoint behind it
+resolves the submission through a join on the caller's own account, so a guessed
+id from another workspace returns nothing rather than a working link.
+
+**Deployments with no bucket.** The tile is offered but disabled, with the
+reason on it, and the public input renders nothing at all. A bare fork sees a
+question type it cannot use rather than one that fails on the first click.
+
+Copy is EN and ES throughout. HubSpot auto-mapping suggests no property for a
+file question and no longer lets the words in "upload your company logo" map a
+PDF into a text property; the webhook test body carries the real answer shape.

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -91,9 +91,11 @@ import { AuthService, type ReqLike } from './auth.service';
 import { WorkspaceService } from './workspace.service';
 import { EmailEffects } from './email-effects';
 import { AnalyticsEffects } from './analytics-effects';
+import { UploadService } from './upload.service';
+import type { ServerEnv } from '@quill/config/env';
 import { assertAdmin, assertCanManageTarget, assertNotSelf, assertOwner } from './permissions';
 import { parseBound, parseIntParam, parseKinds, parseOutboxStatuses, parseStatus } from './query-params';
-import { DB } from './tokens';
+import { DB, ENV } from './tokens';
 
 function parse<T>(schema: { parse: (v: unknown) => T }, body: unknown): T {
   try {
@@ -152,6 +154,11 @@ export class AdminCrudController {
     @Optional() @Inject(AnalyticsEffects) private readonly productAnalytics?: AnalyticsEffects,
     // Last on purpose: existing tests construct this controller positionally.
     @Optional() @Inject(WorkspaceService) private readonly workspacesSvc?: WorkspaceService,
+    // Deployment capability reporting only (`me`): whether file answers are
+    // possible here at all. Optional for the same positional-construction
+    // reason, and absent reads as "no uploads", which is the safe answer.
+    @Optional() @Inject(UploadService) private readonly uploads?: UploadService,
+    @Optional() @Inject(ENV) private readonly env?: ServerEnv,
   ) {}
 
   private ws(): WorkspaceService {
@@ -168,7 +175,17 @@ export class AdminCrudController {
     // Staff of the deployment (by email domain, identity-backed only): the
     // switcher offers them the whole estate to search.
     const staff = this.workspacesSvc ? await this.workspacesSvc.isStaff(req) : false;
-    return { ...view, staff };
+    // Whether this DEPLOYMENT can accept file answers, and how big. The builder
+    // must not offer a question it cannot fulfil, and the size field has to show
+    // the real ceiling rather than a number the API would then refuse. Reported
+    // here, next to `staff`, because the editor already fetches this and a
+    // capability the dashboard reads from its own env would be a second copy of
+    // a switch that lives in the API.
+    const uploads = {
+      enabled: this.uploads?.enabled ?? false,
+      maxFileMb: this.env?.UPLOAD_MAX_FILE_MB ?? 10,
+    };
+    return { ...view, staff, uploads };
   }
 
   /**
@@ -701,6 +718,26 @@ export class AdminCrudController {
    * startedAt), `limit`/`offset`. Returns a paginated envelope `{ items, total,
    * limit, offset }` so the admin table can render page counts.
    */
+  /**
+   * A signed, short-lived URL for one uploaded file on one submission.
+   *
+   * Returns the URL rather than redirecting: the dashboard opens it itself, so
+   * the link never lands in the browser's history or in a referrer, and a stale
+   * page cannot re-follow a redirect whose signature has since expired.
+   */
+  @Get('forms/:id/submissions/:submissionId/files/:stepKey')
+  async submissionFile(
+    @Req() req: ReqLike,
+    @Param('submissionId') submissionId: string,
+    @Param('stepKey') stepKey: string,
+  ) {
+    const p = await this.auth.resolveHost(req);
+    if (!this.uploads) throw new NotFoundException({ error: 'NOT_FOUND', message: 'File uploads are not enabled.' });
+    const r = await this.uploads.downloadUrl(p.accountId, submissionId, stepKey);
+    if ('error' in r) throw new NotFoundException({ error: r.error, message: r.message });
+    return r;
+  }
+
   @Get('forms/:id/submissions')
   async formSubmissions(
     @Req() req: ReqLike,

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -1059,6 +1059,16 @@ function sampleAnswers(steps: { key: string; type: string }[]): Record<string, u
       case 'slider':
         out[s.key] = 5;
         break;
+      case 'file':
+        // The object shape a real file answer has, so an endpoint author wires
+        // against `name` and not against a string that never arrives.
+        out[s.key] = {
+          key: 'uploads/acct/form/session/9f3c.pdf',
+          name: 'sample.pdf',
+          size: '40211',
+          mime: 'application/pdf',
+        };
+        break;
       case 'multiple_choice':
       case 'dropdown':
         out[s.key] = 'sample-option';

--- a/apps/api/src/submission.service.ts
+++ b/apps/api/src/submission.service.ts
@@ -111,7 +111,12 @@ export class SubmissionService {
     if (!f) return null;
     // NEVER leak destination config (webhook URLs/secrets, CRM mappings) to the
     // public renderer — it is server-only integration config.
-    return { slug: f.slug, name: f.name, config: toPublicConfig(f.config) };
+    return {
+      slug: f.slug,
+      name: f.name,
+      config: toPublicConfig(f.config),
+      ...(this.uploads?.enabled ? { uploadMaxMb: this.uploads.maxFileMb } : {}),
+    };
   }
 
   /**

--- a/apps/api/src/upload.service.ts
+++ b/apps/api/src/upload.service.ts
@@ -16,7 +16,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { fileTypeFromBuffer } from 'file-type';
 import type { Db } from '@quill/db';
-import { getPublishedForm } from '@quill/db';
+import { getPublishedForm, getSubmissionAnswersForAccount } from '@quill/db';
 import { parseFileAnswer, type FormConfig, type FormStep } from '@quill/engine';
 import type { SubmissionAnswers, UploadPresignInput, UploadPresignResult } from '@quill/types';
 import { type ServerEnv } from '@quill/config/env';
@@ -109,6 +109,11 @@ export class UploadService {
   /** False on a deployment with no bucket: the question type does not exist here. */
   get enabled(): boolean {
     return this.storage.enabled;
+  }
+
+  /** The deployment's hard per-file ceiling, in MB. An owner may only go lower. */
+  get maxFileMb(): number {
+    return this.env.UPLOAD_MAX_FILE_MB;
   }
 
   /**
@@ -217,6 +222,33 @@ export class UploadService {
     }
 
     return { answers: out };
+  }
+
+  /**
+   * A short-lived download URL for one file answer, or an error.
+   *
+   * Account-scoped at the database (invariant 3): the submission is read
+   * through a JOIN on the caller's own account, so a guessed submission id from
+   * another workspace resolves to nothing rather than to a signed URL. The URL
+   * itself is minted per call, lives minutes, and is never stored or mailed.
+   */
+  async downloadUrl(
+    accountId: string,
+    submissionId: string,
+    stepKey: string,
+  ): Promise<{ url: string; name: string } | UploadError> {
+    if (!this.storage.enabled) {
+      return { error: 'NOT_FOUND', message: 'File uploads are not enabled.', status: 404 };
+    }
+    const row = await getSubmissionAnswersForAccount(this.db, accountId, submissionId);
+    if (!row) return { error: 'NOT_FOUND', message: 'Submission not found.', status: 404 };
+
+    const answers = (row.data ?? {}) as Record<string, unknown>;
+    const file = parseFileAnswer(answers[stepKey] as never);
+    if (!file) return { error: 'NOT_FOUND', message: 'No file on that question.', status: 404 };
+
+    const url = await this.storage.presignGet(file.key, file.name);
+    return { url, name: file.name };
   }
 
   /** The object exists, is within the limit, and its bytes match the name it arrived under. */

--- a/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/actions.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { postSubmission, postFormEvent } from '@/lib/api';
+import { postSubmission, postFormEvent, postUploadPresign, type PresignResult } from '@/lib/api';
 import { postBookingCallback } from '@/lib/booking-embed';
 import { forwardedForChain } from '@/lib/forwarded-for';
-import type { BookingCallbackInput } from '@quill/types';
+import type { BookingCallbackInput, UploadPresignInput } from '@quill/types';
 
 /**
  * Submit a form — partial (past the lead-capture threshold) or complete. The
@@ -34,4 +34,19 @@ export async function recordBookingAction(
   payload: BookingCallbackInput,
 ): Promise<void> {
   await postBookingCallback(accountCode, slug, payload, await forwardedForChain());
+}
+
+/**
+ * Authorize one file upload and hand the browser the URL to PUT to.
+ *
+ * The bytes never come through here: this returns a signed URL and the browser
+ * uploads straight to the bucket. That is the whole point of the flow, because
+ * a Server Action body is capped at 1 MB and a real document is not.
+ */
+export async function presignUploadAction(
+  accountCode: string,
+  slug: string,
+  payload: UploadPresignInput,
+): Promise<PresignResult> {
+  return postUploadPresign(accountCode, slug, payload);
 }

--- a/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/form-renderer.tsx
@@ -45,7 +45,12 @@ import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-em
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
 import { callAction, callActionWithRetry, isTransportError } from '@/lib/call-action';
 import { navigateTop } from '@/lib/top-navigate';
-import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
+import {
+  submitFormAction,
+  recordEventAction,
+  recordBookingAction,
+  presignUploadAction,
+} from './actions';
 import {
   useSessionId,
   captureUtm,
@@ -65,6 +70,7 @@ export function FormRenderer({
   name,
   config,
   locale = 'en',
+  uploadMaxMb,
   startAt,
 }: {
   accountCode: string;
@@ -72,6 +78,8 @@ export function FormRenderer({
   name: string;
   config: FormConfig;
   locale?: string;
+  /** The deployment's per-file ceiling in MB, for `file` steps. */
+  uploadMaxMb?: number;
   /**
    * Start-position hint: a runtime step index, or `'cover'` for the default
    * entry (cover when it exists, else the first step). The builder preview
@@ -85,6 +93,36 @@ export function FormRenderer({
   const formLocale = locale === 'es' ? 'es' : 'en';
   const labels = resolveFormLabels(config, formLocale);
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
+
+  /**
+   * Authorize one upload for a `file` step.
+   *
+   * The session id is what scopes the object key, and the server checks on
+   * submit that the key it is handed sits under THIS session's prefix. So the
+   * value passed here is not a detail: it is the thing that stops one visitor
+   * from claiming another's upload.
+   */
+  const requestUploadTicket = useCallback(
+    async (stepKey: string, file: { name: string; size: number; mime: string }) => {
+      // Through `callAction`, never a bare await: a deploy rotating action ids
+      // mid-session rejects the call, and an unguarded await here would leave
+      // the control stuck on its progress bar with no error and no retry.
+      const r = await callAction(() =>
+        presignUploadAction(accountCode, slug, {
+          sessionId,
+          stepKey,
+          name: file.name,
+          size: file.size,
+          mime: file.mime,
+        }),
+      );
+      if (isTransportError(r)) return { ok: false, message: r.message } as const;
+      return r.ok
+        ? ({ ok: true, ticket: { url: r.upload.url, key: r.upload.key, contentType: r.upload.contentType } } as const)
+        : ({ ok: false, message: r.message } as const);
+    },
+    [accountCode, slug, sessionId],
+  );
   // The cover SCREEN: null when switched off, which is what gates the `cover`
   // phase, the Start CTA and the back-to-cover step.
   const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
@@ -858,6 +896,8 @@ export function FormRenderer({
                 dropdownPlaceholder={m.dropdownPlaceholder}
                 dropdownEmpty={m.dropdownEmpty}
                 locale={locale}
+                onRequestUpload={requestUploadTicket}
+                uploadMaxMb={uploadMaxMb}
               />
 
               {error ? (

--- a/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/page.tsx
@@ -209,6 +209,7 @@ export default async function PublicFormPage({
           name={publicTitle(form.config, form.name)}
           config={form.config}
           locale={locale}
+          uploadMaxMb={form.uploadMaxMb}
         />
       </div>
     </>

--- a/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/public-form.css
@@ -335,6 +335,110 @@
   text-align: center;
 }
 
+/* ── File upload ── */
+.pf-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+/* The idle state is a target, not a text field: it has to read as somewhere to
+   drop or click, and it is the only control here a visitor may not recognise. */
+.pf-upload-drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 24px 16px;
+  font-family: inherit;
+  color: var(--muted-foreground);
+  background: var(--background);
+  border: 1px dashed var(--input);
+  border-radius: var(--pf-radius-sm);
+  cursor: pointer;
+  box-sizing: border-box;
+  transition: border-color 0.12s var(--pf-ease), color 0.12s var(--pf-ease);
+}
+.pf-upload-drop:hover {
+  border-color: var(--pf-primary);
+  color: var(--foreground);
+}
+.pf-upload-drop:focus-visible {
+  outline: none;
+  border-color: var(--pf-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--pf-primary) 30%, transparent);
+}
+.pf-upload-cta {
+  font-size: 16px;
+  color: var(--foreground);
+}
+.pf-upload-accepts {
+  font-size: 13px;
+}
+.pf-upload-file,
+.pf-upload-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 16px;
+  font-size: 15px;
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--input);
+  border-radius: var(--pf-radius-sm);
+  box-sizing: border-box;
+}
+/* A filename is arbitrary length and frequently long. It truncates so the
+   Remove control never leaves the box. */
+.pf-upload-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pf-upload-remove,
+.pf-upload-retry {
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--muted-foreground);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.pf-upload-remove:hover,
+.pf-upload-retry:hover {
+  color: var(--foreground);
+}
+.pf-upload-progress {
+  flex-wrap: wrap;
+}
+.pf-upload-bar {
+  flex: 1 1 100%;
+  height: 4px;
+  background: var(--input);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pf-upload-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--pf-primary);
+  transition: width 0.15s var(--pf-ease);
+}
+.pf-upload-percent {
+  font-size: 13px;
+  color: var(--muted-foreground);
+}
+.pf-upload-error {
+  font-size: 14px;
+  color: var(--destructive);
+}
+
 /* ── Choices — list ── */
 .pf-choices--list {
   display: flex;

--- a/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
+++ b/apps/web/app/[accountCode]/[handle]/[slug]/vertical-form-renderer.tsx
@@ -59,7 +59,12 @@ import { warmBookingEmbed, type BookingScheduledDetails } from '@/lib/booking-em
 import { resolveSchedulerPrefill } from '@/lib/booking-prefill';
 import { callAction, callActionWithRetry, isTransportError } from '@/lib/call-action';
 import { navigateTop } from '@/lib/top-navigate';
-import { submitFormAction, recordEventAction, recordBookingAction } from './actions';
+import {
+  submitFormAction,
+  recordEventAction,
+  recordBookingAction,
+  presignUploadAction,
+} from './actions';
 import {
   useSessionId,
   captureUtm,
@@ -158,18 +163,51 @@ export function VerticalFormRenderer({
   name,
   config,
   locale = 'en',
+  uploadMaxMb,
 }: {
   accountCode: string;
   slug: string;
   name: string;
   config: FormConfig;
   locale?: string;
+  /** The deployment's per-file ceiling in MB, for `file` steps. */
+  uploadMaxMb?: number;
 }) {
   const m = getMessages(locale).renderer;
   // The form's button copy: author overrides, else the stock copy of `locale`.
   const formLocale = locale === 'es' ? 'es' : 'en';
   const labels = resolveFormLabels(config, formLocale);
   const sessionId = useSessionId(`quill-form-${accountCode}-${slug}`);
+
+  /**
+   * Authorize one upload for a `file` step.
+   *
+   * The session id is what scopes the object key, and the server checks on
+   * submit that the key it is handed sits under THIS session's prefix. So the
+   * value passed here is not a detail: it is the thing that stops one visitor
+   * from claiming another's upload.
+   */
+  const requestUploadTicket = useCallback(
+    async (stepKey: string, file: { name: string; size: number; mime: string }) => {
+      // Through `callAction`, never a bare await: a deploy rotating action ids
+      // mid-session rejects the call, and an unguarded await here would leave
+      // the control stuck on its progress bar with no error and no retry.
+      const r = await callAction(() =>
+        presignUploadAction(accountCode, slug, {
+          sessionId,
+          stepKey,
+          name: file.name,
+          size: file.size,
+          mime: file.mime,
+        }),
+      );
+      if (isTransportError(r)) return { ok: false, message: r.message } as const;
+      return r.ok
+        ? ({ ok: true, ticket: { url: r.upload.url, key: r.upload.key, contentType: r.upload.contentType } } as const)
+        : ({ ok: false, message: r.message } as const);
+    },
+    [accountCode, slug, sessionId],
+  );
   // The cover HERO: null when switched off, which is what gates the hero block.
   const coverScreen = config.cover && config.cover.enabled !== false ? config.cover : null;
   // The banner is page CHROME, independent of the hero — see the note in
@@ -767,6 +805,8 @@ export function VerticalFormRenderer({
                     dropdownPlaceholder={m.dropdownPlaceholder}
                     dropdownEmpty={m.dropdownEmpty}
                     locale={locale}
+                    onRequestUpload={requestUploadTicket}
+                    uploadMaxMb={uploadMaxMb}
                   />
                 )}
               </VerticalQuestion>

--- a/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/advanced-settings.tsx
@@ -129,6 +129,9 @@ export function PrefillRow({
     if (step.type === 'email') return 'ana%40acme.com';
     if (step.type === 'phone') return '%2B15555550123';
     if (step.type === 'url') return 'https%3A%2F%2Facme.com';
+    // A file answer is an object written by the upload, not a string, so there
+    // is nothing a prefill URL could carry for it.
+    if (step.type === 'file') return '';
     if (step.type === 'slider') return '5';
     const option = step.options?.[0];
     if (option) return encodeURIComponent(option.value ?? option.label ?? 'value');

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -198,6 +198,8 @@ export interface BuilderMessages {
     /** "{n} pts" */
     pts: string;
     messagePlaceholder: string;
+    /** File step preview: the drop zone's own call to action. */
+    filePlaceholder: string;
     /** The reveal card's in-place copy editing + "plays for {ms} ms" caption. */
     revealHeadlinePlaceholder: string;
     revealSubtitlePlaceholder: string;
@@ -380,6 +382,8 @@ export interface BuilderMessages {
     noResults: string;
     /** Vertical layout: why the reveal tile is off once the form has one. */
     revealVerticalTaken: string;
+    /** Why the file tile is unavailable: this deployment stores no files. */
+    fileStorageOff: string;
     items: Record<GalleryItemId, { title: string; desc: string }>;
   };
   map: {
@@ -497,6 +501,7 @@ export type GalleryItemId =
   | 'long'
   | 'url'
   | 'slider'
+  | 'file'
   | 'message'
   | 'reveal'
   | 'scheduler';
@@ -634,6 +639,7 @@ const en: BuilderMessages = {
     submit: 'Submit',
     pts: '{n} pts',
     messagePlaceholder: 'Write your message…',
+    filePlaceholder: 'Choose a file',
     revealHeadlinePlaceholder: 'Reviewing your answers…',
     revealSubtitlePlaceholder: 'Add a line of reassurance (optional)',
     revealPlays: 'Plays for {ms} ms, then the form continues on its own.',
@@ -795,6 +801,7 @@ const en: BuilderMessages = {
     close: 'Close',
     noResults: 'No matching types.',
     revealVerticalTaken: 'Already added. A one-page form plays its reveal once, after Submit.',
+    fileStorageOff: 'File uploads are not set up on this deployment.',
     items: {
       name: { title: 'Name', desc: 'Full name field' },
       email: { title: 'Email', desc: 'Validated email' },
@@ -806,6 +813,7 @@ const en: BuilderMessages = {
       long: { title: 'Long text', desc: 'Paragraph' },
       url: { title: 'Website', desc: 'Validated URL' },
       slider: { title: 'Slider', desc: 'Rating scale' },
+      file: { title: 'File upload', desc: 'A document or image' },
       message: { title: 'Message', desc: 'Text, no input' },
       reveal: { title: 'Reveal screen', desc: 'A short processing pause' },
       scheduler: {
@@ -1039,6 +1047,7 @@ const es: BuilderMessages = {
     next: 'Siguiente',
     submit: 'Enviar',
     pts: '{n} pts',
+    filePlaceholder: 'Elige un archivo',
     messagePlaceholder: 'Escribe tu mensaje…',
     revealHeadlinePlaceholder: 'Revisando tus respuestas…',
     revealSubtitlePlaceholder: 'Añade una línea que tranquilice (opcional)',
@@ -1202,6 +1211,7 @@ const es: BuilderMessages = {
     close: 'Cerrar',
     noResults: 'No hay tipos que coincidan.',
     revealVerticalTaken: 'Ya añadida. Un formulario de una página muestra su revelación una vez, después de Enviar.',
+    fileStorageOff: 'Este despliegue no tiene configurada la subida de archivos.',
     items: {
       name: { title: 'Nombre', desc: 'Campo de nombre completo' },
       email: { title: 'Correo', desc: 'Correo validado' },
@@ -1213,6 +1223,7 @@ const es: BuilderMessages = {
       long: { title: 'Texto largo', desc: 'Párrafo' },
       url: { title: 'Sitio web', desc: 'URL validada' },
       slider: { title: 'Deslizador', desc: 'Escala de valoración' },
+      file: { title: 'Subir archivo', desc: 'Un documento o imagen' },
       message: { title: 'Mensaje', desc: 'Texto, sin campo' },
       reveal: {
         title: 'Pantalla de revelación',

--- a/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/canvas-question.tsx
@@ -469,6 +469,8 @@ function QuestionEditableBody({
           <NamePreview step={step} m={m} />
         ) : step.type === 'scheduler' ? (
           <SchedulerEmbedPreview step={step} m={m} />
+        ) : step.type === 'file' ? (
+          <FileDropPreview step={step} m={m} />
         ) : (
           <div className="rounded-xl border border-border bg-background px-4 py-3 text-[15px] text-muted-foreground/60">
             {step.placeholder ||
@@ -891,6 +893,27 @@ function RevealCanvas({
  * else the localized default) — so typing a placeholder in the settings panel
  * updates the canvas immediately, exactly as it will publish.
  */
+/**
+ * What the visitor will see: the idle drop zone, not a text placeholder.
+ *
+ * The builder canvas is the only place an author checks their work before
+ * publishing, so a file question that previewed as an empty input would be
+ * lying about the question it is. The accepted types come from the step so
+ * changing them in the settings panel is visible here immediately.
+ */
+function FileDropPreview({ step, m }: { step: FormStep; m: BuilderMessages }) {
+  const types = (step.allowedTypes ?? []).map((t) => t.toUpperCase()).join(', ');
+  return (
+    <div className="flex flex-col items-center gap-1.5 rounded-xl border border-dashed border-border bg-background px-4 py-6 text-center">
+      <i aria-hidden className="pi pi-paperclip text-muted-foreground/60" style={{ fontSize: 16 }} />
+      <span className="text-[15px] text-muted-foreground/60">
+        {step.placeholder || m.canvas.filePlaceholder}
+      </span>
+      {types ? <span className="text-xs text-muted-foreground/50">{types}</span> : null}
+    </div>
+  );
+}
+
 function NamePreview({ step, m }: { step: FormStep; m: BuilderMessages }) {
   const [firstField, secondField] = nameFields(step);
   const firstLabel = (firstField && step.placeholders?.[firstField]) || m.canvas.nameFirstPlaceholder;

--- a/apps/web/app/admin/forms/[id]/edit/_components/file-settings.spec.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/file-settings.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Extension parsing for the file question's settings.
+ *
+ * This is the one piece of that panel with a decision in it. The author types
+ * freely, and what they type becomes the list the public input filters on and
+ * the server checks against, so ".PDF", "pdf" and "  pdf , pdf " all have to
+ * arrive as the same single entry.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseExtensions } from './file-settings';
+
+describe('parseExtensions', () => {
+  it('lowercases and drops the leading dot', () => {
+    expect(parseExtensions('.PDF, .Docx')).toEqual(['pdf', 'docx']);
+  });
+
+  it('accepts commas, spaces or both as separators', () => {
+    expect(parseExtensions('pdf docx')).toEqual(['pdf', 'docx']);
+    expect(parseExtensions('pdf,docx')).toEqual(['pdf', 'docx']);
+    expect(parseExtensions('pdf,  docx,')).toEqual(['pdf', 'docx']);
+  });
+
+  it('de-duplicates, including across spellings', () => {
+    expect(parseExtensions('pdf, .pdf, PDF')).toEqual(['pdf']);
+  });
+
+  it('is empty for empty input rather than producing a blank extension', () => {
+    expect(parseExtensions('')).toEqual([]);
+    expect(parseExtensions('  ,  ,')).toEqual([]);
+    expect(parseExtensions('.')).toEqual([]);
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/file-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/file-settings.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+/**
+ * The `file` question's own settings: what it accepts, and how big.
+ *
+ * Presets rather than a raw extension box, because "pdf, doc, docx, odt, rtf"
+ * is not a decision a form author wants to make, and a plain text field is the
+ * kind of control that produces a question nobody can answer. The extension
+ * field is still there underneath for the author who genuinely needs .dwg, and
+ * the two stay in sync: ticking a preset writes its extensions into the same
+ * list the field edits.
+ *
+ * Every limit here is the author's PREFERENCE. The server enforces its own
+ * ceiling and its own denylist whatever this panel says, so nothing typed here
+ * can widen what the deployment accepts.
+ */
+import { useMemo } from 'react';
+import type { FormStep } from '@quill/engine';
+import { Field, NumberField, TextField } from './fields';
+import type { EditorMessages } from './messages';
+
+/** The groups an author picks from. Order is the order they render in. */
+const PRESETS = [
+  { id: 'documents', ext: ['pdf', 'doc', 'docx', 'txt'] },
+  { id: 'images', ext: ['jpg', 'png', 'gif', 'webp'] },
+  { id: 'sheets', ext: ['xls', 'xlsx', 'csv'] },
+  { id: 'archives', ext: ['zip'] },
+] as const;
+
+type PresetId = (typeof PRESETS)[number]['id'];
+
+function labelFor(id: PresetId, em: EditorMessages): string {
+  switch (id) {
+    case 'documents':
+      return em.props.filePresetDocuments;
+    case 'images':
+      return em.props.filePresetImages;
+    case 'sheets':
+      return em.props.filePresetSheets;
+    case 'archives':
+      return em.props.filePresetArchives;
+  }
+}
+
+/** Normalize what an author typed: lowercase, no dots, no blanks, no repeats. */
+export function parseExtensions(raw: string): string[] {
+  const seen = new Set<string>();
+  for (const piece of raw.split(/[,\s]+/)) {
+    const ext = piece.trim().toLowerCase().replace(/^\./, '');
+    if (ext) seen.add(ext);
+  }
+  return [...seen];
+}
+
+export function FileSettings({
+  step,
+  onUpdate,
+  em,
+  maxFileMb,
+}: {
+  step: FormStep;
+  onUpdate: (patch: Partial<FormStep>) => void;
+  em: EditorMessages;
+  maxFileMb: number;
+}) {
+  const allowed = useMemo(() => step.allowedTypes ?? [], [step.allowedTypes]);
+  const empty = allowed.length === 0;
+
+  // A preset is "on" when every extension it stands for is accepted. Partial
+  // overlap reads as off, so ticking it completes the set rather than doing
+  // nothing visible.
+  const isOn = (p: (typeof PRESETS)[number]): boolean => p.ext.every((e) => allowed.includes(e));
+
+  const toggle = (p: (typeof PRESETS)[number]): void => {
+    const next = isOn(p)
+      ? allowed.filter((e) => !(p.ext as readonly string[]).includes(e))
+      : [...allowed, ...p.ext.filter((e) => !allowed.includes(e))];
+    onUpdate({ allowedTypes: next });
+  };
+
+  return (
+    <section className="flex flex-col gap-3 border-t border-border pt-4">
+      <p className="text-2xs font-semibold uppercase tracking-wide text-faint">{em.types.file}</p>
+
+      <Field label={em.props.fileAllowedTypes} hint={em.props.fileAllowedTypesHint}>
+        <div className="flex flex-wrap gap-1.5 pb-2">
+          {PRESETS.map((p) => {
+            const on = isOn(p);
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="switch"
+                aria-checked={on}
+                onClick={() => toggle(p)}
+                className={
+                  on
+                    ? 'rounded-full border border-primary-edge/60 bg-primary/10 px-3 py-1 text-xs font-medium text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                    : 'rounded-full border border-border px-3 py-1 text-xs text-muted-foreground transition-colors hover:border-primary-edge/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                }
+              >
+                {labelFor(p.id, em)}
+              </button>
+            );
+          })}
+        </div>
+        <TextField
+          aria-label={em.props.fileAllowedTypes}
+          value={allowed.join(', ')}
+          onChange={(e) => onUpdate({ allowedTypes: parseExtensions(e.target.value) })}
+        />
+      </Field>
+
+      {/* An empty list is not "accept anything": the server still refuses what
+          the deployment denies, but the question becomes one the author almost
+          certainly did not mean, so it is called out rather than silently kept. */}
+      {empty ? (
+        <p role="alert" data-testid="file-no-types" className="flex gap-1.5 text-xs text-amber-600">
+          <i aria-hidden className="pi pi-exclamation-triangle mt-0.5 shrink-0" style={{ fontSize: 10 }} />
+          {em.props.fileNoTypes}
+        </p>
+      ) : null}
+
+      <Field
+        label={em.props.fileMaxSize}
+        hint={em.props.fileMaxSizeHint.replaceAll('{max}', String(maxFileMb))}
+      >
+        <NumberField
+          aria-label={em.props.fileMaxSize}
+          min={1}
+          max={maxFileMb}
+          value={step.maxSizeMb ?? ''}
+          onChange={(e) => {
+            const raw = e.target.value.trim();
+            if (raw === '') return onUpdate({ maxSizeMb: undefined });
+            // Clamped on commit, not per keystroke: clamping while typing eats
+            // digits, the way the slider bounds note explains.
+            const n = Math.floor(Number(raw));
+            onUpdate({ maxSizeMb: Number.isFinite(n) && n > 0 ? Math.min(n, maxFileMb) : undefined });
+          }}
+        />
+      </Field>
+    </section>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/logic-map.tsx
@@ -273,6 +273,8 @@ function galleryIdForStep(step: FormStep): GalleryItemId {
       return 'long';
     case 'url':
       return 'url';
+    case 'file':
+      return 'file';
     case 'message':
       return 'message';
     case 'text':

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-settings.tsx
@@ -27,6 +27,7 @@ import { describeCondition, liveGotoRules, liveRuleCount, optionLabel, splitGoto
 import { QuestionHubspotSection } from './question-hubspot';
 import { QuestionVariants } from './question-variants';
 import { SchedulerPanel } from './scheduler-panel';
+import { FileSettings } from './file-settings';
 import { tokenOptionsBefore } from './token-textarea';
 import { HelpTip } from '@/components/ui/help-tip';
 import {
@@ -109,6 +110,7 @@ export function QuestionSettings({
   onRenameKey,
   publicUrl,
   onOpenConnect,
+  uploads,
 }: {
   formId: string;
   step: FormStep;
@@ -138,6 +140,8 @@ export function QuestionSettings({
   publicUrl?: string | null;
   /** Switch the editor to the Connect tab (the mapping's other home). */
   onOpenConnect: () => void;
+  /** The deployment's file-answer ceiling, for the size field's own limit. */
+  uploads?: { enabled: boolean; maxFileMb: number };
 }) {
   const contact = isContactType(step.type);
   // Form-wide "highest possible" total (same math as Results). Drives the
@@ -586,6 +590,15 @@ export function QuestionSettings({
             </p>
           ) : null}
         </section>
+      ) : null}
+
+      {step.type === 'file' ? (
+        <FileSettings
+          step={step}
+          onUpdate={onUpdate}
+          em={em}
+          maxFileMb={uploads?.maxFileMb ?? 10}
+        />
       ) : null}
 
       {step.type === 'email' ? (

--- a/apps/web/app/admin/forms/[id]/edit/_components/question-types.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/question-types.ts
@@ -35,6 +35,7 @@ export const GALLERY: Record<GalleryGroup, GalleryItem[]> = {
     { id: 'long', type: 'textarea', icon: 'pi-align-left' },
     { id: 'url', type: 'url', icon: 'pi-globe' },
     { id: 'slider', type: 'slider', icon: 'pi-sliders-h' },
+    { id: 'file', type: 'file', icon: 'pi-paperclip' },
   ],
   content: [
     { id: 'message', type: 'message', icon: 'pi-comment' },
@@ -64,6 +65,8 @@ export function iconForStep(step: Pick<FormStep, 'type' | 'selectionMode'>): str
       return 'pi-align-left';
     case 'text':
       return 'pi-minus';
+    case 'file':
+      return 'pi-paperclip';
     case 'url':
       return 'pi-globe';
     case 'message':

--- a/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/form-editor.tsx
@@ -124,6 +124,7 @@ export function FormEditor({
   initialHasDraft = false,
   updatedAt,
   lockedValues = {},
+  uploads,
 }: {
   id: string;
   initialName: string;
@@ -141,6 +142,12 @@ export function FormEditor({
    * points at. See `lockedOptionValues`.
    */
   lockedValues?: Record<string, string[]>;
+  /**
+   * What this deployment can do with file answers. Absent or disabled hides the
+   * file question from the gallery: offering an author a question the server
+   * would refuse to accept an answer to is worse than not offering it.
+   */
+  uploads?: { enabled: boolean; maxFileMb: number };
 }) {
   const bm = getBuilderMessages(locale);
   const searchParams = useSearchParams();
@@ -988,6 +995,7 @@ export function FormEditor({
                 {selectedStep && selected != null ? (
                   <QuestionSettings
                     formId={id}
+                    uploads={uploads}
                     onOpenConnect={() => setTab('connect')}
                     publicUrl={publicPath}
                     step={selectedStep}
@@ -1086,11 +1094,12 @@ export function FormEditor({
         m={bm}
         // Vertical: one reveal, always at the end — a second tile pick would
         // create a card the renderer ignores, so it's offered exactly once.
-        disabled={
-          layout === 'vertical' && hasReveal
-            ? { reveal: bm.gallery.revealVerticalTaken }
-            : undefined
-        }
+        disabled={{
+          // One reveal, always at the end: a second tile pick would create a
+          // card the vertical renderer ignores.
+          ...(layout === 'vertical' && hasReveal ? { reveal: bm.gallery.revealVerticalTaken } : {}),
+          ...(uploads?.enabled ? {} : { file: bm.gallery.fileStorageOff }),
+        }}
       />
       {/* The three form-wide views. Branching edits INLINE (R7) — same
           LogicRules/LogicConditions the per-question dialog hosts, same

--- a/apps/web/app/admin/forms/[id]/edit/page.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/page.tsx
@@ -40,6 +40,10 @@ export default async function EditFormPage({ params }: { params: Promise<{ id: s
         // against it, or a CRM mapping pointing at it), and the draft knows
         // neither. Computed here so the builder never pays a request for it.
         lockedValues={lockedOptionValues(form.config)}
+        // A DEPLOYMENT capability, reported by the API rather than read from
+        // the dashboard's own env: two copies of this switch that disagreed
+        // would offer a question whose answers the API refuses.
+        uploads={me.uploads}
         updatedAt={form.updatedAt}
         publicPath={publicPath}
         locale={locale}

--- a/apps/web/app/admin/forms/[id]/integrations/auto-map.spec.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/auto-map.spec.ts
@@ -76,3 +76,20 @@ describe('suggestProperty', () => {
     expect(suggestProperty(q({ key: 'company' }), propertyLookup([{ name: 'email' }]))).toBeNull();
   });
 });
+
+describe('file questions', () => {
+  it('suggests no property: a file answer has none it could fill', () => {
+    expect(suggestProperty(q({ key: 'cv', label: 'Upload your CV', type: 'file' }), HUBSPOT)).toBeNull();
+  });
+
+  it('is not dragged into a mapping by the words in its question', () => {
+    // "company logo" would otherwise match the `company` sweep and put a PDF
+    // into a text property.
+    expect(
+      suggestProperty(q({ key: 'logo', label: 'Upload your company logo', type: 'file' }), HUBSPOT),
+    ).toBeNull();
+    expect(
+      suggestProperty(q({ key: 'site', label: 'Attach your website export', type: 'file' }), HUBSPOT),
+    ).toBeNull();
+  });
+});

--- a/apps/web/app/admin/forms/[id]/integrations/auto-map.ts
+++ b/apps/web/app/admin/forms/[id]/integrations/auto-map.ts
@@ -35,6 +35,11 @@ export function suggestProperty(q: QuestionMeta, byLower: Map<string, string>): 
   if (type === 'phone' || /phone|mobile|whats\s?app|tel[eé]fono|celular|\btel\b/.test(hay))
     return pick('mobilephone', 'phone');
   if (type === 'url') return pick('website');
+  // A file answer is an object holding an object key, so there is no contact
+  // property it could sensibly fill. Returning early also stops the keyword
+  // sweep below from matching on a question like "Upload your company logo"
+  // and mapping a PDF into `company`.
+  if (type === 'file') return null;
   if (/last\s?name|surname|apellidos?/.test(hay)) return pick('lastname');
   if (/first\s?name|given\s?name|primer\s?nombre/.test(hay)) return pick('firstname');
   // Website before company so "company website" maps to website, not company.

--- a/apps/web/app/admin/forms/[id]/submissions/actions.ts
+++ b/apps/web/app/admin/forms/[id]/submissions/actions.ts
@@ -8,3 +8,26 @@ export async function deleteSubmissionAction(formId: string, submissionId: strin
   await adminApi.deleteSubmission(submissionId);
   revalidatePath(`/admin/forms/${formId}/submissions`);
 }
+
+/**
+ * Mint a short-lived download URL for one uploaded file.
+ *
+ * A server action rather than a direct client call, because `adminApi` carries
+ * the session cookie and is server-only. Nothing is revalidated: reading a file
+ * changes no state on the page.
+ */
+export async function submissionFileUrlAction(
+  formId: string,
+  submissionId: string,
+  stepKey: string,
+): Promise<{ ok: true; url: string } | { ok: false }> {
+  try {
+    const { url } = await adminApi.submissionFile(formId, submissionId, stepKey);
+    return { ok: true, url };
+  } catch {
+    // Expired, deleted, or not this account's. The button says so; the reason
+    // stays here, because telling a caller which of those it was would confirm
+    // that another workspace's submission exists.
+    return { ok: false };
+  }
+}

--- a/apps/web/app/admin/forms/[id]/submissions/download-file-button.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/download-file-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+/**
+ * Opens one uploaded file from the submissions table.
+ *
+ * The URL is fetched on click rather than rendered into the page, and that is
+ * the point: a download link is a signed URL that expires in minutes, so a
+ * table of fifty rows rendered with fifty live URLs would be fifty credentials
+ * sitting in the HTML, most of them dead by the time anyone clicked. Asking for
+ * one at the moment of the click means the link is always fresh and never
+ * exists anywhere it does not need to.
+ */
+import { useState } from 'react';
+import { submissionFileUrlAction } from './actions';
+import { callAction, isTransportError } from '@/lib/call-action';
+
+export function DownloadFileButton({
+  formId,
+  submissionId,
+  stepKey,
+  name,
+  labels,
+}: {
+  formId: string;
+  submissionId: string;
+  stepKey: string;
+  /** The respondent's own filename, which is the only useful label. */
+  name: string;
+  labels: { download: string; failed: string };
+}) {
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const open = async (): Promise<void> => {
+    setBusy(true);
+    setFailed(false);
+    const r = await callAction(() => submissionFileUrlAction(formId, submissionId, stepKey));
+    setBusy(false);
+    if (isTransportError(r) || !r.ok) {
+      setFailed(true);
+      return;
+    }
+    // A new tab, not a navigation: the signed URL responds as an attachment,
+    // so the tab closes itself once the download starts and the dashboard page
+    // the person was reading is still there behind it.
+    window.open(r.url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => void open()}
+      disabled={busy}
+      title={failed ? labels.failed : `${labels.download}: ${name}`}
+      className="inline-flex max-w-full items-center gap-1.5 truncate text-left underline decoration-dotted underline-offset-2 hover:decoration-solid disabled:opacity-60"
+    >
+      <i aria-hidden className="pi pi-paperclip shrink-0" style={{ fontSize: 11 }} />
+      <span className="truncate">{name}</span>
+    </button>
+  );
+}

--- a/apps/web/app/admin/forms/[id]/submissions/page.tsx
+++ b/apps/web/app/admin/forms/[id]/submissions/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import type { FormConfig, SubmissionsPage } from '@quill/types';
+import { parseFileAnswer } from '@quill/engine';
 import { formatDateTime, getMessages, t, type FormsMessages, type Locale } from '@quill/shared';
 import { adminApi, ApiError, isAdminRole } from '@/lib/admin-api';
 import { WorkspaceTimezoneField } from '@/app/admin/_components/workspace-timezone-field';
@@ -10,6 +11,7 @@ import { FormTabs } from '@/components/ui/form-tabs';
 import { Skeleton } from '@/components/skeleton';
 import { SubmissionsFilter } from './submissions-filter';
 import { DeleteSubmissionButton } from './row-actions';
+import { DownloadFileButton } from './download-file-button';
 
 export const dynamic = 'force-dynamic';
 
@@ -99,6 +101,10 @@ function formatCell(v: unknown, na: string): string {
   if (v == null || v === '') return na;
   if (Array.isArray(v)) return v.length ? v.join(', ') : na;
   if (typeof v === 'boolean') return v ? '✓' : '';
+  // A file answer is an object. Without this it stringified to [object Object],
+  // and the title attribute of every file cell said so.
+  const file = parseFileAnswer(v as never);
+  if (file) return file.name;
   return String(v);
 }
 
@@ -207,11 +213,33 @@ async function SubmissionsData({
                     </span>
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums">{row.score}</td>
-                  {steps.map((s) => (
-                    <td key={s.key} className="max-w-[240px] truncate px-4 py-3" title={formatCell(data[s.key], '')}>
-                      {formatCell(data[s.key], m.submissions.na)}
-                    </td>
-                  ))}
+                  {steps.map((s) => {
+                    // A file cell is the one answer that is not text: it opens
+                    // the thing rather than describing it.
+                    const file = s.type === 'file' ? parseFileAnswer(data[s.key] as never) : null;
+                    return (
+                      <td
+                        key={s.key}
+                        className="max-w-[240px] truncate px-4 py-3"
+                        title={formatCell(data[s.key], '')}
+                      >
+                        {file ? (
+                          <DownloadFileButton
+                            formId={id}
+                            submissionId={row.id}
+                            stepKey={s.key}
+                            name={file.name}
+                            labels={{
+                              download: m.submissions.download,
+                              failed: m.submissions.downloadFailed,
+                            }}
+                          />
+                        ) : (
+                          formatCell(data[s.key], m.submissions.na)
+                        )}
+                      </td>
+                    );
+                  })}
                   <td className="whitespace-nowrap px-4 py-3 text-right">
                     <DeleteSubmissionButton
                       formId={id}

--- a/apps/web/components/public/file-upload-input.spec.tsx
+++ b/apps/web/components/public/file-upload-input.spec.tsx
@@ -1,0 +1,95 @@
+/**
+ * The `file` step's static render, through `StepInput` the way the renderers
+ * reach it.
+ *
+ * Static markup only, which is the right depth here: the upload itself is an
+ * XMLHttpRequest to a bucket, and a jsdom test of that would be a test of a
+ * mock. What IS worth pinning is everything a visitor sees before any byte
+ * moves, plus the one rule that is a real decision rather than styling: with no
+ * upload route, the step renders nothing instead of a control that would fail
+ * on the first click.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { FormStep } from '@quill/engine';
+import { StepInput } from './step-input';
+
+const step: FormStep = {
+  key: 'cv',
+  type: 'file',
+  question: 'Upload your CV',
+  required: true,
+  allowedTypes: ['pdf', 'docx'],
+};
+
+function render(over: Partial<Parameters<typeof StepInput>[0]> = {}, s: FormStep = step) {
+  return renderToStaticMarkup(
+    <StepInput
+      step={s}
+      value={null}
+      answers={{}}
+      onChange={() => {}}
+      onFieldChange={() => {}}
+      onSelect={() => {}}
+      dropdownPlaceholder="Pick one"
+      dropdownEmpty="No matches"
+      onRequestUpload={async () => ({ ok: false, message: 'no' })}
+      uploadMaxMb={10}
+      {...over}
+    />,
+  );
+}
+
+describe('file step', () => {
+  it('renders nothing at all when the deployment has no upload route', () => {
+    expect(render({ onRequestUpload: undefined })).toBe('');
+  });
+
+  it('offers the picker, with the accepted extensions on the native input', () => {
+    const html = render();
+    expect(html).toContain('data-testid="upload-choose"');
+    expect(html).toContain('type="file"');
+    expect(html).toContain('accept=".pdf,.docx"');
+  });
+
+  it('tells the visitor what is accepted and how big, before they pick', () => {
+    const html = render();
+    expect(html).toContain('PDF, DOCX');
+    expect(html).toContain('10 MB');
+  });
+
+  it("caps the shown limit at the deployment ceiling, never the owner's larger number", () => {
+    const html = render({}, { ...step, maxSizeMb: 500 });
+    expect(html).toContain('10 MB');
+    expect(html).not.toContain('500 MB');
+  });
+
+  it("uses the owner's own lower limit when they set one", () => {
+    expect(render({}, { ...step, maxSizeMb: 2 })).toContain('2 MB');
+  });
+
+  it('shows the uploaded filename, not the object key, once an answer exists', () => {
+    const html = render({
+      value: {
+        key: 'uploads/acct/form/sess/9f3c.pdf',
+        name: 'Ada Lovelace CV.pdf',
+        size: '40211',
+        mime: 'application/pdf',
+      } as never,
+    });
+    expect(html).toContain('Ada Lovelace CV.pdf');
+    expect(html).not.toContain('9f3c');
+    expect(html).not.toContain('uploads/');
+    expect(html).toContain('data-testid="upload-done"');
+  });
+
+  it('honors the placeholder the author wrote', () => {
+    expect(render({}, { ...step, placeholder: 'Attach your portfolio' })).toContain(
+      'Attach your portfolio',
+    );
+  });
+
+  it('renders Spanish copy for a Spanish form', () => {
+    expect(render({ locale: 'es' })).toContain('Elige un archivo');
+  });
+});

--- a/apps/web/components/public/file-upload-input.tsx
+++ b/apps/web/components/public/file-upload-input.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+/**
+ * The `file` step's control: pick a file, watch it upload, keep going.
+ *
+ * The upload happens the moment a file is chosen, not on Continue. A visitor
+ * who picks a 9 MB PDF and immediately presses the button would otherwise sit
+ * on a frozen screen with nothing to look at, and the answer this step commits
+ * is a reference to an object that has to already exist.
+ *
+ * Three moving parts, in order: ask the server action for a signed URL, PUT the
+ * bytes straight to the bucket, then hand the step an answer describing what
+ * landed. Only the last one is state the form cares about, so a failure at
+ * either of the first two leaves the answer untouched and the step invalid,
+ * which is exactly what the engine's required check already knows how to say.
+ *
+ * XMLHttpRequest rather than fetch, deliberately: `fetch` still cannot report
+ * upload progress, and a progress bar is the entire difference between this
+ * feeling broken and feeling normal on a slow connection.
+ */
+import { useCallback, useRef, useState } from 'react';
+import type { AnswerValue, FormStep } from '@quill/engine';
+import { getMessages } from '@quill/shared';
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'uploading'; percent: number; name: string }
+  | { kind: 'failed'; message: string };
+
+export interface UploadTicket {
+  url: string;
+  key: string;
+  contentType: string;
+}
+
+export type RequestTicket = (file: {
+  name: string;
+  size: number;
+  mime: string;
+}) => Promise<{ ok: true; ticket: UploadTicket } | { ok: false; message: string }>;
+
+/** PUT the bytes, reporting progress. Resolves false when the bucket refuses. */
+function put(url: string, contentType: string, file: File, onProgress: (pct: number) => void): Promise<boolean> {
+  return new Promise((resolve) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('PUT', url, true);
+    // Must match the signature byte for byte, or S3 rejects it before storing.
+    xhr.setRequestHeader('Content-Type', contentType);
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
+    };
+    xhr.onload = () => resolve(xhr.status >= 200 && xhr.status < 300);
+    xhr.onerror = () => resolve(false);
+    xhr.onabort = () => resolve(false);
+    xhr.send(file);
+  });
+}
+
+export function FileUploadInput({
+  step,
+  value,
+  onChange,
+  requestTicket,
+  locale,
+  maxSizeMb,
+}: {
+  step: FormStep;
+  value: AnswerValue;
+  onChange: (value: AnswerValue) => void;
+  requestTicket: RequestTicket;
+  locale?: string;
+  /** The deployment's ceiling, so the visitor is told before a pointless upload. */
+  maxSizeMb: number;
+}) {
+  const m = getMessages(locale ?? 'en').renderer.upload;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+
+  const allowed = step.allowedTypes ?? [];
+  const limitMb = Math.min(step.maxSizeMb && step.maxSizeMb > 0 ? step.maxSizeMb : maxSizeMb, maxSizeMb);
+  const accept = allowed.map((e) => `.${e}`).join(',');
+
+  // The committed answer, if there is one. Its shape is the engine's, and the
+  // only field worth showing is the name the visitor's own file had.
+  const uploaded =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string>)
+      : null;
+
+  const onPick = useCallback(
+    async (file: File | undefined) => {
+      if (!file) return;
+
+      // Checked here so an obviously doomed upload never starts. The server
+      // checks both again on its own; this is courtesy, not enforcement.
+      if (file.size > limitMb * 1_000_000) {
+        setPhase({ kind: 'failed', message: m.tooLarge.replaceAll('{max}', String(limitMb)) });
+        return;
+      }
+      const ext = /\.([A-Za-z0-9]{1,12})$/.exec(file.name)?.[1]?.toLowerCase() ?? '';
+      if (allowed.length > 0 && !allowed.includes(ext)) {
+        setPhase({ kind: 'failed', message: m.wrongType });
+        return;
+      }
+
+      setPhase({ kind: 'uploading', percent: 0, name: file.name });
+      const ticket = await requestTicket({
+        name: file.name,
+        size: file.size,
+        mime: file.type || 'application/octet-stream',
+      });
+      if (!ticket.ok) {
+        setPhase({ kind: 'failed', message: ticket.message });
+        return;
+      }
+
+      const ok = await put(ticket.ticket.url, ticket.ticket.contentType, file, (percent) =>
+        setPhase({ kind: 'uploading', percent, name: file.name }),
+      );
+      if (!ok) {
+        setPhase({ kind: 'failed', message: m.failed });
+        return;
+      }
+
+      setPhase({ kind: 'idle' });
+      onChange({
+        key: ticket.ticket.key,
+        name: file.name,
+        size: String(file.size),
+        mime: ticket.ticket.contentType,
+      });
+    },
+    [allowed, limitMb, m, onChange, requestTicket],
+  );
+
+  const reset = useCallback(() => {
+    setPhase({ kind: 'idle' });
+    onChange(null);
+    if (inputRef.current) inputRef.current.value = '';
+  }, [onChange]);
+
+  return (
+    <div className="pf-upload">
+      <input
+        ref={inputRef}
+        type="file"
+        className="sr-only"
+        accept={accept || undefined}
+        aria-label={step.question ?? step.key}
+        onChange={(e) => void onPick(e.target.files?.[0])}
+      />
+
+      {uploaded ? (
+        <div className="pf-upload-file" data-testid="upload-done">
+          <i aria-hidden className="pi pi-paperclip" />
+          <span className="pf-upload-name">{uploaded.name}</span>
+          <button type="button" className="pf-upload-remove" onClick={reset}>
+            {m.remove}
+          </button>
+        </div>
+      ) : phase.kind === 'uploading' ? (
+        <div
+          className="pf-upload-progress"
+          role="progressbar"
+          aria-valuenow={phase.percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          data-testid="upload-progress"
+        >
+          <span className="pf-upload-name">{phase.name}</span>
+          <span className="pf-upload-bar">
+            <span className="pf-upload-bar-fill" style={{ width: `${phase.percent}%` }} />
+          </span>
+          <span className="pf-upload-percent">
+            {m.uploading.replaceAll('{percent}', String(phase.percent))}
+          </span>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="pf-upload-drop"
+          onClick={() => inputRef.current?.click()}
+          data-testid="upload-choose"
+        >
+          <i aria-hidden className="pi pi-paperclip" />
+          <span className="pf-upload-cta">{step.placeholder || m.choose}</span>
+          <span className="pf-upload-accepts">
+            {m.accepts
+              .replaceAll('{types}', allowed.map((e) => e.toUpperCase()).join(', '))
+              .replaceAll('{max}', String(limitMb))}
+          </span>
+        </button>
+      )}
+
+      {phase.kind === 'failed' ? (
+        <p role="alert" className="pf-upload-error" data-testid="upload-error">
+          {phase.message}{' '}
+          <button type="button" className="pf-upload-retry" onClick={() => inputRef.current?.click()}>
+            {m.retry}
+          </button>
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/public/step-input.tsx
+++ b/apps/web/components/public/step-input.tsx
@@ -15,6 +15,7 @@ import {
 import { getMessages } from '@quill/shared';
 import { SearchableDropdown } from './searchable-dropdown';
 import { PhoneInput } from './phone-input';
+import { FileUploadInput, type RequestTicket } from './file-upload-input';
 
 interface StepInputProps {
   step: FormStep;
@@ -43,6 +44,15 @@ interface StepInputProps {
    * fire the `start`/`step_complete` funnel events a real interaction fires.
    */
   onSeed?: (value: AnswerValue) => void;
+  /**
+   * Authorizes one file upload, for a `file` step. Supplied by the renderers,
+   * which know the form's public coordinates; the input itself stays ignorant
+   * of routing. Absent means the step renders nothing to upload with, which is
+   * correct: a deployment with no storage cannot have published this question.
+   */
+  onRequestUpload?: (stepKey: string, file: Parameters<RequestTicket>[0]) => ReturnType<RequestTicket>;
+  /** The deployment's per-file ceiling in MB, for the accepted-files line. */
+  uploadMaxMb?: number;
 }
 
 /** The current multi-select answer as a string[] (defensive against scalars). */
@@ -106,6 +116,8 @@ export function StepInput({
   locale = 'en',
   autoFocus = true,
   onSeed,
+  onRequestUpload,
+  uploadMaxMb,
 }: StepInputProps) {
   switch (step.type) {
     case 'name': {
@@ -194,6 +206,22 @@ export function StepInput({
           placeholder={step.placeholder ?? ''}
           aria-label={step.question ?? step.key}
           autoFocus={autoFocus}
+        />
+      );
+
+    case 'file':
+      // No upload route means the deployment has no storage, and a form with
+      // this question could not have been published there. Rendering nothing
+      // beats rendering a control that would fail on the first click.
+      if (!onRequestUpload) return null;
+      return (
+        <FileUploadInput
+          step={step}
+          value={value}
+          onChange={onChange}
+          requestTicket={(file) => onRequestUpload(step.key, file)}
+          locale={locale}
+          maxSizeMb={uploadMaxMb ?? 10}
         />
       );
 

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -201,6 +201,12 @@ export interface Me {
    * campaign, which is most of the reason to measure it.
    */
   attribution: Record<string, string | number | null | undefined> | null;
+  /**
+   * What this DEPLOYMENT can do with file answers. `enabled` is false wherever
+   * no bucket is configured, which is every bare fork: the builder hides the
+   * question type rather than offering one that could never be answered.
+   */
+  uploads: { enabled: boolean; maxFileMb: number };
   /** `'staff'` when the caller is in this workspace by access grant, not by membership. */
   accessGrant: 'staff' | null;
   /** Staff of the deployment (by email domain, identity-backed only): may search and enter the whole estate. */
@@ -586,6 +592,12 @@ export const adminApi = {
   // Forms
   listForms: () => req<FormSummary[]>('GET', '/v1/forms'),
   getForm: (id: string) => req<FormDetail>('GET', `/v1/forms/${id}`),
+  /** A short-lived signed URL for one uploaded file. Minted per click, never stored. */
+  submissionFile: (formId: string, submissionId: string, stepKey: string) =>
+    req<{ url: string; name: string }>(
+      'GET',
+      `/v1/forms/${formId}/submissions/${submissionId}/files/${encodeURIComponent(stepKey)}`,
+    ),
   createForm: (b: { name: string; slug?: string; config?: unknown; folderId?: string | null }) =>
     req<FormDetail>('POST', '/v1/forms', b),
   updateForm: (id: string, b: { name?: string; config?: unknown }) =>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -4,7 +4,7 @@
  * decoupled.
  */
 import { cache } from 'react';
-import type { PublicForm, PublicProfile } from '@quill/types';
+import type { PublicForm, PublicProfile, UploadPresignInput, UploadPresignResult } from '@quill/types';
 import { serverApiUrl } from './api-url';
 import { forwardedForHeader } from './forwarded-for';
 
@@ -91,4 +91,43 @@ export async function postFormEvent(
       cache: 'no-store',
     },
   ).catch(() => undefined);
+}
+
+export type PresignResult =
+  | { ok: true; upload: UploadPresignResult }
+  | { ok: false; status: number; error: string; message: string };
+
+/**
+ * Ask the API to authorize one file upload.
+ *
+ * Server-side like every other call here, and for the same reason: it forwards
+ * the visitor's own `X-Forwarded-For`, so the API's per-IP rate limit still
+ * sees the visitor rather than this web server. A browser calling the API
+ * directly would need the API's CORS allowlist to name every embed origin;
+ * going through the server action keeps that surface at zero.
+ */
+export async function postUploadPresign(
+  accountCode: string,
+  slug: string,
+  body: UploadPresignInput,
+): Promise<PresignResult> {
+  const res = await fetch(
+    `${API_URL}/v1/public/forms/${encodeURIComponent(accountCode)}/${encodeURIComponent(slug)}/uploads`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(await forwardedForHeader()) },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
+  );
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (res.ok && typeof json.url === 'string') {
+    return { ok: true, upload: json as unknown as UploadPresignResult };
+  }
+  return {
+    ok: false,
+    status: res.status,
+    error: (json.error as string) ?? 'UPLOAD_FAILED',
+    message: (json.message as string) ?? 'Could not upload that file.',
+  };
 }

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -470,6 +470,32 @@ export type DeleteSubmissionResult = 'deleted' | 'absent' | 'forbidden';
  * are distinguished (a second existence probe) so the HTTP layer can idempotent-
  * 204 a genuine already-gone row while 404-ing a cross-account id.
  */
+/**
+ * One submission's answers, but only if the caller's account owns it.
+ *
+ * The JOIN is the whole point: a submission id is guessable enough that reading
+ * one by id alone would let any signed-in account read any other account's
+ * answers. Returns null for "not yours" and for "does not exist" alike, because
+ * the caller must not be able to tell those apart either.
+ */
+export async function getSubmissionAnswersForAccount(
+  db: Db,
+  accountId: string,
+  submissionId: string,
+): Promise<{ formId: string; data: unknown } | null> {
+  const row = await db.get<{ form_id: string; data: unknown }>(
+    sql`SELECT s.form_id, s.data FROM submission s
+        JOIN form f ON f.id = s.form_id
+        WHERE s.id = ${submissionId} AND f.account_id = ${accountId} LIMIT 1`,
+  );
+  if (!row) return null;
+  return {
+    formId: row.form_id,
+    // Postgres hands back parsed jsonb; SQLite hands back the JSON text.
+    data: typeof row.data === 'string' ? JSON.parse(row.data) : row.data,
+  };
+}
+
 export async function deleteSubmissionForAccount(
   db: Db,
   accountId: string,

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -102,6 +102,23 @@ export interface FormsMessages {
       /** Inline hint when the typed number is shorter than the country issues. */
       invalid: string;
     };
+    /** The `file` step's upload control. */
+    upload: {
+      /** The idle drop zone's own call to action. */
+      choose: string;
+      /** Sub-line under it: what is accepted and how big. `{types}` and `{max}`. */
+      accepts: string;
+      /** Progress label while the bytes are moving. `{percent}`. */
+      uploading: string;
+      /** Removes the uploaded file and returns the control to idle. */
+      remove: string;
+      /** The upload did not finish. Offers another try. */
+      failed: string;
+      retry: string;
+      /** Refused before anything was sent. `{max}` is the limit in MB. */
+      tooLarge: string;
+      wrongType: string;
+    };
     /** The `name` step's two inputs — localized defaults rendered when the
      *  builder leaves a placeholder empty (also the editor preview fallback). */
     name: {
@@ -639,6 +656,7 @@ export interface FormsMessages {
         slider: string;
         textarea: string;
         message: string;
+        file: string;
       };
       props: {
         type: string;
@@ -655,6 +673,18 @@ export interface FormsMessages {
         flowGroupHint: string;
         corporateEmailOnly: string;
         corporateEmailHint: string;
+        /** File step: the extensions this question accepts. */
+        fileAllowedTypes: string;
+        fileAllowedTypesHint: string;
+        /** File step: preset groups the owner picks from instead of typing extensions. */
+        filePresetDocuments: string;
+        filePresetImages: string;
+        filePresetSheets: string;
+        filePresetArchives: string;
+        /** File step: the owner's own size limit, capped by the deployment. */
+        fileMaxSize: string;
+        fileMaxSizeHint: string;
+        fileNoTypes: string;
         phoneMinDigits: string;
         /** Phone step: label for the per-form default-country picker (V4-14). */
         phoneDefaultCountry: string;
@@ -1207,6 +1237,9 @@ export interface FormsMessages {
       export: string;
       delete: string;
       deleteConfirm: string;
+      /** File answer: opens the uploaded file in a new tab. */
+      download: string;
+      downloadFailed: string;
       emptyTitle: string;
       emptyBody: string;
       prev: string;
@@ -1812,6 +1845,16 @@ export const en: FormsMessages = {
       noResults: 'No countries found',
       invalid: 'Enter a valid phone number.',
     },
+    upload: {
+      choose: 'Choose a file',
+      accepts: '{types}, up to {max} MB',
+      uploading: 'Uploading {percent}%',
+      remove: 'Remove',
+      failed: 'That upload did not finish.',
+      retry: 'Try again',
+      tooLarge: 'That file is bigger than {max} MB.',
+      wrongType: 'That kind of file is not accepted here.',
+    },
     name: {
       firstPlaceholder: 'First name',
       lastPlaceholder: 'Last name',
@@ -2299,6 +2342,7 @@ export const en: FormsMessages = {
         slider: 'Slider',
         textarea: 'Long text',
         message: 'Message (no input)',
+        file: 'File upload',
       },
       props: {
         type: 'Type',
@@ -2315,6 +2359,16 @@ export const en: FormsMessages = {
         flowGroupHint: 'Lead-capture fields (name, email, phone) never contribute to the score.',
         corporateEmailOnly: 'Require work email',
         corporateEmailHint: 'Blocks Gmail, Hotmail, Yahoo and other personal domains.',
+        fileAllowedTypes: 'Accepted files',
+        fileAllowedTypesHint:
+          'Pick the groups you accept, or type extensions separated by commas. Programs and web pages are never accepted.',
+        filePresetDocuments: 'Documents',
+        filePresetImages: 'Images',
+        filePresetSheets: 'Spreadsheets',
+        filePresetArchives: 'Archives',
+        fileMaxSize: 'Largest file (MB)',
+        fileMaxSizeHint: 'Up to {max} MB on this deployment. Leave empty to allow the full {max} MB.',
+        fileNoTypes: 'Choose at least one kind of file, or nobody can answer this question.',
         phoneMinDigits: 'Minimum digits',
         phoneMinDigitsHelp:
           'The shortest number accepted, not counting the country code. Phone lengths vary by country, so this is the floor that catches an obviously incomplete number.',
@@ -2796,6 +2850,8 @@ export const en: FormsMessages = {
       export: 'Download CSV',
       delete: 'Delete',
       deleteConfirm: 'Delete this submission? This cannot be undone.',
+      download: 'Download',
+      downloadFailed: 'That file could not be opened.',
       emptyTitle: 'No submissions yet',
       emptyBody: 'Responses will show up here as people complete the form.',
       prev: 'Previous',
@@ -3361,6 +3417,16 @@ export const es: FormsMessages = {
       noResults: 'No se encontraron países',
       invalid: 'Introduce un número de teléfono válido.',
     },
+    upload: {
+      choose: 'Elige un archivo',
+      accepts: '{types}, hasta {max} MB',
+      uploading: 'Subiendo {percent}%',
+      remove: 'Quitar',
+      failed: 'La subida no terminó.',
+      retry: 'Intenta de nuevo',
+      tooLarge: 'Ese archivo pesa más de {max} MB.',
+      wrongType: 'Ese tipo de archivo no se acepta aquí.',
+    },
     name: {
       firstPlaceholder: 'Nombre',
       lastPlaceholder: 'Apellidos',
@@ -3850,6 +3916,7 @@ export const es: FormsMessages = {
         slider: 'Deslizador',
         textarea: 'Texto largo',
         message: 'Mensaje (sin campo)',
+        file: 'Subir archivo',
       },
       props: {
         type: 'Tipo',
@@ -3866,6 +3933,16 @@ export const es: FormsMessages = {
         flowGroupHint: 'Los campos de captura (nombre, correo, teléfono) nunca suman al puntaje.',
         corporateEmailOnly: 'Exigir correo corporativo',
         corporateEmailHint: 'Bloquea Gmail, Hotmail, Yahoo y otros dominios personales.',
+        fileAllowedTypes: 'Archivos aceptados',
+        fileAllowedTypesHint:
+          'Elige los grupos que aceptas, o escribe extensiones separadas por comas. Los programas y las páginas web nunca se aceptan.',
+        filePresetDocuments: 'Documentos',
+        filePresetImages: 'Imágenes',
+        filePresetSheets: 'Hojas de cálculo',
+        filePresetArchives: 'Comprimidos',
+        fileMaxSize: 'Archivo más grande (MB)',
+        fileMaxSizeHint: 'Hasta {max} MB en este despliegue. Déjalo vacío para permitir los {max} MB completos.',
+        fileNoTypes: 'Elige al menos un tipo de archivo, o nadie podrá responder esta pregunta.',
         phoneMinDigits: 'Dígitos mínimos',
         phoneMinDigitsHelp:
           'El número más corto que se acepta, sin contar el código de país. La longitud varía según el país, así que este es el piso que atrapa un número claramente incompleto.',
@@ -4349,6 +4426,8 @@ export const es: FormsMessages = {
       export: 'Descargar CSV',
       delete: 'Eliminar',
       deleteConfirm: '¿Eliminar esta respuesta? No se puede deshacer.',
+      download: 'Descargar',
+      downloadFailed: 'No se pudo abrir ese archivo.',
       emptyTitle: 'Aún no hay respuestas',
       emptyBody: 'Las respuestas aparecerán aquí a medida que las personas completen el formulario.',
       prev: 'Anterior',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1225,6 +1225,13 @@ export const publicFormSchema = z.object({
   slug: z.string(),
   name: z.string(),
   config: formConfigSchema,
+  /**
+   * The deployment's per-file ceiling in MB, for a form that asks for a file.
+   * The renderer needs it to tell a visitor "up to 10 MB" before they pick a
+   * 40 MB video, and only the API knows the number. Absent on a deployment
+   * with no storage, which is also one that cannot have published such a form.
+   */
+  uploadMaxMb: z.number().int().positive().optional(),
 });
 export type PublicForm = z.infer<typeof publicFormSchema>;
 


### PR DESCRIPTION
Re-targets the work from [#160](https://github.com/Dapta-Tech/dapta-forms/pull/160), which merged into `feat/file-upload-storage` instead of `develop` and therefore never reached it. That base branch had already been merged and closed by [#159](https://github.com/Dapta-Tech/dapta-forms/pull/159), so the UI half has been sitting on a dead branch.

Same commit, reviewed in #160, nothing added. One commit ahead of `develop`, no conflicts.

`develop` currently has the storage groundwork and nothing a person can see, which is by design but is also not a state worth leaving it in: the question type exists in the engine and the API with no way to add it to a form.

## What it lands

**Builder.** A File upload tile in the gallery's Text group, with four preset groups over a plain extension field, a size cap that reads the deployment's own ceiling from the API, and a canvas preview that draws the real drop zone rather than a text placeholder.

**Public form.** The upload starts when the file is chosen, not on Continue, with a progress bar over XMLHttpRequest because fetch cannot report upload progress. Both layouts. The presign goes through a server action so the visitor's own address still reaches the rate limiter and no embed origin needs a CORS entry, and through `callAction` so a deploy rotating action ids cannot strand the control mid-upload.

**Submissions table.** A file answer renders as its filename with a download control, replacing the `[object Object]` the generic formatter produced. The signed URL is fetched on click, and the endpoint resolves the submission through a join on the caller's own account.

**Deployments with no bucket** get the tile disabled with the reason on it, and the public input renders nothing.

## Checks

Re-run on this base: `pnpm typecheck`, `pnpm lint`, `pnpm build` green; `pnpm test` 2043 green; `dash-check` clean; `publish-gate` passes.