### PR TITLE
feat(builder): pick a Calendly event from the list, or paste its link

### DIFF
--- a/.changeset/scheduler-event-link.md
+++ b/.changeset/scheduler-event-link.md
@@ -1,0 +1,26 @@
+---
+'@quill/shared': patch
+---
+
+Scheduler step: pick from the list, or paste the event's link.
+
+The event-type picker lists what the connected Calendly user owns or hosts,
+and nothing else. A team round robin that user is not a host of never
+appeared, and a workspace with no connection had no list at all. Two changes:
+
+- The picker's last option is "Other event: paste its link". It takes the
+  event page link, that link with Calendly's own query on it, or the whole
+  inline-embed snippet; all three store the same url the picker would have.
+  A link to an event the list already has picks that event instead. Without a
+  connection the panel keeps its connect prompt and adds "Or paste the event
+  link instead". Autofill stays at name and email for a linked event, and the
+  hint says why.
+- The picker now says whose list it is ("Showing the event types {email}
+  owns or hosts"), and the Calendly card in Integrations says the same.
+  Connecting or disconnecting a token drops the cached list at once, so a
+  re-connect as another user shows that user's events immediately instead of
+  after five minutes. Same for HubSpot's property list.
+
+i18n: `admin.editor.settings.schedulerScopedTo`, `schedulerOtherEvent`,
+`schedulerLink*`, `schedulerMapLinkHint`; `admin.integrations.calendlyScopeNote`
+(EN + ES).

--- a/apps/api/src/integrations-connect.spec.ts
+++ b/apps/api/src/integrations-connect.spec.ts
@@ -393,6 +393,26 @@ describe('HubSpot property picker token resolution', () => {
     expect(second.enabled && second.cached).toBe(true);
     expect(second.enabled && second.properties).toEqual(first.enabled && first.properties);
   });
+
+  it('re-connecting HubSpot drops the cached property list', async () => {
+    const byToken = (async (_url: string, init?: RequestInit) => {
+      const auth = ((init?.headers ?? {}) as Record<string, string>).authorization;
+      const second = auth === 'Bearer hs-second-2222';
+      return jsonResponse({
+        results: [{ name: second ? 'portal_b_prop' : 'portal_a_prop', label: 'P', type: 'string' }],
+      });
+    }) as unknown as typeof fetch;
+    build(makeEnv(), byToken);
+
+    await controller.connect(asOwner(), 'hubspot', { token: 'hs-first-1111' });
+    const before = await controller.hubspotProperties(asOwner());
+    expect(before.enabled && before.properties.map((p) => p.name)).toEqual(['portal_a_prop']);
+
+    await controller.connect(asOwner(), 'hubspot', { token: 'hs-second-2222' });
+    const after = await controller.hubspotProperties(asOwner());
+    expect(after.enabled && after.cached).toBe(false);
+    expect(after.enabled && after.properties.map((p) => p.name)).toEqual(['portal_b_prop']);
+  });
 });
 
 describe('Calendly event-type picker token resolution', () => {
@@ -472,6 +492,61 @@ describe('Calendly event-type picker token resolution', () => {
 
   it('reports disabled when no Calendly token exists', async () => {
     build(makeEnv({ CALENDLY_API_TOKEN: undefined }), noopFetch);
+    const res = await controller.calendlyEventTypes(asOwner());
+    expect(res.enabled).toBe(false);
+  });
+
+  it('names the Calendly user the list is scoped to, on a live read and on a cache hit', async () => {
+    const calls: RecordedCall[] = [];
+    build(makeEnv(), calendlyFetch(calls, ME, EVENT_TYPES));
+    await controller.connect(asOwner(), 'calendly', { token: 'cal-account-8888' });
+
+    const first = await controller.calendlyEventTypes(asOwner());
+    const second = await controller.calendlyEventTypes(asOwner());
+    expect(first.enabled && first.cached).toBe(false);
+    expect(second.enabled && second.cached).toBe(true);
+    // The email comes from /users/me — the user Calendly actually scoped to.
+    expect(first.enabled && first.connectedAs).toBe('rep@acme.io');
+    expect(second.enabled && second.connectedAs).toBe('rep@acme.io');
+  });
+
+  it('re-connecting as a different user drops the cached list — the picker never shows the old user', async () => {
+    // Two Calendly users behind two tokens: the list depends on the bearer.
+    const OTHER_ME = { resource: { uri: 'https://api.calendly.com/users/U2', email: 'ops@acme.io' } };
+    const OTHER_TYPES = {
+      collection: [
+        { uri: 'et/9', name: 'Onboarding (round robin)', scheduling_url: 'https://calendly.com/acme-team/onboarding', active: true, duration: 50 },
+      ],
+    };
+    const byToken = (async (url: string, init?: RequestInit) => {
+      const auth = ((init?.headers ?? {}) as Record<string, string>).authorization;
+      const second = auth === 'Bearer cal-second-2222';
+      if (url === CALENDLY_ME_URL) return jsonResponse(second ? OTHER_ME : ME);
+      if (url.startsWith(CALENDLY_EVENT_TYPES_BASE)) return jsonResponse(second ? OTHER_TYPES : EVENT_TYPES);
+      return new Response('{}', { status: 404 });
+    }) as unknown as typeof fetch;
+    build(makeEnv(), byToken);
+
+    await controller.connect(asOwner(), 'calendly', { token: 'cal-first-1111' });
+    const before = await controller.calendlyEventTypes(asOwner());
+    expect(before.enabled && before.connectedAs).toBe('rep@acme.io');
+
+    // Re-connect as the other user WITHIN the cache TTL.
+    await controller.connect(asOwner(), 'calendly', { token: 'cal-second-2222' });
+    const after = await controller.calendlyEventTypes(asOwner());
+    expect(after.enabled && after.cached).toBe(false);
+    expect(after.enabled && after.connectedAs).toBe('ops@acme.io');
+    expect(after.enabled && after.eventTypes.map((e) => e.name)).toEqual(['Onboarding (round robin)']);
+  });
+
+  it('disconnecting drops the cached list — the next read reports disabled, not the stale list', async () => {
+    const calls: RecordedCall[] = [];
+    build(makeEnv({ CALENDLY_API_TOKEN: undefined }), calendlyFetch(calls, ME, EVENT_TYPES));
+    await controller.connect(asOwner(), 'calendly', { token: 'cal-account-8888' });
+    const warm = await controller.calendlyEventTypes(asOwner());
+    expect(warm.enabled).toBe(true);
+
+    await controller.disconnect(asOwner(), 'calendly');
     const res = await controller.calendlyEventTypes(asOwner());
     expect(res.enabled).toBe(false);
   });

--- a/apps/api/src/integrations.controller.ts
+++ b/apps/api/src/integrations.controller.ts
@@ -109,10 +109,18 @@ export interface CalendlyEventTypeDto {
   customQuestions: CalendlyBookingFieldDto[];
 }
 
-/** The event-type-picker response: disabled (no token) or the cached list. */
+/**
+ * The event-type-picker response: disabled (no token) or the cached list.
+ *
+ * `connectedAs` names the Calendly user the list is scoped to (its email, else
+ * its name). Calendly only returns event types that user owns or hosts, so a
+ * team round robin the user is not a host of is simply absent — the builder
+ * shows this so an author knows whose events they are looking at instead of
+ * concluding the picker is broken.
+ */
 export type CalendlyEventTypesResponse =
   | { enabled: false; reason: string }
-  | { enabled: true; cached: boolean; eventTypes: CalendlyEventTypeDto[] };
+  | { enabled: true; cached: boolean; connectedAs: string | null; eventTypes: CalendlyEventTypeDto[] };
 
 const PLACEHOLDER_TOKENS = new Set(['', 'your_private_app_token_here', 'your_token_here']);
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -180,6 +188,15 @@ export class HubspotPropertiesService {
   ) {}
 
   /**
+   * Drop the account's cached list. Called on connect/disconnect: the cache is
+   * keyed by ACCOUNT, not by token, so without this a re-connect kept serving
+   * the previous token's properties for up to the TTL.
+   */
+  invalidate(accountId: string): void {
+    this.cache.delete(accountId);
+  }
+
+  /**
    * The live HubSpot token for an account: its connected (decrypted) token if
    * present, else the single-tenant env fallback. Placeholder env values count
    * as absent so a bare clone reports disabled instead of 401-ing HubSpot.
@@ -236,7 +253,7 @@ export class HubspotPropertiesService {
 }
 
 interface CalendlyMeApiResponse {
-  resource?: { uri?: string };
+  resource?: { uri?: string; email?: string; name?: string };
 }
 interface CalendlyCustomQuestionApi {
   name?: string;
@@ -282,13 +299,27 @@ function toBookingFields(questions: CalendlyCustomQuestionApi[] | undefined): Ca
 @Injectable()
 export class CalendlyEventTypesService {
   // Per-ACCOUNT cache: event types are portal-specific to the connected token.
-  private readonly cache = new Map<string, { data: CalendlyEventTypeDto[]; expires: number }>();
+  // `connectedAs` is cached alongside so a cache hit still says whose list it is.
+  private readonly cache = new Map<
+    string,
+    { data: CalendlyEventTypeDto[]; connectedAs: string | null; expires: number }
+  >();
 
   constructor(
     @Inject(ENV) private readonly env: ServerEnv,
     @Inject(DB) private readonly db: Db,
     private readonly fetchImpl: typeof fetch = fetch,
   ) {}
+
+  /**
+   * Drop the account's cached list. Called on connect/disconnect — see
+   * {@link HubspotPropertiesService.invalidate}. This is the one that bit: an
+   * author re-connected Calendly as a different user and the picker kept
+   * showing the previous user's event types for five minutes.
+   */
+  invalidate(accountId: string): void {
+    this.cache.delete(accountId);
+  }
 
   /** The live Calendly token for an account: connected (decrypted) else env fallback. */
   private async resolveToken(accountId: string): Promise<string | null> {
@@ -313,7 +344,7 @@ export class CalendlyEventTypesService {
     }
     const cached = this.cache.get(accountId);
     if (cached && cached.expires > now) {
-      return { enabled: true, cached: true, eventTypes: cached.data };
+      return { enabled: true, cached: true, connectedAs: cached.connectedAs, eventTypes: cached.data };
     }
     const headers = { authorization: `Bearer ${token}`, 'content-type': 'application/json' };
     // Calendly scopes event types by user, so resolve the token's own user first.
@@ -322,6 +353,9 @@ export class CalendlyEventTypesService {
     const me = (await meRes.json().catch(() => ({}))) as CalendlyMeApiResponse;
     const userUri = me.resource?.uri;
     if (!userUri) return { enabled: false, reason: 'Calendly did not return a user for this token.' };
+    // From the token itself, not the stored connection label: this is the user
+    // Calendly actually scoped the list to.
+    const connectedAs = me.resource?.email?.trim() || me.resource?.name?.trim() || null;
 
     const url = `${CALENDLY_EVENT_TYPES_URL}?user=${encodeURIComponent(userUri)}&active=true&count=100`;
     const res = await this.fetchImpl(url, { headers });
@@ -338,8 +372,8 @@ export class CalendlyEventTypesService {
         customQuestions: toBookingFields(e.custom_questions),
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
-    this.cache.set(accountId, { data: eventTypes, expires: now + CACHE_TTL_MS });
-    return { enabled: true, cached: false, eventTypes };
+    this.cache.set(accountId, { data: eventTypes, connectedAs, expires: now + CACHE_TTL_MS });
+    return { enabled: true, cached: false, connectedAs, eventTypes };
   }
 }
 
@@ -539,7 +573,11 @@ export class IntegrationsController {
       });
     }
 
-    return upsertIntegration(this.db, p.accountId, provider, token, key!, validation.label);
+    const status = await upsertIntegration(this.db, p.accountId, provider, token, key!, validation.label);
+    // The picker caches are keyed by account, so a new token must not keep
+    // serving the old one's list for the rest of the TTL.
+    this.invalidatePickerCache(p.accountId, provider);
+    return status;
   }
 
   /** Disconnect a provider for this account. Idempotent → 204. */
@@ -550,6 +588,13 @@ export class IntegrationsController {
     assertAdmin(p);
     const provider = parseProvider(providerParam);
     await deleteIntegration(this.db, p.accountId, provider);
+    this.invalidatePickerCache(p.accountId, provider);
+  }
+
+  /** Drop the one provider's picker cache for this account (see the services). */
+  private invalidatePickerCache(accountId: string, provider: IntegrationProvider): void {
+    if (provider === 'hubspot') this.hubspot.invalidate(accountId);
+    else this.calendly.invalidate(accountId);
   }
 
   /** HubSpot contact-property picker (per-account token, 5-min cache). */

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -256,6 +256,8 @@ export interface BuilderMessages {
     schedulerLoading: string;
     schedulerConnect: string;
     schedulerConnectCta: string;
+    /** Whose event types the picker lists — `{email}` is the connected Calendly user. */
+    schedulerScopedTo: string;
     schedulerShowDetails: string;
     schedulerMapTitle: string;
     schedulerMapHint: string;
@@ -702,6 +704,8 @@ const en: BuilderMessages = {
     schedulerLoading: 'Loading event types…',
     schedulerConnect: 'Connect Calendly in Integrations to pick an event type.',
     schedulerConnectCta: 'Go to Integrations',
+    schedulerScopedTo:
+      'Showing the event types {email} owns or hosts. A team event only appears if that account is one of its hosts.',
     schedulerShowDetails: 'Show event details',
     schedulerMapTitle: 'Autofill the booking form',
     schedulerMapHint: 'Send answers from earlier questions into the fields this event asks for.',
@@ -1111,6 +1115,8 @@ const es: BuilderMessages = {
     schedulerLoading: 'Cargando tipos de evento…',
     schedulerConnect: 'Conecta Calendly en Integraciones para elegir un tipo de evento.',
     schedulerConnectCta: 'Ir a Integraciones',
+    schedulerScopedTo:
+      'Se muestran los tipos de evento que {email} tiene o de los que es host. Un evento de equipo solo aparece si esa cuenta es uno de sus hosts.',
     schedulerShowDetails: 'Mostrar detalles del evento',
     schedulerMapTitle: 'Autocompletar el formulario de agendamiento',
     schedulerMapHint: 'Envía respuestas de preguntas anteriores a los campos que pide este evento.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/builder-messages.ts
@@ -258,6 +258,16 @@ export interface BuilderMessages {
     schedulerConnectCta: string;
     /** Whose event types the picker lists — `{email}` is the connected Calendly user. */
     schedulerScopedTo: string;
+    /** The picker's last option: configure the step by pasting the event's link. */
+    schedulerOtherEvent: string;
+    schedulerLinkLabel: string;
+    schedulerLinkPlaceholder: string;
+    schedulerLinkHint: string;
+    schedulerLinkInvalid: string;
+    /** No-token state: the way in without connecting. */
+    schedulerLinkInstead: string;
+    /** Autofill hint when the step was configured by link (no custom questions known). */
+    schedulerMapLinkHint: string;
     schedulerShowDetails: string;
     schedulerMapTitle: string;
     schedulerMapHint: string;
@@ -706,6 +716,16 @@ const en: BuilderMessages = {
     schedulerConnectCta: 'Go to Integrations',
     schedulerScopedTo:
       'Showing the event types {email} owns or hosts. A team event only appears if that account is one of its hosts.',
+    schedulerOtherEvent: 'Other event: paste its link',
+    schedulerLinkLabel: 'Calendly event link',
+    schedulerLinkPlaceholder: 'https://calendly.com/team/event, or the embed code',
+    schedulerLinkHint:
+      'Paste the event page link, or the whole embed code from Calendly. Works for events the connected account cannot see, and without a connection.',
+    schedulerLinkInvalid:
+      'That is not a Calendly event link. It should look like https://calendly.com/team/event.',
+    schedulerLinkInstead: 'Or paste the event link instead',
+    schedulerMapLinkHint:
+      'Name and email are autofilled. To map this event’s own questions, pick it from the list instead.',
     schedulerShowDetails: 'Show event details',
     schedulerMapTitle: 'Autofill the booking form',
     schedulerMapHint: 'Send answers from earlier questions into the fields this event asks for.',
@@ -1117,6 +1137,16 @@ const es: BuilderMessages = {
     schedulerConnectCta: 'Ir a Integraciones',
     schedulerScopedTo:
       'Se muestran los tipos de evento que {email} tiene o de los que es host. Un evento de equipo solo aparece si esa cuenta es uno de sus hosts.',
+    schedulerOtherEvent: 'Otro evento: pegar su link',
+    schedulerLinkLabel: 'Link del evento de Calendly',
+    schedulerLinkPlaceholder: 'https://calendly.com/equipo/evento, o el código del embed',
+    schedulerLinkHint:
+      'Pega el link de la página del evento, o el código completo del embed de Calendly. Sirve para eventos que la cuenta conectada no ve, y sin conexión.',
+    schedulerLinkInvalid:
+      'Eso no es un link de evento de Calendly. Debe verse como https://calendly.com/equipo/evento.',
+    schedulerLinkInstead: 'O pega el link del evento',
+    schedulerMapLinkHint:
+      'Nombre y correo se autocompletan. Para mapear las preguntas propias de este evento, elígelo de la lista.',
     schedulerShowDetails: 'Mostrar detalles del evento',
     schedulerMapTitle: 'Autocompletar el formulario de agendamiento',
     schedulerMapHint: 'Envía respuestas de preguntas anteriores a los campos que pide este evento.',

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-link.spec.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-link.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { isLinkConfigured, parseCalendlyLink } from './scheduler-link';
+
+describe('parseCalendlyLink', () => {
+  it('accepts the event page link as copied from the browser', () => {
+    expect(parseCalendlyLink('https://calendly.com/dapta-onboarding/onboarding-scale_up')).toEqual({
+      url: 'https://calendly.com/dapta-onboarding/onboarding-scale_up',
+      slug: 'onboarding-scale_up',
+      name: 'Onboarding scale up',
+    });
+  });
+
+  it('drops the query string and hash — the renderer builds its own', () => {
+    const link = parseCalendlyLink(
+      'https://calendly.com/acme/demo?month=2026-09&hide_gdpr_banner=1#top',
+    );
+    expect(link?.url).toBe('https://calendly.com/acme/demo');
+  });
+
+  it('pulls the data-url out of the whole embed snippet', () => {
+    const snippet = `<!-- Calendly inline widget begin -->
+<div class="calendly-inline-widget" data-url="https://calendly.com/dapta-onboarding/onboarding-scale_up" style="min-width:320px;height:700px;"></div>
+<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
+<!-- Calendly inline widget end -->`;
+    expect(parseCalendlyLink(snippet)?.url).toBe(
+      'https://calendly.com/dapta-onboarding/onboarding-scale_up',
+    );
+  });
+
+  it('finds a link pasted inside other text, and tolerates a missing scheme', () => {
+    expect(parseCalendlyLink('here: https://calendly.com/acme/intro thanks')?.slug).toBe('intro');
+    expect(parseCalendlyLink('calendly.com/acme/intro')?.url).toBe('https://calendly.com/acme/intro');
+    expect(parseCalendlyLink('http://calendly.com/acme/intro')?.url).toBe(
+      'https://calendly.com/acme/intro',
+    );
+  });
+
+  it('keeps a Calendly subdomain and a deeper path (single-use links)', () => {
+    expect(parseCalendlyLink('https://acme.calendly.com/sales/demo')?.url).toBe(
+      'https://acme.calendly.com/sales/demo',
+    );
+    expect(parseCalendlyLink('https://calendly.com/d/abc-123/discovery')?.slug).toBe('discovery');
+  });
+
+  it('rejects anything that is not a Calendly EVENT page', () => {
+    expect(parseCalendlyLink('')).toBeNull();
+    expect(parseCalendlyLink('   ')).toBeNull();
+    expect(parseCalendlyLink('https://calendly.com/acme'), 'owner landing, no event').toBeNull();
+    expect(parseCalendlyLink('https://example.com/acme/demo'), 'wrong host').toBeNull();
+    expect(parseCalendlyLink('https://notcalendly.com/acme/demo'), 'lookalike host').toBeNull();
+    expect(parseCalendlyLink('https://calendly.com.evil.io/acme/demo'), 'host prefix').toBeNull();
+    expect(parseCalendlyLink('not a url'), 'plain text').toBeNull();
+  });
+});
+
+describe('isLinkConfigured', () => {
+  it('is true only when a url was stored without a picked event type', () => {
+    expect(isLinkConfigured({ eventTypeUri: null, url: 'https://calendly.com/a/b' })).toBe(true);
+    expect(isLinkConfigured({ eventTypeUri: 'et/1', url: 'https://calendly.com/a/b' })).toBe(false);
+    expect(isLinkConfigured({ eventTypeUri: null, url: null })).toBe(false);
+    expect(isLinkConfigured({})).toBe(false);
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-link.ts
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-link.ts
@@ -1,0 +1,68 @@
+/**
+ * Turn whatever an author pastes for "the Calendly event" into the scheduling
+ * URL the form embeds — or `null` when it is not one.
+ *
+ * Authors paste three shapes: the event page link copied from the browser,
+ * that link with Calendly's own query string on it (`?month=2026-09`), or the
+ * whole inline-embed snippet Calendly hands out ("Add to website"), with the
+ * URL inside a `data-url` attribute. All three resolve to the same page, so
+ * all three are accepted and normalised to one canonical URL: https, the host
+ * as pasted (a Calendly subdomain is fine), the path only. The query is dropped
+ * because the renderer builds its own (prefill, hide-details); a stale `month`
+ * would otherwise open the widget on a month that has passed.
+ *
+ * Pure, no I/O — unit-tested on its own. It does not check the event EXISTS
+ * (that needs a token the whole point is not to require); the canvas preview
+ * mounts the real widget, which is where a dead link shows.
+ */
+export interface CalendlyLink {
+  /** Canonical scheduling URL to store in `scheduler.url`. */
+  url: string;
+  /** The event's slug (last path segment) — the only name available without a token. */
+  slug: string;
+  /** A readable label derived from the slug, for the canvas and the picker. */
+  name: string;
+}
+
+const CALENDLY_HOST = /(^|\.)calendly\.com$/i;
+const DATA_URL = /data-url\s*=\s*["']([^"']+)["']/i;
+const LOOSE_URL = /https?:\/\/[^\s"'<>]+/i;
+
+export function parseCalendlyLink(input: string): CalendlyLink | null {
+  const raw = input.trim();
+  if (!raw) return null;
+  // The embed snippet first (its `data-url` is the one that matters), then any
+  // URL found in the text, then the text itself as a URL.
+  const candidate = DATA_URL.exec(raw)?.[1] ?? LOOSE_URL.exec(raw)?.[0] ?? raw;
+  let u: URL;
+  try {
+    u = new URL(candidate.includes('://') ? candidate : `https://${candidate}`);
+  } catch {
+    return null;
+  }
+  if (!CALENDLY_HOST.test(u.hostname)) return null;
+  const segments = u.pathname.split('/').filter(Boolean);
+  // `/team/event` is an event page; a bare `/team` is the owner's landing page
+  // (a list of events), which is not something the form can book against.
+  if (segments.length < 2) return null;
+  const slug = segments[segments.length - 1]!;
+  return {
+    url: `https://${u.hostname.toLowerCase()}/${segments.join('/')}`,
+    slug,
+    name: humanizeSlug(slug),
+  };
+}
+
+/** `onboarding-scale_up` → `Onboarding scale up`. Good enough for a label. */
+function humanizeSlug(slug: string): string {
+  const words = decodeURIComponent(slug).replace(/[-_]+/g, ' ').trim();
+  return words ? words[0]!.toUpperCase() + words.slice(1) : slug;
+}
+
+/** True when a scheduler was configured by pasting a link rather than picking from the list. */
+export function isLinkConfigured(scheduler: {
+  eventTypeUri?: string | null;
+  url?: string | null;
+}): boolean {
+  return !scheduler.eventTypeUri && !!scheduler.url?.trim();
+}

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.spec.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.spec.tsx
@@ -1,0 +1,69 @@
+/**
+ * The scheduler panel's "paste a link" mode, on first render.
+ *
+ * `scheduler-link.spec.ts` proves what a pasted link parses to; this proves
+ * the panel puts that field where an author can reach it. Static markup only
+ * (the web suite runs in plain node): the event-type fetch never resolves
+ * here, so the panel stays in its initial `loading` state — which is exactly
+ * the render at issue. A step configured by link must show its link at once,
+ * because that link never depended on the list; a step with nothing picked
+ * shows the loading line and no link field, so the picker stays the first
+ * thing an author meets.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { FormStep } from '@quill/engine';
+import { SchedulerPanel } from './scheduler-panel';
+import { getBuilderMessages } from './builder-messages';
+
+const bm = getBuilderMessages('en');
+
+function render(scheduler: NonNullable<FormStep['scheduler']>) {
+  return renderToStaticMarkup(
+    <SchedulerPanel
+      scheduler={scheduler}
+      onChange={() => {}}
+      fields={[]}
+      laterSteps={[]}
+      goto={undefined}
+      onGotoChange={() => {}}
+      bm={bm}
+    />,
+  );
+}
+
+describe('SchedulerPanel — configured by link', () => {
+  it('shows the saved link immediately, before the event-type list loads', () => {
+    const html = render({
+      provider: 'calendly',
+      eventTypeUri: null,
+      eventTypeName: 'Onboarding scale up',
+      url: 'https://calendly.com/dapta-onboarding/onboarding-scale_up',
+    });
+    expect(html).toContain('data-testid="scheduler-link"');
+    expect(html).toContain('value="https://calendly.com/dapta-onboarding/onboarding-scale_up"');
+    expect(html, 'not waiting on the list').not.toContain(bm.settings.schedulerLoading);
+    // Autofill: name + email only, and the hint says why the event's own
+    // questions are not offered.
+    expect(html).toContain('data-testid="scheduler-map-name"');
+    expect(html).toContain('data-testid="scheduler-map-email"');
+    expect(html).toContain(bm.settings.schedulerMapLinkHint);
+  });
+
+  it('keeps the picker first when nothing is configured', () => {
+    const html = render({ provider: 'calendly', prefill: true });
+    expect(html).toContain(bm.settings.schedulerLoading);
+    expect(html).not.toContain('data-testid="scheduler-link"');
+    expect(html).toContain(bm.settings.schedulerMapPickFirst);
+  });
+
+  it('a picked event type is not link mode, even though it also stores a url', () => {
+    const html = render({
+      provider: 'calendly',
+      eventTypeUri: 'https://api.calendly.com/event_types/ET1',
+      eventTypeName: 'Demo 30m',
+      url: 'https://calendly.com/acme/demo',
+    });
+    expect(html).not.toContain('data-testid="scheduler-link"');
+  });
+});

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import type { FormStep } from '@quill/engine';
 import type { CalendlyEventType } from '@/lib/admin-api';
 import { Select } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
 import { GOTO_END, GOTO_NEXT, buildGoto } from './logic-util';
 import { Switch } from '@/components/ui/switch';
 import { buttonVariants } from '@/components/ui/button';
@@ -13,6 +14,7 @@ import { cn } from '@/lib/cn';
 import { fill } from '@/lib/onboarding';
 import { Field } from './fields';
 import { loadCalendlyEventTypesAction } from './scheduler-actions';
+import { isLinkConfigured, parseCalendlyLink } from './scheduler-link';
 import type { BuilderMessages } from './builder-messages';
 
 type FormScheduler = NonNullable<FormStep['scheduler']>;
@@ -27,9 +29,21 @@ type LoadState =
  * the connected token) and whether the embed shows event details. Connecting
  * Calendly happens once, account-wide, in Integrations — so when no token is
  * connected this prompts the author there instead of erroring (V6).
+ *
+ * The picker's last option is "Other event: paste its link". Calendly only
+ * lists what the connected user owns or hosts, so a team round robin that user
+ * is not a host of never appears — and a workspace with no connection has no
+ * list at all. Pasting the event's link (or its embed snippet) stores the same
+ * `url` the picker would have stored; the public form, the canvas preview and
+ * the booking record all read that url and nothing else. What the link cannot
+ * give is the event's custom questions, so the autofill rows stay at name +
+ * email. If the pasted link IS one of the listed events, that event is picked
+ * instead, so the author gets its name and questions for free.
  */
 /** Sentinel for "end the form here" in the After-booking picker. */
 const AFTER_SUBMIT = '__submit__';
+/** Sentinel option in the event-type picker: configure by pasting a link. */
+const OTHER_EVENT = '__link__';
 
 export function SchedulerPanel({
   scheduler,
@@ -52,6 +66,13 @@ export function SchedulerPanel({
 }) {
   const s = bm.settings;
   const [state, setState] = useState<LoadState>({ status: 'loading' });
+  // "Paste a link" is a mode the author enters (from the picker, or from the
+  // no-token prompt) and a saved link re-enters on open. The raw text is local
+  // so a half-typed link never clobbers the stored url; only a valid one is
+  // written through.
+  const [linkMode, setLinkMode] = useState(() => isLinkConfigured(scheduler));
+  const [linkText, setLinkText] = useState(() => (isLinkConfigured(scheduler) ? (scheduler.url ?? '') : ''));
+  const [linkInvalid, setLinkInvalid] = useState(false);
 
   // Event types are account-level, so fetch once when the panel mounts.
   useEffect(() => {
@@ -76,7 +97,12 @@ export function SchedulerPanel({
   }, [s.schedulerConnect]);
 
   const options =
-    state.status === 'ready' ? state.eventTypes.map((e) => ({ value: e.uri, label: e.name })) : [];
+    state.status === 'ready'
+      ? [
+          ...state.eventTypes.map((e) => ({ value: e.uri, label: e.name })),
+          { value: OTHER_EVENT, label: s.schedulerOtherEvent },
+        ]
+      : [];
 
   // The picked event type drives the autofill rows: Calendly always asks for a
   // name and an email, then whatever custom questions THIS event type defines.
@@ -84,6 +110,81 @@ export function SchedulerPanel({
     state.status === 'ready'
       ? state.eventTypes.find((e) => e.uri === scheduler.eventTypeUri)
       : undefined;
+  const pickerValue = linkMode ? OTHER_EVENT : (scheduler.eventTypeUri ?? '');
+
+  const pickEventType = (uri: string) => {
+    if (uri === OTHER_EVENT) {
+      // Entering link mode drops the picked event (its url would otherwise
+      // keep rendering under a picker that says "other event").
+      setLinkMode(true);
+      setLinkText('');
+      setLinkInvalid(false);
+      onChange({ ...scheduler, provider: 'calendly', eventTypeUri: null, eventTypeName: null, url: null });
+      return;
+    }
+    const et = state.status === 'ready' ? state.eventTypes.find((e) => e.uri === uri) : undefined;
+    setLinkMode(false);
+    setLinkInvalid(false);
+    onChange({
+      ...scheduler,
+      provider: 'calendly',
+      eventTypeUri: uri,
+      eventTypeName: et?.name ?? null,
+      url: et?.schedulingUrl ?? scheduler.url ?? null,
+    });
+  };
+
+  const applyLink = (text: string) => {
+    setLinkText(text);
+    const link = parseCalendlyLink(text);
+    if (!link) {
+      // Empty is "not yet", not "wrong"; anything else that fails to parse is.
+      setLinkInvalid(text.trim() !== '');
+      return;
+    }
+    setLinkInvalid(false);
+    // A link to an event the list already has: pick it properly, so the author
+    // gets the real name and the event's custom questions.
+    const listed =
+      state.status === 'ready'
+        ? state.eventTypes.find((e) => e.schedulingUrl.replace(/\/+$/, '') === link.url)
+        : undefined;
+    if (listed) {
+      pickEventType(listed.uri);
+      return;
+    }
+    onChange({
+      ...scheduler,
+      provider: 'calendly',
+      eventTypeUri: null,
+      eventTypeName: link.name,
+      url: link.url,
+    });
+  };
+
+  const linkField = (
+    <Field label={s.schedulerLinkLabel} hint={s.schedulerLinkHint}>
+      <div data-testid="scheduler-link">
+        <Input
+          type="url"
+          inputMode="url"
+          value={linkText}
+          placeholder={s.schedulerLinkPlaceholder}
+          aria-label={s.schedulerLinkLabel}
+          aria-invalid={linkInvalid || undefined}
+          onChange={(e) => applyLink(e.target.value)}
+        />
+        {linkInvalid ? (
+          <p
+            className="mt-1.5 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive"
+            data-testid="scheduler-link-invalid"
+          >
+            {s.schedulerLinkInvalid}
+          </p>
+        ) : null}
+      </div>
+    </Field>
+  );
   // The catch-all rule this panel owns, mapped back onto the picker.
   const catchAll = goto?.find((r) => r.values.includes('*'));
   const afterValue = !catchAll ? '' : (catchAll.target ?? AFTER_SUBMIT);
@@ -106,50 +207,60 @@ export function SchedulerPanel({
       <p className="text-xs text-muted-foreground">{s.schedulerHint}</p>
 
       {state.status === 'loading' ? (
-        <p className="text-xs text-muted-foreground">{s.schedulerLoading}</p>
+        // A saved link is shown at once — it never depended on the list.
+        linkMode ? linkField : <p className="text-xs text-muted-foreground">{s.schedulerLoading}</p>
       ) : state.status === 'disabled' ? (
-        <div
-          className="flex flex-col items-start gap-2 rounded-md border border-dashed border-border bg-muted/40 p-3"
-          data-testid="scheduler-connect-prompt"
-        >
-          <p className="text-xs text-muted-foreground">{s.schedulerConnect}</p>
-          <Link
-            href="/admin/integrations"
-            className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}
+        <>
+          <div
+            className="flex flex-col items-start gap-2 rounded-md border border-dashed border-border bg-muted/40 p-3"
+            data-testid="scheduler-connect-prompt"
           >
-            {s.schedulerConnectCta}
-          </Link>
-        </div>
-      ) : (
-        <Field label={s.schedulerEventType}>
-          <div data-testid="scheduler-event-select">
-            <Select
-              ariaLabel={s.schedulerEventType}
-              value={scheduler.eventTypeUri ?? ''}
-              placeholder={s.schedulerPickPlaceholder}
-              options={options}
-              searchable
-              onChange={(uri) => {
-                const et = state.eventTypes.find((e) => e.uri === uri);
-                onChange({
-                  ...scheduler,
-                  provider: 'calendly',
-                  eventTypeUri: uri,
-                  eventTypeName: et?.name ?? null,
-                  url: et?.schedulingUrl ?? scheduler.url ?? null,
-                });
-              }}
-            />
+            <p className="text-xs text-muted-foreground">{s.schedulerConnect}</p>
+            <Link
+              href="/admin/integrations"
+              className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}
+            >
+              {s.schedulerConnectCta}
+            </Link>
           </div>
-          {/* Whose list this is. Calendly scopes event types to the token's
-              user, so a team round robin that user does not host is simply
-              absent — say so here, where the author is looking for it. */}
-          {state.connectedAs ? (
-            <p className="mt-1.5 text-xs text-muted-foreground" data-testid="scheduler-scoped-to">
-              {fill(s.schedulerScopedTo, { email: state.connectedAs })}
-            </p>
-          ) : null}
-        </Field>
+          {/* No connection is not a dead end: the link works without one. */}
+          {linkMode ? (
+            linkField
+          ) : (
+            <button
+              type="button"
+              className="self-start text-xs font-medium text-primary underline-offset-2 hover:underline"
+              data-testid="scheduler-link-instead"
+              onClick={() => pickEventType(OTHER_EVENT)}
+            >
+              {s.schedulerLinkInstead}
+            </button>
+          )}
+        </>
+      ) : (
+        <>
+          <Field label={s.schedulerEventType}>
+            <div data-testid="scheduler-event-select">
+              <Select
+                ariaLabel={s.schedulerEventType}
+                value={pickerValue}
+                placeholder={s.schedulerPickPlaceholder}
+                options={options}
+                searchable
+                onChange={pickEventType}
+              />
+            </div>
+            {/* Whose list this is. Calendly scopes event types to the token's
+                user, so a team round robin that user does not host is simply
+                absent — say so here, where the author is looking for it. */}
+            {state.connectedAs ? (
+              <p className="mt-1.5 text-xs text-muted-foreground" data-testid="scheduler-scoped-to">
+                {fill(s.schedulerScopedTo, { email: state.connectedAs })}
+              </p>
+            ) : null}
+          </Field>
+          {linkMode ? linkField : null}
+        </>
       )}
 
       <div className="flex items-center justify-between gap-4">
@@ -195,7 +306,11 @@ export function SchedulerPanel({
       <div className="flex flex-col gap-2 border-t border-border pt-3" data-testid="scheduler-map">
         <p className="text-xs font-medium text-foreground">{s.schedulerMapTitle}</p>
         <p className="text-xs text-muted-foreground">
-          {selected ? s.schedulerMapHint : s.schedulerMapPickFirst}
+          {selected
+            ? s.schedulerMapHint
+            : isLinkConfigured(scheduler)
+              ? s.schedulerMapLinkHint
+              : s.schedulerMapPickFirst}
         </p>
         {bookingFields.map((bf) => (
           <Field key={bf.id} label={bf.label}>

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
@@ -10,6 +10,7 @@ import { Switch } from '@/components/ui/switch';
 import { buttonVariants } from '@/components/ui/button';
 import { ProviderLogo } from '@/components/ui/provider-logo';
 import { cn } from '@/lib/cn';
+import { fill } from '@/lib/onboarding';
 import { Field } from './fields';
 import { loadCalendlyEventTypesAction } from './scheduler-actions';
 import type { BuilderMessages } from './builder-messages';
@@ -19,7 +20,7 @@ type FormScheduler = NonNullable<FormStep['scheduler']>;
 type LoadState =
   | { status: 'loading' }
   | { status: 'disabled'; reason: string }
-  | { status: 'ready'; eventTypes: CalendlyEventType[] };
+  | { status: 'ready'; connectedAs: string | null; eventTypes: CalendlyEventType[] };
 
 /**
  * The scheduler step's settings: pick a Calendly event type (the account's, via
@@ -61,7 +62,7 @@ export function SchedulerPanel({
         if (cancelled) return;
         setState(
           res.enabled
-            ? { status: 'ready', eventTypes: res.eventTypes }
+            ? { status: 'ready', connectedAs: res.connectedAs, eventTypes: res.eventTypes }
             : { status: 'disabled', reason: res.reason },
         );
       })
@@ -140,6 +141,14 @@ export function SchedulerPanel({
               }}
             />
           </div>
+          {/* Whose list this is. Calendly scopes event types to the token's
+              user, so a team round robin that user does not host is simply
+              absent — say so here, where the author is looking for it. */}
+          {state.connectedAs ? (
+            <p className="mt-1.5 text-xs text-muted-foreground" data-testid="scheduler-scoped-to">
+              {fill(s.schedulerScopedTo, { email: state.connectedAs })}
+            </p>
+          ) : null}
         </Field>
       )}
 

--- a/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
+++ b/apps/web/app/admin/forms/[id]/edit/_components/scheduler-panel.tsx
@@ -173,6 +173,13 @@ export function SchedulerPanel({
           aria-label={s.schedulerLinkLabel}
           aria-invalid={linkInvalid || undefined}
           onChange={(e) => applyLink(e.target.value)}
+          // Once the author leaves the field, show what was actually stored:
+          // a pasted embed snippet collapses to its clean event link. Not on
+          // every keystroke, or typing a bare host would jump the caret.
+          onBlur={() => {
+            const link = parseCalendlyLink(linkText);
+            if (link && link.url !== linkText) setLinkText(link.url);
+          }}
         />
         {linkInvalid ? (
           <p

--- a/apps/web/app/admin/integrations/connections-panel.tsx
+++ b/apps/web/app/admin/integrations/connections-panel.tsx
@@ -189,7 +189,14 @@ function ProviderCard({
             </div>
           </div>
         ) : connected && status ? (
-          <ConnectedView status={status} onDisconnect={disconnect} pending={pending} m={m} locale={locale} />
+          <ConnectedView
+            status={status}
+            onDisconnect={disconnect}
+            pending={pending}
+            m={m}
+            locale={locale}
+            note={meta.id === 'calendly' ? m.calendlyScopeNote : null}
+          />
         ) : showConnect ? (
           // Connecting stays available while the server supplies a token — an
           // account can override the shared one with its own.
@@ -314,30 +321,40 @@ function ConnectedView({
   pending,
   m,
   locale,
+  note,
 }: {
   status: IntegrationStatus;
   onDisconnect: () => void;
   pending: boolean;
   m: Msgs;
   locale: Locale;
+  /** A provider-specific line under the identity (what this connection can see). */
+  note?: string | null;
 }) {
   const date = new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
     new Date(status.connectedAt),
   );
   return (
-    <div className="flex flex-wrap items-end justify-between gap-3">
-      <dl className="min-w-0 space-y-0.5 text-sm">
-        {status.label ? (
-          <dd className="font-medium text-foreground">{fill(m.connectedAs, { label: status.label })}</dd>
-        ) : null}
-        <dd className="text-xs text-muted-foreground">
-          {status.last4 ? `${fill(m.endingIn, { last4: status.last4 })} · ` : ''}
-          {fill(m.connectedOn, { date })}
-        </dd>
-      </dl>
-      <Button variant="destructive" size="sm" onClick={onDisconnect} disabled={pending}>
-        {pending ? m.disconnecting : m.disconnect}
-      </Button>
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <dl className="min-w-0 space-y-0.5 text-sm">
+          {status.label ? (
+            <dd className="font-medium text-foreground">{fill(m.connectedAs, { label: status.label })}</dd>
+          ) : null}
+          <dd className="text-xs text-muted-foreground">
+            {status.last4 ? `${fill(m.endingIn, { last4: status.last4 })} · ` : ''}
+            {fill(m.connectedOn, { date })}
+          </dd>
+        </dl>
+        <Button variant="destructive" size="sm" onClick={onDisconnect} disabled={pending}>
+          {pending ? m.disconnecting : m.disconnect}
+        </Button>
+      </div>
+      {note ? (
+        <p className="text-xs text-muted-foreground" data-testid="connection-scope-note">
+          {note}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -504,10 +504,14 @@ export interface CalendlyEventType {
   customQuestions: CalendlyBookingField[];
 }
 
-/** The event-type-picker response: disabled (no token) or the cached list. */
+/**
+ * The event-type-picker response: disabled (no token) or the cached list.
+ * `connectedAs` is the Calendly user the list is scoped to (Calendly only
+ * returns what that user owns or hosts).
+ */
 export type CalendlyEventTypesResponse =
   | { enabled: false; reason: string }
-  | { enabled: true; cached: boolean; eventTypes: CalendlyEventType[] };
+  | { enabled: true; cached: boolean; connectedAs: string | null; eventTypes: CalendlyEventType[] };
 
 export type { FormDestination };
 

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -1514,6 +1514,8 @@ export interface FormsMessages {
       connectedAs: string;
       endingIn: string;
       connectedOn: string;
+      /** Calendly only: the picker lists what the connected user owns or hosts. */
+      calendlyScopeNote: string;
       connectSuccess: string;
       connectError: string;
       tokenRequired: string;
@@ -3108,6 +3110,8 @@ export const en: FormsMessages = {
       connectedAs: 'Connected as {label}',
       endingIn: 'ending in {last4}',
       connectedOn: 'Connected {date}',
+      calendlyScopeNote:
+        'Forms can pick the event types this account owns or hosts. To use a team event, connect an account that is one of its hosts.',
       connectSuccess: '{provider} connected.',
       connectError: 'Could not connect. Check the token and try again.',
       tokenRequired: 'Paste a token first.',
@@ -4693,6 +4697,8 @@ export const es: FormsMessages = {
       connectedAs: 'Conectado como {label}',
       endingIn: 'termina en {last4}',
       connectedOn: 'Conectado el {date}',
+      calendlyScopeNote:
+        'Los formularios pueden elegir los tipos de evento que esta cuenta tiene o de los que es host. Para usar un evento de equipo, conecta una cuenta que sea uno de sus hosts.',
       connectSuccess: '{provider} conectado.',
       connectError: 'No se pudo conectar. Revisa el token e inténtalo de nuevo.',
       tokenRequired: 'Pega un token primero.',


### PR DESCRIPTION
Closes the gap Nicolás hit: the scheduler step could not use the onboarding round robin. The picker never listed it, and there was no other way in.

## Why the event was missing

The picker asks Calendly for `/event_types?user=<the connected token's user>`. Calendly returns what that user **owns or hosts**, nothing else. The connected account was marketing@daptatech.com, which is not a host of the `dapta-onboarding` team round robin, so for that token the event does not exist. Not an error, not an empty list, just absent. Confirmed by reconnecting with a host's token: the event appeared.

Two things made it worse:

- Re-connecting as another user kept showing the old user's list for five minutes. The list is cached per account and connect/disconnect never touched the cache, so the fix looked like it had not worked.
- Nothing said whose list it was.

## What changed

**Paste the event's link.** The picker's last option is "Other event: paste its link". One field, taking the event page link, that link with Calendly's own query on it, or the whole inline-embed snippet Calendly hands out (the `data-url` is pulled out). All three normalise to one canonical url. A link that is not a Calendly event page is refused inline and nothing is written until it parses. If the pasted link is one of the listed events, that event is picked instead, so the author gets its real name and its custom questions. Without a connection the panel keeps its connect prompt and adds "Or paste the event link instead". On blur the field collapses a pasted snippet to the clean link, so what is shown is what was stored.

**Whose list it is.** The event-types response carries `connectedAs` (the email from `/users/me`, cached with the list). The panel says "Showing the event types {email} owns or hosts. A team event only appears if that account is one of its hosts." The Calendly card in Integrations says the same in one line.

**Cache drop on connect/disconnect.** Both picker services expose `invalidate(accountId)`; the connect and disconnect routes call it. HubSpot's property list had the identical hole, fixed the same way.

## The decision that matters

**Link mode is not a second data model.** A picked event stores `eventTypeUri`, `eventTypeName` and `url`; a pasted link stores `url` and a slug-derived name, with `eventTypeUri` null. The public renderer, the canvas preview and the booking record read `url` and nothing else, so a linked step renders and books exactly like a picked one. No schema change, and every saved form is untouched.

What a link cannot give is the event's custom questions (that needs a token that can see it), so a linked step's autofill stays at name + email and the hint says why. Booking enrichment at sync time (invitee name, phone, start) still needs a token that can read the scheduled event; for an event outside that token's reach it degrades as it already did, to the email the form collected.

## Testing

- `integrations-connect.spec.ts`: re-connecting as another Calendly user serves the new user's list immediately; disconnecting reports disabled instead of the stale list; the same for HubSpot; `connectedAs` on a live read and on a cache hit.
- `scheduler-link.spec.ts`, new: page link, query dropped, embed snippet, subdomain, single-use links, owner landing refused, lookalike hosts refused.
- `scheduler-panel.spec.tsx`, new: a saved link shows at once with name + email autofill; nothing configured keeps the picker first; a picked event is not link mode.
- In the browser, zero-infra path with no token: connect prompt plus the link option; the full embed snippet mounts the real Onboarding event on the canvas; a non-Calendly link is refused and the last good link keeps rendering; the saved link is in the field after a reload, before the list loads.

Not verified here: the with-token path (the "Other event" row at the end of the list, and auto-picking a listed event from its pasted link). No Calendly token on this machine. Worth one pass on the PR deploy with Nico's account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
