### PR TITLE
fix(api): report a signing failure as a typed error, not a bare 500

### DIFF
--- a/.changeset/upload-signing-error.md
+++ b/.changeset/upload-signing-error.md
@@ -1,0 +1,16 @@
+---
+'@quill/types': patch
+---
+
+Report a signing failure as a typed error instead of a bare 500.
+
+Minting an upload or download URL reaches AWS for credentials, and that is the
+one step in the flow that fails for reasons the visitor did not cause: no role
+attached to the pod, a role whose session expired, a bucket in another account.
+Unguarded, every one of those surfaced as an Internal Server Error with a stack
+in the log and "that upload did not finish" on screen, which names neither the
+cause nor who can fix it. They now return `UPLOAD_UNAVAILABLE` with a 503.
+
+The owner's download route stopped forcing every failure into a 404 as well.
+"No such file" and "storage is unreachable" are different answers, and
+collapsing them told an owner their file was gone during an outage.

--- a/apps/api/src/admin-crud.controller.ts
+++ b/apps/api/src/admin-crud.controller.ts
@@ -92,6 +92,7 @@ import { WorkspaceService } from './workspace.service';
 import { EmailEffects } from './email-effects';
 import { AnalyticsEffects } from './analytics-effects';
 import { UploadService } from './upload.service';
+import { unwrap } from './http';
 import type { ServerEnv } from '@quill/config/env';
 import { assertAdmin, assertCanManageTarget, assertNotSelf, assertOwner } from './permissions';
 import { parseBound, parseIntParam, parseKinds, parseOutboxStatuses, parseStatus } from './query-params';
@@ -733,9 +734,10 @@ export class AdminCrudController {
   ) {
     const p = await this.auth.resolveHost(req);
     if (!this.uploads) throw new NotFoundException({ error: 'NOT_FOUND', message: 'File uploads are not enabled.' });
-    const r = await this.uploads.downloadUrl(p.accountId, submissionId, stepKey);
-    if ('error' in r) throw new NotFoundException({ error: r.error, message: r.message });
-    return r;
+    // `unwrap`, not a blanket NotFoundException: "no such file" and "storage is
+    // unreachable" are different answers, and collapsing them would tell an
+    // owner their file is gone during an outage.
+    return unwrap(await this.uploads.downloadUrl(p.accountId, submissionId, stepKey));
   }
 
   @Get('forms/:id/submissions')

--- a/apps/api/src/upload.service.spec.ts
+++ b/apps/api/src/upload.service.spec.ts
@@ -53,6 +53,16 @@ class FakeStorage implements ObjectStorage {
   }
 }
 
+/** Signing reaches AWS, so it can fail for reasons the visitor did not cause. */
+class UnsignableStorage extends FakeStorage {
+  override async presignPut(): Promise<string> {
+    throw new Error('Could not load credentials from any providers');
+  }
+  override async presignGet(): Promise<string> {
+    throw new Error('Could not load credentials from any providers');
+  }
+}
+
 const ENV = {
   UPLOAD_MAX_FILE_MB: 10,
   UPLOAD_PRESIGN_TTL_SEC: 600,
@@ -159,6 +169,21 @@ describe('presign', () => {
     const greedy = { version: 1, steps: [{ ...FILE_STEP, maxSizeMb: 500 }] };
     await db.run(sql`UPDATE form SET config = ${JSON.stringify(greedy)} WHERE slug = 'lead-qualifier'`);
     expect(await ask({ size: 11_000_000 })).toMatchObject({ error: 'FILE_TOO_LARGE' });
+  });
+
+  it('reports a signing failure as a typed 503, not a bare 500', async () => {
+    // The shape of a pod with no role attached, or a role whose session died.
+    // Left unguarded this surfaced as an Internal Server Error with a stack in
+    // the log, which names neither the cause nor who can fix it.
+    const broken = new UploadService(db, ENV, new UnsignableStorage());
+    const r = await broken.presign('acme', 'lead-qualifier', {
+      sessionId: 'sess-1',
+      stepKey: 'cv',
+      name: 'resume.pdf',
+      size: 1000,
+      mime: 'application/pdf',
+    } as never);
+    expect(r).toMatchObject({ error: 'UPLOAD_UNAVAILABLE', status: 503 });
   });
 
   it('normalizes a junk mime instead of signing it', async () => {

--- a/apps/api/src/upload.service.ts
+++ b/apps/api/src/upload.service.ts
@@ -158,7 +158,23 @@ export class UploadService {
       originalName: input.name,
     });
     const contentType = sanitizeMime(input.mime);
-    const url = await this.storage.presignPut(key, contentType);
+
+    // Signing reaches AWS for credentials, and that is the one step here that
+    // can fail for a reason the visitor did not cause: no role on the pod, a
+    // role whose session expired, a bucket in another account. Unwrapped, those
+    // surface as a bare 500 with a stack in the log and "the upload did not
+    // finish" on screen, which describes neither the cause nor who can fix it.
+    let url: string;
+    try {
+      url = await this.storage.presignPut(key, contentType);
+    } catch (err) {
+      this.log.error(`failed to sign an upload for form ${form.id}: ${String(err)}`);
+      return {
+        error: 'UPLOAD_UNAVAILABLE',
+        message: 'File uploads are temporarily unavailable.',
+        status: 503,
+      };
+    }
     return { url, key, contentType, expiresInSec: this.env.UPLOAD_PRESIGN_TTL_SEC };
   }
 
@@ -247,8 +263,17 @@ export class UploadService {
     const file = parseFileAnswer(answers[stepKey] as never);
     if (!file) return { error: 'NOT_FOUND', message: 'No file on that question.', status: 404 };
 
-    const url = await this.storage.presignGet(file.key, file.name);
-    return { url, name: file.name };
+    try {
+      const url = await this.storage.presignGet(file.key, file.name);
+      return { url, name: file.name };
+    } catch (err) {
+      this.log.error(`failed to sign a download for submission ${submissionId}: ${String(err)}`);
+      return {
+        error: 'UPLOAD_UNAVAILABLE',
+        message: 'That file cannot be reached right now.',
+        status: 503,
+      };
+    }
   }
 
   /** The object exists, is within the limit, and its bytes match the name it arrived under. */


### PR DESCRIPTION
Found by testing the merged feature, not by reading it.

Minting an upload or download URL reaches AWS for credentials, and that is the one step in the flow that fails for reasons the visitor did not cause: no role attached to the pod, a role whose session expired, a bucket in another account.

Unguarded, every one of those surfaced as a bare Internal Server Error:

```
HTTP/1.1 500 Internal Server Error
{"statusCode":500,"message":"Internal server error"}
```

with `CredentialsProviderError: Could not load credentials from any providers` and a stack in the log, and "that upload did not finish" on screen. That names neither the cause nor who can fix it, and it is exactly the shape a misconfigured IRSA role has, which makes it the most likely thing to hit on the first dev rollout.

Now:

```
HTTP/1.1 503 Service Unavailable
{"error":"UPLOAD_UNAVAILABLE","message":"File uploads are temporarily unavailable."}
```

with a log line naming the form or the submission.

The owner's download route also stopped forcing every failure into a `NotFoundException`. "No such file" and "storage is unreachable" are different answers, and collapsing them would tell an owner their file is gone during an outage.

## Checks

`pnpm typecheck`, `pnpm lint` green; `pnpm test` 2044 green with one new case that pins the 503; `dash-check` clean; `publish-gate` passes. The new test drives a storage adapter whose signing throws, which is the failure reproduced above.